### PR TITLE
fix(client): dock the game log as a rail, not an overlay

### DIFF
--- a/client/src/components/chrome/GameMenu.tsx
+++ b/client/src/components/chrome/GameMenu.tsx
@@ -144,7 +144,10 @@ export function GameMenu({
          container's left edge and is unaffected by the row's flow. */
       className="fixed z-40 flex items-center gap-2"
       style={{
-        left: "calc(env(safe-area-inset-left) + 0.5rem)",
+        // Fixed, so the board grid's rail padding does not apply — the
+        // left-dock log offset has to be added here, mirroring how the action
+        // rail consumes `--game-right-rail-offset`.
+        left: "calc(env(safe-area-inset-left) + 0.5rem + var(--game-left-rail-offset, 0px))",
         top: "calc(env(safe-area-inset-top) + var(--game-top-overlay-offset, 0px) + 0.75rem)",
       }}
     >

--- a/client/src/pages/GamePage.tsx
+++ b/client/src/pages/GamePage.tsx
@@ -1534,6 +1534,13 @@ function GamePageContent({
         className={`relative ${boardChoiceLayerActive && !isReconnecting ? GAME_Z_LAYER.boardChoiceGrid : GAME_Z_LAYER.board} grid min-w-0 h-full${isReconnecting ? " pointer-events-none" : ""}`}
         style={{
           paddingTop: "var(--game-top-overlay-offset, 0px)",
+          // The game log docks as a rail, not an overlay: it publishes its width
+          // as `--game-{left,right}-rail-offset` and the board's content box
+          // shrinks by that much, so nothing is ever hidden underneath it.
+          // Padding (not width/margin) keeps row 3's `100dvh`-derived height
+          // math untouched — only the horizontal content box moves.
+          paddingLeft: "var(--game-left-rail-offset, 0px)",
+          paddingRight: "var(--game-right-rail-offset, 0px)",
           gridTemplateRows,
           gridTemplateColumns: "1fr",
         }}
@@ -1628,10 +1635,11 @@ function GamePageContent({
             flexZone="playerPiles"
             scaleKey="playerPiles"
             className="pointer-events-none absolute left-0 top-0 bottom-0 z-10 flex w-fit flex-col items-start justify-end gap-0.5 p-1 lg:gap-1 lg:p-3 [&>*]:pointer-events-auto [&>div>*]:pointer-events-auto"
-            // Anchor box-scale to the bottom-left dock corner.
+            // Anchor box-scale to the bottom-left dock corner. No left-rail
+            // offset here: this pile is absolutely positioned inside the board
+            // grid, whose padding already accounts for a left-docked log panel.
             style={{
               ...playerZoneRailStyle,
-              left: "var(--game-left-rail-offset, 0px)",
               transformOrigin: "bottom left",
             }}
           >


### PR DESCRIPTION
The log panel already published its width as `--game-left-rail-offset` /
`--game-right-rail-offset`, but only a few `position: fixed` widgets (the
action rail, the stack, the card preview) consumed them. The in-flow board
grid ignored the vars entirely, so opening the log slid the panel over the
battlefield, hand, and piles instead of making room for them.

Consume the offsets as horizontal padding on the board grid so the whole
board compresses. Padding rather than width/margin keeps row 3's
`100dvh`-derived height math untouched — only the horizontal content box
moves.

Two consequences follow from the grid now owning the offset:

- `playerPiles` drops its own `left: var(--game-left-rail-offset)`. It is
  absolutely positioned inside the grid, so the padding already places it;
  keeping the var would double-count on a left-docked log.
- `GameMenu` gains the left offset. It is `fixed` and therefore outside the
  padded grid, mirroring how the action rail consumes the right offset.

Claude-Session: https://claude.ai/code/session_01Qp19AMpKwsQ1tUJhn84giC

https://claude.ai/code/session_01Qp19AMpKwsQ1tUJhn84giC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved game board layout when log panels are docked on the left or right.
  * Adjusted the fixed game menu to remain correctly positioned alongside the left log panel.
  * Prevented duplicate spacing in the player pile area when the left log panel is visible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->