### PR TITLE
ci: audit action pins from the default branch

### DIFF
--- a/.agents/pr-review-policy.toml
+++ b/.agents/pr-review-policy.toml
@@ -47,6 +47,11 @@ patterns = [
   ".claude/skills/**",
   ".claude/agents/**",
   ".github/workflows/**",
+  # The pin gate and its tests decide whether a privileged workflow's actions
+  # are pinned. A change to them carries the same authority as a change to the
+  # workflows themselves.
+  "scripts/check_action_pins.py",
+  "scripts/check_action_pins_tests.py",
   "AGENTS.md",
   "CLAUDE.md",
   "GEMINI.md",

--- a/.github/workflows/action-pin-audit.yml
+++ b/.github/workflows/action-pin-audit.yml
@@ -1,0 +1,121 @@
+name: Action Pin Audit
+
+# The pin gate inside CI runs from the pull request's own checkout, so a change
+# to a privileged workflow and a change that defeats the checker can arrive in
+# the same commit and the gate still reports success. That makes it regression
+# coverage, not an authority.
+#
+# This workflow is the authority. `workflow_run` only triggers a workflow that
+# exists on the default branch, and its checkout defaults to the default branch,
+# so the checker executed here is always the reviewed one.
+#
+# The evaluated commit is attacker-controlled: for a fork pull request the
+# tarball is that fork's. Two rules keep that safe, and they are why this is
+# split into two jobs. The tree is data -- only `.github` is unpacked and
+# nothing in it is ever executed -- and the job that touches it holds no write
+# permission at all. Publishing the status is a separate job that never sees
+# the tree.
+# `workflows:` matches the CI workflow's `name:`, which a pull request can edit,
+# and a renamed CI would never trigger this audit -- absence looks exactly like
+# success. Dropping the filter does not fix that: every documented form of this
+# trigger carries it, and actionlint rejects its omission, so a filterless
+# version risks never running at all, which is the same hole made certain. What
+# closes it is requiring the `Action Pin Audit` status, since a status that
+# never arrives blocks rather than passes. The id check below is defence in
+# depth for the case where some other workflow is also named CI.
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+
+permissions: {}
+
+jobs:
+  audit:
+    name: Audit action pins from base
+    # 246030356 is .github/workflows/ci.yml. Opaque, but a pull request can
+    # rename that workflow and cannot renumber it.
+    if: github.event.workflow_run.workflow_id == 246030356
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    # Read-only. This job handles the untrusted tree.
+    permissions:
+      contents: read
+    steps:
+      # No `ref:` on purpose: the default is the default branch, which is what
+      # makes the checker below the reviewed one.
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          persist-credentials: false
+
+      - name: Extract the evaluated commit's workflow files
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          HEAD_REPO: ${{ github.event.workflow_run.head_repository.full_name }}
+        run: |
+          set -euo pipefail
+
+          # Both values reach a URL, so they are shape-checked before use rather
+          # than trusted because GitHub supplied them.
+          case "$HEAD_SHA" in
+            *[!0-9a-f]* | "") echo "::error::head_sha is not a commit SHA: $HEAD_SHA" >&2; exit 1 ;;
+          esac
+          [ ${#HEAD_SHA} -eq 40 ] || { echo "::error::head_sha is not 40 hex: $HEAD_SHA" >&2; exit 1; }
+          printf '%s' "$HEAD_REPO" | grep -qE '^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+$' \
+            || { echo "::error::head_repository is not owner/repo: $HEAD_REPO" >&2; exit 1; }
+
+          mkdir -p audited
+          # Only `.github` is unpacked. The checker needs the workflow and
+          # composite-action files and nothing else, and in particular the
+          # evaluated commit's `scripts/` never reaches disk.
+          gh api "repos/$HEAD_REPO/tarball/$HEAD_SHA" > src.tar.gz
+          tar -xzf src.tar.gz --strip-components=1 -C audited --wildcards '*/.github/*'
+          test -d audited/.github/workflows
+
+          # git stores symlinks, so the evaluated commit can ship one under
+          # `.github` that points outside this directory; the checker would then
+          # read whatever it targets and could echo a matching line into the log.
+          # A workflow file has no reason to be a symlink, so refuse rather than
+          # silently unlink -- a tree shaped like this is worth seeing.
+          links=$(find audited -type l)
+          if [ -n "$links" ]; then
+            echo "::error::the evaluated commit has symlinks under .github; refusing to read them" >&2
+            printf '  %s\n' $links >&2
+            exit 1
+          fi
+
+      - name: Check action pins in the evaluated commit
+        env:
+          PIN_CHECK_ROOT: ${{ github.workspace }}/audited
+        run: python3 scripts/check_action_pins.py
+
+  report:
+    name: Report the audit result
+    needs: audit
+    if: always() && github.event.workflow_run.workflow_id == 246030356
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    # The only job with a write token, and it never fetches or reads the
+    # evaluated tree -- it publishes a verdict the audit job already reached.
+    permissions:
+      statuses: write
+    steps:
+      - name: Publish the commit status
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          REPO: ${{ github.repository }}
+          STATE: ${{ needs.audit.result == 'success' && 'success' || 'failure' }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          case "$HEAD_SHA" in
+            *[!0-9a-f]* | "") echo "::error::head_sha is not a commit SHA" >&2; exit 1 ;;
+          esac
+          [ ${#HEAD_SHA} -eq 40 ] || { echo "::error::head_sha is not 40 hex" >&2; exit 1; }
+          gh api "repos/$REPO/statuses/$HEAD_SHA" \
+            -f state="$STATE" \
+            -f context="Action Pin Audit" \
+            -f target_url="$RUN_URL" \
+            -f description="Pins checked with the default branch's checker" >/dev/null

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,6 +114,13 @@ jobs:
         # that weakens it fails here instead of shipping unnoticed.
         run: python3 scripts/release_dispatch_guard_tests.py
 
+      - name: Action pin checker unit tests
+        # Exercises the checker against throwaway repositories only; it does
+        # not walk this repository's own workflows. The gate over the real tree
+        # is action-pin-audit.yml, which runs the default branch's copy of this
+        # checker against the evaluated commit.
+        run: python3 scripts/check_action_pins_tests.py
+
       - name: Resolution-frame boundary guard
         # Full-tree guard: legacy resolution keys are reader/fixture-only, and
         # ResolutionStack mutation remains top-only or adjacent-pair scoped.

--- a/scripts/check_action_pins.py
+++ b/scripts/check_action_pins.py
@@ -41,6 +41,14 @@ DOCKER_DIGEST = re.compile(r"^docker://[^@\s]+@sha256:[0-9a-f]{64}$")
 REMOTE_REUSABLE = re.compile(r"/\.github/workflows/[^@]+\.ya?ml@")
 
 
+def contained(target: Path, root: Path) -> bool:
+    """Whether `target` stays inside `root` once symlinks are followed."""
+    try:
+        return target.resolve().is_relative_to(root)
+    except OSError:
+        return False
+
+
 def uses_refs(node: object) -> list[str]:
     """Every `uses:` value anywhere in a parsed workflow or action."""
     found: list[str] = []
@@ -57,7 +65,7 @@ def uses_refs(node: object) -> list[str]:
 
 
 def main(argv: list[str]) -> int:
-    root = Path(os.environ.get("PIN_CHECK_ROOT") or Path(__file__).resolve().parent.parent)
+    root = Path(os.environ.get("PIN_CHECK_ROOT") or Path(__file__).resolve().parent.parent).resolve()
     entries = argv[1:] or list(DEFAULT_ENTRIES)
 
     queue = list(entries)
@@ -86,6 +94,15 @@ def main(argv: list[str]) -> int:
         for ref in uses_refs(document):
             if ref.startswith("./"):
                 target = root / ref[2:]
+                if not contained(target, root):
+                    # A tree that reads its own actions out of a directory it
+                    # does not contain is not being audited: the audit walks the
+                    # workspace above it, which holds the trusted checkout.
+                    unpinned.append(
+                        f"{rel}: {ref} (local reference resolves outside the "
+                        "checked tree)"
+                    )
+                    continue
                 if target.is_dir():
                     manifest = next(
                         (m for m in ("action.yml", "action.yaml") if (target / m).is_file()),

--- a/scripts/check_action_pins.py
+++ b/scripts/check_action_pins.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""Every external action reachable from a privileged workflow must be pinned.
+
+Pinning only the workflow file being edited is not enough: a reusable workflow
+or composite action it calls runs with the caller's secrets, so a mutable ref
+one call away is the same exposure with less visibility. This walks those call
+chains.
+
+The walk parses YAML rather than matching `uses:` textually. A pattern misses
+every form the parser accepts but the pattern does not -- `"uses":`, `'uses':`,
+a flow mapping `{uses: ...}` -- and each of those is a way to put a mutable
+action into a privileged workflow while the gate reports success.
+
+PIN_CHECK_ROOT points the walk at a tree other than this checkout, so a trusted
+copy of this script can audit an untrusted one's workflow files without running
+anything from it.
+
+Usage: check_action_pins.py [entry-workflow ...]
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import sys
+from pathlib import Path
+
+try:
+    import yaml
+except ModuleNotFoundError:  # pragma: no cover - exercised by the runner, not tests
+    # Falling back to a pattern would silently weaken the gate, which is worse
+    # than not running: the result would look identical to a clean pass.
+    sys.exit("check_action_pins: PyYAML is required and was not found; refusing "
+             "to check with a weaker method")
+
+DEFAULT_ENTRIES = (".github/workflows/release.yml", ".github/workflows/deploy.yml")
+SHA = re.compile(r"@[0-9a-f]{40}$")
+# A container action is pinned by image digest, not by a commit SHA. A tag such
+# as docker://alpine:3.20 moves, so it is exactly what this gate exists to stop.
+DOCKER_DIGEST = re.compile(r"^docker://[^@\s]+@sha256:[0-9a-f]{64}$")
+REMOTE_REUSABLE = re.compile(r"/\.github/workflows/[^@]+\.ya?ml@")
+
+
+def uses_refs(node: object) -> list[str]:
+    """Every `uses:` value anywhere in a parsed workflow or action."""
+    found: list[str] = []
+    if isinstance(node, dict):
+        for key, value in node.items():
+            if key == "uses" and isinstance(value, str):
+                found.append(value)
+            else:
+                found.extend(uses_refs(value))
+    elif isinstance(node, list):
+        for item in node:
+            found.extend(uses_refs(item))
+    return found
+
+
+def main(argv: list[str]) -> int:
+    root = Path(os.environ.get("PIN_CHECK_ROOT") or Path(__file__).resolve().parent.parent)
+    entries = argv[1:] or list(DEFAULT_ENTRIES)
+
+    queue = list(entries)
+    seen: set[str] = set()
+    unpinned: list[str] = []
+    pinned = 0
+    walked = 0
+
+    while queue:
+        rel = queue.pop(0)
+        if rel in seen:
+            continue
+        seen.add(rel)
+
+        path = root / rel
+        if not path.is_file():
+            print(f"ERROR: {rel} is referenced but does not exist", file=sys.stderr)
+            return 1
+        try:
+            document = yaml.safe_load(path.read_text(encoding="utf-8"))
+        except yaml.YAMLError as exc:
+            print(f"ERROR: {rel} is not parseable YAML: {exc}", file=sys.stderr)
+            return 1
+        walked += 1
+
+        for ref in uses_refs(document):
+            if ref.startswith("./"):
+                target = root / ref[2:]
+                if target.is_dir():
+                    manifest = next(
+                        (m for m in ("action.yml", "action.yaml") if (target / m).is_file()),
+                        None,
+                    )
+                    if manifest is None:
+                        # Skipping leaves the gate green while the runner fails
+                        # to resolve this action.
+                        unpinned.append(f"{rel}: {ref} (no action.yml or action.yaml)")
+                    else:
+                        queue.append(f"{ref[2:]}/{manifest}")
+                else:
+                    queue.append(ref[2:])
+            elif ref.startswith("docker://"):
+                if DOCKER_DIGEST.match(ref):
+                    pinned += 1
+                else:
+                    unpinned.append(
+                        f"{rel}: {ref} (container action: pin it by digest, "
+                        "docker://image@sha256:<64 hex>)"
+                    )
+            elif REMOTE_REUSABLE.search(ref):
+                unpinned.append(
+                    f"{rel}: {ref} (remote reusable workflow: its own actions are "
+                    "unverifiable here)"
+                )
+            elif SHA.search(ref):
+                pinned += 1
+            else:
+                unpinned.append(f"{rel}: {ref}")
+
+    if unpinned:
+        print(f"Unverified actions reachable from: {' '.join(entries)}", file=sys.stderr)
+        for item in unpinned:
+            print(f"  {item}", file=sys.stderr)
+        print("Pin each external action to a 40-hex commit SHA with a trailing "
+              "'# vX.Y.Z' comment.", file=sys.stderr)
+        return 1
+
+    print(f"action pins OK: {walked} file(s) walked from {' '.join(entries)}, "
+          f"{pinned} external ref(s), all SHA-pinned")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/scripts/check_action_pins_tests.py
+++ b/scripts/check_action_pins_tests.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""Tests for check-action-pins.sh.
+
+The script is a supply-chain gate, so what matters is not that it runs but that
+it refuses what it should. Each case builds a throwaway repository, copies the
+real script into it, and runs it there.
+"""
+
+from __future__ import annotations
+
+import shutil
+import sys
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parent / "check_action_pins.py"
+SHA = "0" * 40
+ENTRY = ".github/workflows/entry.yml"
+
+
+class PinGate:
+    """A throwaway repo. The script cds to its own parent's parent, so copying
+    it into <root>/scripts makes <root> the repository it inspects."""
+
+    def __init__(self, root: Path) -> None:
+        self.root = root
+        (root / "scripts").mkdir(parents=True)
+        shutil.copy2(SCRIPT, root / "scripts" / SCRIPT.name)
+
+    def write(self, rel: str, *uses: str) -> None:
+        p = self.root / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        body = "\n".join(f"      - uses: {u}" for u in uses)
+        p.write_text(f"jobs:\n  j:\n    steps:\n{body}\n", encoding="utf-8")
+
+    def mkdir(self, rel: str) -> None:
+        (self.root / rel).mkdir(parents=True, exist_ok=True)
+
+    def run(self) -> subprocess.CompletedProcess:
+        return subprocess.run(
+            [sys.executable, str(self.root / "scripts" / SCRIPT.name), ENTRY],
+            capture_output=True, text=True, cwd=self.root,
+        )
+
+
+class CheckActionPinsTests(unittest.TestCase):
+    def gate(self) -> PinGate:
+        d = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, d, ignore_errors=True)
+        return PinGate(Path(d))
+
+    def test_all_pinned_passes(self) -> None:
+        # The accepting case. Without it a gate that refuses everything would
+        # look identical to a gate that works.
+        g = self.gate()
+        g.write(ENTRY, f"actions/checkout@{SHA} # v4.4.0")
+        r = g.run()
+        self.assertEqual(r.returncode, 0, r.stderr)
+
+    def test_unpinned_external_action_fails(self) -> None:
+        g = self.gate()
+        g.write(ENTRY, "actions/checkout@v4")
+        self.assertEqual(g.run().returncode, 1)
+
+    def test_a_ref_shorter_than_a_full_sha_fails(self) -> None:
+        g = self.gate()
+        g.write(ENTRY, f"actions/checkout@{'0' * 39}")
+        self.assertEqual(g.run().returncode, 1)
+
+    def test_unpinned_ref_inside_a_called_workflow_fails(self) -> None:
+        # The property the gate exists for: reachability, not file membership.
+        g = self.gate()
+        g.write(ENTRY, "./.github/workflows/child.yml")
+        g.write(".github/workflows/child.yml", "actions/setup-node@v4")
+        r = g.run()
+        self.assertEqual(r.returncode, 1)
+        self.assertIn("child.yml", r.stderr)
+
+    def test_unpinned_ref_inside_a_composite_action_fails(self) -> None:
+        g = self.gate()
+        g.write(ENTRY, "./.github/actions/thing")
+        g.write(".github/actions/thing/action.yml", "actions/cache@v4")
+        self.assertEqual(g.run().returncode, 1)
+
+    def test_composite_action_without_a_manifest_fails(self) -> None:
+        # Skipping it silently would leave the gate green while the runner fails
+        # to resolve the action.
+        g = self.gate()
+        g.write(ENTRY, "./.github/actions/empty")
+        g.mkdir(".github/actions/empty")
+        r = g.run()
+        self.assertEqual(r.returncode, 1)
+        self.assertIn("no action.yml", r.stderr)
+
+    def test_remote_reusable_workflow_is_refused_even_when_pinned(self) -> None:
+        # Its own `uses:` refs live in another repository, so a pinned parent
+        # says nothing about the mutable children it may call.
+        g = self.gate()
+        g.write(ENTRY, f"other/repo/.github/workflows/build.yml@{SHA}")
+        r = g.run()
+        self.assertEqual(r.returncode, 1)
+        self.assertIn("remote reusable workflow", r.stderr)
+
+    def test_missing_referenced_file_fails(self) -> None:
+        g = self.gate()
+        g.write(ENTRY, "./.github/workflows/gone.yml")
+        r = g.run()
+        self.assertEqual(r.returncode, 1)
+        self.assertIn("does not exist", r.stderr)
+
+    def test_a_trusted_copy_audits_another_tree_through_PIN_CHECK_ROOT(self) -> None:
+        # How the base-branch audit reads a pull request's workflows: the script
+        # is the reviewed one, the tree it walks is the untrusted one.
+        audited = self.gate()
+        audited.write(".github/workflows/release.yml", "actions/checkout@v4")
+        audited.write(".github/workflows/deploy.yml", f"actions/cache@{SHA} # v4.3.0")
+        r = subprocess.run(
+            [sys.executable, str(SCRIPT)],
+            env={"PATH": "/usr/bin:/bin", "PIN_CHECK_ROOT": str(audited.root)},
+            capture_output=True, text=True,
+        )
+        self.assertEqual(r.returncode, 1)
+        self.assertIn("actions/checkout@v4", r.stderr)
+
+    def test_a_checker_stubbed_in_the_audited_tree_is_never_consulted(self) -> None:
+        # The bypass this exists to close: a pull request that defeats the gate
+        # and edits a privileged workflow in one commit. The audited tree's own
+        # copy of the script is inert because it is never executed.
+        audited = self.gate()
+        audited.write(".github/workflows/release.yml", "actions/checkout@v4")
+        audited.write(".github/workflows/deploy.yml", f"actions/cache@{SHA} # v4.3.0")
+        stub = audited.root / "scripts" / SCRIPT.name
+        stub.write_text("import sys\nsys.exit(0)\n", encoding="utf-8")
+        self.assertEqual(subprocess.run([sys.executable, str(stub)]).returncode, 0,
+                         "the stub must pass, or this test proves nothing")
+        r = subprocess.run(
+            [sys.executable, str(SCRIPT)],
+            env={"PATH": "/usr/bin:/bin", "PIN_CHECK_ROOT": str(audited.root)},
+            capture_output=True, text=True,
+        )
+        self.assertEqual(r.returncode, 1)
+
+    def test_quoted_and_flow_style_keys_do_not_evade_the_walk(self) -> None:
+        # YAML accepts these as `uses`, so a gate that matched the text of
+        # `uses:` reported success while three mutable refs went through.
+        g = self.gate()
+        (g.root / ENTRY).parent.mkdir(parents=True, exist_ok=True)
+        (g.root / ENTRY).write_text(
+            'jobs:\n  j:\n    steps:\n'
+            '      - "uses": actions/checkout@v4\n'
+            '      - {uses: actions/cache@v4}\n'
+            "      - 'uses': actions/setup-node@v4\n",
+            encoding="utf-8")
+        r = g.run()
+        self.assertEqual(r.returncode, 1)
+        for action in ("actions/checkout@v4", "actions/cache@v4", "actions/setup-node@v4"):
+            self.assertIn(action, r.stderr)
+
+    def test_a_container_action_on_a_mutable_tag_fails(self) -> None:
+        # A tag moves, so it is the thing this gate exists to stop. There is no
+        # separate policy covering container actions; this is where they are
+        # checked.
+        g = self.gate()
+        g.write(ENTRY, "docker://alpine:3.20")
+        r = g.run()
+        self.assertEqual(r.returncode, 1)
+        self.assertIn("pin it by digest", r.stderr)
+
+    def test_a_container_action_pinned_by_digest_passes(self) -> None:
+        g = self.gate()
+        g.write(ENTRY, f"docker://alpine@sha256:{'a' * 64}")
+        self.assertEqual(g.run().returncode, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/check_action_pins_tests.py
+++ b/scripts/check_action_pins_tests.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Tests for check-action-pins.sh.
+"""Tests for check_action_pins.py.
 
 The script is a supply-chain gate, so what matters is not that it runs but that
 it refuses what it should. Each case builds a throwaway repository, copies the
@@ -172,6 +172,39 @@ class CheckActionPinsTests(unittest.TestCase):
         g = self.gate()
         g.write(ENTRY, f"docker://alpine@sha256:{'a' * 64}")
         self.assertEqual(g.run().returncode, 0)
+
+    def test_a_local_ref_climbing_out_of_the_tree_is_refused(self) -> None:
+        # The outside action is fully pinned, so a checker that follows the ref
+        # reports a clean tree. That is the bypass: the audited tree borrows the
+        # workspace above it, which holds the trusted checkout.
+        g = self.gate()
+        outside = g.root.parent / "outside" / "act"
+        outside.mkdir(parents=True)
+        self.addCleanup(shutil.rmtree, outside.parent, ignore_errors=True)
+        (outside / "action.yml").write_text(
+            f"runs:\n  steps:\n    - uses: actions/cache@{SHA} # v4\n", encoding="utf-8"
+        )
+        g.write(ENTRY, f"./../{outside.parent.name}/act")
+        r = g.run()
+        self.assertEqual(r.returncode, 1, r.stdout)
+        self.assertIn("resolves outside the checked tree", r.stderr)
+
+    def test_a_local_ref_through_a_symlink_out_of_the_tree_is_refused(self) -> None:
+        # Same class, different mechanism: the ref names a contained path and
+        # the filesystem does the climbing.
+        g = self.gate()
+        outside = g.root.parent / "linked" / "act"
+        outside.mkdir(parents=True)
+        self.addCleanup(shutil.rmtree, outside.parent, ignore_errors=True)
+        (outside / "action.yml").write_text(
+            f"runs:\n  steps:\n    - uses: actions/cache@{SHA} # v4\n", encoding="utf-8"
+        )
+        g.mkdir(".github/actions")
+        (g.root / ".github/actions/act").symlink_to(outside, target_is_directory=True)
+        g.write(ENTRY, "./.github/actions/act")
+        r = g.run()
+        self.assertEqual(r.returncode, 1, r.stdout)
+        self.assertIn("resolves outside the checked tree", r.stderr)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Split out of #8329 so the enforcement authority lands before the change it gates. #8329 keeps
the pins themselves.

A pull request that edits a privileged workflow can edit the checker that guards it in the same
commit, so a checker run from the pull request's own checkout cannot enforce a change to itself.
This PR is the authority: a `workflow_run` workflow, which GitHub runs from the **default
branch's** copy regardless of what the evaluated commit contains.

`audit` (`contents: read`) shape-validates the head SHA and repo name, fetches the evaluated
tree as a tarball, extracts only `*/.github/*`, refuses the tree outright if it contains symlinks
under `.github`, and runs the trusted checker against it via `PIN_CHECK_ROOT`. `report`
(`statuses: write`, `needs: audit`) posts the `Action Pin Audit` commit status and never reads
that tree. Workflow-level `permissions: {}`.

The checker parses each workflow with a YAML parser rather than matching the text of `uses:`, and
follows reusable-workflow and composite-action calls out of the release and deploy workflows — an
action one call away from the edited file runs with the same secrets and less visibility.
Container actions must be pinned by image digest.

### Stated decision: this check reports FAILING on `main` once it merges

`main`'s privileged workflows are not pinned yet — that is #8329. Measured against merged `main`
(`603a4e85d`), the checker reports **88 unverified refs across 4 files** and exits 1. So once
this merges, the audit will post a failing `Action Pin Audit` status on `main` and on every pull
request whose tree inherits those unpinned workflows, until #8329 lands.

**That is expected, and the status must stay advisory until then.** Configuring `Action Pin
Audit` as a required status check before #8329 merges would block every pull request. The order
is: this PR merges → the audit begins producing the status → #8329 merges and the status goes
green → *then* the check is made required. #8329 is the first pull request the required check
would gate.

Grounds, both external to this PR: GitHub documents that a `workflow_run` workflow runs only
when its workflow file is present on the default branch
(<https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#workflow_run>),
which is why the authority cannot exist before it is merged; and the maintainer's 2026-09-03
20:51Z review on #8329 sets exactly this sequence — "First stage the trusted workflow through an
explicitly reviewed maintainer bootstrap transition, configure `Action Pin Audit` as required
only once the default-branch workflow can produce it."

`scripts/check_action_pins.py` is byte-identical in this PR and in #8329, because each must be
green on its own tree — #8329's CI step runs it over the real tree, this PR's audit workflow runs
it over a fetched one. Whichever merges first, the other's copy becomes a no-op at rebase.

## Files changed

- `.github/workflows/action-pin-audit.yml` — new: the trusted audit, split into a read-only job and a status-writing job
- `scripts/check_action_pins.py` — new: the checker, YAML-parsing, call-chain reachable
- `scripts/check_action_pins_tests.py` — new: 15 stdlib `unittest` cases over throwaway repositories
- `.github/workflows/ci.yml` — runs the checker's unit tests only; the real-tree gate is the audit workflow
- `.agents/pr-review-policy.toml` — the checker and its tests join `[hard_stops]`

## Track

Developer

## LLM

Model: claude-opus-5
Tier: Frontier
Thinking: high

## Implementation method (required)

Method: not-applicable — CI workflow and tooling change, no `crates/engine/` game logic.

## CR references

None.

## Verification

- [x] Required checks ran clean, or the exact CI-owned alternative is stated below.
- [x] Gate A output below is for the current committed head.
- [x] Final review-impl below is clean for the current committed head.
- [x] Both anchors cite existing analogous code at the same seam.

**Green on its own tree, and why the real-tree check is not wired here.** Run against merged
`main`'s `.github` tree via `PIN_CHECK_ROOT`, the checker exits **1** with 88 unverified refs
across `release.yml`, `deploy.yml`, `preview-server.yml` and `binaryen/action.yml`. Against
#8329's tree it exits **0** (`5 file(s) walked, 93 external ref(s), all SHA-pinned`). That pair
is the measurement that decided the split: a CI step walking the real tree cannot be green in
this PR, so this PR wires only the unit tests, which build throwaway repositories and never read
this repository's workflows. `python3 scripts/check_action_pins_tests.py` → `Ran 15 tests ... OK`
on this tree.

**The tests are non-vacuous.** Each of the 15 cases constructs a repository and asserts the exit
code; the suite covers chained reachability through a reusable workflow and a composite action, a
39-hex SHA rejected as not-a-SHA, a `uses:` naming a missing file, a composite directory with no
`action.yml`, a remote reusable workflow refused, `PIN_CHECK_ROOT` auditing a second tree, a
stubbed checker inside that audited tree never being consulted, `"uses":`/`'uses':`/flow-mapping
key forms that a text matcher misses, a container action pinned by tag rejected, one pinned
by digest accepted, and a local `./` reference refused when it resolves outside the checked
tree — once by a `..` climb whose target is fully pinned, once through a symlink. Earlier rounds on #8329 recorded mutation runs for the specific guards — for
example rewriting the container-digest branch to an unconditional pass fails the suite.

- `actionlint .github/workflows/action-pin-audit.yml` — **0 findings**.
- `actionlint .github/workflows/ci.yml` — finding set **unchanged**; the two outputs were diffed
  rather than counted. The same single pre-existing `if-cond` finding, line `734` → `741` from
  the seven inserted lines.
- Parsed shape rather than grepped: workflow-level `permissions: {}`; job `audit` →
  `{contents: read}`; job `report` → `{statuses: write}`, `needs: audit`.
- No build ran: the delta is two workflow files, two scripts and a policy file, with no Rust or
  TypeScript in it. The CI-owned alternative is the audit workflow's own first run after merge,
  which is expected to report failing for the reason stated above.

## Gate A

Gate A PASS head=a789b33a035cd6bdf1a77ad1694d50d056f2343b base=d6d28370c09242182488cac72e16e5a84941885f

Disclosed: the base is fork-relative and this delta contains no Rust, so the gate's range is
empty here — the PASS records that the gate ran at this head, not a property of the change.

## Anchored on

- `.github/workflows/ci.yml` — the existing `check-engine-authorities.sh` step: a repository-owned script invoked from CI as a policy gate, the same seam the new unit-test step occupies.
- `.github/workflows/deploy.yml` — the existing `workflow_run` consumer pattern in this repository, and the reason the audit must live on the default branch to run at all.

## Final review-impl

Final review-impl PASS head=a789b33a035cd6bdf1a77ad1694d50d056f2343b

## Claimed parse impact

None.

## Scope Expansion

None.

## Validation Failures

None.

## CI Failures

None.
