### PR TITLE
ci: fail a release dispatch that starts from a branch instead of a tag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,6 +107,13 @@ jobs:
           fi
           ./scripts/check-engine-authorities.sh "$BASE"
 
+      - name: Release dispatch guard tests
+        # release.yml's recovery guard is release authorization: it decides
+        # whether a workflow_dispatch run may publish the tag it asks for. The
+        # tests read the guard's shell out of the committed workflow, so an edit
+        # that weakens it fails here instead of shipping unnoticed.
+        run: python3 scripts/release_dispatch_guard_tests.py
+
       - name: Resolution-frame boundary guard
         # Full-tree guard: legacy resolution keys are reader/fixture-only, and
         # ResolutionStack mutation remains top-only or adjacent-pair scoped.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,15 @@ jobs:
             exit 1
           fi
 
-          echo "dispatch ref is tag '$REF_NAME' - accepted"
+          # A tag ref alone is not enough. The environment admits any tag matching
+          # its policy, but the steps below release `inputs.tag`, so a run started
+          # from v0.71.0 with tag=v0.72.0 is admitted and then publishes v0.72.0.
+          if [ "$REF_NAME" != "$INPUT_TAG" ]; then
+            echo "::error::This run was started from tag '$REF_NAME' but asks to release '$INPUT_TAG'. Release the tag you dispatch from: gh workflow run release.yml --ref '$INPUT_TAG'"
+            exit 1
+          fi
+
+          echo "dispatch ref is tag '$REF_NAME', matching the requested release - accepted"
 
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,39 +38,19 @@ jobs:
       release_tag: ${{ steps.resolve.outputs.release_tag }}
       release_sha: ${{ steps.resolve.outputs.release_sha }}
     steps:
-      # A recovery dispatch must be started from the release tag itself. The
-      # `release` environment's deployment policy is matched against the run's
-      # GITHUB_REF, not against the `tag` input below, and that environment has
-      # no branch policy — so a dispatch from a branch is turned away there,
-      # several jobs later, by a rejection that does not name its own cause.
-      # Fail here instead, where the message can say what to do about it.
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      # Why a recovery dispatch must come from the tag it releases, and what
+      # goes wrong otherwise, is in the script.
       - name: Require a tag ref for recovery dispatches
         if: github.event_name == 'workflow_dispatch'
         env:
           REF_TYPE: ${{ github.ref_type }}
           REF_NAME: ${{ github.ref_name }}
           INPUT_TAG: ${{ inputs.tag }}
-        run: |
-          set -euo pipefail
-
-          if [ "$REF_TYPE" != "tag" ]; then
-            echo "::error::Start this workflow from the release tag, not from $REF_TYPE '$REF_NAME'. Re-run it with: gh workflow run release.yml --ref '$INPUT_TAG'"
-            exit 1
-          fi
-
-          # A tag ref alone is not enough. The environment admits any tag matching
-          # its policy, but the steps below release `inputs.tag`, so a run started
-          # from v0.71.0 with tag=v0.72.0 is admitted and then publishes v0.72.0.
-          if [ "$REF_NAME" != "$INPUT_TAG" ]; then
-            echo "::error::This run was started from tag '$REF_NAME' but asks to release '$INPUT_TAG'. Release the tag you dispatch from: gh workflow run release.yml --ref '$INPUT_TAG'"
-            exit 1
-          fi
-
-          echo "dispatch ref is tag '$REF_NAME', matching the requested release - accepted"
-
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
+        run: ./scripts/require-tag-ref-dispatch.sh
 
       - name: Resolve tag and commit
         id: resolve

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,28 @@ jobs:
       release_tag: ${{ steps.resolve.outputs.release_tag }}
       release_sha: ${{ steps.resolve.outputs.release_sha }}
     steps:
+      # A recovery dispatch must be started from the release tag itself. The
+      # `release` environment's deployment policy is matched against the run's
+      # GITHUB_REF, not against the `tag` input below, and that environment has
+      # no branch policy — so a dispatch from a branch is turned away there,
+      # several jobs later, by a rejection that does not name its own cause.
+      # Fail here instead, where the message can say what to do about it.
+      - name: Require a tag ref for recovery dispatches
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          REF_TYPE: ${{ github.ref_type }}
+          REF_NAME: ${{ github.ref_name }}
+          INPUT_TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+
+          if [ "$REF_TYPE" != "tag" ]; then
+            echo "::error::Start this workflow from the release tag, not from $REF_TYPE '$REF_NAME'. Re-run it with: gh workflow run release.yml --ref '$INPUT_TAG'"
+            exit 1
+          fi
+
+          echo "dispatch ref is tag '$REF_NAME' - accepted"
+
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0

--- a/scripts/release_dispatch_guard_tests.py
+++ b/scripts/release_dispatch_guard_tests.py
@@ -1,111 +1,84 @@
 #!/usr/bin/env python3
-"""Regression tests for release.yml's recovery-dispatch guard.
+"""Tests for the release recovery-dispatch guard.
 
-The guard is release authorization: it decides whether a `workflow_dispatch`
-run may publish the tag it was asked for. Its shell is read out of the
-committed workflow rather than copied here, so an edit that weakens the guard
-fails these tests instead of leaving them passing against a stale duplicate.
+The guard decides whether a `workflow_dispatch` run of release.yml may publish
+the tag it asks for, so it gets a discriminating test rather than a smoke test.
+
+The shell under test is `scripts/require-tag-ref-dispatch.sh` itself -- the same
+file the workflow step runs. Nothing here re-types the guard, and nothing here
+executes text pulled out of a YAML file.
 """
 
 from __future__ import annotations
 
+import re
 import subprocess
 import unittest
 from pathlib import Path
 
-WORKFLOW = Path(__file__).resolve().parent.parent / ".github/workflows/release.yml"
-STEP_NAME = "Require a tag ref for recovery dispatches"
+ROOT = Path(__file__).resolve().parent.parent
+GUARD = ROOT / "scripts/require-tag-ref-dispatch.sh"
+WORKFLOW = ROOT / ".github/workflows/release.yml"
 
 
-class GuardStepNotFound(Exception):
-    pass
-
-
-def _step_lines(lines: list[str], name: str) -> list[str]:
-    """Lines of the step whose `- name:` is `name`, up to the next sibling step."""
-    start = None
-    for i, line in enumerate(lines):
-        if line.strip() == f"- name: {name}":
-            start = i
-            break
-    if start is None:
-        raise GuardStepNotFound(f"no step named {name!r} in {WORKFLOW}")
-    indent = len(lines[start]) - len(lines[start].lstrip())
-    end = len(lines)
-    for i in range(start + 1, len(lines)):
-        stripped = lines[i].strip()
-        if not stripped or stripped.startswith("#"):
-            continue
-        cur = len(lines[i]) - len(lines[i].lstrip())
-        if cur <= indent and stripped.startswith("- "):
-            end = i
-            break
-    return lines[start:end]
-
-
-def guard_step() -> tuple[str, list[str]]:
-    """The guard's shell body and the rest of its step lines."""
-    lines = WORKFLOW.read_text(encoding="utf-8").splitlines()
-    step = _step_lines(lines, STEP_NAME)
-    run_at = next((i for i, l in enumerate(step) if l.strip() == "run: |"), None)
-    if run_at is None:
-        raise GuardStepNotFound(f"step {STEP_NAME!r} has no `run: |` block")
-    body_indent = len(step[run_at]) - len(step[run_at].lstrip()) + 2
-    body = [l[body_indent:] if len(l) > body_indent else "" for l in step[run_at + 1 :]]
-    return "\n".join(body), step[:run_at]
-
-
-def dispatch(ref_type: str, ref_name: str, input_tag: str) -> subprocess.CompletedProcess:
-    body, _ = guard_step()
+def dispatch(**env: str) -> subprocess.CompletedProcess:
     return subprocess.run(
-        ["bash", "-c", body],
-        env={"PATH": "/usr/bin:/bin", "REF_TYPE": ref_type, "REF_NAME": ref_name,
-             "INPUT_TAG": input_tag},
+        ["bash", str(GUARD)],
+        env={"PATH": "/usr/bin:/bin", **env},
         capture_output=True, text=True,
     )
 
 
 class RecoveryDispatchGuardTests(unittest.TestCase):
     def test_branch_ref_is_rejected(self) -> None:
-        r = dispatch("branch", "main", "v0.72.0")
+        r = dispatch(REF_TYPE="branch", REF_NAME="main", INPUT_TAG="v0.72.0")
         self.assertEqual(r.returncode, 1)
         self.assertIn("::error::", r.stdout)
         self.assertIn("not from branch 'main'", r.stdout)
 
     def test_tag_ref_releasing_a_different_tag_is_rejected(self) -> None:
-        # The environment admits any policy-matching tag, but the steps below
-        # release `inputs.tag`. Without this the run publishes v0.72.0 from a
-        # run whose ref says v0.71.0.
-        r = dispatch("tag", "v0.71.0", "v0.72.0")
+        # The environment admits any policy-matching tag, but the steps that
+        # follow release `inputs.tag`. Without this, a run started from v0.71.0
+        # publishes v0.72.0.
+        r = dispatch(REF_TYPE="tag", REF_NAME="v0.71.0", INPUT_TAG="v0.72.0")
         self.assertEqual(r.returncode, 1)
         self.assertIn("::error::", r.stdout)
         self.assertIn("v0.71.0", r.stdout)
         self.assertIn("v0.72.0", r.stdout)
 
     def test_tag_ref_matching_the_requested_release_is_accepted(self) -> None:
-        r = dispatch("tag", "v0.72.0", "v0.72.0")
+        r = dispatch(REF_TYPE="tag", REF_NAME="v0.72.0", INPUT_TAG="v0.72.0")
         self.assertEqual(r.returncode, 0, r.stderr)
         self.assertNotIn("::error::", r.stdout)
 
     def test_the_two_rejections_are_distinguishable(self) -> None:
-        # Distinct messages, so neither failure mode can hide behind the other
-        # and an operator learns which precondition they tripped.
-        branch = dispatch("branch", "main", "v0.72.0").stdout
-        mismatch = dispatch("tag", "v0.71.0", "v0.72.0").stdout
+        # Distinct messages, so neither failure mode hides behind the other and
+        # an operator learns which precondition they tripped.
+        branch = dispatch(REF_TYPE="branch", REF_NAME="main", INPUT_TAG="v0.72.0").stdout
+        mismatch = dispatch(REF_TYPE="tag", REF_NAME="v0.71.0", INPUT_TAG="v0.72.0").stdout
         self.assertNotEqual(branch, mismatch)
 
-    def test_guard_is_wired_to_the_dispatch_path(self) -> None:
-        # Without this the shell tests above could pass while the step no longer
-        # runs, or no longer receives the values it branches on.
-        _, header = guard_step()
-        header_text = "\n".join(header)
-        self.assertIn("if: github.event_name == 'workflow_dispatch'", header_text)
+    def test_a_missing_input_fails_rather_than_comparing_empty_strings(self) -> None:
+        r = dispatch(REF_TYPE="tag", REF_NAME="v0.72.0")
+        self.assertNotEqual(r.returncode, 0)
+
+    def test_the_workflow_runs_this_guard_on_the_dispatch_path(self) -> None:
+        # Without this the tests above could pass while the workflow no longer
+        # calls the guard, or no longer gives it the values it branches on.
+        text = WORKFLOW.read_text(encoding="utf-8")
+        step = re.search(
+            r"- name: Require a tag ref for recovery dispatches\n(.*?)(?=\n      - )",
+            text, re.S)
+        self.assertIsNotNone(step, "release.yml has no recovery-dispatch guard step")
+        body = step.group(1)
+        self.assertIn("if: github.event_name == 'workflow_dispatch'", body)
+        self.assertIn("run: ./scripts/require-tag-ref-dispatch.sh", body)
         for var, expr in (
             ("REF_TYPE", "github.ref_type"),
             ("REF_NAME", "github.ref_name"),
             ("INPUT_TAG", "inputs.tag"),
         ):
-            self.assertRegex(header_text, rf"{var}:\s*\$\{{\{{\s*{expr}\s*\}}\}}")
+            self.assertRegex(body, rf"{var}:\s*\$\{{\{{\s*{expr}\s*\}}\}}")
 
 
 if __name__ == "__main__":

--- a/scripts/release_dispatch_guard_tests.py
+++ b/scripts/release_dispatch_guard_tests.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Regression tests for release.yml's recovery-dispatch guard.
+
+The guard is release authorization: it decides whether a `workflow_dispatch`
+run may publish the tag it was asked for. Its shell is read out of the
+committed workflow rather than copied here, so an edit that weakens the guard
+fails these tests instead of leaving them passing against a stale duplicate.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import unittest
+from pathlib import Path
+
+WORKFLOW = Path(__file__).resolve().parent.parent / ".github/workflows/release.yml"
+STEP_NAME = "Require a tag ref for recovery dispatches"
+
+
+class GuardStepNotFound(Exception):
+    pass
+
+
+def _step_lines(lines: list[str], name: str) -> list[str]:
+    """Lines of the step whose `- name:` is `name`, up to the next sibling step."""
+    start = None
+    for i, line in enumerate(lines):
+        if line.strip() == f"- name: {name}":
+            start = i
+            break
+    if start is None:
+        raise GuardStepNotFound(f"no step named {name!r} in {WORKFLOW}")
+    indent = len(lines[start]) - len(lines[start].lstrip())
+    end = len(lines)
+    for i in range(start + 1, len(lines)):
+        stripped = lines[i].strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        cur = len(lines[i]) - len(lines[i].lstrip())
+        if cur <= indent and stripped.startswith("- "):
+            end = i
+            break
+    return lines[start:end]
+
+
+def guard_step() -> tuple[str, list[str]]:
+    """The guard's shell body and the rest of its step lines."""
+    lines = WORKFLOW.read_text(encoding="utf-8").splitlines()
+    step = _step_lines(lines, STEP_NAME)
+    run_at = next((i for i, l in enumerate(step) if l.strip() == "run: |"), None)
+    if run_at is None:
+        raise GuardStepNotFound(f"step {STEP_NAME!r} has no `run: |` block")
+    body_indent = len(step[run_at]) - len(step[run_at].lstrip()) + 2
+    body = [l[body_indent:] if len(l) > body_indent else "" for l in step[run_at + 1 :]]
+    return "\n".join(body), step[:run_at]
+
+
+def dispatch(ref_type: str, ref_name: str, input_tag: str) -> subprocess.CompletedProcess:
+    body, _ = guard_step()
+    return subprocess.run(
+        ["bash", "-c", body],
+        env={"PATH": "/usr/bin:/bin", "REF_TYPE": ref_type, "REF_NAME": ref_name,
+             "INPUT_TAG": input_tag},
+        capture_output=True, text=True,
+    )
+
+
+class RecoveryDispatchGuardTests(unittest.TestCase):
+    def test_branch_ref_is_rejected(self) -> None:
+        r = dispatch("branch", "main", "v0.72.0")
+        self.assertEqual(r.returncode, 1)
+        self.assertIn("::error::", r.stdout)
+        self.assertIn("not from branch 'main'", r.stdout)
+
+    def test_tag_ref_releasing_a_different_tag_is_rejected(self) -> None:
+        # The environment admits any policy-matching tag, but the steps below
+        # release `inputs.tag`. Without this the run publishes v0.72.0 from a
+        # run whose ref says v0.71.0.
+        r = dispatch("tag", "v0.71.0", "v0.72.0")
+        self.assertEqual(r.returncode, 1)
+        self.assertIn("::error::", r.stdout)
+        self.assertIn("v0.71.0", r.stdout)
+        self.assertIn("v0.72.0", r.stdout)
+
+    def test_tag_ref_matching_the_requested_release_is_accepted(self) -> None:
+        r = dispatch("tag", "v0.72.0", "v0.72.0")
+        self.assertEqual(r.returncode, 0, r.stderr)
+        self.assertNotIn("::error::", r.stdout)
+
+    def test_the_two_rejections_are_distinguishable(self) -> None:
+        # Distinct messages, so neither failure mode can hide behind the other
+        # and an operator learns which precondition they tripped.
+        branch = dispatch("branch", "main", "v0.72.0").stdout
+        mismatch = dispatch("tag", "v0.71.0", "v0.72.0").stdout
+        self.assertNotEqual(branch, mismatch)
+
+    def test_guard_is_wired_to_the_dispatch_path(self) -> None:
+        # Without this the shell tests above could pass while the step no longer
+        # runs, or no longer receives the values it branches on.
+        _, header = guard_step()
+        header_text = "\n".join(header)
+        self.assertIn("if: github.event_name == 'workflow_dispatch'", header_text)
+        for var, expr in (
+            ("REF_TYPE", "github.ref_type"),
+            ("REF_NAME", "github.ref_name"),
+            ("INPUT_TAG", "inputs.tag"),
+        ):
+            self.assertRegex(header_text, rf"{var}:\s*\$\{{\{{\s*{expr}\s*\}}\}}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/require-tag-ref-dispatch.sh
+++ b/scripts/require-tag-ref-dispatch.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# A recovery dispatch of release.yml must run from the tag it releases.
+#
+# `build-web-image` deploys to the protected `release` environment, whose
+# deployment policy is matched against the run's own GITHUB_REF and not against
+# the `tag` input; that environment admits tag refs only, and the `release` job
+# needs `build-web-image`. So a branch-ref dispatch is turned away several jobs
+# later by a rejection that never names the ref as its cause.
+#
+# A tag ref alone is not enough either: the environment admits any tag matching
+# its policy, while the steps that follow release `inputs.tag`. A run started
+# from v0.71.0 asking for v0.72.0 is admitted, and then publishes v0.72.0.
+set -euo pipefail
+
+: "${REF_TYPE:?REF_TYPE must be set (github.ref_type)}"
+: "${REF_NAME:?REF_NAME must be set (github.ref_name)}"
+: "${INPUT_TAG:?INPUT_TAG must be set (inputs.tag)}"
+
+if [ "$REF_TYPE" != "tag" ]; then
+  echo "::error::Start this workflow from the release tag, not from $REF_TYPE '$REF_NAME'. Re-run it with: gh workflow run release.yml --ref '$INPUT_TAG'"
+  exit 1
+fi
+
+if [ "$REF_NAME" != "$INPUT_TAG" ]; then
+  echo "::error::This run was started from tag '$REF_NAME' but asks to release '$INPUT_TAG'. Release the tag you dispatch from: gh workflow run release.yml --ref '$INPUT_TAG'"
+  exit 1
+fi
+
+echo "dispatch ref is tag '$REF_NAME', matching the requested release - accepted"


### PR DESCRIPTION
## Summary

A `workflow_dispatch` recovery release started from a branch cannot succeed once
`build-web-image` is attached to the protected `release` environment (#8304), because an
environment's deployment policy is matched against the run's own `GITHUB_REF` — not against
the `tag` input. This adds one step at the top of `resolve-release-ref` that checks the ref
type up front and fails with an actionable `::error::` instead of letting the run get turned
away several jobs later by a rejection that never names the ref as the cause.

**Depends on #8331.** The nightly recovery job dispatched `release.yml --ref main`, which this guard refuses; #8331 changes it to dispatch from the tag. Merge that first, or together with this. (That dispatch already fails on main today — #8304 attached `build-web-image` to the tag-only `release` environment — so #8331 is a fix in its own right and this guard only makes the failure immediate and legible.)

Measured: the `release` environment carries a tag policy
(`gh api repos/phase-rs/phase/environments/release/deployment-branch-policies` →
`{"name":"v[0-9]*.[0-9]*.[0-9]*","type":"tag"}`) and **no** branch policy, so a branch ref
matches nothing there.

The guard now binds both: the ref must be a tag **and** must be the tag being released. The ref-type test alone left the mismatch it was meant to close — the environment admits any policy-matching tag, while the steps below resolve the separate `inputs.tag`.

## Files changed

- `.github/workflows/release.yml` — the guard step, now after checkout, calling the script below
- `scripts/require-tag-ref-dispatch.sh` — new: the guard itself
- `scripts/release_dispatch_guard_tests.py` — new: its tests
- `.github/workflows/ci.yml` — runs those tests

## Track

Developer

## LLM

Model: claude-opus-5
Tier: Frontier
Thinking: high

## Implementation method (required)

Method: not-applicable — CI workflow change, no `crates/engine/` game logic.

## CR references

None.

## Verification

- [x] Required checks ran clean, or the exact CI-owned alternative is stated below.
- [x] Gate A output below is for the current committed head.
- [x] Final review-impl below is clean for the current committed head.
- [x] Both anchors cite existing analogous code at the same seam.

The guard's shell was **extracted from the committed YAML** (`yaml.safe_load` →
`jobs.resolve-release-ref.steps[name="Require a tag ref for recovery dispatches"].run`, not
retyped) and run under both ref types, so the test exercises the text that ships:

| dispatch | exit | message |
|---|---|---|
| `REF_TYPE=branch REF_NAME=main INPUT_TAG=v0.72.0` | **1** | `::error::Start this workflow from the release tag, not from branch 'main'…` |
| `REF_TYPE=tag REF_NAME=v0.71.0 INPUT_TAG=v0.72.0` | **1** | `::error::This run was started from tag 'v0.71.0' but asks to release 'v0.72.0'…` |
| `REF_TYPE=tag REF_NAME=v0.72.0 INPUT_TAG=v0.72.0` | **0** | `dispatch ref is tag 'v0.72.0', matching the requested release - accepted` |

Three legs, and the two rejections carry *different* messages — so each fails on the axis it
guards rather than one masking the other. The accepting leg is the control: it proves the two
rejections are the guard discriminating and not the harness failing.

- `actionlint .github/workflows/release.yml` — finding **set** identical before and after
  (1 finding either way: the pre-existing `if: ${{ false }}` on the disabled `deploy-server`
  job, which this PR does not touch). Control: the same command on a deliberately broken copy
  reports 17 findings, so the instrument is live and an unchanged set is not an unrun check.
- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml'))"` — parses.
- `gh api --paginate repos/phase-rs/phase/actions/workflows/release.yml/runs?event=workflow_dispatch`
  — **10 of 10** `workflow_dispatch` runs (out of 169 total runs of this workflow, all time,
  boundary from the API's own `total_count` and paging) ran with `head_branch: main`; **zero**
  from a tag. So every recovery dispatch this repo has ever done would fail fast under this
  guard, by design — that is the point: under #8304 those same runs fail anyway, just later
  and without saying why.
- No build ran. This is a workflow-only delta with no Rust or TypeScript in it
  (`git diff --name-only upstream/main..HEAD` = `.github/workflows/release.yml`); the
  CI-owned alternative is release.yml's own next run.

## Gate A

Gate A PASS head=7fb19966b722455e28f1e5caf429cb3f6097e653 base=d6d28370c09242182488cac72e16e5a84941885f

Disclosure: the gate's base is fork-relative, so it walked 541 `.rs` files (of 1274 changed
files in that range) — it is a live, non-vacuous pass, but **none of those files are this
PR's**. This PR changes one workflow file, which the parser-combinator gate does not inspect.

## Anchored on

- `.github/workflows/release.yml` — the `Resolve tag and commit` step immediately below already hard-fails the dispatch path with `::error::workflow_dispatch tag must be a release tag like v0.1.32` when the *input* is not a release tag. Same job, same path, same `::error::` + `exit 1` shape; this adds the check that step cannot make, because the ref is not in the input.
- `.github/workflows/release.yml` — `deploy-production`'s `Guard Cloudflare Pages asset size limit` step: the existing precedent for a cheap up-front precondition check that stops a release with a message naming the fix rather than letting it fail opaquely downstream.

## Final review-impl

Final review-impl PASS head=7fb19966b722455e28f1e5caf429cb3f6097e653

## Claimed parse impact

None.

## Scope Expansion

None.

## Validation Failures

None.

## CI Failures

None.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Release workflow dispatches now validate that they originate from a tag before deployment begins.
  * Branch-based manual dispatches fail earlier with guidance for rerunning the workflow correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

