### PR TITLE
fix(engine): park trigger ordering while a resolution frame is live

### DIFF
--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -20470,7 +20470,7 @@ mod stage2_injector_tests {
 
         assert_eq!(
             producers.len() + readers.len() + in_test,
-            45,
+            46,
             "CR 603.5 prompt census drifted. A new PRODUCER must have its recipient bound \
              somewhere — the mint's conjunct (a) covers exactly ONE of them. A new READER is \
              the benign case (U4's own consumption arm was one).\n\
@@ -20478,10 +20478,12 @@ mod stage2_injector_tests {
         );
         assert_eq!(
             (producers.len(), readers.len(), in_test),
-            (5, 9, 31),
+            (5, 9, 32),
             "the partition, not just the total: five PRODUCTION producers, nine PRODUCTION \
-             readers (they read `state.waiting_for` and never write it), 31 `#[cfg(test)]` lines \
-             (the 31st is `sba.rs`'s paused-resolution fixture for the CR 704.4 safety-net guard).\nproducers={producers:#?}\n\
+             readers (they read `state.waiting_for` and never write it), 32 `#[cfg(test)]` lines \
+             (the 31st is `sba.rs`'s paused-resolution fixture for the CR 704.4 safety-net guard; \
+             the 32nd is `triggers.rs`'s positive reach-guard row for \
+             `resolution_frame_is_live_off_priority`).\nproducers={producers:#?}\n\
              readers={readers:#?}"
         );
         assert_eq!(

--- a/crates/engine/src/game/engine_priority.rs
+++ b/crates/engine/src/game/engine_priority.rs
@@ -278,6 +278,14 @@ fn run_post_action_pipeline_from_with_policy(
         // the disjunct is inert at the reducer's own pipeline call and bites only
         // at the unguarded `pass_priority_once_with_pipeline` seam.
         if super::engine_resolution_choices::handles(&state.waiting_for)
+            // CR 603.3b + CR 608.2d: a resolution paused on one of its own
+            // choices has not reached a priority boundary, so its earlier
+            // siblings' triggers must not be ordered yet. `handles` is an
+            // action-dispatch predicate and misses the direct-choice frame
+            // family (`OptionalEffectChoice`, `OpponentMayChoice`,
+            // `ProliferateChoice`, the resolution `PayCost`); the frame stack
+            // answers structurally for all of them.
+            || triggers::resolution_frame_is_live_off_priority(state)
             || state.pending_replacement.is_some()
             || state.pending_resolution_completion.is_some()
             || deferred_trigger_batch_was_sba_choice_parked

--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -9545,6 +9545,61 @@ pub(crate) fn resolution_completion_can_settle(state: &GameState) -> bool {
     true
 }
 
+/// CR 603.3b + CR 608.2d: whether a resolution frame is live while a
+/// non-`Priority` prompt is open, so a freshly collected trigger batch must be
+/// PARKED into `deferred_triggers` rather than ordered now.
+///
+/// CR 603.3b places triggered abilities on the stack — and therefore orders
+/// them — only for abilities that triggered "since the last time a player
+/// received priority", i.e. at a priority boundary (CR 117.5, CR 704.3). A
+/// spell paused on one of its own CR 608.2d choices ("you may put a land card
+/// from your hand onto the battlefield") has NOT reached such a boundary: that
+/// choice is announced *while applying the effect*, and no player receives
+/// priority for it. Its earlier siblings' triggers are still "waiting to be put
+/// on the stack" (CR 704.3) and must stay parked until the resolution completes
+/// (CR 603.3 + CR 117.5). CR 608.2c is what keeps the later sentence part of
+/// the same resolution.
+///
+/// This is the collection-side counterpart of the `resolution_stack` clause of
+/// [`resolution_completion_can_settle`], which already refuses to DRAIN (or
+/// offer CR 603.3b ordering) for the same structural reason. It corresponds to
+/// that one clause only, narrowed to non-`Priority` waits. Of the other refusal
+/// conditions there, `pending_replacement` and the `handles` half are already
+/// guarded collection-side by the neighbouring disjuncts at this same fork;
+/// `is_pending_trigger_construction_active`, `pending_cost_move_resume`,
+/// `pending_deferred_life_cost_resume` and `pending_triggered_mana_resume` are
+/// not.
+///
+/// The `Priority` test keeps the guard off genuine CR 117.5 boundaries, where a
+/// batch must be ordered promptly rather than deferred; an unconditional guard
+/// is measurably rejected by
+/// `analysis::corpus_tests::drive_row_classifies_corpus_via_shared_pipeline`.
+/// The `resolution_stack` test is a deliberate narrowing to non-`Priority`
+/// waits that own a live frame — CR 508.2b / CR 510.3a put declare-attackers
+/// and combat-damage triggers on the stack before the active player gets
+/// priority, and this guard stays off those windows because no resolution
+/// frame is live there — measured indirectly by the P7 regression filter, not
+/// pinned by any assertion. No existing test distinguishes it: both
+/// single-conjunct-dropped variants pass the full ordering/combat regression
+/// filter, so this conjunct is pinned only by the unit rows in
+/// `resolution_frame_is_live_off_priority_requires_a_live_frame_and_a_non_priority_wait`.
+///
+/// Structural on purpose. The historical guard at the collection seam
+/// enumerated pause shapes via `engine_resolution_choices::handles`, which is
+/// an action-DISPATCH predicate; measured against the closed specification
+/// [`crate::types::resolution::DirectChoiceGate::matches`], it admits only four
+/// of the ten permitted (gate, prompt) pairs and misses `OptionalEffectChoice`,
+/// `OpponentMayChoice`, `ProliferateChoice` and the resolution-scoped sacrifice
+/// `PayCost`. Asking the frame stack covers every present and future
+/// direct-choice frame by construction, and covers every install route —
+/// including the frame-push wrappers that bypass
+/// `GameState::install_direct_choice_frame` entirely. It is added BESIDE
+/// `handles` at the fork rather than in place of it: `handles` still carries
+/// the resolution-owned prompts that own no frame.
+pub(crate) fn resolution_frame_is_live_off_priority(state: &GameState) -> bool {
+    !matches!(state.waiting_for, WaitingFor::Priority { .. }) && !state.resolution_stack.is_empty()
+}
+
 /// Which deferred-trigger drain, if any, a post-action seam owns.
 ///
 /// Every variant still goes through `resolution_completion_can_settle`, so the
@@ -21504,6 +21559,77 @@ pub mod tests {
             crate::types::ability::effect_variant_name(&sub.effect),
             "GainLife"
         );
+    }
+
+    /// CR 603.3b + CR 508.2b + CR 510.3a: the collection-side guard must fire
+    /// ONLY when a non-`Priority` wait is open AND a resolution frame is live.
+    /// Each row below is failed by a different over-broad predicate, so this
+    /// test — not any integration test — is what pins the two conjuncts.
+    #[test]
+    fn resolution_frame_is_live_off_priority_requires_a_live_frame_and_a_non_priority_wait() {
+        use crate::game::combat::AttackTarget;
+        use crate::game::scenario::{GameRunner, GameScenario, P0, P1};
+        use crate::types::resolution::OptionalEffectFrame;
+
+        fn runner_with_source() -> (GameRunner, ObjectId) {
+            let mut scenario = GameScenario::new();
+            let source_id = scenario.add_creature(P0, "Frame Source", 2, 2).id();
+            (scenario.build(), source_id)
+        }
+
+        fn live_frame(source_id: ObjectId) -> OptionalEffectFrame {
+            OptionalEffectFrame {
+                ability: Box::new(ResolvedAbility::new(
+                    Effect::Draw {
+                        count: QuantityExpr::Fixed { value: 1 },
+                        target: TargetFilter::Controller,
+                    },
+                    vec![],
+                    source_id,
+                    P0,
+                )),
+                trigger_event: None,
+                trigger_events: Vec::new(),
+                trigger_match_count: None,
+            }
+        }
+
+        // Row 1 — a settled Priority window with a frame still live (mid-`RepeatFor`
+        // shape). Must be FALSE: dropping the `Priority` conjunct returns true here.
+        let (mut runner, source_id) = runner_with_source();
+        let state = runner.state_mut();
+        state.push_optional_effect_frame(live_frame(source_id));
+        state.waiting_for = WaitingFor::Priority { player: P0 };
+        assert!(!resolution_frame_is_live_off_priority(state));
+
+        // Row 2 — a non-`Priority` combat wait with an EMPTY frame stack
+        // (CR 508.2b / CR 510.3a). Must be FALSE: dropping the `resolution_stack`
+        // conjunct returns true here.
+        let (mut runner, _) = runner_with_source();
+        let state = runner.state_mut();
+        assert!(state.resolution_stack.is_empty());
+        state.waiting_for = WaitingFor::DeclareAttackers {
+            player: P0,
+            valid_attacker_ids: Vec::new(),
+            valid_attack_targets: vec![AttackTarget::Player(P1)],
+            valid_attack_targets_by_attacker: None,
+            attacker_constraints: Default::default(),
+        };
+        assert!(!resolution_frame_is_live_off_priority(state));
+
+        // Row 3 — POSITIVE REACH-GUARD: a direct-choice prompt above a live frame.
+        // Must be TRUE, so a predicate that always returns false fails too.
+        let (mut runner, source_id) = runner_with_source();
+        let state = runner.state_mut();
+        state.push_optional_effect_frame(live_frame(source_id));
+        state.waiting_for = WaitingFor::OptionalEffectChoice {
+            player: P0,
+            source_id,
+            description: None,
+            may_trigger_key: None,
+            same_card_may_trigger_choice_available: false,
+        };
+        assert!(resolution_frame_is_live_off_priority(state));
     }
 
     /// CR 400.7d: an emerge-cast permanent's ETB "instead create X of those

--- a/crates/engine/tests/integration/eureka_moment_draw_trigger_strands_optional_frame.rs
+++ b/crates/engine/tests/integration/eureka_moment_draw_trigger_strands_optional_frame.rs
@@ -1,0 +1,291 @@
+//! Discord thread 1545121827792093275 — `ai-getAction-panic`, 4p Commander vs
+//! AI, build v0.71.0 (d3f532c). The reporter's capture panics in
+//! `turns::start_next_turn` ("requires an empty stack, no pending resolution
+//! carrier, and a settled Priority window") with `stack 0`, `waiting_for
+//! Priority`, an `OptionalEffect` frame still on `resolution_stack`, and a
+//! triggered `resolving_stack_entry` that can never complete.
+//!
+//! The capture's frame is Eureka Moment's second sibling ("You may put a land
+//! card from your hand onto the battlefield"), and its opponent controls
+//! Smothering Tithe. The first sibling draws TWO cards, so Smothering Tithe
+//! fires twice and its controller must order the pair (CR 603.3b). That
+//! `OrderTriggers` prompt is installed while the spell's own `OptionalEffect`
+//! frame is the top resolution frame, so the optional-effect prompt is lost and
+//! the frame is never drained.
+//!
+//! In a debug build the mismatch is caught immediately by
+//! `debug_assert_runtime_resolution_invariants`; the shipped WASM is a release
+//! build, where the residue survives to the hard `assert!` in
+//! `start_next_turn`.
+//!
+//! The seam under test is the collection-side CR 603.3b guard at the
+//! park-vs-process fork in `engine_priority.rs::run_post_action_pipeline`, and
+//! the class is every direct-choice resolution frame permitted by
+//! `types::resolution::DirectChoiceGate::matches` — not Eureka Moment, which is
+//! only the reported instance. `OptionalEffect` and `Proliferate` are the two
+//! frame kinds exercised here.
+//!
+//! Smothering Tithe's Oracle text below is verbatim from Scryfall. The Discord
+//! brief and this file's first revision both paraphrased it as "that player
+//! creates a Treasure token unless they pay {2}", which inverts the Treasure's
+//! controller and routes the engine through an `UnlessPayment` interception the
+//! scenario driver cannot answer.
+//!
+//! The synthesized control card `"One Draw Moment"` — named at each control
+//! call site, with its synthesized Oracle text in the one-draw arm of
+//! `draw_then_optional_land_scenario`'s `match draws` — is deliberately exempt
+//! from that verbatim-Oracle rule: it varies exactly one axis, draw count, and
+//! exists to isolate the trigger-count discriminator, so its Oracle text is a
+//! controlled variable rather than a card under test.
+//!
+//! Non-overlap with `raw_resolution_stack_restore.rs`: that module's deferral
+//! marker covers a `SpellResolution` frame stranded at the *restore* boundary,
+//! a different frame kind and a different cause, and its own doc states that
+//! fixing the runtime writer will not move it.
+
+use engine::game::scenario::GameScenario;
+use engine::types::game_state::WaitingFor;
+use engine::types::identifiers::ObjectId;
+use engine::types::phase::Phase;
+use engine::types::player::PlayerId;
+use engine::types::zones::Zone;
+
+const CASTER: PlayerId = PlayerId(0);
+const TITHE: PlayerId = PlayerId(1);
+
+const SMOTHERING_TITHE: &str = "Whenever an opponent draws a card, that player may pay {2}. \
+                                If the player doesn't, you create a Treasure token.";
+
+/// CR 603.3b + CR 608.2d: triggers that fired during an earlier sibling effect
+/// are ordered only after the resolution finishes, so ordering them can never
+/// displace the resolving spell's own "may" prompt.
+#[test]
+fn two_draw_triggers_do_not_strand_the_optional_land_frame() {
+    let outcome = cast_draw_then_optional_land("Eureka Moment", 2);
+    assert_no_resolution_residue(&outcome);
+}
+
+/// Control: one draw fires ONE Smothering Tithe trigger, which needs no APNAP
+/// ordering. Passing here while the two-draw case fails isolates the
+/// `OrderTriggers` prompt as the discriminator — not "a trigger fired during an
+/// earlier sibling effect".
+#[test]
+fn one_draw_trigger_does_not_strand_the_optional_land_frame() {
+    let outcome = cast_draw_then_optional_land("One Draw Moment", 1);
+    assert_no_resolution_residue(&outcome);
+}
+
+/// Parking is deferral, not dropping: once the optional choice is answered the
+/// parked pair reaches the stack and both instances resolve. A fix that
+/// silently discarded the batch would still pass the two residue tests above,
+/// so this positive delta is what catches it.
+///
+/// Under Smothering Tithe's real text the drawing player may pay `{2}`; the
+/// scenario driver does not pay, so each resolution creates a Treasure for the
+/// Tithe's controller (`TITHE`, `PlayerId(1)`) — CR 603.3b's ordering authority
+/// is the trigger's controller, not the resolving spell's.
+#[test]
+fn parked_draw_triggers_reach_the_stack_after_the_optional_choice_is_answered() {
+    let outcome = cast_draw_then_optional_land_accepting("Eureka Moment", 2);
+    assert_no_resolution_residue(&outcome);
+    assert_eq!(
+        treasures_controlled_by(&outcome, TITHE),
+        2,
+        "both parked Smothering Tithe triggers must reach the stack and resolve"
+    );
+}
+
+/// Control for the row above: one draw fires one trigger and yields one
+/// Treasure, so the two-draw arm's `2` is a count delta rather than "Treasures
+/// happen at all".
+#[test]
+fn one_parked_draw_trigger_reaches_the_stack_after_the_optional_choice_is_answered() {
+    let outcome = cast_draw_then_optional_land_accepting("One Draw Moment", 1);
+    assert_no_resolution_residue(&outcome);
+    assert_eq!(treasures_controlled_by(&outcome, TITHE), 1);
+}
+
+/// The class is not `OptionalEffect`-specific: a `Proliferate` tail
+/// (CR 701.34a) pauses on `WaitingFor::ProliferateChoice` above a
+/// `ResolutionFrame::Proliferate`, a second (frame, prompt) pair from the same
+/// `DirectChoiceGate::matches` specification, and strands identically.
+#[test]
+fn two_draw_triggers_do_not_strand_a_proliferate_frame() {
+    let outcome = cast_draw_then_proliferate("Eureka Proliferation", 2);
+    assert_no_resolution_residue(&outcome);
+    assert_eq!(
+        outcome.state().resolution_stack.len(),
+        1,
+        "the row must actually reach the proliferate pause, or it passes vacuously"
+    );
+}
+
+/// Control on the proliferate axis: one draw fires ONE trigger, which needs no
+/// APNAP ordering. It rests at `ProliferateChoice` with a live frame, which is
+/// also the row on which `assert_no_resolution_residue`'s `validate` call is an
+/// applied check rather than an empty-stack no-op.
+#[test]
+fn one_draw_trigger_does_not_strand_a_proliferate_frame() {
+    let outcome = cast_draw_then_proliferate("One Draw Proliferation", 1);
+    assert_no_resolution_residue(&outcome);
+    assert_eq!(
+        outcome.state().resolution_stack.len(),
+        1,
+        "the control must actually reach the proliferate pause"
+    );
+}
+
+/// Hostile — empty/no-choice path. With no Smothering Tithe on the battlefield
+/// the draw fires nothing, so the fork's park branch is never taken and the
+/// optional prompt is raised and answered normally.
+#[test]
+fn no_triggers_leaves_the_optional_prompt_untouched() {
+    let (mut runner, spell) = draw_then_optional_land_scenario(2, "Eureka Moment", 2, &[]);
+    let outcome = runner.cast(spell).resolve();
+
+    assert_no_resolution_residue(&outcome);
+    assert!(
+        matches!(outcome.final_waiting_for(), WaitingFor::Priority { .. }),
+        "with no observers the resolution must run to a Priority rest, got {:?}",
+        outcome.final_waiting_for()
+    );
+    assert_eq!(treasures_controlled_by(&outcome, TITHE), 0);
+}
+
+/// Hostile — multi-authority. Two triggers with DIFFERENT controllers form two
+/// singleton CR 603.3b groups, which are auto-ordered and raise no prompt. The
+/// fix must change only WHEN ordering is offered, never WHICH batches need it.
+///
+/// Both triggers resolve, one Treasure to each opponent. A mid-resolution
+/// `OrderTriggers` above the live `OptionalEffect` frame would additionally
+/// trip `debug_assert_runtime_resolution_invariants` inside `resolve()`.
+#[test]
+fn two_triggers_from_different_controllers_need_no_ordering() {
+    const THIRD: PlayerId = PlayerId(2);
+
+    let (mut runner, spell) =
+        draw_then_optional_land_scenario(3, "One Draw Moment", 1, &[TITHE, THIRD]);
+    let outcome = runner.cast(spell).accept_optional().resolve();
+
+    assert_no_resolution_residue(&outcome);
+    assert_eq!(treasures_controlled_by(&outcome, TITHE), 1);
+    assert_eq!(treasures_controlled_by(&outcome, THIRD), 1);
+}
+
+fn treasures_controlled_by(
+    outcome: &engine::game::scenario::CastOutcome,
+    player: PlayerId,
+) -> usize {
+    outcome
+        .state()
+        .objects
+        .values()
+        .filter(|obj| {
+            obj.zone == Zone::Battlefield && obj.controller == player && obj.name == "Treasure"
+        })
+        .count()
+}
+
+fn cast_draw_then_optional_land(name: &str, draws: u8) -> engine::game::scenario::CastOutcome {
+    let (mut runner, spell) = draw_then_optional_land_scenario(2, name, draws, &[TITHE]);
+    runner.cast(spell).resolve()
+}
+
+/// Same recipe, but the controller accepts the "may" rather than taking the
+/// driver's `OptionalPolicy::Decline` default, so the optional prompt is
+/// provably still answerable after the trigger batch was parked.
+fn cast_draw_then_optional_land_accepting(
+    name: &str,
+    draws: u8,
+) -> engine::game::scenario::CastOutcome {
+    let (mut runner, spell) = draw_then_optional_land_scenario(2, name, draws, &[TITHE]);
+    runner.cast(spell).accept_optional().resolve()
+}
+
+/// Shared `/card-test` recipe for the `OptionalEffect` rows. `tithe_controllers`
+/// is the CR 603.3b ordering-authority axis: zero observers (no batch at all),
+/// one (a same-controller batch), or two distinct opponents (two singleton
+/// groups that need no ordering choice).
+fn draw_then_optional_land_scenario(
+    players: u8,
+    name: &str,
+    draws: u8,
+    tithe_controllers: &[PlayerId],
+) -> (engine::game::scenario::GameRunner, ObjectId) {
+    let oracle = match draws {
+        1 => "Draw a card. You may put a land card from your hand onto the battlefield.",
+        2 => "Draw two cards. You may put a land card from your hand onto the battlefield.",
+        _ => unreachable!("only the one- and two-draw arms are modelled"),
+    };
+    let mut scenario = GameScenario::new_n_player(players, 42);
+    scenario.at_phase(Phase::PreCombatMain);
+    for controller in tithe_controllers {
+        scenario.add_enchantment_from_oracle(*controller, "Smothering Tithe", SMOTHERING_TITHE);
+    }
+    let spell = scenario
+        .add_spell_to_hand_from_oracle(CASTER, name, false, oracle)
+        .id();
+    scenario.add_land_to_hand(CASTER, "Forest");
+    scenario.with_library_top(CASTER, &["Grizzly Bears", "Runeclaw Bear"]);
+    (scenario.build(), spell)
+}
+
+/// The `Proliferate` arm of the same class (CR 701.34a). The counter-bearing
+/// creature is a load-bearing reach-guard: without it `collect_proliferate_eligible`
+/// is empty, the proliferate action completes synchronously and never pushes a
+/// resolution frame, and both arms would pass vacuously with an empty stack.
+fn cast_draw_then_proliferate(name: &str, draws: u8) -> engine::game::scenario::CastOutcome {
+    let oracle = match draws {
+        1 => "Draw a card. Proliferate.",
+        2 => "Draw two cards. Proliferate.",
+        _ => unreachable!("only the one- and two-draw arms are modelled"),
+    };
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.add_enchantment_from_oracle(TITHE, "Smothering Tithe", SMOTHERING_TITHE);
+    scenario
+        .add_creature(CASTER, "Counter Bearer", 2, 2)
+        .with_plus_counters(1);
+    let spell = scenario
+        .add_spell_to_hand_from_oracle(CASTER, name, false, oracle)
+        .id();
+    scenario.with_library_top(CASTER, &["Grizzly Bears", "Runeclaw Bear"]);
+    let mut runner = scenario.build();
+    runner.cast(spell).resolve()
+}
+
+/// A pending resolution frame is only ever legitimate behind the prompt that
+/// owns it. Wherever the pipeline comes to rest, the frame stack and the wait
+/// must agree — and at a `Priority` rest there must be no residue at all,
+/// because `turns::start_next_turn` asserts exactly that.
+///
+/// Frame/wait agreement is `DirectChoiceGate::matches`, which is private; its
+/// public wrapper `ResolutionStack::validate` is the callable authority and is
+/// what the engine's own `debug_assert_runtime_resolution_invariants` applies.
+///
+/// Two honest limits. `validate` early-returns on an empty frame stack, so on
+/// the Eureka rows (which rest with `resolution_stack.len() == 0`) it is a
+/// documented invariant rather than an applied check; it does real work on the
+/// proliferate rows, which rest at `ProliferateChoice` with one live frame. And
+/// it runs against the typed `state.resolution_stack` only — the engine's debug
+/// assert first calls the `pub(crate)` `canonicalize_legacy_resolution_state`,
+/// which additionally merges unmigrated legacy frame families that an
+/// integration test cannot reach.
+fn assert_no_resolution_residue(outcome: &engine::game::scenario::CastOutcome) {
+    let halt = outcome.final_waiting_for().clone();
+    let state = outcome.state();
+    state
+        .resolution_stack
+        .validate(&state.waiting_for)
+        .unwrap_or_else(|error| {
+            panic!("the frame stack and the wait must agree at every rest: {error}")
+        });
+    if matches!(halt, WaitingFor::Priority { .. }) {
+        assert!(
+            state.resolution_stack.is_empty() && state.resolving_stack_entry.is_none(),
+            "a Priority rest must carry no resolution residue (resolution_stack {}, carrier {})",
+            state.resolution_stack.len(),
+            state.resolving_stack_entry.is_some(),
+        );
+    }
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -247,6 +247,7 @@ mod escape_tunnel_landfall;
 mod esper_origins_flashback_transform;
 mod etali_primal_sickness_poison;
 mod etrata_cloak_enters_under_cloaker_5944;
+mod eureka_moment_draw_trigger_strands_optional_frame;
 mod evelyn_regression;
 mod excess_damage_quantity_channel;
 mod exchange_life_totals_cards;


### PR DESCRIPTION
CR 603.3b places triggered abilities on the stack -- and therefore orders
them -- only for abilities that triggered "since the last time a player
received priority", i.e. at a priority boundary (CR 117.5, CR 704.3). A
spell paused on one of its own CR 608.2d choices has not reached such a
boundary: that choice is announced while applying the effect, and no
player receives priority for it. Its earlier siblings' triggers are still
waiting to be put on the stack and must stay parked until the resolution
completes (CR 603.3 + CR 117.5).

The collection seam in `run_post_action_pipeline` decided this by asking
`engine_resolution_choices::handles`, an action-DISPATCH predicate. Measured
against the closed specification `DirectChoiceGate::matches`, it admits only
four of the ten permitted (gate, prompt) pairs and misses
`OptionalEffectChoice`, `OpponentMayChoice`, `ProliferateChoice` and the
resolution-scoped sacrifice `PayCost`.

So a spell whose earlier sibling drew two cards, firing an opponent's
Smothering Tithe twice, raised `WaitingFor::OrderTriggers` over Eureka
Moment's live `OptionalEffect` frame. That destroyed the "you may put a land
card from your hand onto the battlefield" prompt and orphaned the frame; the
residue survived to the hard `assert!` in `turns::start_next_turn` and ended
the game at Cleanup. In a debug build
`debug_assert_runtime_resolution_invariants` catches it at once, but it is
`#[cfg(debug_assertions)]` and compiled out of the shipped WASM.

Ask the frame stack structurally, beside the existing `handles` disjunct
rather than in place of it. That covers every direct-choice frame and every
install route, including the frame-push wrappers that bypass
`install_direct_choice_frame`. The drain side's
`resolution_completion_can_settle` already refuses to offer CR 603.3b
ordering while a frame is live; this is its collection-side counterpart,
narrowed to non-`Priority` waits.

Removing the new disjunct alone turns 3 of the 8 new rows red, across two
frame kinds (`OptionalEffect` and `Proliferate`).

The CR 603.5 prompt census pins move 45 -> 46 and (5, 9, 31) -> (5, 9, 32):
the new predicate's positive reach-guard row constructs an
`OptionalEffectChoice`, which the source census counts as a `#[cfg(test)]`
occurrence. The producer list is unchanged at five.

Reported on Discord thread 1545121827792093275.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed trigger handling during non-priority resolution prompts so triggers are deferred until the active resolution completes.
  * Prevented a crash when draw-related effects generate triggers during optional or proliferate resolutions.

* **Tests**
  * Added integration coverage for trigger ordering across optional and proliferate resolution frames, including multiple draw and controller scenarios.
  * Expanded diagnostic checks for live resolution-frame detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->