### PR TITLE
ci: dispatch the nightly recovery release from the tag ref

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -478,11 +478,16 @@ jobs:
           TAG: ${{ needs.cut-nightly-release.outputs.release_tag }}
         run: |
           set -euo pipefail
-          # Dispatch from main, not from the tag: --ref selects which release.yml is
-          # EXECUTED, and the tag's copy is frozen at whatever was broken when it was cut,
-          # so a CI fix landed on main could never reach a stuck tag. `-f tag=` still pins
-          # the SOURCE that gets built to the tag's SHA (see release.yml resolve-release-ref),
-          # so this changes the CI config only, never the released code.
+          # Dispatch from the tag, not from main. release.yml's build-web-image
+          # deploys to the protected `release` environment, whose deployment policy
+          # is matched against the run's own GITHUB_REF and admits tag refs only;
+          # the `release` job needs build-web-image, so a run started from a branch
+          # produces no release at all.
+          #
+          # The cost of that is real and accepted: recovery executes the release.yml
+          # frozen in the tag, so a workflow already broken when the tag was cut
+          # cannot be rescued by a fix on main. Re-cut the tag instead.
+          #
           # --repo is required: this job has no checkout, so gh cannot infer the
           # repository from a local git directory and dies with "not a git repository".
-          gh workflow run release.yml --repo "$GITHUB_REPOSITORY" --ref main -f tag="$TAG"
+          gh workflow run release.yml --repo "$GITHUB_REPOSITORY" --ref "$TAG" -f tag="$TAG"


### PR DESCRIPTION
## Summary

The nightly recovery release cannot succeed as dispatched. #8304 attached `build-web-image`
to the protected `release` environment, whose deployment policy is matched against the run's
own `GITHUB_REF`; the `release` job needs `build-web-image`; and the environment carries one
tag rule and no branch policy. `nightly-release.yml` dispatches with `--ref main`, so that
run is refused at `build-web-image` and produces no release — at the moment recovery exists
for. No release has run since #8304 merged, so this is latent rather than observed.

Dispatch from the tag instead. `-f tag=` still names it, so the ref and the input agree by
construction.

**The trade this accepts, stated plainly:** the previous comment argued for `main` because
`--ref` selects which `release.yml` *executes*, and a tag's copy is frozen at whatever was
broken when it was cut — so a CI fix on main could rescue a stuck tag. That property is gone.
A workflow already broken at cut time now needs the tag re-cut. The alternative was widening
the `release` environment with a branch policy for `main`; this repository chose to keep the
environment tag-only.

Introduced by #8304. #8330 adds a guard that makes a branch-ref dispatch fail immediately
with an actionable message instead of being refused several jobs later; this change is what
makes the nightly pass that guard.

## Files changed

- `.github/workflows/nightly-release.yml` — `--ref main` → `--ref "$TAG"`, and the comment above it now states the trade being made

## Track

Developer

## LLM

Model: claude-opus-5
Tier: Frontier
Thinking: high

## Implementation method (required)

Method: not-applicable — CI workflow change, no `crates/engine/` game logic.

## CR references

None.

## Verification

- [x] Required checks ran clean, or the exact CI-owned alternative is stated below.
- [x] Gate A output below is for the current committed head.
- [x] Final review-impl below is clean for the current committed head.
- [x] Both anchors cite existing analogous code at the same seam.

Three premises, each measured rather than assumed:

**(i) `--ref` accepts a tag.** GitHub's REST documentation for *Create a workflow dispatch
event* describes the `ref` body parameter with the sentence: **"The reference can be a branch
or tag name."** (`gh workflow run --ref` is a wrapper over that endpoint.) Not probed against
this repository on purpose — a dispatch here would start a real release.

**(ii) the tags this workflow mints match the environment's rule.** The rule is
`{"type":"tag","name":"v[0-9]*.[0-9]*.[0-9]*"}` (`gh api
repos/phase-rs/phase/environments/release/deployment-branch-policies`). The nightly builds
its tag as `VERSION="$major.$minor.$patch"` then `TAG="v$VERSION"`, all three integers, so
the shape is always `vN.N.N`. Checked against the last 10 real tags: `v0.72.0 … v0.63.0`,
**10/10 match**. Control: `main` does not match, which is the whole failure being fixed.

**(iii) the dispatch then satisfies #8330's identity guard.** That guard compares
`github.ref_name` with `inputs.tag`. Both are `"$TAG"` from
`needs.cut-nightly-release.outputs.release_tag` after this change, so they are equal by
construction rather than by convention — for a tag-ref run `github.ref_name` is the bare tag
name (`v0.72.0`), the same string `-f tag=` receives.

- `actionlint .github/workflows/nightly-release.yml` — **0 findings**, before and after.
- No build ran: the delta is one workflow file with no Rust or TypeScript in it
  (`git diff --name-only upstream/main..HEAD` = `.github/workflows/nightly-release.yml`).
  The CI-owned alternative is the workflow's own next scheduled run.

## Gate A

Gate A PASS head=1f729be31b6f26dc4826ed4426bd1ad4a87de7f0 base=d6d28370c09242182488cac72e16e5a84941885f

## Anchored on

- `.github/workflows/release.yml` — `resolve-release-ref`'s `Resolve tag and commit` step reads `inputs.tag` on the dispatch path and pins the built source to that tag's SHA, so moving the run's ref changes which workflow executes, never which code is released.
- `.github/workflows/release.yml` — `build-web-image`'s `environment: release`, added in #8304, is the constraint this change satisfies.

## Final review-impl

Final review-impl PASS head=1f729be31b6f26dc4826ed4426bd1ad4a87de7f0

## Claimed parse impact

None.

## Scope Expansion

None.

## Validation Failures

None.

## CI Failures

None.
