### PR TITLE
ci: pin the publishing workflows' actions to commit SHAs

### DIFF
--- a/.github/actions/binaryen/action.yml
+++ b/.github/actions/binaryen/action.yml
@@ -50,7 +50,7 @@ runs:
 
     - name: Restore cached Binaryen archive
       id: cache
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
         # Cache the ARCHIVE, not the extracted executables. Extracted binaries
         # restore straight onto PATH with nothing left to check, so a poisoned

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,6 +121,18 @@ jobs:
         # checker against the evaluated commit.
         run: python3 scripts/check_action_pins_tests.py
 
+      - name: Action pin regression coverage
+        # Walks reusable-workflow and composite-action calls out of the
+        # release/deploy workflows: those run with deploy and signing secrets,
+        # so an action one call away from the edited file is the same exposure
+        # with less visibility. Pinning only top-level files would miss it.
+        #
+        # This runs from the pull request's checkout, so it is fast feedback and
+        # NOT the control: a commit can change a privileged workflow and this
+        # checker together. The authority is action-pin-audit.yml, which runs
+        # the default branch's copy of the checker against this commit.
+        run: python3 scripts/check_action_pins.py
+
       - name: Resolution-frame boundary guard
         # Full-tree guard: legacy resolution keys are reader/fixture-only, and
         # ResolutionStack mutation remains top-only or adjacent-pair scoped.

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -99,15 +99,15 @@ jobs:
       draft_pools_hash16: ${{ steps.card-data-hash.outputs.draft_pools_hash16 }}
       engine_fingerprint: ${{ steps.engine-fingerprint.outputs.fingerprint }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           ref: ${{ env.DEPLOY_SHA }}
 
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
         with:
           cache-shared-key: rust-tool
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22
 
@@ -142,7 +142,7 @@ jobs:
         # missing); a restore-keys fallback would pin the file-existence-gated
         # fetches to stale data forever.
         id: mtgjson-cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: data/mtgjson
           key: mtgjson-full-${{ steps.mtgjson-key.outputs.suffix }}
@@ -211,7 +211,7 @@ jobs:
         # "the data is whole" gate. cache-hit gating skips a redundant save,
         # which would otherwise just warn that the key already exists.
         if: ${{ steps.mtgjson-cache.outputs.cache-hit != 'true' }}
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: data/mtgjson
           key: mtgjson-full-${{ steps.mtgjson-key.outputs.suffix }}
@@ -230,7 +230,7 @@ jobs:
         # NO restore-keys: every input to the output is in the key, so an
         # inexact hit is by construction a stale pool.
         id: draft-pools-cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: client/public/draft-pools.json
           key: mtgjson-draft-pools-${{ steps.mtgjson-key.outputs.draft_pools_suffix }}
@@ -267,7 +267,7 @@ jobs:
         # file-existence-gated, so the next run fetches only the sets that are
         # still missing and regenerates a complete pool.
         if: ${{ steps.draft-pools-cache.outputs.cache-hit != 'true' && steps.draft-sets.outputs.failed == '0' }}
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: client/public/draft-pools.json
           key: mtgjson-draft-pools-${{ steps.mtgjson-key.outputs.draft_pools_suffix }}
@@ -313,7 +313,7 @@ jobs:
         # The publication job runs on a fresh runner. Transfer only its
         # generated inputs so the preview-server matrix can overlap Scryfall,
         # audit, compression, and R2 work instead of re-generating card data.
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: preview-inputs
           path: |
@@ -344,15 +344,15 @@ jobs:
       actions: write
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           ref: ${{ env.DEPLOY_SHA }}
 
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
         with:
           cache-shared-key: rust-tool
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22
 
@@ -365,13 +365,13 @@ jobs:
         # Exact-key-only: the generators skip downloads for existing files, so
         # a stale restore-key hit would pin the staging payload to old data.
         id: scryfall-cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: data/scryfall
           key: scryfall-${{ steps.cache-keys.outputs.day }}
 
       - name: Download preview inputs
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: preview-inputs
 
@@ -412,7 +412,7 @@ jobs:
         # NO restore-keys: every input to the output is in the key, so an
         # inexact hit is by construction a stale map.
         id: locale-images-cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: client/public/scryfall-images.v2.*.json
           key: mtgjson-locale-images-v2-${{ steps.mtgjson-key.outputs.suffix }}-${{ steps.cache-keys.outputs.day }}-${{ hashFiles('scripts/gen-scryfall-locale-images.sh') }}
@@ -432,7 +432,7 @@ jobs:
         # Banked the moment the maps exist, so the AllSetFiles download is never
         # paid twice for the same inputs even if a later step fails.
         if: ${{ steps.locale-images-cache.outputs.cache-hit != 'true' }}
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: client/public/scryfall-images.v2.*.json
           key: mtgjson-locale-images-v2-${{ steps.mtgjson-key.outputs.suffix }}-${{ steps.cache-keys.outputs.day }}-${{ hashFiles('scripts/gen-scryfall-locale-images.sh') }}
@@ -442,7 +442,7 @@ jobs:
         # it here keeps a later failure from re-hitting the Scryfall API on the
         # next run — the throttle flakiness this cache exists to avoid.
         if: ${{ steps.scryfall-cache.outputs.cache-hit != 'true' }}
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: data/scryfall
           key: scryfall-${{ steps.cache-keys.outputs.day }}
@@ -566,11 +566,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           ref: ${{ env.DEPLOY_SHA }}
 
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
         with:
           targets: wasm32-unknown-unknown
           cache-shared-key: rust-wasm
@@ -581,7 +581,7 @@ jobs:
           # authoritative.
           rustflags: ""
 
-      - uses: taiki-e/install-action@v2
+      - uses: taiki-e/install-action@e67fa11c4b9316fa714ddf0abed07a0c3143b95b # v2.87.4
         with:
           tool: wasm-bindgen-cli@0.2.121
 
@@ -591,7 +591,7 @@ jobs:
       # build-wasm.sh's assert_wasm_stack guard parses the shipped wasm's memory
       # section with node; declare the dependency explicitly (release.yml already
       # sets up node for its build-wasm job).
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22
 
@@ -599,7 +599,7 @@ jobs:
         run: ./scripts/build-wasm.sh release
 
       - name: Upload WASM artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: wasm
           path: client/src/wasm/*
@@ -640,11 +640,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           ref: ${{ env.DEPLOY_SHA }}
 
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
         with:
           targets: wasm32-unknown-unknown
           cache-shared-key: rust-wasm
@@ -653,7 +653,7 @@ jobs:
           # RUSTFLAGS would override them.
           rustflags: ""
 
-      - uses: taiki-e/install-action@v2
+      - uses: taiki-e/install-action@e67fa11c4b9316fa714ddf0abed07a0c3143b95b # v2.87.4
         with:
           # Must match the pinned wasm-bindgen crate version in
           # lobby-worker/broker-wasm/Cargo.toml (schema versions must be exact).
@@ -663,7 +663,7 @@ jobs:
         uses: ./.github/actions/binaryen
 
       - name: Deploy preview lobby Worker
-        uses: cloudflare/wrangler-action@v4
+        uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4.0.0
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
@@ -724,21 +724,21 @@ jobs:
       name: github-pages
       url: ${{ steps.deploy.outputs.page_url }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           ref: ${{ env.DEPLOY_SHA }}
 
       - name: Download WASM artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: wasm
           path: client/src/wasm
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
         with:
           version: 9
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22
           cache: pnpm
@@ -855,16 +855,16 @@ jobs:
         run: cp client/dist/index.html client/dist/404.html
 
       - name: Configure Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
         with:
           path: client/dist
 
       - name: Deploy to GitHub Pages
         id: deploy
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5
 
   # ── Server binary compile (parallel with card-data) ─────────────────────────
   # phase-server is compiled NATIVELY as a static musl binary, then uploaded as
@@ -896,11 +896,11 @@ jobs:
             triple: aarch64-unknown-linux-musl
             cargo_cmd: zigbuild
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           ref: ${{ env.DEPLOY_SHA }}
 
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
         with:
           cache-shared-key: rust-server-${{ matrix.arch }}
 
@@ -938,7 +938,7 @@ jobs:
           cp target/${{ matrix.triple }}/server-release/phase-server ./phase-server
 
       - name: Upload server binary artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: server-binary-${{ matrix.arch }}
           path: phase-server
@@ -966,12 +966,12 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           ref: ${{ env.DEPLOY_SHA }}
 
       - name: Download server binary artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           pattern: server-binary-*
           path: prebuilt
@@ -990,7 +990,7 @@ jobs:
         run: echo "short_sha=${DEPLOY_SHA::12}" >> "$GITHUB_OUTPUT"
 
       - name: Login to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -998,16 +998,16 @@ jobs:
 
       # QEMU only runs the runtime stage's apt-get for the arm64 leg; the
       # binaries are prebuilt, so nothing heavy is emulated.
-      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
         with:
           platforms: arm64
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       - name: Build and push preview image
         # BINARY_STAGE=prebuilt makes Docker copy the prebuilt musl binaries
         # instead of compiling in-container — the build is just apt + COPY.
         # One manifest list covers both platforms under the same tag/digest.
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: .
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/preview-server.yml
+++ b/.github/workflows/preview-server.yml
@@ -149,11 +149,11 @@ jobs:
             triple: x86_64-pc-windows-msvc
             extension: .exe
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           ref: ${{ inputs.commit }}
 
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
         with:
           cache-shared-key: rust-server-${{ matrix.os }}
 
@@ -184,7 +184,7 @@ jobs:
         shell: pwsh
 
       - name: Upload preview server binary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: preview-server-${{ matrix.triple }}
           path: phase-server-${{ matrix.triple }}${{ matrix.extension }}
@@ -240,28 +240,28 @@ jobs:
               ;;
           esac
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         if: steps.publication-gate.outputs.already_published != 'true'
         with:
           node-version: 22
 
       - name: Download Linux binary
         if: steps.publication-gate.outputs.already_published != 'true'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: preview-server-x86_64-unknown-linux-musl
           path: artifacts/x86_64-unknown-linux-musl
 
       - name: Download macOS binary
         if: steps.publication-gate.outputs.already_published != 'true'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: preview-server-aarch64-apple-darwin
           path: artifacts/aarch64-apple-darwin
 
       - name: Download Windows binary
         if: steps.publication-gate.outputs.already_published != 'true'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: preview-server-x86_64-pc-windows-msvc
           path: artifacts/x86_64-pc-windows-msvc

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
       release_tag: ${{ steps.resolve.outputs.release_tag }}
       release_sha: ${{ steps.resolve.outputs.release_sha }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 0
 
@@ -95,11 +95,11 @@ jobs:
       RELEASE_SHA: ${{ needs.resolve-release-ref.outputs.release_sha }}
       WRANGLER_VERSION: "4.113.0"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           ref: ${{ env.RELEASE_SHA }}
 
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
         with:
           target: wasm32-unknown-unknown
           cache-shared-key: rust-wasm
@@ -109,18 +109,18 @@ jobs:
           # build-wasm.sh's assert_wasm_stack guard.
           rustflags: ""
 
-      - uses: taiki-e/install-action@v2
+      - uses: taiki-e/install-action@e67fa11c4b9316fa714ddf0abed07a0c3143b95b # v2.87.4
         with:
           tool: wasm-bindgen-cli@0.2.121
 
       - name: Set up Binaryen
         uses: ./.github/actions/binaryen
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
         with:
           version: 9
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22
           cache: pnpm
@@ -158,7 +158,7 @@ jobs:
         # fresh data; a restore-keys fallback would pin the file-existence-gated
         # fetches to stale data forever.
         id: mtgjson-cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: data/mtgjson
           key: mtgjson-full-${{ steps.mtgjson-key.outputs.suffix }}
@@ -170,7 +170,7 @@ jobs:
       # Scryfall API load (and the Cloudflare-throttle flakiness it causes).
       - name: Restore Scryfall bulk data
         id: scryfall-cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: data/scryfall
           key: scryfall-${{ steps.cache-keys.outputs.day }}
@@ -227,7 +227,7 @@ jobs:
         # exactly when the directory is incomplete and must not be frozen under
         # an immutable key.
         if: ${{ steps.mtgjson-cache.outputs.cache-hit != 'true' }}
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: data/mtgjson
           key: mtgjson-full-${{ steps.mtgjson-key.outputs.suffix }}
@@ -246,7 +246,7 @@ jobs:
         # NO restore-keys: every input to the output is in the key, so an
         # inexact hit is by construction a stale pool.
         id: draft-pools-cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: client/public/draft-pools.json
           key: mtgjson-draft-pools-${{ steps.mtgjson-key.outputs.draft_pools_suffix }}
@@ -286,7 +286,7 @@ jobs:
         # sets/ dir must not be frozen under a key that only rolls when MTGJSON
         # publishes. See deploy.yml for the full reasoning.
         if: ${{ steps.draft-pools-cache.outputs.cache-hit != 'true' && steps.draft-sets.outputs.failed == '0' }}
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: client/public/draft-pools.json
           key: mtgjson-draft-pools-${{ steps.mtgjson-key.outputs.draft_pools_suffix }}
@@ -342,7 +342,7 @@ jobs:
         # NO restore-keys: every input to the output is in the key, so an
         # inexact hit is by construction a stale map.
         id: locale-images-cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: client/public/scryfall-images.v2.*.json
           key: mtgjson-locale-images-v2-${{ steps.mtgjson-key.outputs.suffix }}-${{ steps.cache-keys.outputs.day }}-${{ hashFiles('scripts/gen-scryfall-locale-images.sh') }}
@@ -362,7 +362,7 @@ jobs:
         # Banked the moment the maps exist, so the AllSetFiles download is never
         # paid twice for the same inputs even if a later step fails.
         if: ${{ steps.locale-images-cache.outputs.cache-hit != 'true' }}
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: client/public/scryfall-images.v2.*.json
           key: mtgjson-locale-images-v2-${{ steps.mtgjson-key.outputs.suffix }}-${{ steps.cache-keys.outputs.day }}-${{ hashFiles('scripts/gen-scryfall-locale-images.sh') }}
@@ -372,7 +372,7 @@ jobs:
         # it here keeps a later failure from re-hitting the Scryfall API on the
         # next run — the throttle flakiness this cache exists to avoid.
         if: ${{ steps.scryfall-cache.outputs.cache-hit != 'true' }}
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: data/scryfall
           key: scryfall-${{ steps.cache-keys.outputs.day }}
@@ -551,7 +551,7 @@ jobs:
             client/dist/card-data-????????????????.json.br
 
       - name: Upload frontend artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: frontend-dist
           path: client/dist
@@ -589,11 +589,11 @@ jobs:
             triple: aarch64-unknown-linux-musl
             cargo_cmd: zigbuild
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           ref: ${{ env.RELEASE_SHA }}
 
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
         with:
           cache-shared-key: rust-server-linux-${{ matrix.arch }}
           # CI owns the warning-as-error gate. Release profiles compile out
@@ -632,7 +632,7 @@ jobs:
           cp target/${{ matrix.triple }}/server-release/phase-server ./phase-server
 
       - name: Upload server binary artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: server-binary-linux-${{ matrix.arch }}
           path: phase-server
@@ -655,12 +655,12 @@ jobs:
       RELEASE_SHA: ${{ needs.resolve-release-ref.outputs.release_sha }}
       IMAGE_NAME: ghcr.io/${{ github.repository_owner }}/phase-server
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           ref: ${{ env.RELEASE_SHA }}
 
       - name: Download server binaries
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           pattern: server-binary-linux-*
           path: prebuilt
@@ -675,7 +675,7 @@ jobs:
           done
 
       - name: Login to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -683,16 +683,16 @@ jobs:
 
       # QEMU only runs the runtime stage's apt-get for the arm64 leg; the
       # binaries are prebuilt, so nothing heavy is emulated.
-      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
         with:
           platforms: arm64
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       - name: Build and push release image
         # BINARY_STAGE=prebuilt: copy the musl binaries from build-server-binary
         # instead of compiling in-container — the build is just apt + COPY.
         # One manifest list covers both platforms under the same tag/digest.
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         env:
           DOCKER_BUILD_RECORD_UPLOAD: false
         with:
@@ -772,10 +772,10 @@ jobs:
       # is held outside client/public/ so the GitHub Pages preview deploy
       # (deploy.yml) never serves it at /_headers.
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Download frontend artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: frontend-dist
           path: dist
@@ -794,7 +794,7 @@ jobs:
           fi
 
       - name: Deploy to Cloudflare Pages
-        uses: cloudflare/wrangler-action@v4
+        uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4.0.0
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
@@ -812,7 +812,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           ref: ${{ needs.resolve-release-ref.outputs.release_sha }}
 
@@ -826,7 +826,7 @@ jobs:
             echo "lobby-worker/ is not present in this release commit; skipping lobby Worker deploy."
           fi
 
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
         if: steps.lobby-worker.outputs.exists == 'true'
         with:
           targets: wasm32-unknown-unknown
@@ -836,7 +836,7 @@ jobs:
           # env RUSTFLAGS would override.
           rustflags: ""
 
-      - uses: taiki-e/install-action@v2
+      - uses: taiki-e/install-action@e67fa11c4b9316fa714ddf0abed07a0c3143b95b # v2.87.4
         if: steps.lobby-worker.outputs.exists == 'true'
         with:
           # Must match the pinned wasm-bindgen crate version in
@@ -852,7 +852,7 @@ jobs:
         # `wrangler deploy` runs the [build] command in lobby-worker/wrangler.toml
         # (scripts/build-broker-wasm.sh release): cargo build -> wasm32,
         # wasm-bindgen, wasm-opt. The toolchain installed above is inherited.
-        uses: cloudflare/wrangler-action@v4
+        uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4.0.0
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
@@ -891,11 +891,11 @@ jobs:
             triple: x86_64-pc-windows-msvc
             extension: .exe
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           ref: ${{ env.RELEASE_SHA }}
 
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
         with:
           cache-shared-key: rust-server-${{ matrix.os }}
           # Keep this artifact build consistent with the primary Linux build:
@@ -913,7 +913,7 @@ jobs:
         # Reuse the single musl build from build-server-binary, placed at the
         # canonical target path so the packaging step is identical across OSes.
         if: matrix.triple == 'x86_64-unknown-linux-musl'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: server-binary-linux-amd64
           path: target/x86_64-unknown-linux-musl/server-release
@@ -932,7 +932,7 @@ jobs:
         shell: pwsh
 
       - name: Upload slim server binary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: phase-server-slim-${{ matrix.triple }}
           path: phase-server-slim-${{ matrix.triple }}${{ matrix.extension }}
@@ -1024,17 +1024,17 @@ jobs:
       SERVER_ARTIFACT_MINISIGN_PRIVATE_KEY: ${{ secrets.SERVER_ARTIFACT_MINISIGN_PRIVATE_KEY }}
       WRANGLER_VERSION: "4.113.0"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           ref: ${{ env.RELEASE_SHA }}
           fetch-depth: 0
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           path: artifacts
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22
 
@@ -1197,7 +1197,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Create release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         with:
           tag_name: ${{ env.RELEASE_TAG }}
           body_path: changelog.md


### PR DESCRIPTION
## Summary

Split: the trusted audit that enforces this rule now lives in #8338, and this PR is the pins
themselves. #8338 merges first so the authority exists before the change it gates; this is the
first pull request the `Action Pin Audit` check would gate.

`release.yml` and `deploy.yml` run with the deploy, signing and registry secrets, and every
external action they used was referenced by a moving tag — so the code those steps executed was
whatever the tag pointed at that morning.

Pinning stops at the top-level file only if the walk does. Both workflows call a reusable
workflow and a composite action that receive the same secrets, so `preview-server.yml` and
`.github/actions/binaryen/action.yml` are pinned here too: an action one call away from the
edited file is the same exposure with less visibility.

CI gains a step that runs `main`'s checker over this repository's tree. It is fast feedback and
deliberately **not** the authority — a commit can change a privileged workflow and the checker
together, and CI would run the changed checker. The gate that cannot be edited by the commit it
evaluates is `action-pin-audit.yml`, merged in #8338, which runs the default branch's copy against
the evaluated tree. This PR no longer carries its own copy of `scripts/check_action_pins.py`: #8338
merged first, so the duplicate dropped out at rebase exactly as stated there.

## Files changed

- `.github/workflows/release.yml` — external actions pinned to commit SHAs
- `.github/workflows/deploy.yml` — same
- `.github/workflows/preview-server.yml` — same; reached as a reusable workflow from `deploy.yml`
- `.github/actions/binaryen/action.yml` — same; reached as a composite action
- `.github/workflows/ci.yml` — runs `main`'s checker over this tree as regression coverage

## Track

Developer

## LLM

Model: claude-opus-5
Tier: Frontier
Thinking: high

## Implementation method (required)

Method: not-applicable — CI workflow and tooling change, no `crates/engine/` game logic.

## CR references

None.

## Verification

- [x] Required checks ran clean, or the exact CI-owned alternative is stated below.
- [x] Gate A output below is for the current committed head.
- [x] Final review-impl below is clean for the current committed head.
- [x] Both anchors cite existing analogous code at the same seam.

**The population, named.** The set the claim quantifies over is *every external `uses:` reference
reachable from the two privileged workflows*, not *every workflow file*. The checker walks that
set from the `release.yml` and `deploy.yml` entry points and follows each `uses:` it finds:

```
$ python3 scripts/check_action_pins.py
action pins OK: 5 file(s) walked from .github/workflows/release.yml .github/workflows/deploy.yml, 93 external ref(s), all SHA-pinned
```

**93 = 88 + 5.** The diff replaces **88** mutable `uses:` lines with 88 SHA-pinned ones across 4
files, resolving to **19** distinct actions. The remaining 5 were already pinned on `main` —
`build-web-image`'s, added by #8304 — and are untouched here.

**Against merged `main` the same checker exits 1**, reporting those 88 refs across
`release.yml`, `deploy.yml`, `preview-server.yml` and `binaryen/action.yml`. That pair — exit 1
on `main`, exit 0 here — is the discriminating evidence that this PR's CI step is not vacuous,
and it is why the step lives here rather than in #8338, whose tree is `main`'s and cannot be
green under a real-tree check.

**Reachability, not per-file scanning.** `preview-server.yml` (7 refs) is reached only through
`uses: ./.github/workflows/preview-server.yml` in `deploy.yml`, which passes
`CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_ACCOUNT_ID` and `SERVER_ARTIFACT_MINISIGN_PRIVATE_KEY`;
`binaryen/action.yml` (1 ref) only through a composite-action call. Neither file names itself in
the entry set, so a per-file audit of the two privileged workflows would have reported clean.

- Each SHA was resolved against its upstream repository and carries a trailing `# vX.Y.Z` comment
  so the ref stays readable.
- `actionlint .github/workflows/deploy.yml` and `.../preview-server.yml` — **0 findings** each.
  `.../release.yml` — 1 finding, the pre-existing `constant expression "false" in condition`, at
  the same line as on `main`. `.../ci.yml` — finding set **unchanged**, the two outputs diffed
  rather than counted; the same single pre-existing `if-cond` finding, line `741` → `753` from
  the twelve inserted lines.
- No build ran: the delta is four workflow/action files plus the CI step that invokes the
  checker, with no Rust or TypeScript in it.

## Gate A

Gate A PASS head=8176074b7f23673162741f2ad777dbd8ac82ba6c base=d6d28370c09242182488cac72e16e5a84941885f

Disclosed: the base is fork-relative and this delta contains no Rust, so the gate's range is
empty here — the PASS records that the gate ran at this head, not a property of the change.

## Anchored on

- `.github/workflows/release.yml` — `build-web-image`'s five already-pinned actions, added by #8304: the pin form used here (40-hex SHA plus a trailing version comment) is that job's, applied to the rest of the file.
- `.github/workflows/ci.yml` — the existing `check-engine-authorities.sh` step: a repository-owned script invoked from CI as a policy gate, the same seam the new regression step occupies.

## Final review-impl

Final review-impl PASS head=8176074b7f23673162741f2ad777dbd8ac82ba6c

## Claimed parse impact

None.

## Scope Expansion

None.

## Validation Failures

None.

## CI Failures

None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security & Reliability**
  * GitHub Actions used by deployment, preview, release, and build workflows are now pinned to immutable commit references for more predictable execution.

* **CI Improvements**
  * Added automated tests for release recovery safeguards.
  * Added checks and regression coverage to detect unpinned or improperly referenced actions in privileged workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->