### PR TITLE
fix(client): stabilize draft pick feedback

### DIFF
--- a/client/src/components/draft/PackDisplay.tsx
+++ b/client/src/components/draft/PackDisplay.tsx
@@ -329,6 +329,7 @@ function PackCard({
       <button
         type="button"
         data-pack-card-activation
+        aria-pressed={state === "selected"}
         disabled={locked}
         onClick={(event) => {
           if (Date.now() < ignoreCompatibilityClickUntil.current) return;

--- a/client/src/components/draft/PackDisplay.tsx
+++ b/client/src/components/draft/PackDisplay.tsx
@@ -217,7 +217,7 @@ function PackCard({
     <motion.div
       data-instance-id={card.instance_id}
       data-visual-state={state}
-      className={`relative shrink-0 select-none overflow-visible rounded-md caret-transparent ring-1 ${state === "selected" ? "transition-transform" : "transition-all"} duration-150 ${locked ? "" : `cursor-pointer ${desktopLayout ? "hover:scale-[1.05]" : ""}`} ${state === "selected" ? "z-10 ring-2 ring-arcane shadow-[0_0_7px_3px_#38bdf8] motion-safe:animate-[draft-pack-selected-glow_4.8s_ease-in-out_infinite]" : state === "failure-restored" ? "ring-red-300" : "ring-white/15 hover:ring-white/20"} ${state === "submitting" || state === "waiting" ? "opacity-55 grayscale" : ""}`}
+      className={`relative shrink-0 select-none overflow-visible rounded-md caret-transparent ring-1 ${state === "selected" ? "transition-transform" : "transition-all"} duration-150 ${locked ? "" : "cursor-pointer"} ${state === "selected" ? "z-10 ring-2 ring-arcane shadow-[0_0_7px_3px_#38bdf8]" : state === "failure-restored" ? "ring-red-300" : "ring-white/15 hover:ring-white/20"} ${state === "submitting" || state === "waiting" ? "opacity-55 grayscale" : ""}`}
       style={{ width, flexBasis: width, aspectRatio: "488 / 680" }}
       onMouseEnter={() => onHover(cardInfo(card))}
       onMouseLeave={() => onHover(null)}

--- a/client/src/components/draft/PackDisplay.tsx
+++ b/client/src/components/draft/PackDisplay.tsx
@@ -192,12 +192,10 @@ function PackCard({
     card.name,
     { setCode: card.set_code, collectorNumber: card.collector_number },
   );
-  const [loadedSrc, setLoadedSrc] = useState<string | null>(null);
   const touchStart = useRef<{ x: number; y: number } | null>(null);
   const touchMoved = useRef(false);
   const lastTouchTapAt = useRef<number | null>(null);
   const ignoreCompatibilityClickUntil = useRef(0);
-  const imageLoaded = src !== null && loadedSrc === src;
   const longPress = useLongPress(() => onHover(cardInfo(card)), { delay: 500 });
 
   return (
@@ -306,11 +304,7 @@ function PackCard({
             alt={displayName}
             draggable={false}
             className="h-full w-full object-contain"
-            onLoad={() => setLoadedSrc(src)}
-            onError={() => {
-              setLoadedSrc(null);
-              advanceFailedSource?.(src);
-            }}
+            onError={() => advanceFailedSource?.(src)}
           />
         )}
       </button>
@@ -327,11 +321,6 @@ function PackCard({
         >
           ↺
         </button>
-      )}
-      {!imageLoaded && (
-        <div className="absolute inset-x-1 bottom-1 flex items-center gap-1 rounded bg-black/80 p-1">
-          <span className="min-w-0 flex-1 truncate px-1 text-[10px] text-white/85">{card.name}</span>
-        </div>
       )}
       {local !== null && (
         <>
@@ -635,7 +624,7 @@ export function PackDisplay({
       )}
       <div
         data-pack-toolbar
-        className={`flex min-w-0 shrink-0 flex-nowrap items-center gap-3 overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden ${phoneToolbarPinned ? "sticky top-0 z-20 bg-slate-950 py-1" : ""}`}
+        className={`flex min-w-0 shrink-0 flex-nowrap items-center gap-3 overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden ${phoneToolbarPinned ? "sticky top-0 z-20 bg-slate-950 py-1" : "min-h-9"}`}
       >
         <div data-pack-status-controls className="flex shrink-0 items-center gap-2">
           <span className="text-sm text-fg">

--- a/client/src/components/draft/PackDisplay.tsx
+++ b/client/src/components/draft/PackDisplay.tsx
@@ -217,7 +217,7 @@ function PackCard({
     <motion.div
       data-instance-id={card.instance_id}
       data-visual-state={state}
-      className={`relative shrink-0 select-none overflow-visible rounded-md caret-transparent ring-1 ${state === "selected" ? "transition-transform" : "transition-all"} duration-150 ${locked ? "" : "cursor-pointer"} ${state === "selected" ? "z-10 ring-2 ring-arcane shadow-[0_0_7px_3px_#38bdf8]" : state === "failure-restored" ? "ring-red-300" : "ring-white/15 hover:ring-white/20"} ${state === "submitting" || state === "waiting" ? "opacity-55 grayscale" : ""}`}
+      className={`relative shrink-0 select-none overflow-visible rounded-md caret-transparent ring-1 ${state === "selected" ? "transition-transform" : "transition-all"} duration-150 ${locked ? "" : `cursor-pointer ${desktopLayout ? "hover:scale-[1.05]" : ""}`} ${state === "selected" ? "z-10 ring-2 ring-arcane shadow-[0_0_7px_3px_#38bdf8]" : state === "failure-restored" ? "ring-red-300" : "ring-white/15 hover:ring-white/20"} ${state === "submitting" || state === "waiting" ? "opacity-55 grayscale" : ""}`}
       style={{ width, flexBasis: width, aspectRatio: "488 / 680" }}
       onMouseEnter={() => onHover(cardInfo(card))}
       onMouseLeave={() => onHover(null)}

--- a/client/src/components/draft/PackDisplay.tsx
+++ b/client/src/components/draft/PackDisplay.tsx
@@ -507,7 +507,9 @@ export function PackDisplay({
   }, [view?.current_pack_number, view?.pick_number]);
 
   if (!view) return null;
-  const visibleRetained = retained.filter((entry) => sameDraftStep(entry.step, currentStep!));
+  const visibleRetained = retained.filter((entry) => (
+    entry.generation === localGeneration && sameDraftStep(entry.step, currentStep!)
+  ));
   if (pack.length === 0 && visibleRetained.length === 0) return <div className="flex justify-center py-12 text-white/40">{t("pack.waitingNext")}</div>;
 
   const updateStates = (update: (current: Readonly<Record<string, CardVisualRecord>>) => Readonly<Record<string, CardVisualRecord>>) => {
@@ -764,9 +766,12 @@ export function PackDisplay({
             const card = slot.card;
             const selected = selectedCard === card.instance_id || additionalCards.includes(card.instance_id);
             const waiting = local?.pendingIntent?.kind !== "auto-pick" && local?.pendingIntent?.instanceIds.includes(card.instance_id);
+            const visualRecord = states[card.instance_id];
             const state = waiting
               ? "waiting"
-              : states[card.instance_id]?.state ?? (selected ? "selected" : "default");
+              : visualRecord?.generation === localGeneration
+                ? visualRecord.state
+                : selected ? "selected" : "default";
             return <PackCard
               key={card.instance_id}
               card={card}

--- a/client/src/components/draft/PackDisplay.tsx
+++ b/client/src/components/draft/PackDisplay.tsx
@@ -140,6 +140,11 @@ interface PackDisplayProps {
 
 type CardVisualState = "leaving" | "submitting" | "waiting" | "failure-restored" | "selected" | "default";
 
+interface DraftStep {
+  readonly packNumber: number;
+  readonly pickNumber: number;
+}
+
 interface RetainedCard {
   readonly card: DraftCardInstance;
   readonly sourceIndex: number;
@@ -148,6 +153,7 @@ interface RetainedCard {
   readonly height: number;
   readonly token: string;
   readonly generation: number;
+  readonly step: DraftStep;
 }
 
 interface CardVisualRecord {
@@ -163,6 +169,15 @@ interface ScheduledVisual {
 
 const DOUBLE_TAP_DELAY_MS = 350;
 const TOUCH_TAP_MOVE_THRESHOLD_PX = 10;
+
+const draftStep = (view: DraftPlayerView): DraftStep => ({
+  packNumber: view.current_pack_number,
+  pickNumber: view.pick_number,
+});
+
+const sameDraftStep = (left: DraftStep, right: DraftStep) => (
+  left.packNumber === right.packNumber && left.pickNumber === right.pickNumber
+);
 
 const cardInfo = (card: DraftCardInstance): CardHoverInfo => ({
   name: card.name,
@@ -349,6 +364,7 @@ export function PackDisplay({
   const [retained, setRetained] = useState<readonly RetainedCard[]>([]);
   const statesRef = useRef<Readonly<Record<string, CardVisualRecord>>>({});
   const viewRef = useRef(controller.view);
+  const previousStepRef = useRef<DraftStep | null>(null);
   const requestOrder = useRef(0);
   const timers = useRef(new Map<string, ScheduledVisual>());
   const packSequenceRef = useRef<HTMLDivElement>(null);
@@ -391,6 +407,7 @@ export function PackDisplay({
   const draftEffects = view?.draft_effects ?? [];
   const local = controller.kind === "local-workspace" ? controller : null;
   const isOrderedSelection = view?.pick_selection_mode === "Ordered";
+  const currentStep = view === null ? null : draftStep(view);
 
   useEffect(() => {
     const live = new Set(controller.view?.current_pack?.map((card) => card.instance_id) ?? []);
@@ -409,6 +426,17 @@ export function PackDisplay({
     setStates({});
     setRetained([]);
   }, [localGeneration]);
+  useEffect(() => {
+    const previousStep = previousStepRef.current;
+    const currentStep = viewRef.current === null ? null : draftStep(viewRef.current);
+    previousStepRef.current = currentStep;
+    if (previousStep === null || currentStep === null || sameDraftStep(previousStep, currentStep)) return;
+    setRetained((current) => {
+      const stale = current.filter((entry) => !sameDraftStep(entry.step, currentStep));
+      cancelTimersFor(stale.map((entry) => entry.card.instance_id));
+      return current.filter((entry) => sameDraftStep(entry.step, currentStep));
+    });
+  }, [view?.current_pack_number, view?.pick_number]);
   useEffect(() => {
     if (pack.length === 1 && selectedCard === null && !locked) controller.selectCard(pack[0].instance_id);
   }, [controller, locked, pack, selectedCard]);
@@ -453,7 +481,8 @@ export function PackDisplay({
   }, [view?.current_pack_number, view?.pick_number]);
 
   if (!view) return null;
-  if (pack.length === 0 && retained.length === 0) return <div className="flex justify-center py-12 text-white/40">{t("pack.waitingNext")}</div>;
+  const visibleRetained = retained.filter((entry) => sameDraftStep(entry.step, currentStep!));
+  if (pack.length === 0 && visibleRetained.length === 0) return <div className="flex justify-center py-12 text-white/40">{t("pack.waitingNext")}</div>;
 
   const updateStates = (update: (current: Readonly<Record<string, CardVisualRecord>>) => Readonly<Record<string, CardVisualRecord>>) => {
     const next = update(statesRef.current);
@@ -483,7 +512,7 @@ export function PackDisplay({
     }
     return next;
   });
-  const settle = (token: string, generation: number, cards: readonly DraftCardInstance[], indices: readonly number[], sizes: readonly { width: number; height: number }[], result: PackDropSettlement) => {
+  const settle = (token: string, generation: number, step: DraftStep, cards: readonly DraftCardInstance[], indices: readonly number[], sizes: readonly { width: number; height: number }[], result: PackDropSettlement) => {
     const ids = cards.map((card) => card.instance_id);
     if (!requestIsCurrent(ids, token, generation)) return;
     if (result.kind !== "outcome") {
@@ -492,10 +521,15 @@ export function PackDisplay({
     }
     switch (result.outcome.status) {
       case "acknowledged": {
+        const currentStep = viewRef.current === null ? null : draftStep(viewRef.current);
+        if (currentStep === null || !sameDraftStep(step, currentStep)) {
+          setCardStates(ids, token, generation, null);
+          break;
+        }
         const live = new Set(viewRef.current?.current_pack?.map((card) => card.instance_id) ?? []);
         const departed = cards.flatMap((card, index): RetainedCard[] => live.has(card.instance_id) ? [] : [{
           card, sourceIndex: indices[index], requestOrder: requestOrder.current,
-          width: sizes[index]?.width ?? 0, height: sizes[index]?.height ?? 0, token, generation,
+          width: sizes[index]?.width ?? 0, height: sizes[index]?.height ?? 0, token, generation, step,
         }]);
         setCardStates(ids, token, generation, null);
         if (departed.length > 0) {
@@ -530,6 +564,7 @@ export function PackDisplay({
     const token = crypto.randomUUID();
     requestOrder.current += 1;
     const generation = local.interactionGeneration;
+    const step = draftStep(view);
     const ids = cards.map((card) => card.instance_id);
     const indices = cards.map((card) => pack.indexOf(card));
     beginRequest(ids, token, generation);
@@ -538,7 +573,7 @@ export function PackDisplay({
       : ids.length === 1
         ? await local.pickCard(ids[0], destination)
         : await local.pickCardStep(ids, destination);
-    settle(token, generation, cards, indices, cards.map(() => ({ width: 0, height: 0 })), { kind: "outcome", outcome });
+    settle(token, generation, step, cards, indices, cards.map(() => ({ width: 0, height: 0 })), { kind: "outcome", outcome });
   };
   const select = (id: string) => {
     if (locked) return;
@@ -592,7 +627,7 @@ export function PackDisplay({
     && selectedCards.length === requiredCount;
   const slots = [
     ...pack.map((card, sourceIndex) => ({ kind: "live" as const, card, sourceIndex, requestOrder: -1 })),
-    ...retained.map((entry) => ({ kind: "retained" as const, ...entry })),
+    ...visibleRetained.map((entry) => ({ kind: "retained" as const, ...entry })),
   ].sort((left, right) => left.sourceIndex - right.sourceIndex || left.requestOrder - right.requestOrder);
 
   const mobileLayout = responsiveLayout === "phone-portrait" || responsiveLayout === "phone-landscape";
@@ -735,6 +770,7 @@ export function PackDisplay({
                 const ids = cards.map((candidate) => candidate.instance_id);
                 const indices = cards.map((candidate) => pack.indexOf(candidate));
                 const generation = local.interactionGeneration;
+                const step = draftStep(view);
                 let admission: PackDropAdmission | null = null;
                 return {
                   kind: cards.length === 2 ? "draft-effect" : "pick",
@@ -753,7 +789,7 @@ export function PackDisplay({
                   },
                   onSettled: (result) => {
                     if (admission === null) return;
-                    settle(admission.requestToken, admission.interactionGeneration, cards, indices, cards.map(() => ({ width, height: width * 680 / 488 })), result);
+                    settle(admission.requestToken, admission.interactionGeneration, step, cards, indices, cards.map(() => ({ width, height: width * 680 / 488 })), result);
                   },
                 } as PackDropSource;
               }}

--- a/client/src/components/draft/PackDisplay.tsx
+++ b/client/src/components/draft/PackDisplay.tsx
@@ -147,6 +147,7 @@ interface DraftStep {
 
 interface RetainedCard {
   readonly card: DraftCardInstance;
+  readonly imageSrc: string | null;
   readonly sourceIndex: number;
   readonly requestOrder: number;
   readonly width: number;
@@ -184,8 +185,27 @@ const cardInfo = (card: DraftCardInstance): CardHoverInfo => ({
   sourcePrinting: { setCode: card.set_code, collectorNumber: card.collector_number },
 });
 
+function RetainedPackCard({ entry, fallbackWidth }: { entry: RetainedCard; fallbackWidth: number }) {
+  const width = entry.width || fallbackWidth;
+  return (
+    <motion.div
+      data-instance-id={entry.card.instance_id}
+      data-visual-state="leaving"
+      initial={false}
+      style={{ width, height: entry.height || undefined, flexBasis: width, aspectRatio: "488 / 680" }}
+      className="shrink-0 overflow-hidden rounded-md ring-1 ring-amber-300/50"
+    >
+      {entry.imageSrc === null ? (
+        <span className="flex h-full items-center justify-center text-xs text-white/60">{entry.card.name}</span>
+      ) : (
+        <img src={entry.imageSrc} alt={entry.card.name} draggable={false} className="h-full w-full object-contain" />
+      )}
+    </motion.div>
+  );
+}
+
 function PackCard({
-  card, state, width, locked, local, doubleTapPickEnabled, doubleClickPickEnabled, allowTouchPackDrag, desktopLayout, onSelect, onDestination, onDoubleClickPick, onHover, makeDropSource,
+  card, state, width, locked, local, doubleTapPickEnabled, doubleClickPickEnabled, allowTouchPackDrag, desktopLayout, onSelect, onDestination, onDoubleClickPick, onHover, onImageSource, makeDropSource,
 }: {
   card: DraftCardInstance;
   state: CardVisualState;
@@ -200,6 +220,7 @@ function PackCard({
   onDestination(destination: DraftPickDestination): void;
   onDoubleClickPick(): void;
   onHover(info: CardHoverInfo | null): void;
+  onImageSource(instanceId: string, src: string): void;
   makeDropSource(): PackDropSource | null;
 }) {
   const { t } = useTranslation("draft");
@@ -212,6 +233,10 @@ function PackCard({
   const lastTouchTapAt = useRef<number | null>(null);
   const ignoreCompatibilityClickUntil = useRef(0);
   const longPress = useLongPress(() => onHover(cardInfo(card)), { delay: 500 });
+
+  useEffect(() => {
+    if (src !== null) onImageSource(card.instance_id, src);
+  }, [card.instance_id, onImageSource, src]);
 
   return (
     <motion.div
@@ -363,6 +388,7 @@ export function PackDisplay({
   const [states, setStates] = useState<Readonly<Record<string, CardVisualRecord>>>({});
   const [retained, setRetained] = useState<readonly RetainedCard[]>([]);
   const statesRef = useRef<Readonly<Record<string, CardVisualRecord>>>({});
+  const imageSourcesRef = useRef(new Map<string, string>());
   const viewRef = useRef(controller.view);
   const previousStepRef = useRef<DraftStep | null>(null);
   const requestOrder = useRef(0);
@@ -528,7 +554,8 @@ export function PackDisplay({
         }
         const live = new Set(viewRef.current?.current_pack?.map((card) => card.instance_id) ?? []);
         const departed = cards.flatMap((card, index): RetainedCard[] => live.has(card.instance_id) ? [] : [{
-          card, sourceIndex: indices[index], requestOrder: requestOrder.current,
+          card, imageSrc: imageSourcesRef.current.get(card.instance_id) ?? null,
+          sourceIndex: indices[index], requestOrder: requestOrder.current,
           width: sizes[index]?.width ?? 0, height: sizes[index]?.height ?? 0, token, generation, step,
         }]);
         setCardStates(ids, token, generation, null);
@@ -733,11 +760,7 @@ export function PackDisplay({
       >
         <AnimatePresence initial={false}>
           {slots.map((slot) => {
-            if (slot.kind === "retained") return (
-              <motion.div key={`retained:${slot.token}:${slot.card.instance_id}`} data-instance-id={slot.card.instance_id} data-visual-state="leaving" initial={false} style={{ width: slot.width || width, height: slot.height || undefined, flexBasis: slot.width || width, aspectRatio: "488 / 680" }} className="shrink-0 rounded-md ring-1 ring-amber-300/50">
-                <span className="flex h-full items-center justify-center text-xs text-white/60">{slot.card.name}</span>
-              </motion.div>
-            );
+            if (slot.kind === "retained") return <RetainedPackCard key={`retained:${slot.token}:${slot.card.instance_id}`} entry={slot} fallbackWidth={width} />;
             const card = slot.card;
             const selected = selectedCard === card.instance_id || additionalCards.includes(card.instance_id);
             const waiting = local?.pendingIntent?.kind !== "auto-pick" && local?.pendingIntent?.instanceIds.includes(card.instance_id);
@@ -762,6 +785,7 @@ export function PackDisplay({
                 else void request(chosenCards(card), "deck");
               }}
               onHover={onCardHover}
+              onImageSource={(instanceId, imageSrc) => imageSourcesRef.current.set(instanceId, imageSrc)}
               makeDropSource={() => {
                 if (local === null || locked) return null;
                 const cards = chosenCards(card);

--- a/client/src/components/draft/__tests__/CardPoolBoard.test.tsx
+++ b/client/src/components/draft/__tests__/CardPoolBoard.test.tsx
@@ -1535,6 +1535,7 @@ describe("card pool board primitives", () => {
     );
     expect(columns).toHaveClass("min-w-0", "flex-1");
     expect(columns).not.toHaveClass("min-w-max");
+    expect(columns?.parentElement).toHaveClass("p-[18px]");
     expect(columns?.parentElement?.parentElement).toHaveClass("overflow-x-hidden");
   });
 
@@ -1572,6 +1573,7 @@ describe("card pool board primitives", () => {
     expect([...container.querySelectorAll<HTMLElement>("[data-board-column]")]
       .map((column) => column.dataset.boardColumn)).toEqual(["0", "1", "2", "3", "4", "5", "6"]);
     expect(container.querySelectorAll("header[aria-label^='Column ']")).toHaveLength(7);
+    expect(container.querySelector("[data-board-columns]")).toHaveClass("p-[18px]");
 
     rerender(
       <CardPoolBoard

--- a/client/src/components/draft/__tests__/CardPoolBoard.test.tsx
+++ b/client/src/components/draft/__tests__/CardPoolBoard.test.tsx
@@ -1535,7 +1535,7 @@ describe("card pool board primitives", () => {
     );
     expect(columns).toHaveClass("min-w-0", "flex-1");
     expect(columns).not.toHaveClass("min-w-max");
-    expect(columns?.parentElement).toHaveClass("p-[18px]");
+    expect(columns?.parentElement).toHaveClass("p-[20px]");
     expect(columns?.parentElement?.parentElement).toHaveClass("overflow-x-hidden");
   });
 
@@ -1573,7 +1573,7 @@ describe("card pool board primitives", () => {
     expect([...container.querySelectorAll<HTMLElement>("[data-board-column]")]
       .map((column) => column.dataset.boardColumn)).toEqual(["0", "1", "2", "3", "4", "5", "6"]);
     expect(container.querySelectorAll("header[aria-label^='Column ']")).toHaveLength(7);
-    expect(container.querySelector("[data-board-columns]")).toHaveClass("p-[18px]");
+    expect(container.querySelector("[data-board-columns]")).toHaveClass("p-[20px]");
 
     rerender(
       <CardPoolBoard

--- a/client/src/components/draft/__tests__/CardPoolBoard.test.tsx
+++ b/client/src/components/draft/__tests__/CardPoolBoard.test.tsx
@@ -1535,7 +1535,7 @@ describe("card pool board primitives", () => {
     );
     expect(columns).toHaveClass("min-w-0", "flex-1");
     expect(columns).not.toHaveClass("min-w-max");
-    expect(columns?.parentElement).toHaveClass("p-[20px]");
+    expect(columns?.parentElement).toHaveClass("p-6");
     expect(columns?.parentElement?.parentElement).toHaveClass("overflow-x-hidden");
   });
 
@@ -1573,7 +1573,7 @@ describe("card pool board primitives", () => {
     expect([...container.querySelectorAll<HTMLElement>("[data-board-column]")]
       .map((column) => column.dataset.boardColumn)).toEqual(["0", "1", "2", "3", "4", "5", "6"]);
     expect(container.querySelectorAll("header[aria-label^='Column ']")).toHaveLength(7);
-    expect(container.querySelector("[data-board-columns]")).toHaveClass("p-[20px]");
+    expect(container.querySelector("[data-board-columns]")).toHaveClass("p-6");
 
     rerender(
       <CardPoolBoard

--- a/client/src/components/draft/__tests__/CardPoolBoard.test.tsx
+++ b/client/src/components/draft/__tests__/CardPoolBoard.test.tsx
@@ -1184,11 +1184,14 @@ describe("card pool board primitives", () => {
       .toHaveAttribute("data-board-row", "0");
     expect(screen.getByRole("button", { name: "Inspect spell" }).closest("[data-board-row]"))
       .toHaveAttribute("data-board-row", "1");
+    const cardArea = container.querySelector<HTMLElement>("[data-card-area]")!;
+    expect(cardArea).toHaveClass("row-start-2", "row-span-2", "grid-rows-subgrid");
     for (const row of container.querySelectorAll("[data-board-row]")) {
-      expect(row).toHaveClass("border", "border-hairline", "bg-black/28");
+      expect(row).toHaveClass("border", "border-hairline");
       expect(row).toHaveClass(row.getAttribute("data-board-row") === "1"
         ? "rounded-[7px]"
-        : "rounded-b-[7px]");
+        : "relative");
+      expect(row).toHaveStyle({ gridRow: String(Number(row.getAttribute("data-board-row")) + 1) });
     }
     expect(workspaceChanges).toHaveBeenLastCalledWith(expect.objectContaining({
       placements: expect.objectContaining({
@@ -1590,7 +1593,7 @@ describe("card pool board primitives", () => {
       .toEqual([6, 1]);
   });
 
-  it("highlights_only_the_active_drop_column_in_white", () => {
+  it("glows_the_entire_active_one_row_card_area_without_its_header", () => {
     const pool = [card("first")];
     const { container } = render(
       <CardPoolBoard
@@ -1610,21 +1613,23 @@ describe("card pool board primitives", () => {
     const columns = container.querySelectorAll<HTMLElement>("section[data-drop-state]");
     const board = container.querySelector<HTMLElement>("[data-board-columns]")?.parentElement;
     const panel = container.firstElementChild;
-    const highlight = columns[1].querySelector<HTMLElement>('[data-drop-highlight="active"]');
+    const cardArea = columns[1].querySelector<HTMLElement>("[data-card-area]")!;
+    const header = columns[1].querySelector("header")!;
     expect(columns[1]).toHaveAttribute("data-drop-state", "active");
     expect(columns[1]).toHaveClass("border-hairline");
     expect(columns[1]).not.toHaveClass("border-white", "bg-white/10");
-    expect(highlight).toHaveClass("absolute", "inset-0", "border-2", "border-white");
-    expect(highlight?.closest("header")).toBeNull();
+    expect(cardArea).toHaveClass("draft-card-area-drop-active");
+    expect(header.contains(cardArea)).toBe(false);
+    expect(columns[1].querySelector('[data-drop-highlight="active"]')).not.toBeInTheDocument();
     expect(columns[0]).toHaveAttribute("data-drop-state", "idle");
-    expect(columns[0].querySelector('[data-drop-highlight="active"]')).not.toBeInTheDocument();
+    expect(columns[0].querySelector("[data-card-area]")).not.toHaveClass("draft-card-area-drop-active");
     expect(panel).toHaveClass("border-hairline");
     expect(board).not.toHaveClass("border-dashed", "border-amber-300");
   });
 
-  it("highlights_only_the_active_drop_row_when_two_rows_are_visible", () => {
+  it("glows_the_entire_active_two_row_card_area_while_preserving_row_targeting", () => {
     const pool = [card("first")];
-    const { container } = render(
+    const { container, rerender } = render(
       <CardPoolBoard
         zone="deck"
         pool={pool}
@@ -1641,14 +1646,32 @@ describe("card pool board primitives", () => {
 
     const activeColumn = container.querySelectorAll<HTMLElement>("section[data-drop-state]")[1];
     const rows = activeColumn.querySelectorAll<HTMLElement>("[data-board-row]");
-    const highlights = activeColumn.querySelectorAll<HTMLElement>('[data-drop-highlight="active"]');
+    const cardArea = activeColumn.querySelector<HTMLElement>("[data-card-area]")!;
     expect(activeColumn).toHaveAttribute("data-drop-state", "active");
     expect(rows[0]).toHaveAttribute("data-drop-state", "idle");
     expect(rows[1]).toHaveAttribute("data-drop-state", "active");
-    expect(highlights).toHaveLength(1);
-    expect(highlights[0].closest("[data-board-row]")).toBe(rows[1]);
-    expect(activeColumn.querySelector("[data-card-area] > [data-drop-highlight='active']"))
-      .not.toBeInTheDocument();
+    expect(cardArea).toHaveClass("draft-card-area-drop-active", "row-start-2", "row-span-2");
+    expect(activeColumn.querySelector("header")?.contains(cardArea)).toBe(false);
+    expect(activeColumn.querySelector("header")).toHaveClass("z-10");
+    expect(activeColumn.querySelector('[data-drop-highlight="active"]')).not.toBeInTheDocument();
+    expect(rows[0]).toHaveStyle({ gridRow: "1" });
+    expect(rows[1]).toHaveStyle({ gridRow: "2" });
+
+    rerender(
+      <CardPoolBoard
+        zone="deck"
+        pool={pool}
+        poolGroups={groups(["first"])}
+        workspace={placedState(["first"])}
+        preferences={{ ...preferences, showHeaders: false }}
+        cardPreviewMode="none"
+        cardPreviewHoverDelayMs={0}
+        dropState={{ zoneActive: true, column: 1, row: 1 }}
+        onWorkspaceChange={vi.fn()}
+        onPreferencesChange={vi.fn()}
+      />,
+    );
+    expect(container.querySelector<HTMLElement>("[data-card-area]")).toHaveClass("rounded-[8px]");
   });
 
   it("reveals_sixteen_percent_of_the_card_width_between_stacked_cards", () => {
@@ -1670,7 +1693,7 @@ describe("card pool board primitives", () => {
     expect(screen.getByRole("button", { name: "Inspect first" }).parentElement?.style.marginTop).toBe("");
     const second = screen.getByRole("button", { name: "Inspect second" });
     const secondWrapper = second.parentElement;
-    expect(second.closest("section")?.querySelector("[data-card-area]")).toHaveClass("contents");
+    expect(second.closest("section")?.querySelector("[data-card-area]")).toHaveClass("grid-rows-subgrid", "row-span-2");
     expect(second.closest("section")?.querySelector("[data-card-area]")).not.toHaveClass("p-2");
     expect(secondWrapper?.style.marginTop).toBe("-123.3442622951%");
     second.getBoundingClientRect = () => ({

--- a/client/src/components/draft/__tests__/DraftWorkspace.test.tsx
+++ b/client/src/components/draft/__tests__/DraftWorkspace.test.tsx
@@ -576,16 +576,19 @@ describe("draft workspace shell", () => {
     const deck = container.querySelector<HTMLElement>('[data-zone="deck"]')!;
     const board = deck.querySelector<HTMLElement>("div[data-drop-state]")!;
     const column = deck.querySelector<HTMLElement>('[data-board-column="0"]')!;
+    const cardArea = column.querySelector<HTMLElement>("[data-card-area]")!;
     const row = column.querySelector<HTMLElement>('[data-board-row="0"]')!;
-    const compactSideboard = container.querySelector<HTMLElement>('[data-drop-target="collapsed-sideboard"]')!;
+    const compactSideboard = screen.getByRole("region", { name: "Compact sideboard" });
+    const compactSideboardTarget = container.querySelector<HTMLElement>('[data-drop-target="collapsed-sideboard"]')!;
     const rect = (left: number, top: number, right: number, bottom: number) => ({
       left, top, right, bottom, width: right - left, height: bottom - top,
       x: left, y: top, toJSON: () => ({}),
     }) as DOMRect;
     board.getBoundingClientRect = () => rect(0, 0, 160, 160);
     column.getBoundingClientRect = () => rect(0, 0, 160, 160);
+    cardArea.getBoundingClientRect = () => rect(0, 0, 160, 160);
     row.getBoundingClientRect = () => rect(0, 0, 160, 160);
-    compactSideboard.getBoundingClientRect = () => rect(200, 0, 360, 160);
+    compactSideboardTarget.getBoundingClientRect = () => rect(200, 0, 360, 160);
 
     const boardCard = within(deck).getByRole("button", { name: "Inspect deck" });
     boardCard.getBoundingClientRect = () => rect(0, 0, 100, 140);
@@ -1776,26 +1779,93 @@ describe("draft workspace shell", () => {
     const target = container.querySelector<HTMLElement>('[data-drop-target="collapsed-sideboard"]')!;
     expect(registerCollapsedSideboard).toHaveBeenCalledWith(target);
     expect(target).toHaveAttribute("data-drop-state", "active");
-    // The highlight must not alter the target's own box, or the drop test flickers.
-    expect(target).not.toHaveClass("border", "border-dashed", "border-amber-300");
-    const highlight = target.querySelector<HTMLElement>('[data-drop-highlight="active"]')!;
-    expect(highlight).toBeInTheDocument();
-    expect(highlight).toHaveClass("pointer-events-none", "absolute", "inset-0");
-    // The highlight frames the card slot only, so it must sit outside the panel header.
-    expect(highlight.closest("header")).toBeNull();
-    expect(highlight.parentElement).toBe(
-      target.querySelector("[data-card-height-baseline]")!.parentElement,
-    );
+    expect(target).toHaveAttribute("data-sideboard-card-area");
+    expect(target).toHaveClass("draft-card-area-drop-active");
+    expect(target.closest('[aria-label="Compact sideboard"]')).toHaveClass("overflow-visible");
+    expect(target.closest("header")).toBeNull();
+    expect(target.closest('[aria-label="Compact sideboard"]')?.querySelector("header")).toHaveClass("z-10");
+    expect(target.closest('[aria-label="Compact sideboard"]')?.querySelector("[data-sideboard-body]")).not.toBeInTheDocument();
+    expect(target.querySelector("[data-card-stack], [data-instance-id]")).not.toBeInTheDocument();
+    expect(target.querySelector('[data-drop-highlight="active"]')).not.toBeInTheDocument();
 
     activeTarget = null;
     rerender(<DraftWorkspace {...props} />);
     expect(target).toHaveAttribute("data-drop-state", "idle");
-    expect(target.querySelector('[data-drop-highlight="active"]')).not.toBeInTheDocument();
+    expect(target).not.toHaveClass("draft-card-area-drop-active");
+    expect(target.closest('[aria-label="Compact sideboard"]')).toHaveClass("overflow-hidden");
 
     rerender(<DraftWorkspace {...props} preferences={preferences({ sideboardCollapsed: false })} />);
     expect(container.querySelector('[data-drop-target="collapsed-sideboard"]')).not.toBeInTheDocument();
     expect(registerCollapsedSideboard.mock.calls.some(([element]) => element === null)).toBe(true);
     expect(registerSideboard).toHaveBeenCalledWith(expect.any(HTMLElement));
+  });
+
+  it.each([
+    ["desktop", "deck"],
+    ["desktop", "sideboard"],
+    ["phone-portrait", "deck"],
+    ["phone-portrait", "sideboard"],
+    ["phone-landscape", "deck"],
+    ["phone-landscape", "sideboard"],
+    ["tablet-portrait", "deck"],
+    ["tablet-portrait", "sideboard"],
+    ["tablet-landscape", "deck"],
+    ["tablet-landscape", "sideboard"],
+  ] as const)("uses_card_area_only_drop_feedback_for_%s_%s_builder_layouts", (responsiveLayout, activeZone) => {
+    const registerCollapsedSideboard = vi.fn();
+    const registerColumn = vi.fn(() => vi.fn());
+    const activeTarget: DraftWorkspaceDragController["activeTarget"] = {
+      zone: activeZone,
+      column: 0,
+      row: null,
+    };
+    const controller = {
+      announcement: "", activeTarget, dragPreview: null,
+      handlePointerDown: vi.fn(), handleWorkspacePointerDown: vi.fn(),
+      handlePointerMove: vi.fn(), handlePointerUp: vi.fn(),
+      handlePointerCancel: vi.fn(), handleLostPointerCapture: vi.fn(),
+      consumeCompatibilityActivation: vi.fn(() => false),
+      registerBoard: vi.fn(() => vi.fn()), registerColumn, registerCollapsedSideboard,
+      dropState: vi.fn((zone: "deck" | "sideboard") => ({
+        zoneActive: zone === activeZone,
+        column: zone === activeZone ? 0 : null,
+        row: null,
+      })),
+      invalidateGeometry: vi.fn(), dispose: vi.fn(),
+    } satisfies DraftWorkspaceDragController;
+    const cards = [card("deck"), card("side")];
+    const { container } = render(
+      <DraftWorkspace
+        pool={cards}
+        poolGroups={groups(cards)}
+        workspace={state({
+          deck: { zone: "deck", row: 0, column: 0, order: 0 },
+          side: { zone: "sideboard", row: 0, column: 0, order: 0 },
+        })}
+        preferences={preferences({ sideboardCollapsed: true, builderPhoneSideboardCollapsed: true })}
+        responsiveLayout={responsiveLayout}
+        responsiveContext="builder"
+        dragController={controller}
+        onWorkspaceChange={vi.fn()}
+        onPreferencesChange={vi.fn()}
+      />,
+    );
+
+    const sideboard = screen.getByRole("region", { name: "Compact sideboard" });
+    const sideboardArea = sideboard.querySelector<HTMLElement>("[data-sideboard-card-area]")!;
+    expect(sideboardArea).toHaveAttribute("data-drop-target", "collapsed-sideboard");
+    expect(sideboardArea.classList.contains("draft-card-area-drop-active")).toBe(activeZone === "sideboard");
+    expect(sideboard.querySelector("header")?.contains(sideboardArea)).toBe(false);
+    expect(registerCollapsedSideboard).toHaveBeenCalledWith(sideboardArea);
+
+    if (responsiveLayout !== "desktop") {
+      expect(sideboard.querySelector("[data-sideboard-body], [data-card-stack], [data-instance-id]")).not.toBeInTheDocument();
+    }
+
+    const deckArea = container.querySelector<HTMLElement>('[data-zone="deck"] [data-card-area]')!;
+  expect(deckArea.classList.contains("draft-card-area-drop-active")).toBe(activeZone === "deck");
+    expect(deckArea.closest("section")?.querySelector("header")?.contains(deckArea)).toBe(false);
+    expect(registerColumn).toHaveBeenCalledWith("deck", 0);
   });
 
   it("renders_one_collapsed_sideboard_slot_without_duplicate_identities", () => {

--- a/client/src/components/draft/__tests__/DraftWorkspace.test.tsx
+++ b/client/src/components/draft/__tests__/DraftWorkspace.test.tsx
@@ -1539,6 +1539,54 @@ describe("draft workspace shell", () => {
       .toHaveTextContent("Pick in progress.");
   });
 
+  it("preserves_loaded_workspace_images_through_a_pick_lock", () => {
+    const cards = [card("deck", "Deck Card"), card("side", "Sideboard Card")];
+    const workspace = state({
+      deck: { zone: "deck", row: 0, column: 0, order: 0 },
+      side: { zone: "sideboard", row: 0, column: 0, order: 0 },
+    });
+    const sharedProps = {
+      pool: cards,
+      poolGroups: groups(cards),
+      workspace,
+      onWorkspaceChange: vi.fn(),
+      onPreferencesChange: vi.fn(),
+    };
+    const expanded = render(
+      <DraftWorkspace {...sharedProps} preferences={preferences({ sideboardCollapsed: false })} interactionLocked={false} />,
+    );
+    const deckImage = screen.getByAltText("Deck Card");
+    const sideboardImage = screen.getByAltText("Sideboard Card");
+
+    expanded.rerender(
+      <DraftWorkspace {...sharedProps} preferences={preferences({ sideboardCollapsed: false })} interactionLocked />,
+    );
+
+    expect(screen.getByAltText("Deck Card")).toBe(deckImage);
+    expect(screen.getByAltText("Sideboard Card")).toBe(sideboardImage);
+    expect(deckImage).toHaveAttribute("src", "/card.png");
+    expect(sideboardImage).toHaveAttribute("src", "/card.png");
+    expect(expanded.container.querySelector("fieldset")).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Inspect Deck Card" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Inspect Sideboard Card" })).toBeDisabled();
+    expanded.unmount();
+
+    const compact = render(
+      <DraftWorkspace {...sharedProps} preferences={preferences({ sideboardCollapsed: true })} interactionLocked={false} />,
+    );
+    const compactImage = screen.getByAltText("Sideboard Card");
+
+    compact.rerender(
+      <DraftWorkspace {...sharedProps} preferences={preferences({ sideboardCollapsed: true })} interactionLocked />,
+    );
+
+    expect(screen.getByAltText("Sideboard Card")).toBe(compactImage);
+    expect(compactImage).toHaveAttribute("src", "/card.png");
+    expect(compact.container.querySelector("fieldset")).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Inspect Sideboard Card" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Move Sideboard Card to Deck" })).toBeDisabled();
+  });
+
   it("moves_deck_to_sideboard_with_destination_columns_rows_position_and_announcement", () => {
     const cards = [card("moving")];
     const workspaceChanges = vi.fn();

--- a/client/src/components/draft/__tests__/PackDisplay.pod.test.tsx
+++ b/client/src/components/draft/__tests__/PackDisplay.pod.test.tsx
@@ -131,8 +131,8 @@ describe("PackDisplay pod controller", () => {
       "ring-2",
       "ring-arcane",
       "shadow-[0_0_7px_3px_#38bdf8]",
-      "motion-safe:animate-[draft-pack-selected-glow_4.8s_ease-in-out_infinite]",
     );
+    expect(selected).not.toHaveClass("motion-safe:animate-[draft-pack-selected-glow_4.8s_ease-in-out_infinite]");
     expect(selected).not.toHaveClass("!duration-0", "transition-all", "scale-105");
     expect(screen.queryByRole("button", { name: "Confirm Pick" })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Auto-pick" })).not.toBeInTheDocument();

--- a/client/src/components/draft/__tests__/PackDisplay.workspace.test.tsx
+++ b/client/src/components/draft/__tests__/PackDisplay.workspace.test.tsx
@@ -220,15 +220,18 @@ function RealDragPackHarness({
   confirmPick,
   onSelectionChange,
   viewOverride,
+  advancedView,
   responsiveLayout = "desktop",
 }: {
   onDrop(request: DraftDropRequest): DraftDropDispatch;
   confirmPick?: ConfirmPick;
   onSelectionChange?(instanceId: string | null): void;
   viewOverride?: DraftPlayerView;
+  advancedView?: DraftPlayerView;
   responsiveLayout?: "desktop" | "tablet-portrait";
 }) {
   const [selectedCard, setSelectedCard] = useState<string | null>(null);
+  const [renderedView, setRenderedView] = useState(viewOverride ?? view);
   const [interaction, setInteraction] = useState<DraftPickInteractionSnapshot>({
     interactionGeneration: 4,
     pickInteractionLocked: false,
@@ -267,7 +270,7 @@ function RealDragPackHarness({
     <>
       <PackDisplay
         controller={controller({
-          view: viewOverride ?? view,
+          view: renderedView,
           dragController: drag,
           pendingIntent: interaction.pendingPickIntent,
           interactionLocked: interaction.pickInteractionLocked,
@@ -280,6 +283,7 @@ function RealDragPackHarness({
         responsiveLayout={responsiveLayout}
       />
       <div data-testid="real-drag-target" ref={drag.registerCollapsedSideboard} />
+      {advancedView !== undefined && <button type="button" onClick={() => setRenderedView(advancedView)}>advance pack</button>}
       <button type="button" onClick={() => publish({ interactionGeneration: 4, pickInteractionLocked: false, pendingPickIntent: null })}>unlock</button>
     </>
   );
@@ -1260,6 +1264,78 @@ describe("PackDisplay local workspace controller", () => {
     await act(async () => resolveOutcome({ status: "ignored", reason: "busy" }));
     fireEvent.click(screen.getByRole("button", { name: "unlock" }));
     expect(source).toHaveAttribute("data-visual-state", "default");
+  });
+
+  it("does_not_retain_a_direct_pick_after_the_engine_advances_to_the_next_pick", async () => {
+    vi.useFakeTimers();
+    let resolvePick!: (outcome: { status: "acknowledged" }) => void;
+    const pickCard = vi.fn().mockReturnValue(new Promise((resolve) => { resolvePick = resolve; }));
+    const initial = controller({ pickCard });
+    const rendered = render(<PackDisplay controller={initial} presentation={{ packScale: 1, setPackScale: vi.fn() }} onCardHover={vi.fn()} />);
+    const picked = rendered.container.querySelector<HTMLElement>('[data-instance-id="unknown"]')!;
+
+    fireEvent.click(within(picked).getByRole("button", { name: "Pick Same to Deck" }));
+    rendered.rerender(<PackDisplay controller={{ ...initial, view: { ...view, pick_number: 1, current_pack: [cards[1]] } }} presentation={{ packScale: 1, setPackScale: vi.fn() }} onCardHover={vi.fn()} />);
+    await act(async () => resolvePick({ status: "acknowledged" }));
+
+    expect(rendered.container.querySelector('[data-instance-id="unknown"]')).not.toBeInTheDocument();
+    expect(rendered.container.querySelector('[data-visual-state="leaving"]')).not.toBeInTheDocument();
+    expect(rendered.container.querySelector('[data-instance-id="common"]')).toBeInTheDocument();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("keeps_same_step_departures_but_clears_them_and_their_timers_on_a_new_pack", async () => {
+    vi.useFakeTimers();
+    let resolvePick!: (outcome: { status: "acknowledged" }) => void;
+    const pickCard = vi.fn().mockReturnValue(new Promise((resolve) => { resolvePick = resolve; }));
+    const initial = controller({ pickCard });
+    const rendered = render(<PackDisplay controller={initial} presentation={{ packScale: 1, setPackScale: vi.fn() }} onCardHover={vi.fn()} />);
+    const picked = rendered.container.querySelector<HTMLElement>('[data-instance-id="unknown"]')!;
+
+    fireEvent.click(within(picked).getByRole("button", { name: "Pick Same to Deck" }));
+    rendered.rerender(<PackDisplay controller={{ ...initial, view: { ...view, current_pack: [cards[1]] } }} presentation={{ packScale: 1, setPackScale: vi.fn() }} onCardHover={vi.fn()} />);
+    await act(async () => resolvePick({ status: "acknowledged" }));
+    expect(rendered.container.querySelector('[data-instance-id="unknown"][data-visual-state="leaving"]')).toBeInTheDocument();
+    expect(vi.getTimerCount()).toBe(1);
+
+    rendered.rerender(<PackDisplay controller={{ ...initial, view: { ...view, current_pack_number: 1, pick_number: 0, current_pack: [] } }} presentation={{ packScale: 1, setPackScale: vi.fn() }} onCardHover={vi.fn()} />);
+
+    expect(screen.getByText("Waiting for next pack...")).toBeInTheDocument();
+    expect(rendered.container.querySelector('[data-instance-id="unknown"]')).not.toBeInTheDocument();
+    expect(rendered.container.querySelector('[data-visual-state="leaving"]')).not.toBeInTheDocument();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("does_not_retain_a_real_drag_pick_after_the_engine_advances_to_an_empty_pack", async () => {
+    vi.useFakeTimers();
+    let resolveOutcome!: (outcome: { status: "acknowledged" }) => void;
+    const onDrop = vi.fn((request: DraftDropRequest): DraftDropDispatch => ({
+      requestToken: request.requestToken,
+      interactionGeneration: request.interactionGeneration,
+      outcome: new Promise((resolve) => { resolveOutcome = resolve; }),
+    }));
+    const rendered = render(<RealDragPackHarness onDrop={onDrop} advancedView={{ ...view, current_pack_number: 1, pick_number: 0, current_pack: [] }} />);
+    const source = rendered.container.querySelector<HTMLElement>('[data-instance-id="unknown"]')!;
+    const target = screen.getByTestId("real-drag-target");
+    source.setPointerCapture = vi.fn();
+    source.releasePointerCapture = vi.fn();
+    target.getBoundingClientRect = () => ({ left: 0, top: 0, right: 200, bottom: 200, width: 200, height: 200, x: 0, y: 0, toJSON: () => ({}) }) as DOMRect;
+
+    fireEvent.pointerDown(source, { button: 0, clientX: 5, clientY: 5, isPrimary: true, pointerId: 96, pointerType: "mouse" });
+    fireEvent.pointerMove(source, { clientX: 20, clientY: 20, pointerId: 96, pointerType: "mouse" });
+    fireEvent.pointerUp(source, { clientX: 20, clientY: 20, pointerId: 96, pointerType: "mouse" });
+    expect(onDrop).toHaveBeenCalledTimes(1);
+    expect(source).toHaveAttribute("data-visual-state", "waiting");
+
+    fireEvent.click(screen.getByRole("button", { name: "advance pack" }));
+    expect(screen.getByText("Waiting for next pack...")).toBeInTheDocument();
+    await act(async () => resolveOutcome({ status: "acknowledged" }));
+    fireEvent.click(screen.getByRole("button", { name: "unlock" }));
+
+    expect(rendered.container.querySelector('[data-instance-id="unknown"]')).not.toBeInTheDocument();
+    expect(rendered.container.querySelector('[data-visual-state="leaving"]')).not.toBeInTheDocument();
+    expect(screen.getByText("Waiting for next pack...")).toBeInTheDocument();
+    expect(vi.getTimerCount()).toBe(0);
   });
 
   it("suppresses_the_trailing_desktop_shell_click_after_a_collapsed_sideboard_drop", async () => {

--- a/client/src/components/draft/__tests__/PackDisplay.workspace.test.tsx
+++ b/client/src/components/draft/__tests__/PackDisplay.workspace.test.tsx
@@ -1200,6 +1200,7 @@ describe("PackDisplay local workspace controller", () => {
 
   it("renders_all_six_visual_states_with_drag_admission_waiting_and_token_precedence", () => {
     vi.useFakeTimers();
+    imageState.src = "https://images.example.test/same.jpg";
     let source!: PackDropSource;
     const localDrag = {
       ...dragController,
@@ -1238,7 +1239,9 @@ describe("PackDisplay local workspace controller", () => {
     act(() => acknowledgedSource.onAdmission({ kind: "dispatch", requestToken: "acknowledged", interactionGeneration: 4 }));
     rendered.rerender(<PackDisplay controller={{ ...initial, view: { ...view, current_pack: [cards[1]] } }} presentation={{ packScale: 1, setPackScale: vi.fn() }} onCardHover={vi.fn()} />);
     act(() => acknowledgedSource.onSettled({ kind: "outcome", outcome: { status: "acknowledged" } }));
-    expect(rendered.container.querySelector('[data-instance-id="unknown"][data-visual-state="leaving"]')).toBeInTheDocument();
+    const departure = rendered.container.querySelector<HTMLElement>('[data-instance-id="unknown"][data-visual-state="leaving"]')!;
+    expect(departure).toBeInTheDocument();
+    expect(within(departure).getByRole("img", { name: "Same" })).toHaveAttribute("src", imageState.src);
   });
 
   it("commits_submitting_before_real_drag_dispatch_then_renders_waiting_after_lock_publication", async () => {

--- a/client/src/components/draft/__tests__/PackDisplay.workspace.test.tsx
+++ b/client/src/components/draft/__tests__/PackDisplay.workspace.test.tsx
@@ -630,6 +630,7 @@ describe("PackDisplay local workspace controller", () => {
     expect(localDrag.handlePointerDown).toHaveBeenCalledWith(expect.anything(), expect.anything());
     fireEvent.click(within(cardElement).getByRole("button", { name: "Same" }));
     expect(cardElement).toHaveAttribute("data-visual-state", "selected");
+    expect(within(cardElement).getByRole("button", { name: "Same" })).toHaveAttribute("aria-pressed", "true");
     expect(cardElement).toHaveClass(
       "transition-transform",
       "duration-150",

--- a/client/src/components/draft/__tests__/PackDisplay.workspace.test.tsx
+++ b/client/src/components/draft/__tests__/PackDisplay.workspace.test.tsx
@@ -301,14 +301,16 @@ describe("PackDisplay local workspace controller", () => {
     alternateFaceState.values = {};
   });
 
-  it("uses_arcane_cyan_for_the_selected_pack_keyframe_without_the_old_green", () => {
+  it("uses_static_selected_pack_feedback_and_a_static_card_area_drop_glow", () => {
     const css = readFileSync(resolve(process.cwd(), "src/index.css"), "utf8");
-    const keyframe = css.match(/@keyframes draft-pack-selected-glow \{[\s\S]*?\n\}/)?.[0];
+    const dropGlow = css.match(/@utility draft-card-area-drop-active \{[\s\S]*?\n\}/)?.[0];
 
     expect(css).toContain("--color-arcane: #38bdf8");
-    expect(keyframe).toContain("var(--color-arcane)");
-    expect(keyframe).toContain("rgb(56 189 248 / 0.55)");
-    expect(keyframe).not.toMatch(/(?:rgb|rgba)\(3,\s*139,\s*6/);
+    expect(css).not.toContain("@keyframes draft-pack-selected-glow");
+    expect(dropGlow).toContain("background-color: rgb(255 255 255 / 0.08)");
+    expect(dropGlow).toContain("inset 0 0 0 1px rgb(255 255 255 / 0.92)");
+    expect(dropGlow).toContain("0 0 18px 2px rgb(255 255 255 / 0.42)");
+    expect(dropGlow).not.toMatch(/\b(border|transform|animation)\b/);
   });
 
   it("renders_authoritative_sequence_once_and_preserves_duplicate_names_and_unknown_rarity", () => {
@@ -634,8 +636,8 @@ describe("PackDisplay local workspace controller", () => {
       "ring-2",
       "ring-arcane",
       "shadow-[0_0_7px_3px_#38bdf8]",
-      "motion-safe:animate-[draft-pack-selected-glow_4.8s_ease-in-out_infinite]",
     );
+    expect(cardElement).not.toHaveClass("motion-safe:animate-[draft-pack-selected-glow_4.8s_ease-in-out_infinite]");
     expect(cardElement).not.toHaveClass("transition-all");
     expect(cardElement).not.toHaveClass("!duration-0");
 
@@ -775,11 +777,7 @@ describe("PackDisplay local workspace controller", () => {
     await vi.waitFor(() => expect(confirmPick).toHaveBeenCalledWith("deck"));
   });
 
-  it.each([
-    ["desktop", true],
-    ["phone-portrait", false],
-    ["tablet-landscape", false],
-  ] as const)("uses_the_reduced_hover_scale_only_for_%s", (responsiveLayout, hasDesktopHover) => {
+  it.each(["desktop", "phone-portrait", "tablet-landscape"] as const)("keeps_%s_pack_cards_geometry_stable_on_hover", (responsiveLayout) => {
     const rendered = render(
       <PackDisplay
         controller={controller()}
@@ -790,7 +788,8 @@ describe("PackDisplay local workspace controller", () => {
     );
     const packCard = rendered.container.querySelector<HTMLElement>('[data-instance-id="unknown"]')!;
 
-    expect(packCard.classList.contains("hover:scale-[1.05]")).toBe(hasDesktopHover);
+    expect(packCard).toHaveClass("cursor-pointer", "hover:ring-white/20");
+    expect(packCard.classList.contains("hover:scale-[1.05]")).toBe(false);
     expect(packCard.classList.contains("hover:scale-[1.08]")).toBe(false);
   });
 
@@ -1099,7 +1098,8 @@ describe("PackDisplay local workspace controller", () => {
     expect(screen.queryByRole("button", { name: "Confirm Pick" })).not.toBeInTheDocument();
     const firstCard = rendered.container.querySelector<HTMLElement>('[data-instance-id="unknown"]')!;
     const cardButton = within(firstCard).getByRole("button", { name: "Same" });
-    expect(firstCard).toHaveClass("select-none", "caret-transparent", "transition-all", "duration-150", "cursor-pointer", "hover:scale-[1.05]", "hover:ring-white/20");
+    expect(firstCard).toHaveClass("select-none", "caret-transparent", "transition-all", "duration-150", "cursor-pointer", "hover:ring-white/20");
+    expect(firstCard).not.toHaveClass("hover:scale-[1.05]");
 
     fireEvent.click(cardButton, { detail: 1, pointerType: "mouse" });
     expect(selectCard).not.toHaveBeenCalled();
@@ -1113,8 +1113,8 @@ describe("PackDisplay local workspace controller", () => {
       "ring-2",
       "ring-arcane",
       "shadow-[0_0_7px_3px_#38bdf8]",
-      "motion-safe:animate-[draft-pack-selected-glow_4.8s_ease-in-out_infinite]",
     );
+    expect(firstCard).not.toHaveClass("motion-safe:animate-[draft-pack-selected-glow_4.8s_ease-in-out_infinite]");
     expect(firstCard).not.toHaveClass("transition-all");
     expect(firstCard).not.toHaveClass("!duration-0");
     expect(firstCard).not.toHaveClass("scale-105");

--- a/client/src/components/draft/__tests__/PackDisplay.workspace.test.tsx
+++ b/client/src/components/draft/__tests__/PackDisplay.workspace.test.tsx
@@ -1458,6 +1458,7 @@ describe("PackDisplay local workspace controller", () => {
     const first = rendered.container.querySelector<HTMLElement>('[data-instance-id="unknown"]')!;
     fireEvent.click(within(first).getByRole("button", { name: "Pick Same to Deck" }));
     rendered.rerender(<PackDisplay controller={{ ...initial, interactionGeneration: 5 }} presentation={{ packScale: 1, setPackScale: vi.fn() }} onCardHover={vi.fn()} />);
+    expect(first).toHaveAttribute("data-visual-state", "default");
     await act(async () => resolvePick({ status: "rejected", reason: "invalid-request" }));
     expect(first).toHaveAttribute("data-visual-state", "default");
 

--- a/client/src/components/draft/__tests__/PackDisplay.workspace.test.tsx
+++ b/client/src/components/draft/__tests__/PackDisplay.workspace.test.tsx
@@ -318,6 +318,7 @@ describe("PackDisplay local workspace controller", () => {
       "overflow-x-auto",
       "[scrollbar-width:none]",
       "[&::-webkit-scrollbar]:hidden",
+      "min-h-9",
     );
     expect(screen.queryByText(/cards? in pack/i)).not.toBeInTheDocument();
     expect(screen.queryByText("Mythic Rare")).not.toBeInTheDocument();
@@ -334,7 +335,7 @@ describe("PackDisplay local workspace controller", () => {
     expect(scaleControls[1]).not.toHaveTextContent(`${DRAFT_WORKSPACE_PACK_SCALE_DEFAULT}×`);
     expect(scaleControls[1].querySelector("svg")).toHaveAttribute("viewBox", "0 0 20 20");
     const firstCard = container.querySelector<HTMLElement>('[data-instance-id="unknown"]')!;
-    expect(firstCard.querySelector(".absolute.bottom-1 > span")).toHaveTextContent("Same");
+    expect(within(firstCard).getByText("Same")).toHaveClass("text-white/50");
     expect(within(firstCard).getByRole("button", { name: "Pick Same to Deck" })).toHaveClass("sr-only");
     expect(within(firstCard).getByRole("button", { name: "Pick Same to Sideboard" })).toHaveClass("sr-only");
   });
@@ -450,16 +451,13 @@ describe("PackDisplay local workspace controller", () => {
     expect(localDrag.handlePointerUp).toHaveBeenCalled();
   });
 
-  it("hides_each_name_footer_after_that_card_image_loads", () => {
+  it("keeps_resolved_pack_images_free_of_name_footers_before_native_load", () => {
     imageState.src = "/card.png";
     const { container } = render(<PackDisplay controller={controller()} presentation={{ packScale: 1, setPackScale: vi.fn() }} onCardHover={vi.fn()} />);
     const firstCard = container.querySelector<HTMLElement>('[data-instance-id="unknown"]')!;
-    const footer = () => firstCard.querySelector(".absolute.bottom-1");
 
-    expect(footer()).toHaveTextContent("Same");
-    fireEvent.load(within(firstCard).getByRole("img", { name: "Same" }));
-
-    expect(footer()).not.toBeInTheDocument();
+    expect(within(firstCard).getByRole("img", { name: "Same" })).toHaveAttribute("src", "/card.png");
+    expect(firstCard.querySelector(".absolute.bottom-1")).not.toBeInTheDocument();
     expect(within(firstCard).getByRole("button", { name: "Pick Same to Deck" })).toHaveClass("sr-only");
     expect(within(firstCard).getByRole("button", { name: "Pick Same to Sideboard" })).toHaveClass("sr-only");
   });
@@ -1123,10 +1121,10 @@ describe("PackDisplay local workspace controller", () => {
     }
     expect(confirmButton).toHaveClass("!min-h-9", "select-none", "!py-0", "caret-transparent");
     expect(confirmButton.parentElement).toHaveAttribute("data-pack-status-controls");
-    expect(confirmButton.closest("[data-pack-toolbar]")).toHaveClass("flex-nowrap", "overflow-x-auto");
+    expect(confirmButton.closest("[data-pack-toolbar]")).toHaveClass("flex-nowrap", "overflow-x-auto", "min-h-9");
     fireEvent.click(confirmButton);
     expect(confirmPick).toHaveBeenCalledWith("deck");
-    expect(within(firstCard).getByText("Same", { selector: "div > span" })).toBeInTheDocument();
+    expect(within(firstCard).getByRole("button", { name: "Same" })).toHaveTextContent("Same");
   });
 
   it("blocks_incomplete_duplicate_and_stale_effect_sources_but_dispatches_a_complete_live_pair", async () => {

--- a/client/src/components/draft/__tests__/PackDisplay.workspace.test.tsx
+++ b/client/src/components/draft/__tests__/PackDisplay.workspace.test.tsx
@@ -777,7 +777,11 @@ describe("PackDisplay local workspace controller", () => {
     await vi.waitFor(() => expect(confirmPick).toHaveBeenCalledWith("deck"));
   });
 
-  it.each(["desktop", "phone-portrait", "tablet-landscape"] as const)("keeps_%s_pack_cards_geometry_stable_on_hover", (responsiveLayout) => {
+  it.each([
+    ["desktop", true],
+    ["phone-portrait", false],
+    ["tablet-landscape", false],
+  ] as const)("uses_the_desktop_hover_scale_only_for_%s", (responsiveLayout, hasDesktopHover) => {
     const rendered = render(
       <PackDisplay
         controller={controller()}
@@ -789,7 +793,7 @@ describe("PackDisplay local workspace controller", () => {
     const packCard = rendered.container.querySelector<HTMLElement>('[data-instance-id="unknown"]')!;
 
     expect(packCard).toHaveClass("cursor-pointer", "hover:ring-white/20");
-    expect(packCard.classList.contains("hover:scale-[1.05]")).toBe(false);
+    expect(packCard.classList.contains("hover:scale-[1.05]")).toBe(hasDesktopHover);
     expect(packCard.classList.contains("hover:scale-[1.08]")).toBe(false);
   });
 
@@ -1098,8 +1102,7 @@ describe("PackDisplay local workspace controller", () => {
     expect(screen.queryByRole("button", { name: "Confirm Pick" })).not.toBeInTheDocument();
     const firstCard = rendered.container.querySelector<HTMLElement>('[data-instance-id="unknown"]')!;
     const cardButton = within(firstCard).getByRole("button", { name: "Same" });
-    expect(firstCard).toHaveClass("select-none", "caret-transparent", "transition-all", "duration-150", "cursor-pointer", "hover:ring-white/20");
-    expect(firstCard).not.toHaveClass("hover:scale-[1.05]");
+    expect(firstCard).toHaveClass("select-none", "caret-transparent", "transition-all", "duration-150", "cursor-pointer", "hover:scale-[1.05]", "hover:ring-white/20");
 
     fireEvent.click(cardButton, { detail: 1, pointerType: "mouse" });
     expect(selectCard).not.toHaveBeenCalled();

--- a/client/src/components/draft/workspace/CardPoolBoard.tsx
+++ b/client/src/components/draft/workspace/CardPoolBoard.tsx
@@ -490,8 +490,8 @@ export function CardPoolBoard({
         )}
         {visualColumnCap === undefined ? (
           <div className={model.rowCount === 2
-          ? "grid w-full grid-cols-[2rem_minmax(0,1fr)] grid-rows-[auto_auto_auto] gap-x-2 p-[18px]"
-          : "flex w-full gap-2 p-[18px]"
+          ? "grid w-full grid-cols-[2rem_minmax(0,1fr)] grid-rows-[auto_auto_auto] gap-x-2 p-[20px]"
+          : "flex w-full gap-2 p-[20px]"
           }>
           {model.rowCount === 2 && (
             <div
@@ -527,7 +527,7 @@ export function CardPoolBoard({
           </div>
           </div>
         ) : (
-          <div data-board-columns className="grid min-w-0 gap-y-2 p-[18px]">
+          <div data-board-columns className="grid min-w-0 gap-y-2 p-[20px]">
             {visualColumnGroups.map((columns, groupIndex) => (
               model.rowCount === 2 ? (
                 <div

--- a/client/src/components/draft/workspace/CardPoolBoard.tsx
+++ b/client/src/components/draft/workspace/CardPoolBoard.tsx
@@ -437,7 +437,7 @@ export function CardPoolBoard({
       touchDragEnabled={touchDragEnabled}
       touchScrollEnabled={touchScrollEnabled}
       makeDragSource={makeDragSource}
-      registerRoot={registerColumn?.(zone, column.column)}
+      registerCardArea={registerColumn?.(zone, column.column)}
       registerCard={(instanceId) => (element) => {
         if (element === null) cardRefs.current.delete(instanceId);
         else cardRefs.current.set(instanceId, element);

--- a/client/src/components/draft/workspace/CardPoolBoard.tsx
+++ b/client/src/components/draft/workspace/CardPoolBoard.tsx
@@ -490,8 +490,8 @@ export function CardPoolBoard({
         )}
         {visualColumnCap === undefined ? (
           <div className={model.rowCount === 2
-          ? "grid w-full grid-cols-[2rem_minmax(0,1fr)] grid-rows-[auto_auto_auto] gap-x-2 p-2"
-          : "flex w-full gap-2 p-2"
+          ? "grid w-full grid-cols-[2rem_minmax(0,1fr)] grid-rows-[auto_auto_auto] gap-x-2 p-[18px]"
+          : "flex w-full gap-2 p-[18px]"
           }>
           {model.rowCount === 2 && (
             <div
@@ -527,7 +527,7 @@ export function CardPoolBoard({
           </div>
           </div>
         ) : (
-          <div data-board-columns className="grid min-w-0 gap-y-2 p-2">
+          <div data-board-columns className="grid min-w-0 gap-y-2 p-[18px]">
             {visualColumnGroups.map((columns, groupIndex) => (
               model.rowCount === 2 ? (
                 <div

--- a/client/src/components/draft/workspace/CardPoolBoard.tsx
+++ b/client/src/components/draft/workspace/CardPoolBoard.tsx
@@ -490,8 +490,8 @@ export function CardPoolBoard({
         )}
         {visualColumnCap === undefined ? (
           <div className={model.rowCount === 2
-          ? "grid w-full grid-cols-[2rem_minmax(0,1fr)] grid-rows-[auto_auto_auto] gap-x-2 p-[20px]"
-          : "flex w-full gap-2 p-[20px]"
+          ? "grid w-full grid-cols-[2rem_minmax(0,1fr)] grid-rows-[auto_auto_auto] gap-x-2 p-6"
+          : "flex w-full gap-2 p-6"
           }>
           {model.rowCount === 2 && (
             <div
@@ -527,7 +527,7 @@ export function CardPoolBoard({
           </div>
           </div>
         ) : (
-          <div data-board-columns className="grid min-w-0 gap-y-2 p-[20px]">
+          <div data-board-columns className="grid min-w-0 gap-y-2 p-6">
             {visualColumnGroups.map((columns, groupIndex) => (
               model.rowCount === 2 ? (
                 <div

--- a/client/src/components/draft/workspace/CardPoolColumn.tsx
+++ b/client/src/components/draft/workspace/CardPoolColumn.tsx
@@ -30,7 +30,7 @@ interface CardPoolColumnProps {
   dragController?: DraftWorkspaceDragController;
   touchDragEnabled?: boolean;
   touchScrollEnabled?: boolean;
-  registerRoot?: RefCallback<HTMLElement>;
+  registerCardArea?: RefCallback<HTMLElement>;
   showHeader: boolean;
   canRemove: boolean;
   registerCard(instanceId: string): RefCallback<HTMLButtonElement>;
@@ -123,7 +123,7 @@ export function CardPoolColumn({
   dragController,
   touchDragEnabled = false,
   touchScrollEnabled = false,
-  registerRoot,
+  registerCardArea,
   showHeader,
   canRemove,
   registerCard,
@@ -159,11 +159,10 @@ export function CardPoolColumn({
 
   return (
     <section
-      ref={registerRoot}
       style={column.rows.length === 2 ? { borderColor: "transparent", gridTemplateRows: "subgrid" } : undefined}
       className={`h-full min-w-0 select-none overflow-visible border caret-transparent ${column.rows.length === 2
         ? "row-span-3 grid grid-rows-subgrid bg-transparent shadow-none"
-        : "rounded-[8px] border-hairline bg-black/28 shadow-[inset_0_1px_0_rgba(255,255,255,0.035)] transition-colors hover:border-hairline-hover"
+        : "flex flex-col rounded-[8px] border-hairline bg-black/28 shadow-[inset_0_1px_0_rgba(255,255,255,0.035)] transition-colors hover:border-hairline-hover"
       }`}
       data-board-column={column.column}
       data-drop-state={column.drop.state}
@@ -181,7 +180,7 @@ export function CardPoolColumn({
         <header
           ref={registerHeader(column.column)}
           tabIndex={-1}
-          className="relative row-start-1 flex h-8 min-h-8 items-center gap-1 overflow-hidden whitespace-nowrap rounded-t-[7px] border-b border-hairline bg-white/[0.045] px-2 text-xs text-fg-muted"
+          className="relative z-10 row-start-1 flex h-8 min-h-8 items-center gap-1 overflow-hidden whitespace-nowrap rounded-t-[7px] border-b border-hairline bg-white/[0.045] px-2 text-xs text-fg-muted"
           aria-label={headerName}
         >
           <span data-card-count aria-hidden="true" className="shrink-0 font-mono text-sm tabular-nums text-fg">{column.header.count}</span>
@@ -210,41 +209,31 @@ export function CardPoolColumn({
         </header>
       )}
       <div
+        ref={registerCardArea}
         data-card-area
-        className={column.rows.length === 2 ? "contents" : "relative grid flex-1 gap-2"}
+        className={`${column.rows.length === 2
+          ? `relative row-start-2 row-span-2 grid min-h-0 min-w-0 grid-rows-subgrid ${showHeader ? "rounded-b-[8px]" : "rounded-[8px]"} border border-hairline bg-black/28`
+          : `relative grid min-h-0 flex-1 gap-2 ${showHeader ? "rounded-b-[7px]" : "rounded-[7px]"}`
+        } ${column.drop.active ? "draft-card-area-drop-active" : ""}`}
         style={column.rows.length === 2
-          ? undefined
+          ? { gridTemplateRows: "subgrid" }
           : { gridTemplateRows: `repeat(${column.rows.length}, minmax(0, 1fr))` }
         }
       >
-        {column.drop.active && column.rows.length === 1 && (
-          <span
-            aria-hidden="true"
-            data-drop-highlight="active"
-            className="pointer-events-none absolute inset-0 z-20 border-2 border-white"
-          />
-        )}
         {column.rows.map((row) => (
             <div
               key={row.key}
-              className={`${column.rows.length === 2 ? `${row.row === 1 ? "mt-2 rounded-[7px]" : "rounded-b-[7px]"} border border-hairline bg-black/28` : ""} relative grid min-w-0`}
-              style={column.rows.length === 2 ? { gridRow: row.row + 2 } : undefined}
+              className={`${column.rows.length === 2 ? `${row.row === 1 ? "mt-2 rounded-[7px]" : ""} border border-hairline` : ""} relative grid min-w-0`}
+              style={column.rows.length === 2 ? { gridRow: row.row + 1 } : undefined}
               data-board-row={row.row}
               data-drop-state={row.drop.state}
               aria-describedby={row.drop.active ? `${row.key}:drop-description` : undefined}
             >
               <span aria-hidden="true" data-card-height-baseline className="block aspect-[488/680] w-full self-start [grid-area:1/1]" />
               {row.drop.active && (
-                <>
-                  <span id={`${row.key}:drop-description`} className="sr-only">
-                    {t(row.drop.descriptionKey!)}
-                  </span>
-                  <span
-                    aria-hidden="true"
-                    data-drop-highlight="active"
-                    className={`pointer-events-none absolute inset-0 z-20 border-2 border-white ${row.row === 1 ? "rounded-[6px]" : "rounded-b-[6px]"}`}
-                  />
-                </>
+                <span id={`${row.key}:drop-description`} className="sr-only">
+                  {t(row.drop.descriptionKey!)}
+                </span>
               )}
               <div data-card-stack className="min-w-0 [grid-area:1/1]">
                 {row.cards.map((card, stackIndex) => (

--- a/client/src/components/draft/workspace/CompactSideboard.tsx
+++ b/client/src/components/draft/workspace/CompactSideboard.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from "react-i18next";
-import type { CSSProperties } from "react";
+import type { CSSProperties, RefCallback } from "react";
 
 import type { DraftCardInstance, DraftPoolGroups } from "../../../adapter/draft-adapter";
 import type { CardHoverInfo } from "../../card/CardPreview";
@@ -25,6 +25,7 @@ interface CompactSideboardProps {
   preferences: Readonly<Record<DraftZone, DraftBoardPreferences>>;
   interactionLocked?: boolean;
   dropActive?: boolean;
+  registerCardArea?: RefCallback<HTMLElement>;
   dragController?: DraftWorkspaceDragController;
   touchDragEnabled?: boolean;
   collapsed?: boolean;
@@ -57,6 +58,7 @@ export function CompactSideboard({
   preferences,
   interactionLocked = false,
   dropActive = false,
+  registerCardArea,
   dragController,
   touchDragEnabled = false,
   collapsed = true,
@@ -206,15 +208,15 @@ export function CompactSideboard({
       data-zone="sideboard"
       data-responsive-sideboard-layout={responsiveLayout}
       data-sideboard-collapsed={collapsed ? "true" : "false"}
-      className={`min-w-0 overflow-hidden rounded-card border border-hairline text-fg shadow-[0_10px_26px_rgba(0,0,0,0.2)] ${tabletPortraitLayout && !collapsed ? "bg-slate-950" : "bg-black/18"} ${isLandscapeBuilderPhone || draftPhoneLayout || tabletLayout ? "flex h-full min-h-0 flex-col" : builderPhoneLayout ? "flex shrink-0 flex-col" : ""}`}
+      className={`min-w-0 ${dropActive ? "overflow-visible" : "overflow-hidden"} rounded-card border border-hairline text-fg shadow-[0_10px_26px_rgba(0,0,0,0.2)] ${tabletPortraitLayout && !collapsed ? "bg-slate-950" : "bg-black/18"} ${isLandscapeBuilderPhone || draftPhoneLayout || tabletLayout ? "flex h-full min-h-0 flex-col" : builderPhoneLayout ? "flex shrink-0 flex-col" : ""}`}
     >
-      <header className={sideRailCollapsed
-        ? "relative flex h-full min-h-0 flex-col items-center justify-start gap-1 bg-white/[0.035] px-1 py-2"
+      <header className={`relative z-10 ${sideRailCollapsed
+        ? "relative flex min-h-11 shrink-0 flex-col items-center justify-start gap-1 bg-white/[0.035] px-1 py-2"
         : draftPhoneLandscapeExpanded
           ? "flex shrink-0 flex-col items-start gap-1 border-b border-hairline bg-white/[0.035] px-2 py-1.5"
         : tabletPortraitCollapsed
-          ? "relative flex h-full min-h-0 items-center justify-center border-b border-hairline bg-slate-950 px-12 py-1"
-        : "flex min-h-11 shrink-0 items-center gap-2 border-b border-hairline bg-white/[0.035] px-2 py-1.5"}
+          ? "relative flex min-h-11 shrink-0 items-center justify-center border-b border-hairline bg-slate-950 px-12 py-1"
+        : "flex min-h-11 shrink-0 items-center gap-2 border-b border-hairline bg-white/[0.035] px-2 py-1.5"}`}
       >
         {sideRailCollapsed && (draftPhoneLandscapeSideRail
           ? <span className="relative z-10 mt-10">{sideboardToggle}</span>
@@ -253,21 +255,18 @@ export function CompactSideboard({
         {!sideRailCollapsed && !tabletPortraitCollapsed && !draftPhoneLandscapeExpanded && sideboardToggle}
       </header>
       {(!collapsibleCompactSideboard || !collapsed) && <div
+        ref={registerCardArea}
+        data-sideboard-card-area
+        data-drop-target="collapsed-sideboard"
+        data-drop-state={dropActive ? "active" : "idle"}
         data-sideboard-slot={builderPhoneLayout || scrollableCardLayout ? undefined : ""}
         data-sideboard-body={builderPhoneLayout || scrollableCardLayout ? "" : undefined}
-        className={scrollableCardLayout
+        className={`${scrollableCardLayout
           ? "relative min-h-0 flex-1 touch-pan-y overflow-y-auto overscroll-contain bg-black/12 p-2 thin-scrollbar"
           : builderPhoneLayout
             ? "relative shrink-0 overflow-visible bg-black/12 p-2"
-          : `relative grid min-w-0 bg-black/12 ${responsiveLayout === "desktop" || responsiveLayout === "phone-landscape" ? "aspect-[488/680]" : ""}`}
+            : `relative grid min-w-0 bg-black/12 ${responsiveLayout === "desktop" || responsiveLayout === "phone-landscape" ? "aspect-[488/680]" : ""}`} ${dropActive ? "draft-card-area-drop-active" : ""}`}
       >
-        {dropActive && (
-          <span
-            aria-hidden="true"
-            data-drop-highlight="active"
-            className="pointer-events-none absolute inset-0 z-20 border-2 border-white"
-          />
-        )}
         <span
           aria-hidden="true"
           data-card-height-baseline
@@ -368,6 +367,15 @@ export function CompactSideboard({
           </button>
         ))}
       </div>}
+      {collapsibleCompactSideboard && collapsed && (
+        <div
+          ref={registerCardArea}
+          data-sideboard-card-area
+          data-drop-target="collapsed-sideboard"
+          data-drop-state={dropActive ? "active" : "idle"}
+          className={`min-h-11 flex-1 ${dropActive ? "draft-card-area-drop-active" : ""}`}
+        />
+      )}
     </section>
   );
 }

--- a/client/src/components/draft/workspace/DraftWorkspace.tsx
+++ b/client/src/components/draft/workspace/DraftWorkspace.tsx
@@ -530,11 +530,8 @@ export function DraftWorkspace({
           >
             {deck}
             {!deckCollapsed && !builderCompact && <section
-              ref={dragController?.registerCollapsedSideboard}
               aria-label={t("workspace.zone.sideboard")}
               data-zone="sideboard"
-              data-drop-target="collapsed-sideboard"
-              data-drop-state={sideboardDropActive ? "active" : "idle"}
               className={tabletPortraitLayout
                 ? sideboardCollapsed
                   ? "h-full min-h-0 min-w-0"
@@ -552,6 +549,7 @@ export function DraftWorkspace({
                 preferences={boardPreferences}
                 interactionLocked={interactionLocked}
                 dropActive={sideboardDropActive}
+                registerCardArea={dragController?.registerCollapsedSideboard}
                 collapsed={sideboardCollapsed}
                 {...(dragController === undefined ? {} : { dragController })}
                 onToggle={toggleSideboard}

--- a/client/src/components/draft/workspace/DraftWorkspace.tsx
+++ b/client/src/components/draft/workspace/DraftWorkspace.tsx
@@ -155,11 +155,9 @@ export function DraftWorkspace({
   const { t } = useTranslation(["draft", "common"]);
   const [filter, setFilter] = useState<DraftWorkspaceFilter>("deck");
   const [compactSort, setCompactSort] = useState<DraftBoardSort>(preferences.deck.sort);
-  const [lockEpoch, setLockEpoch] = useState(0);
   const [deckCollapsed, setDeckCollapsed] = useState(false);
   const [viewportWidth, setViewportWidth] = useState(() => window.innerWidth);
   const cardPreviewMode = usePreferencesStore((state) => state.draftCardPreviewMode);
-  const previousLocked = useRef(interactionLocked);
   const normalizedWorkspaceSourceRef = useRef<DraftWorkspaceState | null>(null);
   const boardPreferences = { deck: preferences.deck, sideboard: preferences.sideboard };
   const normalized = normalizeWorkspaceForBoardGeometry(
@@ -315,13 +313,6 @@ export function DraftWorkspace({
       onWorkspaceChange(normalized);
     }
   }, [interactionLocked, normalized, onWorkspaceChange, workspace]);
-
-  useEffect(() => {
-    if (!previousLocked.current && interactionLocked) {
-      setLockEpoch((current) => current + 1);
-    }
-    previousLocked.current = interactionLocked;
-  }, [interactionLocked]);
 
   useLayoutEffect(() => {
     const mediaQueries = typeof window.matchMedia === "function"
@@ -528,7 +519,7 @@ export function DraftWorkspace({
       <div role="status" aria-live="polite" aria-atomic="true" className="sr-only">
         {interactionLocked ? t("workspace.locked") : dragController?.announcement ?? ""}
       </div>
-      <fieldset key={lockEpoch} disabled={interactionLocked} className="contents">
+      <fieldset disabled={interactionLocked} className="contents">
         {sideboardCollapsed || builderPhoneLayout || draftPhoneLayout || tabletLayout ? (
           <div
             data-workspace-composition="collapsed"

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -171,13 +171,9 @@ html {
   color-scheme: dark;
 }
 
-@keyframes draft-pack-selected-glow {
-  0%, 100% {
-    box-shadow: 0 0 7px 3px var(--color-arcane);
-  }
-  50% {
-    box-shadow: 0 0 4px 2px rgb(56 189 248 / 0.55);
-  }
+@utility draft-card-area-drop-active {
+  background-color: rgb(255 255 255 / 0.08);
+  box-shadow: inset 0 0 0 1px rgb(255 255 255 / 0.92), 0 0 18px 2px rgb(255 255 255 / 0.42);
 }
 
 body {


### PR DESCRIPTION
## Summary

Stabilizes draft pick feedback across desktop and responsive workspaces: card art remains visible during acknowledged departures, selected feedback is static and announced semantically, and deck/sideboard drop targets receive a static body-only glow without layout movement. It also prevents stale visual feedback from crossing interaction generations and restores desktop hover scaling.

## Files changed

- client/src/components/draft/PackDisplay.tsx
- client/src/components/draft/__tests__/CardPoolBoard.test.tsx
- client/src/components/draft/__tests__/DraftWorkspace.test.tsx
- client/src/components/draft/__tests__/PackDisplay.pod.test.tsx
- client/src/components/draft/__tests__/PackDisplay.workspace.test.tsx
- client/src/components/draft/workspace/CardPoolBoard.tsx
- client/src/components/draft/workspace/CardPoolColumn.tsx
- client/src/components/draft/workspace/CompactSideboard.tsx
- client/src/components/draft/workspace/DraftWorkspace.tsx
- client/src/index.css

## Track

Developer

## LLM

Model: GPT-5.6 Terra (via GitHub Copilot)
Tier: Frontier
Thinking: high

## Implementation method (required)

Method: /engine-implementer

## CR references

None.

## Verification

- [x] Required checks ran clean, or the exact CI-owned alternative is stated below.
- [x] Gate A output below is for the current committed head.
- [x] Final review-impl below is clean for the current committed head.
- [x] Both anchors cite existing analogous code at the same seam.

- `pnpm test -- --run src/components/draft/__tests__/PackDisplay.pod.test.tsx src/components/draft/__tests__/PackDisplay.workspace.test.tsx src/components/draft/__tests__/CardPoolBoard.test.tsx src/components/draft/__tests__/DraftWorkspace.test.tsx` - 4 files, 168 tests passed.
- `pnpm run type-check` - passed.
- `pnpm lint` - passed with 0 errors and 44 pre-existing warnings.
- `./scripts/check-parser-combinators.sh` - Gate G and Gate A passed for the current head.
- Final GPT-5.6 Terra implementation review - no actionable findings.

## Gate A

Gate A PASS head=8bc9b9947e23d19ad8530bf72da4804d13c9255c base=6884506bfad8bc5bffa660dea10d0bcf2fd930c3

## Anchored on

- client/src/components/draft/workspace/CompactSideboard.tsx:211 - active drop targets account for outer glow paint at a containment boundary.
- client/src/components/draft/BotDifficultySelector.tsx:35 - selected draft controls expose their state with `aria-pressed`.

## Final review-impl

Final review-impl PASS head=8bc9b9947e23d19ad8530bf72da4804d13c9255c

## Claimed parse impact

None.

## Scope Expansion

None.

## Validation Failures

None.

## CI Failures

None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved drag-and-drop feedback with clearer card-area highlighting across draft layouts.
  * Preserved card images when selections are locked or the draft advances.
  * Added accessible pressed-state indicators for selected cards.
* **Bug Fixes**
  * Prevented stale cards, visual states, and timers from carrying over between draft steps.
  * Improved handling of failed card images.
* **Style**
  * Refined board spacing, card-area borders, drop effects, and pinned-toolbar sizing.
  * Replaced pulsing selection animation with a clearer static visual treatment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->