### PR TITLE
fix(client): surface why the card database is missing

### DIFF
--- a/client/src/adapter/__tests__/wasm-adapter.test.ts
+++ b/client/src/adapter/__tests__/wasm-adapter.test.ts
@@ -505,6 +505,66 @@ describe("WasmAdapter", () => {
     });
   });
 
+  // The pool that actually broke the live site was fetched fine and then
+  // rejected by serde, so these pin the distinction the old code lost: a
+  // schema-rejected database must not be reported as an uncalled loader.
+  describe("card database load failure reaches the caller", () => {
+    const SCHEMA_ERROR =
+      "Failed to parse card database: unknown variant `Tap`, expected one of `DealDamage`, `SetTapState`";
+
+    it("reports the underlying cause, not a missing-loader message", async () => {
+      mockWorkerClient.loadCardDbFromUrl.mockRejectedValueOnce(new Error(SCHEMA_ERROR));
+      const err = await adapter
+        .checkDeckCompatibility({ main_deck: ["Forest"] })
+        .then(() => null, (e: Error) => e);
+      expect(err).toBeInstanceOf(Error);
+      expect(err!.message).toContain("unknown variant `Tap`");
+      expect(err!.message).not.toContain("Call loadCardDb");
+    });
+
+    it("does not consult the worker once the database is known to be absent", async () => {
+      mockWorkerClient.loadCardDbFromUrl.mockRejectedValueOnce(new Error(SCHEMA_ERROR));
+      await expect(
+        adapter.checkDeckCompatibility({ main_deck: ["Forest"] }),
+      ).rejects.toThrow();
+      expect(mockWorkerClient.evaluateDeckCompatibility).not.toHaveBeenCalled();
+    });
+
+    // The discriminator: without this, every assertion above would still pass
+    // if the strict gate simply rejected unconditionally.
+    it("still delegates normally when the database loads", async () => {
+      const request = { main_deck: ["Forest"] };
+      await expect(adapter.checkDeckCompatibility(request)).resolves.toEqual({
+        standard: { compatible: true, reasons: [] },
+      });
+      expect(mockWorkerClient.evaluateDeckCompatibility).toHaveBeenCalledWith(request);
+    });
+
+    // serde names every variant it rejected, which is thousands of characters.
+    it("trims a very long cause but keeps the diagnostic head", async () => {
+      const longCause = `${SCHEMA_ERROR}${", `Filler`".repeat(400)}`;
+      mockWorkerClient.loadCardDbFromUrl.mockRejectedValueOnce(new Error(longCause));
+      const err = await adapter
+        .checkDeckCompatibility({ main_deck: ["Forest"] })
+        .then(() => null, (e: Error) => e);
+      expect(err).toBeInstanceOf(Error);
+      expect(err!.message).toContain("unknown variant `Tap`");
+      expect(err!.message).toMatch(/…$/);
+      expect(err!.message.length).toBeLessThan(longCause.length);
+      // The full text stays reachable for diagnosis even though the message is trimmed.
+      expect((err as Error & { cause?: Error }).cause?.message).toBe(longCause);
+    });
+
+    it("applies to game creation too, not only the compatibility chip", async () => {
+      mockWorkerClient.loadCardDbFromUrl.mockRejectedValueOnce(new Error(SCHEMA_ERROR));
+      await adapter.initialize();
+      await expect(
+        adapter.initializeGame({ main_deck: ["Forest"] }),
+      ).rejects.toThrow("unknown variant `Tap`");
+      expect(mockWorkerClient.initializeGame).not.toHaveBeenCalled();
+    });
+  });
+
   // Symmetric with the block above, and load-bearing for exactly one reason: a
   // copy-paste slip inside `evaluateDeckFormatGate`'s real implementation —
   // calling `evaluateDeckCompatibility` instead of `evaluateDeckFormatGate` —

--- a/client/src/adapter/wasm-adapter.ts
+++ b/client/src/adapter/wasm-adapter.ts
@@ -178,6 +178,22 @@ export function getHostAdapter(): WasmAdapter {
  * Falls back to direct main-thread WASM calls if Worker creation fails
  * (e.g., restrictive CSP, very old browser).
  */
+/** How much of a card-database load failure to put in a user-facing message.
+ *  serde's "unknown variant" error enumerates every variant of the enum it
+ *  rejected, which runs to thousands of characters; everything diagnostic is in
+ *  the opening clause, so the tail is noise in a toast. */
+const CARD_DB_ERROR_MAX_CHARS = 180;
+
+function describeCardDbError(err: unknown): string {
+  const message = err instanceof Error ? err.message : String(err ?? "");
+  if (!message) return "";
+  const trimmed =
+    message.length > CARD_DB_ERROR_MAX_CHARS
+      ? `${message.slice(0, CARD_DB_ERROR_MAX_CHARS)}…`
+      : message;
+  return `: ${trimmed}`;
+}
+
 export class WasmAdapter implements EngineAdapter, AiDecisionDiagnosticsCapability {
   private initialized = false;
   cardDbLoaded = false;
@@ -328,6 +344,14 @@ export class WasmAdapter implements EngineAdapter, AiDecisionDiagnosticsCapabili
   // Concurrent callers now share one load; mirrors `initPromise` above.
   private cardDbPromise: Promise<void> | null = null;
 
+  // Why the failure is kept rather than only logged: `ensureCardDb` is
+  // best-effort by design and resolves even when the load failed, so callers
+  // that require the database cannot tell *why* it is absent. Without this the
+  // engine worker answers them with "Card database not loaded", which names a
+  // missing call rather than the real cause -- a schema-rejected pool reads as
+  // a forgotten `loadCardDb`.
+  private cardDbError: unknown = null;
+
   private ensureCardDb(): Promise<void> {
     if (this.cardDbLoaded) return Promise.resolve();
     if (this.cardDbPromise) return this.cardDbPromise;
@@ -344,7 +368,9 @@ export class WasmAdapter implements EngineAdapter, AiDecisionDiagnosticsCapabili
         if (this.engine && this.aiPool && !this.aiPool.isCardDbLoaded) {
           await this.ensureAiPool();
         }
+        this.cardDbError = null;
       } catch (err) {
+        this.cardDbError = err;
         console.warn("Failed to load card database:", err);
       }
     })();
@@ -735,20 +761,28 @@ export class WasmAdapter implements EngineAdapter, AiDecisionDiagnosticsCapabili
     }
   }
 
-  private async requireCardDbForRestore(): Promise<void> {
+  private async requireCardDb(): Promise<void> {
     await this.ensureCardDb();
     // Soft-failed ensureCardDb leaves cardDbLoaded false and skips
     // rehydrate_game_from_card_db — restored CardName NamedChoices then have
     // empty legal actions and softlock the AI (#6393). Refuse DB-less restore
     // / P2P host resume the same way warmCardDatabase surfaces load failure.
+    // Every caller that reads CARD_DB goes through here, so the cause travels
+    // with the refusal instead of staying behind in a console warning.
     if (!this.cardDbLoaded) {
-      throw new Error("Card database failed to load");
+      // `new Error(msg, { cause })` is ES2022 and this bundle targets ES2020,
+      // so the cause is attached the way `network/connection.ts` does it.
+      const error = new Error(
+        `Card database failed to load${describeCardDbError(this.cardDbError)}`,
+      );
+      Object.assign(error, { cause: this.cardDbError });
+      throw error;
     }
   }
 
   async restoreState(state: PersistedGameState): Promise<void> {
     this.assertInitialized();
-    await this.requireCardDbForRestore();
+    await this.requireCardDb();
     const json = JSON.stringify(state);
     if (this.engine) await this.engine.restoreState(json);
     else await this.fallback!.restoreState(json);
@@ -851,7 +885,7 @@ export class WasmAdapter implements EngineAdapter, AiDecisionDiagnosticsCapabili
     this.assertInitialized();
     // Same CARD_DB requirement as restoreState — resume rehydrates abilities
     // only when the DB is loaded (engine-wasm resume_multiplayer_host_state).
-    await this.requireCardDbForRestore();
+    await this.requireCardDb();
     const json = JSON.stringify(state);
     const resumed = this.engine
       ? await this.engine.resumeMultiplayerHostState(json)
@@ -897,7 +931,7 @@ export class WasmAdapter implements EngineAdapter, AiDecisionDiagnosticsCapabili
    */
   async warmCardDatabase(): Promise<void> {
     await this.initialize();
-    await this.requireCardDbForRestore();
+    await this.requireCardDb();
   }
 
   /**
@@ -908,7 +942,7 @@ export class WasmAdapter implements EngineAdapter, AiDecisionDiagnosticsCapabili
    */
   async checkDeckCompatibility(request: unknown): Promise<unknown> {
     await this.initialize();
-    await this.ensureCardDb();
+    await this.requireCardDb();
     if (this.engine) {
       return this.engine.evaluateDeckCompatibility(request);
     }
@@ -929,7 +963,7 @@ export class WasmAdapter implements EngineAdapter, AiDecisionDiagnosticsCapabili
    */
   async evaluateDeckFormatGate(request: unknown): Promise<unknown> {
     await this.initialize();
-    await this.ensureCardDb();
+    await this.requireCardDb();
     if (this.engine) {
       return this.engine.evaluateDeckFormatGate(request);
     }
@@ -971,21 +1005,21 @@ export class WasmAdapter implements EngineAdapter, AiDecisionDiagnosticsCapabili
    */
   async getCardFaceData(cardName: string): Promise<unknown> {
     await this.initialize();
-    await this.ensureCardDb();
+    await this.requireCardDb();
     if (this.engine) return this.engine.getCardFaceData(cardName);
     return this.fallback!.getCardFaceData(cardName);
   }
 
   async getCardParseDetails(cardName: string): Promise<unknown> {
     await this.initialize();
-    await this.ensureCardDb();
+    await this.requireCardDb();
     if (this.engine) return this.engine.getCardParseDetails(cardName);
     return this.fallback!.getCardParseDetails(cardName);
   }
 
   async getCardRulings(cardName: string): Promise<unknown> {
     await this.initialize();
-    await this.ensureCardDb();
+    await this.requireCardDb();
     if (this.engine) return this.engine.getCardRulings(cardName);
     return this.fallback!.getCardRulings(cardName);
   }
@@ -1059,7 +1093,7 @@ export class WasmAdapter implements EngineAdapter, AiDecisionDiagnosticsCapabili
   ): Promise<SubmitResult> {
     this.assertInitialized();
     if (deckData) {
-      await this.ensureCardDb();
+      await this.requireCardDb();
     }
     const seed = Math.floor(Math.random() * Number.MAX_SAFE_INTEGER);
     if (this.engine) {
@@ -1103,7 +1137,7 @@ export class WasmAdapter implements EngineAdapter, AiDecisionDiagnosticsCapabili
   ): Promise<SubmitResult> {
     this.assertInitialized();
     if (deckData) {
-      await this.ensureCardDb();
+      await this.requireCardDb();
     }
     const seed = Math.floor(Math.random() * Number.MAX_SAFE_INTEGER);
     if (this.engine) {


### PR DESCRIPTION
## Summary

A failed card-database load is reported to the user as a bug that isn't there: *"Compatibility check unavailable: Card database not loaded. Call loadCardDb or loadCardDbFromUrl first."* The loader **did** run. It failed, and the reason was discarded into a `console.warn`. This keeps the cause and lets it reach the caller.

Found while diagnosing a live self-hosted site (#8327, the packaging half): the pool fetched fine — 200, 9.68 MB — and was then rejected by the engine schema with `unknown variant 'Tap'`. Nothing in the UI could say so.

## Files changed

- `client/src/adapter/wasm-adapter.ts` — retain the load error in `ensureCardDb`; rename the existing strict gate `requireCardDbForRestore` → `requireCardDb` and have it report the retained cause; route the CARD_DB-reading paths through it
- `client/src/adapter/__tests__/wasm-adapter.test.ts` — five cases covering the class, its boundary, and the truncation

## Track

Non-developer

## LLM

Model: claude-opus-5
Tier: Frontier
Thinking: high

## Implementation method (required)

Method: not-applicable — client adapter only; no `crates/engine/` game logic is touched.

## CR references

None. Client error-reporting change, no rules behavior.

## Verification

- [x] Required checks ran clean, or the exact CI-owned alternative is stated below.
- [x] Gate A output below is for the current committed head.
- [x] Final review-impl below is clean for the current committed head.
- [x] Both anchors cite existing analogous code at the same seam.

- `npx tsc -b --noEmit --force` — exit **0**. (`-b --force`, not `-p`: `-p` is vacuous against a solution config.)
- `npx vitest run src/adapter/__tests__/wasm-adapter.test.ts` — **57 passed / 57**, exit 0.
- `npx eslint` on both changed files — exit **0**.
- **Non-vacuity, measured by mutation rather than asserted.** With the new tests held fixed and `wasm-adapter.ts` reverted to `upstream/main`, the suite goes to **4 failed / 53 passed**: the cause-reporting, no-worker-round-trip, truncation, and game-creation cases all fail. The fifth new test — "still delegates normally when the database loads" — passes both before and after **on purpose**: it is the control that proves the other four are not satisfied by a gate that simply rejects everything. Source restored from the commit afterwards; `git status --porcelain` clean.

## Gate A

Gate A PASS head=583ed46b3f2cfb831f6613702e8af958a66286e0 base=d6d28370c09242182488cac72e16e5a84941885f

**Disclosure — inapplicable to this diff rather than evidence for it.** Two TypeScript files, zero `.rs`. The run is non-vacuous, but its base is a fork's `origin/main`, so what it walks is fork-to-upstream drift, not this PR.

## Anchored on

- `client/src/adapter/wasm-adapter.ts` — `requireCardDbForRestore` (as it was) already did exactly this for restore and P2P resume: await the best-effort load, then refuse if the latch is still false. This PR generalises that existing gate rather than inventing a second mechanism; `warmCardDatabase` was already routed through it.
- `client/src/network/connection.ts:284` — `Object.assign(wrapped, { cause: err, … })`. The house pattern for attaching a cause under an ES2020 target, which is why this does not use `new Error(msg, { cause })`.

## Final review-impl

Final review-impl PASS head=583ed46b3f2cfb831f6613702e8af958a66286e0

The judgement call worth reviewing is **scope**, so it is stated explicitly. Seven paths read CARD_DB and all produced the same misleading message; fixing only the reported one would leave six siblings wrong. The enumeration and its single exclusion:

- **Routed to the strict gate (7 newly):** `checkDeckCompatibility`, `evaluateDeckFormatGate`, `getCardFaceData`, `getCardParseDetails`, `getCardRulings`, `initializeGame`, `initializeMultiplayerHostGame`. Plus the 3 already there via the rename: `restoreState`, `resumeMultiplayerHostState`, `warmCardDatabase`.
- **Deliberately left soft (1):** the Debug CreateCard retry in `submitAction`. It calls `ensureCardDb` as best-effort recovery from a specific engine error and must not throw.

None of the routed paths gains a throw it did not already have — each already rejected when the database was absent, via the worker. What changes is which error, and that it arrives without a pointless worker round-trip.

The boundary is guarded at both ends, and the refusing end needed no new test: the existing `submitAction` cases assert `loadCardDbFromUrl` was **not** called, so admitting that call site into the class would fail them. Two admitted members are covered by new tests at opposite ends of the class (`checkDeckCompatibility`, `initializeGame`).

Two call sites reason about the swallow in comments, and both are consistent with this change rather than broken by it: `GameSetupPage.tsx` deliberately lets Start through on an errored warm *because* "initializeGame awaits ensureCardDb itself", and `p2p-adapter.ts` names `"Card database not loaded" when ensureCardDb swallowed a fetch failure` among the rejections it forwards to a toast, noting "the original error is preserved". Both now carry a true message instead of a misleading one. Their comments are left alone, as their descriptions remain accurate.

## Claimed parse impact

None.

## Scope Expansion

The class, not the single reported call site — reasoned above and enumerated with its one exclusion. Deliberately **not** included: changing `ensureCardDb`'s own contract. It stays best-effort, because `GameSetupPage.tsx` and the Debug CreateCard retry depend on that, and the strict behaviour already had a home.

## Validation Failures

None.

## CI Failures

None.

---

**No new user-facing strings, so the 7-locale parity gate is untouched.** `myDecks.compatibilityError` already interpolates `{{error}}` — it is the key that rendered the misleading message in the first place, so every locale renders the improved one with no change.

Sibling of #8327, which fixes the packaging defect that produced the schema-rejected pool. They are independent: #8327 stops the bad pool being pinned, this one makes any future load failure say what happened. Either is useful alone.
