### PR TITLE
fix(engine): serialize structured map keys

### DIFF
--- a/crates/engine/src/game/game_object.rs
+++ b/crates/engine/src/game/game_object.rs
@@ -492,7 +492,11 @@ pub struct GameObject {
     /// CR 702.16p: Per [`StaticGateKey::def_index`] on this source and enchanted
     /// host, the controlled attachments matching that effect's resolved protection
     /// quality when it first started applying to that host.
-    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    #[serde(
+        default,
+        skip_serializing_if = "HashMap::is_empty",
+        with = "crate::types::deterministic_serde::hash_map_entries"
+    )]
     pub protection_start_exempt_attachments:
         HashMap<ProtectionEffectHostKey, ProtectionStartSnapshot>,
     /// CR 702.95b-d: Soulbond pair relationship. Pairing is symmetric:

--- a/crates/engine/src/types/deterministic_serde.rs
+++ b/crates/engine/src/types/deterministic_serde.rs
@@ -146,6 +146,89 @@ fn cautious_map_capacity<K, V>(hint: Option<usize>) -> usize {
     hint.unwrap_or(0).min(max_entries)
 }
 
+/// Serde adapter for hash maps whose typed keys cannot be represented as JSON
+/// object keys. The wire form is a key-sorted sequence of `[key, value]` pairs.
+pub(crate) mod hash_map_entries {
+    use std::collections::{hash_map::Entry, HashMap};
+    use std::fmt;
+    use std::hash::{BuildHasher, Hash};
+    use std::marker::PhantomData;
+
+    use serde::de::{Error as _, SeqAccess, Visitor};
+    use serde::ser::SerializeSeq;
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+    pub(crate) fn serialize<K, V, H, S>(
+        values: &HashMap<K, V, H>,
+        serializer: S,
+    ) -> Result<S::Ok, S::Error>
+    where
+        K: Ord + Serialize,
+        V: Serialize,
+        S: Serializer,
+    {
+        let mut entries: Vec<_> = values.iter().collect();
+        entries.sort_unstable_by_key(|(key, _)| *key);
+
+        let mut sequence = serializer.serialize_seq(Some(entries.len()))?;
+        for (key, value) in entries {
+            sequence.serialize_element(&(key, value))?;
+        }
+        sequence.end()
+    }
+
+    struct HashMapEntriesVisitor<K, V, H>(PhantomData<(K, V, H)>);
+
+    impl<'de, K, V, H> Visitor<'de> for HashMapEntriesVisitor<K, V, H>
+    where
+        K: Deserialize<'de> + Eq + Hash,
+        V: Deserialize<'de>,
+        H: BuildHasher + Default,
+    {
+        type Value = HashMap<K, V, H>;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+            formatter.write_str("a sequence of unique typed key-value pairs")
+        }
+
+        fn visit_seq<A>(self, mut access: A) -> Result<Self::Value, A::Error>
+        where
+            A: SeqAccess<'de>,
+        {
+            // A wire-provided size hint is only an optimization. Cap it like
+            // Serde's cautious collection allocation; the map grows normally
+            // past this cap.
+            let capacity = super::cautious_map_capacity::<K, V>(access.size_hint());
+            let mut values = HashMap::with_capacity_and_hasher(capacity, H::default());
+            while let Some((key, value)) = access.next_element()? {
+                match values.entry(key) {
+                    Entry::Vacant(entry) => {
+                        entry.insert(value);
+                    }
+                    Entry::Occupied(_) => {
+                        return Err(A::Error::custom(
+                            "duplicate key in typed hash-map entry sequence",
+                        ));
+                    }
+                }
+            }
+            Ok(values)
+        }
+    }
+
+    pub(crate) fn deserialize<'de, K, V, H, D>(
+        deserializer: D,
+    ) -> Result<HashMap<K, V, H>, D::Error>
+    where
+        K: Deserialize<'de> + Eq + Hash,
+        V: Deserialize<'de>,
+        H: BuildHasher + Default,
+        D: Deserializer<'de>,
+    {
+        deserializer.deserialize_seq(HashMapEntriesVisitor(PhantomData))
+    }
+}
+
 impl<'de, K, V> Visitor<'de> for NumericHashMapVisitor<K, V>
 where
     K: Eq + Hash + NumericMapKey,
@@ -463,8 +546,8 @@ pub(crate) mod test_support {
 mod tests {
     use std::collections::{HashMap, HashSet};
 
-    use serde::de::value::{Error as ValueError, MapAccessDeserializer};
-    use serde::de::{DeserializeSeed, IntoDeserializer, MapAccess};
+    use serde::de::value::{Error as ValueError, MapAccessDeserializer, SeqAccessDeserializer};
+    use serde::de::{DeserializeSeed, IntoDeserializer, MapAccess, SeqAccess};
     use serde::{Deserialize, Serialize};
 
     use super::test_support::ReverseBuildHasher;
@@ -473,6 +556,7 @@ mod tests {
 
     type Set = HashSet<u64, ReverseBuildHasher>;
     type Map<V> = HashMap<u64, V, ReverseBuildHasher>;
+    type StructuredEntryMap = HashMap<(u64, u64), String, ReverseBuildHasher>;
 
     #[derive(Serialize)]
     struct StandardFixture<'a> {
@@ -578,6 +662,118 @@ mod tests {
             })
             .expect("fixture should serialize"),
             r#"{"empty_set":[],"singleton_set":[7],"empty_map":{},"singleton_map":{"7":"seven"},"no_set":null,"no_map":null}"#
+        );
+    }
+
+    #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
+    struct HashMapEntriesFixture {
+        #[serde(with = "super::hash_map_entries")]
+        values: StructuredEntryMap,
+    }
+
+    #[test]
+    fn hash_map_entries_sorts_typed_keys_and_round_trips_the_exact_pair_shape() {
+        let ascending_insertion = HashMapEntriesFixture {
+            values: StructuredEntryMap::from_iter([
+                ((1, 1), "one".to_string()),
+                ((2, 2), "two".to_string()),
+                ((3, 3), "three".to_string()),
+            ]),
+        };
+        assert_eq!(
+            ascending_insertion
+                .values
+                .keys()
+                .copied()
+                .collect::<Vec<_>>(),
+            vec![(3, 3), (2, 2), (1, 1)],
+            "hostile hashing must expose descending native iteration"
+        );
+
+        let reverse_insertion = HashMapEntriesFixture {
+            values: StructuredEntryMap::from_iter([
+                ((3, 3), "three".to_string()),
+                ((2, 2), "two".to_string()),
+                ((1, 1), "one".to_string()),
+            ]),
+        };
+        let expected = r#"{"values":[[[1,1],"one"],[[2,2],"two"],[[3,3],"three"]]}"#;
+        let ascending_bytes = serde_json::to_string(&ascending_insertion).unwrap();
+        let reverse_bytes = serde_json::to_string(&reverse_insertion).unwrap();
+        assert_eq!(ascending_bytes, expected);
+        assert_eq!(
+            reverse_bytes, expected,
+            "insertion order must not affect bytes"
+        );
+
+        let restored: HashMapEntriesFixture = serde_json::from_str(expected).unwrap();
+        assert_eq!(restored, ascending_insertion);
+        assert_eq!(serde_json::to_string(&restored).unwrap(), expected);
+    }
+
+    #[test]
+    fn hash_map_entries_rejects_duplicates_and_malformed_wire_shapes() {
+        let duplicate = serde_json::from_str::<HashMapEntriesFixture>(
+            r#"{"values":[[[1,1],"first"],[[1,1],"second"]]}"#,
+        )
+        .unwrap_err();
+        assert!(
+            duplicate
+                .to_string()
+                .contains("duplicate key in typed hash-map entry sequence"),
+            "duplicate typed keys with different values must be rejected: {duplicate}"
+        );
+
+        for (description, malformed) in [
+            ("object-shaped map", r#"{"values":{"[1,1]":"one"}}"#),
+            ("one-element entry tuple", r#"{"values":[[[1,1]]]}"#),
+            (
+                "wrong typed-key component",
+                r#"{"values":[[[1,"one"],"value"]]}"#,
+            ),
+        ] {
+            assert!(
+                serde_json::from_str::<HashMapEntriesFixture>(malformed).is_err(),
+                "{description} must be rejected"
+            );
+        }
+    }
+
+    struct EnormousHintSeqAccess {
+        entry: Option<serde_json::Value>,
+    }
+
+    impl<'de> SeqAccess<'de> for EnormousHintSeqAccess {
+        type Error = serde_json::Error;
+
+        fn next_element_seed<T>(&mut self, seed: T) -> Result<Option<T::Value>, Self::Error>
+        where
+            T: DeserializeSeed<'de>,
+        {
+            self.entry
+                .take()
+                .map(|entry| seed.deserialize(entry.into_deserializer()))
+                .transpose()
+        }
+
+        fn size_hint(&self) -> Option<usize> {
+            Some(usize::MAX)
+        }
+    }
+
+    #[test]
+    fn hash_map_entries_caps_untrusted_sequence_size_hints() {
+        let access = EnormousHintSeqAccess {
+            entry: Some(serde_json::json!([[7, 8], "seven-eight"])),
+        };
+
+        let values: StructuredEntryMap =
+            super::hash_map_entries::deserialize(SeqAccessDeserializer::new(access)).unwrap();
+
+        assert_eq!(values.get(&(7, 8)).map(String::as_str), Some("seven-eight"));
+        assert_eq!(
+            super::cautious_map_capacity::<(u64, u64), String>(Some(usize::MAX)),
+            1024 * 1024 / std::mem::size_of::<((u64, u64), String)>()
         );
     }
 

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -263,35 +263,6 @@ mod legacy_trigger_definition_ref_map {
     }
 }
 
-/// Serde adapter for trigger occurrence ledgers. JSON object keys must be
-/// strings, while a `TriggerDefinitionRef` is structured identity; encode the
-/// map as an explicit entry list rather than flattening or guessing a key.
-mod trigger_definition_ref_map {
-    use super::*;
-
-    pub fn serialize<S, H>(
-        map: &HashMap<TriggerDefinitionRef, u32, H>,
-        serializer: S,
-    ) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        let mut entries: Vec<_> = map.iter().collect();
-        entries.sort_unstable_by_key(|(key, _)| *key);
-        entries.serialize(serializer)
-    }
-
-    pub fn deserialize<'de, D>(
-        deserializer: D,
-    ) -> Result<HashMap<TriggerDefinitionRef, u32>, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        Vec::<(TriggerDefinitionRef, u32)>::deserialize(deserializer)
-            .map(|entries| entries.into_iter().collect())
-    }
-}
-
 /// Deserializes the object store and validates the one legacy trigger shape
 /// that can be materialized without guessing: a complete ordered payload list
 /// proven by the persisted printed base slots. Runtime copied/granted payloads
@@ -17991,7 +17962,7 @@ declare_game_state! {
     #[serde(
         default,
         skip_serializing_if = "HashMap::is_empty",
-        with = "trigger_definition_ref_map"
+        with = "crate::types::deterministic_serde::hash_map_entries"
     )]
     pub trigger_fire_counts_this_turn: HashMap<TriggerDefinitionRef, u32>,
     /// CR 603.2: Tracks per-opponent-per-turn firing for
@@ -27197,6 +27168,12 @@ mod tests {
 
     #[derive(Serialize)]
     struct TriggerRefFixture<'a> {
+        #[serde(serialize_with = "crate::types::deterministic_serde::hash_map_entries::serialize")]
+        values: &'a HashMap<TriggerDefinitionRef, u32, ReverseBuildHasher>,
+    }
+
+    #[derive(Serialize)]
+    struct LegacyTriggerRefFixture<'a> {
         #[serde(serialize_with = "legacy_trigger_definition_ref_map::serialize")]
         values: &'a HashMap<TriggerDefinitionRef, u32, ReverseBuildHasher>,
     }
@@ -27396,12 +27373,21 @@ mod tests {
             vec![2, 1, 0],
             "hostile trigger map must expose descending native iteration"
         );
+        let trigger_bytes = serde_json::to_string(&TriggerRefFixture {
+            values: &trigger_values,
+        })
+        .expect("trigger-ref fixture should serialize");
         assert_eq!(
-            serde_json::to_string(&TriggerRefFixture {
+            trigger_bytes,
+            r#"{"values":[[{"source":{"object_id":7,"incarnation":3},"occurrence":{"type":"Printed","data":{"base_set":1,"printed_index":0}}},10],[{"source":{"object_id":7,"incarnation":3},"occurrence":{"type":"Printed","data":{"base_set":1,"printed_index":1}}},11],[{"source":{"object_id":7,"incarnation":3},"occurrence":{"type":"Printed","data":{"base_set":1,"printed_index":2}}},12]]}"#
+        );
+        assert_eq!(
+            trigger_bytes,
+            serde_json::to_string(&LegacyTriggerRefFixture {
                 values: &trigger_values,
             })
-            .expect("trigger-ref fixture should serialize"),
-            r#"{"values":[[{"source":{"object_id":7,"incarnation":3},"occurrence":{"type":"Printed","data":{"base_set":1,"printed_index":0}}},10],[{"source":{"object_id":7,"incarnation":3},"occurrence":{"type":"Printed","data":{"base_set":1,"printed_index":1}}},11],[{"source":{"object_id":7,"incarnation":3},"occurrence":{"type":"Printed","data":{"base_set":1,"printed_index":2}}},12]]}"#
+            .expect("legacy trigger-ref oracle should serialize"),
+            "the shared adapter must preserve the established canonical bytes"
         );
         let trigger_round_trip = legacy_trigger_definition_ref_map::deserialize(
             &mut serde_json::Deserializer::from_str(

--- a/crates/engine/tests/integration/deterministic_game_state_serde.rs
+++ b/crates/engine/tests/integration/deterministic_game_state_serde.rs
@@ -31,6 +31,7 @@ const HASH_SET: &str = "serialize_with=\"crate::types::deterministic_serde::hash
 const OPTION_HASH_SET: &str =
     "serialize_with=\"crate::types::deterministic_serde::option_hash_set\"";
 const HASH_MAP: &str = "serialize_with=\"crate::types::deterministic_serde::hash_map\"";
+const HASH_MAP_ENTRIES: &str = "with=\"crate::types::deterministic_serde::hash_map_entries\"";
 const OPTION_HASH_MAP: &str =
     "serialize_with=\"crate::types::deterministic_serde::option_hash_map\"";
 const VEC_HASH_MAP: &str = "serialize_with=\"crate::types::deterministic_serde::vec_hash_map\"";
@@ -52,7 +53,6 @@ enum Classification {
     Canonical(&'static str),
     SerdeSkip,
     DeserializeOnlyOrRuntime,
-    NonStringJsonMapKey,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -363,11 +363,16 @@ fn expected_manifest() -> BTreeMap<String, OwnerSpec> {
         "im::HashMap<im::HashMap>",
         Classification::Canonical(IM_HASH_MAP_OF_IM_HASH_MAP),
     );
+    add_spec(
+        &mut specs,
+        game_state,
+        "GameState",
+        None,
+        "trigger_fire_counts_this_turn",
+        "HashMap",
+        Classification::Canonical(HASH_MAP_ENTRIES),
+    );
     for (field, adapter) in [
-        (
-            "trigger_fire_counts_this_turn",
-            "with=\"trigger_definition_ref_map\"",
-        ),
         ("activated_abilities_this_turn", "with=\"tuple_key_map\""),
         ("activated_abilities_this_game", "with=\"tuple_key_map\""),
         ("ability_resolutions_this_turn", "with=\"tuple_key_map\""),
@@ -601,7 +606,7 @@ fn expected_manifest() -> BTreeMap<String, OwnerSpec> {
             None,
             "protection_start_exempt_attachments",
             "HashMap",
-            Classification::NonStringJsonMapKey,
+            Classification::Canonical(HASH_MAP_ENTRIES),
         ),
         (
             "src/game/game_object.rs",
@@ -1145,11 +1150,6 @@ fn serde_hash_owner_census_is_exhaustive_and_every_canonical_owner_names_its_ada
                 actual.serde
             ),
             Classification::DeserializeOnlyOrRuntime => {}
-            Classification::NonStringJsonMapKey => assert!(
-                !actual.serde.contains("deterministic_serde"),
-                "{id}: the non-string JSON key owner must not invent a generic wire adapter; actual serde={}",
-                actual.serde
-            ),
         }
     }
 
@@ -2295,7 +2295,7 @@ fn populated_stack_resolution_session_round_trips_deterministically_through_raw_
 }
 
 #[test]
-fn populated_protection_tuple_map_keeps_its_existing_non_string_json_key_failure() {
+fn protection_tuple_map_round_trips_deterministically_through_all_persistence_forms() {
     let mut state = GameState::new(FormatConfig::standard(), 2, 42);
     let mut object = GameObject::new(
         ObjectId(1),
@@ -2304,17 +2304,122 @@ fn populated_protection_tuple_map_keeps_its_existing_non_string_json_key_failure
         "Protection Fixture".to_string(),
         Zone::Battlefield,
     );
-    object.protection_start_exempt_attachments.insert(
-        (0, 0, ObjectId(2)),
-        ProtectionStartSnapshot {
-            resolved_quality: ProtectionTarget::Color(ManaColor::White),
-            attachment_ids: vec![ObjectId(3)],
-        },
+    assert!(
+        serde_json::to_value(&object)
+            .expect("empty protection fixture serializes")
+            .get("protection_start_exempt_attachments")
+            .is_none(),
+        "the empty transient map remains omitted"
     );
-    assert_eq!(object.protection_start_exempt_attachments.len(), 1);
+
+    let lower_key = (0, 2, ObjectId(1));
+    let lower_snapshot = ProtectionStartSnapshot {
+        resolved_quality: ProtectionTarget::Color(ManaColor::White),
+        attachment_ids: vec![ObjectId(3), ObjectId(4)],
+    };
+    let upper_key = (1, 0, ObjectId(1));
+    let upper_snapshot = ProtectionStartSnapshot {
+        resolved_quality: ProtectionTarget::CardType("Artifact".to_string()),
+        attachment_ids: vec![ObjectId(5)],
+    };
+    object
+        .protection_start_exempt_attachments
+        .insert(upper_key, upper_snapshot.clone());
+    object
+        .protection_start_exempt_attachments
+        .insert(lower_key, lower_snapshot.clone());
+    assert_eq!(object.protection_start_exempt_attachments.len(), 2);
     state.objects.insert(ObjectId(1), object);
 
-    let error = serde_json::to_value(&state)
-        .expect_err("the existing tuple-key map has no nonempty JSON representation");
-    assert_eq!(error.to_string(), "key must be a string");
+    let mut opposite_insertion = state.clone();
+    let opposite_map = &mut opposite_insertion
+        .objects
+        .get_mut(&ObjectId(1))
+        .expect("fixture object exists")
+        .protection_start_exempt_attachments;
+    opposite_map.clear();
+    opposite_map.insert(lower_key, lower_snapshot);
+    opposite_map.insert(upper_key, upper_snapshot);
+
+    let bare_bytes = serde_json::to_string(&state).expect("populated bare state serializes");
+    assert_eq!(
+        serde_json::to_string(&opposite_insertion)
+            .expect("opposite-insertion bare state serializes"),
+        bare_bytes,
+        "hash insertion order must not affect canonical state bytes"
+    );
+    let bare_value: serde_json::Value =
+        serde_json::from_str(&bare_bytes).expect("bare state bytes are JSON");
+    assert_eq!(
+        bare_value["objects"]["1"]["protection_start_exempt_attachments"],
+        serde_json::json!([
+            [
+                [0, 2, 1],
+                {
+                    "resolved_quality": {"Color": "White"},
+                    "attachment_ids": [3, 4]
+                }
+            ],
+            [
+                [1, 0, 1],
+                {
+                    "resolved_quality": {"CardType": "Artifact"},
+                    "attachment_ids": [5]
+                }
+            ]
+        ]),
+        "the nonempty field is a typed-key-sorted sequence of exact key/value tuples"
+    );
+
+    let bare_restored: GameState =
+        serde_json::from_str(&bare_bytes).expect("bare state round trips");
+    assert_eq!(
+        bare_restored
+            .objects
+            .get(&ObjectId(1))
+            .expect("restored bare object exists")
+            .protection_start_exempt_attachments,
+        state
+            .objects
+            .get(&ObjectId(1))
+            .expect("source fixture object exists")
+            .protection_start_exempt_attachments
+    );
+    assert_eq!(
+        serde_json::to_string(&bare_restored).expect("restored bare state reserializes"),
+        bare_bytes,
+        "bare-state bytes remain stable after restore"
+    );
+
+    for (persistence_name, persisted) in [
+        ("raw", PersistedGameState::Raw(Box::new(state.clone()))),
+        ("trusted", PersistedGameState::capture(state.clone())),
+    ] {
+        let bytes = serde_json::to_string(&persisted)
+            .unwrap_or_else(|error| panic!("{persistence_name} state serializes: {error}"));
+        let restored: PersistedGameState = serde_json::from_str(&bytes)
+            .unwrap_or_else(|error| panic!("{persistence_name} state deserializes: {error}"));
+        assert_eq!(
+            serde_json::to_string(&restored)
+                .unwrap_or_else(|error| panic!("{persistence_name} state reserializes: {error}")),
+            bytes,
+            "{persistence_name} persistence bytes remain stable after restore"
+        );
+        let restored = restored
+            .into_game_state()
+            .unwrap_or_else(|error| panic!("{persistence_name} state finalizes: {error}"));
+        assert_eq!(
+            restored
+                .objects
+                .get(&ObjectId(1))
+                .expect("restored persisted object exists")
+                .protection_start_exempt_attachments,
+            state
+                .objects
+                .get(&ObjectId(1))
+                .expect("source fixture object exists")
+                .protection_start_exempt_attachments,
+            "{persistence_name} persistence restores every protection snapshot"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

`GameObject::protection_start_exempt_attachments` used `(usize, usize, ObjectId)` as a `HashMap` key. Once populated, `serde_json` could not encode that key as a JSON object key and returned `key must be a string`.

This adds a shared deterministic adapter that encodes structured-key maps as sorted typed `[key, value]` entries, rejects duplicate or malformed entries, and round-trips populated protection snapshots through bare, raw, and trusted persisted state. The serializer census identifies this protection field as the only known structured-key JSON-map failure, covering #8178 and the reproduced Benevolent Blessing reports #7940 and #7604.

Closes #8178
Closes #7940
Closes #7604

## Files changed

- `crates/engine/src/types/deterministic_serde.rs`
- `crates/engine/src/types/game_state.rs`
- `crates/engine/src/game/game_object.rs`
- `crates/engine/tests/integration/deterministic_game_state_serde.rs`

## Track

Developer

## LLM

Model: gpt-5.6-sol
Tier: Frontier
Thinking: ultra

## Implementation method (required)

Method: /engine-implementer

## CR references

None. This changes serialization plumbing only.

## Verification

- [x] Required checks ran clean, or the exact CI-owned alternative is stated below.
- [x] Gate A output below is for the current committed head.
- [x] Final review-impl below is clean for the current committed head.
- [x] Both anchors cite existing analogous code at the same seam.

- `cargo fmt --all -- --check` — passed at shipment head `565e0c8e6a896375eafa7279c0dad8642a2fbdfd`.
- `cargo test -p phase-engine --lib types::deterministic_serde::tests` — 9 passed at shipment head.
- `cargo test -p phase-engine --test integration deterministic_game_state_serde::` — 8 passed at shipment head.
- `cargo check -p engine-wasm --target wasm32-unknown-unknown` — passed at shipment head.
- `cargo check -p phase-server` — passed at shipment head.
- `cargo test -p phase-engine --lib` — 20,464 passed at pipeline-reviewed head `bd2da814a7fdb3493ac9442f943e3ec962bb685e`.
- Integration suite excluding the base-matched 3 MiB stack-budget abort — 6,025 passed at the pipeline-reviewed head.
- `cargo clippy --all-targets -- -D warnings` — passed at the pipeline-reviewed head.

## Gate A

```text
Gate G PASS (router/grant architecture: strict router vs permissive grant boundary intact)
Gate A PASS head=565e0c8e6a896375eafa7279c0dad8642a2fbdfd base=dd17663982e1fea4eb415e8f5d7ed7e3b8887a37
```

## Anchored on

- `crates/engine/src/types/deterministic_serde.rs:367` — existing helper sorts borrowed map entries before emitting canonical wire order.
- `crates/engine/src/types/deterministic_serde.rs:472` — existing `SortedHashMap` wrapper centralizes deterministic serialization for unordered maps.

## Final review-impl

Final review-impl PASS head=565e0c8e6a896375eafa7279c0dad8642a2fbdfd

## Pipeline report

```text
Pipeline-reviewed head: bd2da814a7fdb3493ac9442f943e3ec962bb685e
Current branch head: bd2da814a7fdb3493ac9442f943e3ec962bb685e
Pipeline status: current
Current-head review: none
```

## PR handoff

```text
Pipeline-reviewed head: bd2da814a7fdb3493ac9442f943e3ec962bb685e
Current branch head: 565e0c8e6a896375eafa7279c0dad8642a2fbdfd
Pipeline status: historical — cherry-picked onto origin/main dd17663982e1fea4eb415e8f5d7ed7e3b8887a37
Current-head review: clean at 565e0c8e6a896375eafa7279c0dad8642a2fbdfd
```

## Claimed parse impact

None.

## Scope Expansion

`GameState::trigger_fire_counts_this_turn` now uses the same generic typed-entry adapter in place of its field-local equivalent. Its canonical wire bytes remain unchanged and are covered by an exact-byte compatibility test.

## Validation Failures

The full integration invocation aborted in `game_state_stack_budget::four_player_commander_action_fits_a_bounded_stack` under its 3 MiB stack limit. The untouched base `fc6e05362775a6748e9aae21299476f4a507d988` was independently rebuilt and aborted identically; the remaining 6,025 integration tests passed on the pipeline-reviewed candidate.

## CI Failures

None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the consistency of saved game data by ensuring certain map-based values are serialized in a stable, predictable order.
  - Added validation to reject malformed or duplicate entries when loading persisted game data.
  - Improved reliability for empty and populated game-state round trips, including protection and trigger-related values.

- **Tests**
  - Expanded coverage for deterministic ordering, persistence compatibility, malformed input, and empty-state handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->