### PR TITLE
ci: gate the server image on the release environment too

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -647,6 +647,9 @@ jobs:
     permissions:
       contents: read
       packages: write
+    # Same gate as build-web-image: the release environment admits tag refs
+    # only, so a wrong-ref run publishes neither image rather than half a pair.
+    environment: release
     env:
       RELEASE_TAG: ${{ needs.resolve-release-ref.outputs.release_tag }}
       RELEASE_SHA: ${{ needs.resolve-release-ref.outputs.release_sha }}


### PR DESCRIPTION
## Summary

`build-web-image` deploys to the protected `release` environment; `build-server-image` does
not. The environment's policy is matched against the run's own `GITHUB_REF`, not against any
workflow input, and it carries one tag rule and no branch policy. So a run started from a ref
the environment refuses publishes `phase-server:$TAG` **and `:latest`** while the web image is
turned away and the `release` job never runs — half a pair, with a tag that would then name
two images built from different runs.

This puts both publishing jobs behind the same gate, so such a run publishes neither.

**The trade, stated plainly.** A tag admitted by the push trigger (`v*`) but refused by the
environment rule (`v[0-9]*.[0-9]*.[0-9]*`) previously still published the server image; it now
publishes nothing. That is the point — a release that cannot complete should leave no images
behind — but it is a real behavior change, not a no-op. No such tag exists today: of 161 tags
in the repository, 138 are admitted by the trigger and **0** are refused by the policy.

Related, and deliberately separate:

- **#8304** introduced the asymmetry by attaching `environment: release` to the new
  `build-web-image` without changing the older server-image job.
- **#8331** (merged) fixed the caller that actually tripped it — the nightly recovery dispatch
  ran from `--ref main`, which this environment refuses. That closes the path at the caller;
  this change closes it at the publisher, and also covers the case #8331 cannot: a *tag* ref
  that the environment rule rejects.
- **#8329** (open) SHA-pins this job's actions. On `main` `build-server-image` has 6 `uses:`
  refs and **0** are pinned, while `build-web-image` has 5 and all 5 are pinned — the same
  asymmetry in a different dimension. Both PRs touch `release.yml` in disjoint regions
  (this one the job header, #8329 the `uses:` lines inside its steps).

## Files changed

- `.github/workflows/release.yml` — `environment: release` on `build-server-image`, with a comment naming the coupling

## Track

Developer

## LLM

Model: claude-opus-5
Tier: Frontier
Thinking: high

## Implementation method (required)

Method: not-applicable — CI workflow change, no `crates/engine/` game logic.

## CR references

None.

## Verification

- [x] Required checks ran clean, or the exact CI-owned alternative is stated below.
- [x] Gate A output below is for the current committed head.
- [x] Final review-impl below is clean for the current committed head.
- [x] Both anchors cite existing analogous code at the same seam.

**The environment is a gate and nothing else.** `gh api repos/phase-rs/phase/environments/release`
→ one `branch_policy` protection rule, `reviewers: 0`, `wait_timer: null`; `secrets` and
`variables` both `total_count: 0`. Attaching a job to it therefore cannot add an approval step
or hand the job anything it did not already have — it only constrains which refs may run it.

**The policy rule and the trigger, and the gap between them.**
`.../environments/release/deployment-branch-policies` → exactly 1 rule,
`{"name":"v[0-9]*.[0-9]*.[0-9]*","type":"tag"}`. `release.yml`'s push trigger is `tags: ["v*"]`
(read from the parsed workflow, not grepped). Walking the full local tag namespace after
`git fetch --tags`: **161 tags**, **138** admitted by `v*`, **0** of those refused by the
policy rule. Positive control on the same matcher, since a zero here is otherwise
indistinguishable from a dead instrument: `vNEXT`, `v-beta`, `valpha`, `v2.3` are each
admitted-by-trigger and refused-by-policy, so the instrument does find gap members when they
exist. The empty gap is a measurement, not an assumption — and it is the population this PR's
behavior change is scoped to.

**The change lands where intended.** Parsing the workflow and reading each job's `environment`
key rather than grepping: 10 jobs walked, exactly 2 carry `environment: release` —
`build-server-image` (new) and `build-web-image` (pre-existing); the other 8 carry none.

- `actionlint .github/workflows/release.yml` — finding set **unchanged**: 1 finding before
  (`constant expression "false" in condition ... [if-cond]`, a pre-existing `if: ${{ false }}`)
  and the same 1 finding after, its line number moved `944` → `947` by the three inserted
  lines. Diffed the two outputs rather than comparing counts.
- No build ran: `git diff --name-only upstream/main..HEAD` = `.github/workflows/release.yml`,
  with no Rust or TypeScript in the delta. The CI-owned alternative is the next tagged release
  run of this workflow.

## Gate A

Gate A PASS head=00d75abbc690c23edceed7dfd2d6dcb41200abb4 base=d6d28370c09242182488cac72e16e5a84941885f

Disclosed: the base is fork-relative and this delta contains no parser or Rust changes, so the
gate's range is empty for this PR — the PASS is vacuous here and is reported as evidence that
the gate ran at this head, not as evidence about the change.

## Anchored on

- `.github/workflows/release.yml` — `build-web-image`'s `environment: release`, added in #8304: the same key, in the same position between `permissions:` and `env:`, on the sibling job that publishes the other half of the pair.
- `.github/workflows/release.yml` — `release` job's `needs: [..., build-server-image, build-web-image]`: both images are already required for a release to be created, which is why publishing one without the other is the anomaly this closes.

## Final review-impl

Final review-impl PASS head=00d75abbc690c23edceed7dfd2d6dcb41200abb4

## Claimed parse impact

None.

## Scope Expansion

None.

## Validation Failures

None.

## CI Failures

None.
