### PR TITLE
fix(engine): scope Resolve All to the requester and bind Full Control

### DIFF
--- a/client/src/adapter/__tests__/p2p-adapter-multiplayer.test.ts
+++ b/client/src/adapter/__tests__/p2p-adapter-multiplayer.test.ts
@@ -3860,14 +3860,14 @@ describe("P2P wire-protocol version gate", () => {
   // Both halves stamp LITERALS. A frame built from WIRE_PROTOCOL_VERSION
   // cannot tell a bumped client from an unbumped one, which is why every
   // other handshake fixture in the suite is useless as an instrument for a
-  // bump. Revert 40 → 39 and BOTH halves red: the v39 frame stops being
-  // refused, and the v40 frame stops being admitted. The admitting half is
-  // the reach-guard — without it "refuses v39" is also satisfied by a client
+  // bump. Revert 41 → 40 and BOTH halves red: the v40 frame stops being
+  // refused, and the v41 frame stops being admitted. The admitting half is
+  // the reach-guard — without it "refuses v40" is also satisfied by a client
   // that refuses everything.
-  it("refuses the previous wire protocol (v39) and admits its own (v40)", async () => {
+  it("refuses the previous wire protocol (v40) and admits its own (v41)", async () => {
     const refusing = makeGuest();
     await refusing.adapter.initialize();
-    await refusing.conn.simulateData(setupFrameAt(39));
+    await refusing.conn.simulateData(setupFrameAt(40));
 
     await expect(refusing.adapter.initializeGame()).rejects.toMatchObject({
       code: "P2P_REJECTED",
@@ -3879,7 +3879,7 @@ describe("P2P wire-protocol version gate", () => {
 
     const admitting = makeGuest();
     await admitting.adapter.initialize();
-    await admitting.conn.simulateData(setupFrameAt(40));
+    await admitting.conn.simulateData(setupFrameAt(41));
 
     await expect(admitting.adapter.initializeGame()).resolves.toBeDefined();
     expect(admitting.emitted).not.toHaveBeenCalledWith(

--- a/client/src/adapter/types.ts
+++ b/client/src/adapter/types.ts
@@ -613,7 +613,13 @@ export interface PhaseStop {
 }
 
 /** Standing engine preference for ordinary priority recommendations. */
-export type PriorityPassingMode = "Standard" | "SkipLowUseWindows";
+export type PriorityPassingMode = "Standard" | "SkipLowUseWindows" | "FullControl";
+
+/** CR 117.3d: which priority representatives a Resolve All request binds.
+ *  `Own` is the player-facing button — it pre-commits only the requester and so
+ *  can never be blocked by another seat. `Shared` opens the table-wide consent
+ *  protocol the engine uses for stack compression. */
+export type ResolveAllScope = { type: "Own" } | { type: "Shared" };
 
 export type Zone =
   | "Library"
@@ -2574,7 +2580,7 @@ export type PrecastCopyShortcutResponse =
 
 export type GameAction =
   | { type: "PassPriority" }
-  | { type: "BeginResolveAll"; data: { max_resolutions: number } }
+  | { type: "BeginResolveAll"; data: { max_resolutions: number; scope: ResolveAllScope } }
   | {
       type: "RespondResolveAllConsent";
       data: { epoch: number; decision: { type: "Grant" } | { type: "Decline" } };

--- a/client/src/adapter/ws-adapter.ts
+++ b/client/src/adapter/ws-adapter.ts
@@ -203,6 +203,11 @@ export class NativeEngineVersionMismatchError extends Error {
  * `crates/server-core/src/protocol.rs`. Bump in lockstep when either side
  * adds, removes, renames, or changes the type of a protocol variant field.
  *
+ * 57 — `GameAction::BeginResolveAll` gained `scope: ResolveAllScope` (`Own`
+ *      binds only the requester and resolves immediately; `Shared` opens the
+ *      table-wide consent protocol), and `PriorityPassingMode` gained
+ *      `FullControl`, which is now engine-authoritative rather than a
+ *      frontend-only toggle.
  * 56 — Host-only authoritative-state export request/response variants. Native
  *      P2P sends each player a redacted view, so the host must ask its local
  *      server for the trusted engine envelope rather than export that view.
@@ -391,7 +396,7 @@ export class NativeEngineVersionMismatchError extends Error {
  *      into a MulliganDecisionPhase::BottomCards sub-phase on
  *      WaitingFor::MulliganDecision.
  */
-export const PROTOCOL_VERSION = 56;
+export const PROTOCOL_VERSION = 57;
 
 /**
  * Lowest server protocol version this client will accept in the handshake.

--- a/client/src/game/__tests__/dispatchResolveAll.test.ts
+++ b/client/src/game/__tests__/dispatchResolveAll.test.ts
@@ -34,7 +34,7 @@ describe("dispatchResolveAll", () => {
     await dispatchResolveAll(0);
 
     expect(submitAction).toHaveBeenCalledWith(
-      { type: "BeginResolveAll", data: { max_resolutions: 0 } },
+      { type: "BeginResolveAll", data: { max_resolutions: 0, scope: { type: "Own" } } },
       0,
     );
     expect(resolveAll).not.toHaveBeenCalled();

--- a/client/src/game/dispatch.ts
+++ b/client/src/game/dispatch.ts
@@ -994,7 +994,14 @@ export async function restoreGameState(
  */
 export async function dispatchResolveAll(requester: number): Promise<void> {
   await dispatchAction(
-    { type: "BeginResolveAll", data: { max_resolutions: 0 } },
+    // CR 117.3d: the button is the requester's own pre-commitment. `Own` cannot
+    // be blocked by a seat that declines or an AI seat that never answers;
+    // `Shared` (the table-wide consent proposal the engine uses for stack
+    // compression) is deliberately not reachable from this control.
+    {
+      type: "BeginResolveAll",
+      data: { max_resolutions: 0, scope: { type: "Own" } },
+    },
     requester,
   );
 }

--- a/client/src/hooks/__tests__/useGameplayPreferencesSync.test.tsx
+++ b/client/src/hooks/__tests__/useGameplayPreferencesSync.test.tsx
@@ -9,6 +9,7 @@ import {
   useGameStore,
 } from "../../stores/gameStore";
 import { usePreferencesStore } from "../../stores/preferencesStore";
+import { useUiStore } from "../../stores/uiStore";
 
 vi.mock("../../game/dispatch", () => ({ dispatchActionForGameSession: vi.fn() }));
 
@@ -28,6 +29,7 @@ describe("useGameplayPreferencesSync", () => {
       engineCommitEpoch: 0,
       gameSessionGeneration: nextGameSessionGeneration(),
     });
+    useUiStore.setState({ fullControl: false });
   });
 
   afterEach(() => cleanup());
@@ -119,5 +121,42 @@ describe("useGameplayPreferencesSync", () => {
 
     act(() => usePreferencesStore.getState().setPhaseStops([]));
     await waitFor(() => expect(dispatchActionForGameSession).toHaveBeenCalledTimes(3));
+  });
+
+  it("overrides the synced mode while Full Control is on, and restores it when off", async () => {
+    useGameStore.setState({ adapter, gameState, engineCommitEpoch: 1 });
+    renderHook(() => useGameplayPreferencesSync());
+    await waitFor(() => expect(dispatchActionForGameSession).toHaveBeenCalledTimes(2));
+    expect(dispatchActionForGameSession).toHaveBeenLastCalledWith(
+      { type: "SetPriorityPassingMode", data: { mode: "Standard" } },
+      adapter,
+      expect.any(Number),
+    );
+
+    // Full Control lives in `uiStore`, not `preferencesStore`, so it reaches the
+    // engine only through its own subscription.
+    act(() => useUiStore.getState().toggleFullControl());
+    await waitFor(() => {
+      expect(dispatchActionForGameSession).toHaveBeenLastCalledWith(
+        { type: "SetPriorityPassingMode", data: { mode: "FullControl" } },
+        adapter,
+        expect.any(Number),
+      );
+    });
+
+    // An unrelated `uiStore` write must not re-dispatch: the subscription is a
+    // plain (non-selector) one guarded on the previous `fullControl` value.
+    const callsAfterOverride = vi.mocked(dispatchActionForGameSession).mock.calls.length;
+    act(() => useUiStore.setState({ selectedCardIds: [] }));
+    expect(dispatchActionForGameSession).toHaveBeenCalledTimes(callsAfterOverride);
+
+    act(() => useUiStore.getState().toggleFullControl());
+    await waitFor(() => {
+      expect(dispatchActionForGameSession).toHaveBeenLastCalledWith(
+        { type: "SetPriorityPassingMode", data: { mode: "Standard" } },
+        adapter,
+        expect.any(Number),
+      );
+    });
   });
 });

--- a/client/src/hooks/useGameplayPreferencesSync.ts
+++ b/client/src/hooks/useGameplayPreferencesSync.ts
@@ -8,6 +8,23 @@ import type {
 import { dispatchActionForGameSession } from "../game/dispatch";
 import { useGameStore } from "../stores/gameStore";
 import { usePreferencesStore } from "../stores/preferencesStore";
+import { useUiStore } from "../stores/uiStore";
+
+/**
+ * The mode the engine must hold for this player.
+ *
+ * CR 117.1: Full Control is a standing refusal to give up any priority window,
+ * so it has to be engine state, not a frontend flag. An auto-pass session
+ * another player installed (Resolve All) is driven inside the engine's own
+ * priority loop and never consults a client, so a purely local toggle could not
+ * stop it. It stays a per-session `uiStore` toggle in the UI — this only
+ * projects it onto the synced preference while it is on.
+ */
+function effectivePriorityPassingMode(): PriorityPassingMode {
+  return useUiStore.getState().fullControl
+    ? "FullControl"
+    : usePreferencesStore.getState().priorityPassingMode;
+}
 
 type LastSent = {
   adapter: EngineAdapter;
@@ -62,7 +79,8 @@ async function drainGameplayPreferenceSync(): Promise<void> {
       } = useGameStore.getState();
       if (!adapter || !gameState) continue;
 
-      const { phaseStops: stops, priorityPassingMode: mode } = usePreferencesStore.getState();
+      const stops = usePreferencesStore.getState().phaseStops;
+      const mode = effectivePriorityPassingMode();
       const sent = successfulSendFor(adapter, generation);
 
       if (!sent.stops || !phaseStopsEqual(sent.stops, stops)) {
@@ -95,7 +113,7 @@ async function drainGameplayPreferenceSync(): Promise<void> {
         continue;
       }
 
-      const currentMode = usePreferencesStore.getState().priorityPassingMode;
+      const currentMode = effectivePriorityPassingMode();
       if (currentMode !== mode) {
         syncRequested = true;
         continue;
@@ -116,7 +134,7 @@ async function drainGameplayPreferenceSync(): Promise<void> {
 
         if (
           isCurrentSession(adapter, generation)
-          && usePreferencesStore.getState().priorityPassingMode === mode
+          && effectivePriorityPassingMode() === mode
         ) {
           lastSent = { ...successfulSendFor(adapter, generation), mode };
         } else {
@@ -152,10 +170,23 @@ export function useGameplayPreferencesSync(): void {
       { fireImmediately: true },
     );
     const unsubPreferences = usePreferencesStore.subscribe(sendGameplayPreferences);
+    // Full Control lives in `uiStore` (a per-session toggle, not a persisted
+    // preference), so it needs its own subscription to reach the engine.
+    // `uiStore` is a plain zustand store with no `subscribeWithSelector`
+    // middleware, so the selector overload is unavailable — hence the explicit
+    // previous-value guard, which also keeps unrelated UI state changes from
+    // re-dispatching the preference.
+    let lastFullControl = useUiStore.getState().fullControl;
+    const unsubFullControl = useUiStore.subscribe((state) => {
+      if (state.fullControl === lastFullControl) return;
+      lastFullControl = state.fullControl;
+      sendGameplayPreferences();
+    });
 
     return () => {
       unsubGame();
       unsubPreferences();
+      unsubFullControl();
     };
   }, []);
 }

--- a/client/src/network/__tests__/protocol.test.ts
+++ b/client/src/network/__tests__/protocol.test.ts
@@ -36,8 +36,8 @@ const viewerInteractionWithProducedMana = {
 } as never;
 
 describe("encodeWireMessage / decodeWireMessage", () => {
-  it("pins the P2P wire protocol to v40", () => {
-    expect(WIRE_PROTOCOL_VERSION).toBe(40);
+  it("pins the P2P wire protocol to v41", () => {
+    expect(WIRE_PROTOCOL_VERSION).toBe(41);
   });
 
   it("defaults shortcut actions for a legacy payload created before the additive field", () => {

--- a/client/src/network/protocol.ts
+++ b/client/src/network/protocol.ts
@@ -255,7 +255,7 @@ export function legalActionsFromWire(wire: LegalActionsWire): LegalActionsResult
  *       sub-phase on WaitingFor::MulliganDecision; the MulliganBottomCards
  *       variant was removed
  */
-export const WIRE_PROTOCOL_VERSION = 40 as const;
+export const WIRE_PROTOCOL_VERSION = 41 as const;
 
 export type P2PMessage = P2PAuthorityWire & (
   | {

--- a/crates/engine-wasm/src/lib.rs
+++ b/crates/engine-wasm/src/lib.rs
@@ -3451,7 +3451,7 @@ mod tests {
         ContinuousModification, Duration, Effect, QuantityExpr, QuantityRef, ResolvedAbility,
         TargetFilter, TargetRef,
     };
-    use engine::types::actions::ResolveAllConsentDecision;
+    use engine::types::actions::{ResolveAllConsentDecision, ResolveAllScope};
     use engine::types::card::CardFace;
     use engine::types::card_type::{CardType, CoreType};
     use engine::types::counter::{CounterMatch, CounterType};
@@ -4740,6 +4740,8 @@ mod tests {
         state.resolve_all_consent_run = Some(ResolveAllConsentRun {
             epoch: EPOCH,
             max_resolutions: StackResolutionBudget::default(),
+            // A table-wide run: both seats are participants and both granted.
+            scope: ResolveAllScope::Shared,
             priority_snapshot: ResolveAllPrioritySnapshot {
                 waiting_player: PlayerId(0),
                 priority_player: PlayerId(0),

--- a/crates/engine/src/ai_support/mod.rs
+++ b/crates/engine/src/ai_support/mod.rs
@@ -1926,6 +1926,17 @@ pub fn auto_pass_recommended(state: &GameState, actions: &[GameAction]) -> bool 
         return false;
     }
 
+    // CR 117.1: Full Control is a standing refusal to give up ANY window, so no
+    // recommendation is ever issued. Deliberately ABOVE the CR 117.3d yield rung
+    // below — that rung is the one other place this function can answer `true`
+    // over a hold, and the engine-side gates in `game::engine` (which cover
+    // passes that never reach a frontend) do not consult yields. Ordering Full
+    // Control first is what keeps the recommendation and the authoritative loop
+    // from disagreeing about the same window.
+    if state.priority_passing_mode(mode_owner) == PriorityPassingMode::FullControl {
+        return false;
+    }
+
     // CR 117.3d: A standing priority yield for the top-of-stack trigger is an
     // explicit pre-commitment to pass. It deliberately overrides the castability
     // and meaningful-action holds below (including the issue #4388 opponent-turn

--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -8,14 +8,14 @@ use crate::types::ability::{EffectScope, TapStateChange};
 use crate::types::action_rejection::{ActionRejection, ActionRejectionCode};
 use crate::types::actions::{
     DebugAction, GameAction, MayTriggerAutoChoiceOp, PriorityYieldOp, ResolveAllConsentDecision,
-    TriggerOrderTemplateOp,
+    ResolveAllScope, TriggerOrderTemplateOp,
 };
 use crate::types::events::{BendingType, ContestRound, GameEvent, ManaTapState};
 use crate::types::game_state::{
     ActionResult, AssistState, AutoMayChoice, AutoPassMode, AutoPassRequest, CastOfferKind,
     CastingVariant, ConvokeMode, CostResume, GameState, LandPlayRecord, LoopDetectionMode,
     ManaAbilityResume, MayTriggerAutoChoiceKey, PayCostKind, PendingCostMoveResume,
-    PendingCounterPostAction, PendingEffectResolved, PersistedRestoreError,
+    PendingCounterPostAction, PendingEffectResolved, PersistedRestoreError, PriorityPassingMode,
     ResolveAllConsentParticipant, ResolveAllConsentRun, ResolveAllPrioritySnapshot, RetargetScope,
     StackEntry, StackEntryKind, StackResolutionAutoPassOverlay, StackResolutionBudget,
     StackResolutionEntryFence, StackResolutionPolicy, StackResolutionSession, WaitingFor,
@@ -7973,6 +7973,24 @@ enum AutoPassDecision {
 /// interrupt logic is boundary-agnostic — both `EndOfCurrentTurn` and
 /// `MyNextTurnStart` behave identically within a priority window.
 fn priority_auto_pass_decision(state: &GameState, player: PlayerId) -> AutoPassDecision {
+    // CR 117.1 + CR 723.5: Full Control is the player's standing refusal to have
+    // any window taken from them, and it outranks every auto-pass session —
+    // including one another player installed, which is what reaches this loop
+    // without ever consulting the frontend. Checked BEFORE the no-session `Exit`
+    // arm because `Exit` itself falls through to a pass when someone else holds
+    // a live `UntilStackEmpty` session. Preference ownership follows the
+    // authorized submitter, as it does in `auto_pass_recommended`.
+    if state.priority_passing_mode(turn_control::authorized_submitter_for_player(state, player))
+        == PriorityPassingMode::FullControl
+    {
+        // `Finish` also drops a stale session this player owns; both variants
+        // break the loop, so either way the window is theirs.
+        return if state.auto_pass.contains_key(&player) {
+            AutoPassDecision::Finish
+        } else {
+            AutoPassDecision::Break
+        };
+    }
     let Some(mode) = state.auto_pass.get(&player) else {
         return AutoPassDecision::Exit;
     };
@@ -8315,6 +8333,20 @@ fn stack_resolution_session_priority_decision(
         let Some(session) = state.stack_resolution_session.as_ref() else {
             return StackResolutionSessionPriorityDecision::NotActive;
         };
+        // CR 117.1: a Full Control holder is never auto-passed by a session —
+        // theirs or anyone else's. Scoped to `Automatic`: an EXPLICIT
+        // PassPriority is that player's own deliberate decision and still drives
+        // the session. This is the only gate covering a session REPRESENTATIVE,
+        // whose windows are otherwise passed without even the meaningful-action
+        // check below. (The no-session case is handled one layer out, by
+        // `priority_auto_pass_decision`.)
+        if matches!(pass_kind, StackResolutionSessionPassKind::Automatic)
+            && state
+                .priority_passing_mode(turn_control::authorized_submitter_for_player(state, holder))
+                == PriorityPassingMode::FullControl
+        {
+            return StackResolutionSessionPriorityDecision::Pause;
+        }
 
         let current_representatives = super::topology::canonical_priority_representatives(
             state,
@@ -8862,6 +8894,7 @@ fn begin_resolve_all_consent(
     state: &mut GameState,
     priority_player: PlayerId,
     max_resolutions: u32,
+    scope: ResolveAllScope,
 ) -> Result<WaitingFor, EngineError> {
     match state
         .stack_resolution_session
@@ -8870,8 +8903,8 @@ fn begin_resolve_all_consent(
     {
         // An AI-issued recheck is an internal, provisional shortcut. An
         // explicit Resolve All proposal is the priority holder's replacement
-        // shortcut, so restore the saved preferences before asking every
-        // representative for the new proposal's consent.
+        // shortcut, so restore the saved preferences before installing the
+        // requester's own session below.
         Some(StackResolutionPolicy::RecheckNoMeaningfulPriorityAction) => {
             take_and_restore_stack_resolution_session(state);
         }
@@ -8885,6 +8918,10 @@ fn begin_resolve_all_consent(
     super::priority::pass_priority_legality(state, priority_player)?;
     let current_representative =
         super::topology::priority_pass_representative(state, priority_player);
+    // CR 117.3d / CR 117.4: `Own` binds the requester alone (no consent to ask,
+    // so nobody can block it); `Shared` opens the table-wide compression
+    // proposal, rotated so the requester is first and self-granted. See
+    // `ResolveAllScope`.
     let mut representatives = super::topology::priority_pass_participants(state);
     let Some(current_index) = representatives
         .iter()
@@ -8894,7 +8931,10 @@ fn begin_resolve_all_consent(
             "Resolve All requires a live priority representative".to_string(),
         ));
     };
-    representatives.rotate_left(current_index);
+    match scope {
+        ResolveAllScope::Own => representatives = vec![current_representative],
+        ResolveAllScope::Shared => representatives.rotate_left(current_index),
+    }
 
     let epoch = state.next_resolve_all_consent_epoch;
     let next_epoch = epoch.checked_add(1).ok_or_else(|| {
@@ -8907,6 +8947,7 @@ fn begin_resolve_all_consent(
     state.resolve_all_consent_run = Some(ResolveAllConsentRun {
         epoch,
         max_resolutions: StackResolutionBudget::from_legacy_max_resolutions(max_resolutions),
+        scope,
         priority_snapshot: ResolveAllPrioritySnapshot {
             waiting_player: priority_player,
             priority_player: state.priority_player,
@@ -8933,6 +8974,9 @@ fn begin_resolve_all_consent(
         ),
     });
 
+    // An `Own` run is single-participant and self-granted, so it materializes on
+    // the spot and never raises a consent prompt. A `Shared` run queues the
+    // remaining representatives for the table-wide compression proposal.
     if state
         .resolve_all_consent_run
         .as_ref()
@@ -9831,9 +9875,13 @@ fn apply_action(
             }
             return pass_installed_auto_pass_priority(state, *player, &mut events);
         }
-        (WaitingFor::Priority { player }, GameAction::BeginResolveAll { max_resolutions }) => {
-            begin_resolve_all_consent(state, *player, max_resolutions)?
-        }
+        (
+            WaitingFor::Priority { player },
+            GameAction::BeginResolveAll {
+                max_resolutions,
+                scope,
+            },
+        ) => begin_resolve_all_consent(state, *player, max_resolutions, scope)?,
         (
             WaitingFor::ResolveAllConsent {
                 epoch,
@@ -16662,6 +16710,14 @@ pub fn start_game_with_starting_player(
     state.active_player = starting_player;
     state.priority_player = starting_player;
     state.current_starting_player = starting_player;
+    // CR 103.8 + CR 500: the starting player takes their first turn HERE — turn 1
+    // is established inline rather than through `turns::start_next_turn`, which is
+    // where every later turn's per-player count is incremented. Without this the
+    // starting player's `turns_taken` stays one behind every other seat for the
+    // whole game, so `QuantityRef::TurnsTaken` ("the number of turns you've taken
+    // this game") and every "your Nth turn" condition read low for exactly the
+    // player who has taken the MOST turns.
+    state.players[starting_player.0 as usize].turns_taken += 1;
     // First-game default chooser is the starting player; BO3 restarts can pre-set this.
     if state.next_game_chooser.is_none() {
         state.next_game_chooser = Some(starting_player);
@@ -16718,6 +16774,10 @@ pub fn start_game_skip_mulligan(state: &mut GameState) -> ActionResult {
     state.active_player = starting_player;
     state.priority_player = starting_player;
     state.current_starting_player = starting_player;
+    // CR 103.8 + CR 500: see the matching increment in
+    // `start_game_with_starting_player` — turn 1 bypasses `turns::start_next_turn`,
+    // so the starting player's own first turn must be counted here.
+    state.players[starting_player.0 as usize].turns_taken += 1;
     state.phase = Phase::Untap;
 
     events.push(GameEvent::TurnStarted {
@@ -17138,7 +17198,7 @@ mod resolve_all_consent_session_tests {
         let mut state = GameState::new(FormatConfig::free_for_all(), 1, 0x51_1E);
         state.stack.push_back(no_op_entry(1, P0));
 
-        let waiting = begin_resolve_all_consent(&mut state, P0, 1)
+        let waiting = begin_resolve_all_consent(&mut state, P0, 1, ResolveAllScope::Shared)
             .expect("the sole representative is already unanimous");
 
         assert!(matches!(waiting, WaitingFor::Priority { player: P0 }));
@@ -17155,7 +17215,7 @@ mod resolve_all_consent_session_tests {
     fn two_headed_giant_final_grant_overlays_only_canonical_team_representatives() {
         let mut state = GameState::new(FormatConfig::two_headed_giant(), 4, 0x2A6);
         state.stack.push_back(no_op_entry(1, P0));
-        let waiting = begin_resolve_all_consent(&mut state, P0, 7)
+        let waiting = begin_resolve_all_consent(&mut state, P0, 7, ResolveAllScope::Shared)
             .expect("the active team representative begins consent");
         let WaitingFor::ResolveAllConsent {
             epoch,

--- a/crates/engine/src/game/engine_auto_pass_decision_tests.rs
+++ b/crates/engine/src/game/engine_auto_pass_decision_tests.rs
@@ -8,7 +8,7 @@ use crate::types::ability::{
     AbilityDefinition, AbilityKind, CopyRetargetPermission, Effect, PtValue, QuantityExpr,
     ResolvedAbility, StaticDefinition, TargetFilter,
 };
-use crate::types::actions::GameAction;
+use crate::types::actions::{GameAction, ResolveAllScope};
 use crate::types::card_type::CoreType;
 use crate::types::events::GameEvent;
 use crate::types::game_state::{
@@ -2214,7 +2214,10 @@ fn resolve_all_supersedes_a_rechecking_ai_session_and_retains_auto_pass_baseline
     let result = apply(
         &mut state,
         PlayerId(0),
-        GameAction::BeginResolveAll { max_resolutions: 0 },
+        GameAction::BeginResolveAll {
+            max_resolutions: 0,
+            scope: ResolveAllScope::Shared,
+        },
     )
     .expect("the priority holder may replace an AI recheck with Resolve All");
 

--- a/crates/engine/src/game/engine_resolve_batch.rs
+++ b/crates/engine/src/game/engine_resolve_batch.rs
@@ -999,7 +999,7 @@ mod tests {
         AbilityCost, AbilityDefinition, AbilityKind, CopyRetargetPermission, Effect,
         ManaContribution, ManaProduction, QuantityExpr, ResolvedAbility, TargetFilter,
     };
-    use crate::types::actions::ResolveAllConsentDecision;
+    use crate::types::actions::{ResolveAllConsentDecision, ResolveAllScope};
     use crate::types::card_type::{CardType, CoreType};
     use crate::types::format::FormatConfig;
     use crate::types::game_state::{
@@ -1396,7 +1396,10 @@ mod tests {
         super::super::engine::apply(
             &mut state,
             PlayerId(0),
-            GameAction::BeginResolveAll { max_resolutions: 0 },
+            GameAction::BeginResolveAll {
+                max_resolutions: 0,
+                scope: ResolveAllScope::Shared,
+            },
         )
         .expect("priority holder begins the consent run");
         let epoch = match &state.waiting_for {
@@ -1449,7 +1452,10 @@ mod tests {
         super::super::engine::apply(
             &mut state,
             PlayerId(0),
-            GameAction::BeginResolveAll { max_resolutions: 0 },
+            GameAction::BeginResolveAll {
+                max_resolutions: 0,
+                scope: ResolveAllScope::Shared,
+            },
         )
         .expect("priority holder begins the consent run");
         let epoch = match &state.waiting_for {

--- a/crates/engine/src/game/engine_tests.rs
+++ b/crates/engine/src/game/engine_tests.rs
@@ -5515,6 +5515,39 @@ fn start_game_skips_draw_on_first_turn() {
     assert!(!state.players[0].hand.contains(&id));
 }
 
+// CR 103.8 + CR 500: the starting player TAKES their first turn, so it must
+// count toward `turns_taken` like every other turn. Turn 1 is established
+// inline by the game-start path rather than by `turns::start_next_turn`, so
+// before this was fixed the starting player stayed permanently one turn behind
+// every other seat — `QuantityRef::TurnsTaken` read low for exactly the player
+// who had taken the most turns.
+#[test]
+fn start_game_counts_the_starting_players_first_turn() {
+    for starting_player in [PlayerId(0), PlayerId(1)] {
+        let mut state = new_game(42);
+        start_game_with_starting_player(&mut state, starting_player);
+
+        assert_eq!(
+            state.players[starting_player.0 as usize].turns_taken, 1,
+            "the starting player's own first turn counts"
+        );
+        for player in state.players.iter() {
+            if player.id != starting_player {
+                assert_eq!(
+                    player.turns_taken, 0,
+                    "a player who has not had a turn yet counts none"
+                );
+            }
+        }
+    }
+
+    // `start_game_skip_mulligan` establishes turn 1 through the same inline
+    // path and must agree.
+    let mut state = new_game(42);
+    start_game_skip_mulligan(&mut state);
+    assert_eq!(state.players[0].turns_taken, 1);
+}
+
 #[test]
 fn start_game_emits_game_started_event() {
     let mut state = new_game(42);

--- a/crates/engine/src/game/replay.rs
+++ b/crates/engine/src/game/replay.rs
@@ -293,7 +293,7 @@ mod tests {
         AbilityDefinition, AbilityKind, Effect, QuantityExpr, ResolvedAbility, TargetFilter,
         TriggerBaseSetInstanceRef, TriggerDefinitionOccurrenceRef,
     };
-    use crate::types::actions::{GameAction, ResolveAllConsentDecision};
+    use crate::types::actions::{GameAction, ResolveAllConsentDecision, ResolveAllScope};
     use crate::types::card_type::CoreType;
     use crate::types::format::FormatConfig;
     use crate::types::game_state::{
@@ -540,7 +540,10 @@ mod tests {
         initial.stack.push_back(no_op_entry(1, PlayerId(0)));
         let mut log = ReplayLog::new(header);
 
-        let begin = GameAction::BeginResolveAll { max_resolutions: 0 };
+        let begin = GameAction::BeginResolveAll {
+            max_resolutions: 0,
+            scope: ResolveAllScope::Shared,
+        };
         let mut consent = initial.clone();
         apply(&mut consent, PlayerId(0), begin.clone())
             .expect("P0 can begin Resolve All from priority");
@@ -698,7 +701,10 @@ mod tests {
             );
         }
 
-        let begin = GameAction::BeginResolveAll { max_resolutions: 0 };
+        let begin = GameAction::BeginResolveAll {
+            max_resolutions: 0,
+            scope: ResolveAllScope::Shared,
+        };
         apply(&mut initial, PlayerId(0), begin).expect("P0 begins Resolve All consent");
         let WaitingFor::ResolveAllConsent { epoch, .. } = initial.waiting_for else {
             panic!(

--- a/crates/engine/src/game/turn_control.rs
+++ b/crates/engine/src/game/turn_control.rs
@@ -1,6 +1,7 @@
 use std::collections::BTreeSet;
 
 use crate::types::ability::ControlWindow;
+use crate::types::actions::ResolveAllScope;
 use crate::types::game_state::{
     ActivePlayerControl, ActiveSearchDecisionAuthority, GameState, ResolveAllConsentRun,
     ScheduledTurnControl, WaitingFor,
@@ -411,7 +412,17 @@ pub(crate) fn resolve_all_consent_authority_matches_live(
         .into_iter()
         .collect();
 
-    frozen_representatives == live_representatives
+    // CR 117.4: a `Shared` run is a table-wide proposal, so a seat that became
+    // a priority participant after the snapshot would otherwise be bound by a
+    // consent it never gave — the live set must match exactly. An `Own` run
+    // binds only the requester and asks nobody, so it stays coherent as long as
+    // every seat it froze is still a live participant.
+    let membership_holds = match run.scope {
+        ResolveAllScope::Own => frozen_representatives.is_subset(&live_representatives),
+        ResolveAllScope::Shared => frozen_representatives == live_representatives,
+    };
+
+    membership_holds
         && run.participants.iter().all(|participant| {
             live_authorized_submitter_for_player(state, participant.representative)
                 == participant.authorized_submitter

--- a/crates/engine/src/types/action_stable_order.rs
+++ b/crates/engine/src/types/action_stable_order.rs
@@ -824,14 +824,16 @@ fn cmp_payload(a: &GameAction, b: &GameAction) -> Ordering {
         }
         GameAction::BeginResolveAll {
             max_resolutions: a0,
+            scope: a1,
         } => {
             let GameAction::BeginResolveAll {
                 max_resolutions: b0,
+                scope: b1,
             } = b
             else {
                 unreachable!("cmp_payload: same-variant invariant");
             };
-            cmp_val(a0, b0)
+            cmp_val(a0, b0).then_with(|| cmp_val(a1, b1))
         }
         GameAction::RespondResolveAllConsent {
             epoch: a0,
@@ -1711,6 +1713,7 @@ mod tests {
         DecisionGroupKey, DecisionKind, DecisionTemplate, IterationCount, ReplayMode,
     };
     use crate::game::combat::AttackTarget;
+    use crate::types::actions::ResolveAllScope;
     use crate::types::actions::{
         MayTriggerAutoChoiceOp, PrecastCopyShortcutResponse, ResolveAllConsentDecision,
     };
@@ -1729,8 +1732,14 @@ mod tests {
     #[test]
     fn newer_action_variants_compare_their_payloads() {
         assert_distinct_order(
-            GameAction::BeginResolveAll { max_resolutions: 1 },
-            GameAction::BeginResolveAll { max_resolutions: 2 },
+            GameAction::BeginResolveAll {
+                max_resolutions: 1,
+                scope: ResolveAllScope::Own,
+            },
+            GameAction::BeginResolveAll {
+                max_resolutions: 2,
+                scope: ResolveAllScope::Own,
+            },
         );
         assert_distinct_order(
             GameAction::RespondResolveAllConsent {
@@ -1876,8 +1885,14 @@ mod tests {
             },
         );
         assert_distinct_order(
-            GameAction::BeginResolveAll { max_resolutions: 1 },
-            GameAction::BeginResolveAll { max_resolutions: 2 },
+            GameAction::BeginResolveAll {
+                max_resolutions: 1,
+                scope: ResolveAllScope::Own,
+            },
+            GameAction::BeginResolveAll {
+                max_resolutions: 2,
+                scope: ResolveAllScope::Own,
+            },
         );
         assert_distinct_order(
             GameAction::RespondResolveAllConsent {

--- a/crates/engine/src/types/actions.rs
+++ b/crates/engine/src/types/actions.rs
@@ -968,11 +968,16 @@ pub enum GameAction {
         source_name: String,
         cost: crate::types::mana::ManaCost,
     },
-    /// Begins the table-consent protocol for the forthcoming Resolve All batch.
-    /// Phase 1 only records unanimous consent; it deliberately does not drive
-    /// priority or resolve the batch.
+    /// Begins a Resolve All batch. `scope` selects whether this binds only the
+    /// requester (`Own` — the player-facing button, resolves immediately) or
+    /// opens the table-wide consent protocol (`Shared` — engine stack
+    /// compression). See [`ResolveAllScope`].
     BeginResolveAll {
         max_resolutions: u32,
+        /// `#[serde(default)]` migrates payloads written before the scope
+        /// existed to `Own`, the weaker of the two authorities.
+        #[serde(default)]
+        scope: ResolveAllScope,
     },
     /// Answers the currently queued Resolve All consent prompt. `epoch` makes
     /// delayed transport submissions fail closed rather than answering a newer
@@ -996,6 +1001,33 @@ pub enum GameAction {
 pub enum ResolveAllConsentDecision {
     Grant,
     Decline,
+}
+
+/// CR 117.3d + CR 117.4: which priority representatives a Resolve All request
+/// binds.
+///
+/// `Own` is the player-facing shortcut: a pre-commitment to pass the
+/// REQUESTER'S OWN priority windows while the current stack cohort drains. One
+/// player can never decide another's passes, so it asks nobody and cannot be
+/// blocked by a seat that declines or (an AI seat) never answers. Every other
+/// seat keeps its ordinary windows and its non-representative meaningful-action
+/// protection in `stack_resolution_session_priority_decision`, so CR 117.4 still
+/// requires their real passes before anything resolves.
+///
+/// `Shared` is the table-wide compression proposal: it asks every representative
+/// for consent, and a unanimous grant makes them all representatives of one
+/// session. That is strictly stronger than `Own` — a representative's windows
+/// are passed WITHOUT the meaningful-action check — which is exactly what lets
+/// the engine collapse a stack whose other players could still have acted. It
+/// is opt-in for that reason.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Default, Serialize, Deserialize)]
+#[serde(tag = "type", content = "data")]
+pub enum ResolveAllScope {
+    /// Bind only the requester. The default so a payload written before this
+    /// field existed cannot silently acquire table-wide authority.
+    #[default]
+    Own,
+    Shared,
 }
 
 /// CR 117.3d: The mutation a `GameAction::SetPriorityYield` performs on the

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -22,6 +22,7 @@ use super::ability::{
     TriggerBaseSetInstanceRef, TriggerCondition, TriggerDefinition, TriggerDefinitionOccurrenceRef,
     TriggerDefinitionRef, TriggerEntry,
 };
+use super::actions::ResolveAllScope;
 use super::attribution::ObjectAttribution;
 use super::card::{CardFace, PrintedCardRef, TokenImageRef};
 use super::card_type::{CoreType, Supertype};
@@ -2092,6 +2093,15 @@ pub struct ResolveAllConsentRun {
     #[serde(default)]
     pub max_resolutions: StackResolutionBudget,
     pub priority_snapshot: ResolveAllPrioritySnapshot,
+    /// Which seats this run binds. `Own` runs cover only the requester, so the
+    /// live-authority check accepts them as a SUBSET of the current priority
+    /// participants; a `Shared` run is a table-wide proposal and must still
+    /// match the live set exactly, or a seat that became a participant after
+    /// the snapshot would be bound by a consent it never gave (CR 117.4).
+    /// Defaults to `Own` so a save written before this field existed cannot
+    /// silently acquire table-wide authority.
+    #[serde(default)]
+    pub scope: ResolveAllScope,
     pub participants: Vec<ResolveAllConsentParticipant>,
     /// The complete sparse auto-pass map captured before a fresh Resolve All
     /// run installs its temporary shared-resolution overlay. `None` identifies
@@ -15487,21 +15497,36 @@ pub enum AutoPassMode {
     },
 }
 
-/// How the engine recommends passing ordinary priority windows for one player.
+/// THE single per-player authority for auto-passing ordinary priority windows,
+/// as a graduated scale from "never" to "skip the low-use ones".
 ///
-/// This is an opt-in interface preference, not a change to priority itself:
-/// every recommended pass is still submitted as `GameAction::PassPriority` and
-/// resolved by the normal CR 117.3d / CR 117.4 engine path. `Standard` preserves
-/// the existing meaningful-action-aware recommendation ladder.
-/// `SkipLowUseWindows` adds a
+/// Two consumers read it, and they differ in force:
+///
+/// - `ai_support::auto_pass_recommended` — a *recommendation* to the frontend.
+///   Every recommended pass is still submitted as `GameAction::PassPriority`
+///   and resolved by the normal CR 117.3d / CR 117.4 path.
+/// - `game::engine`'s `run_auto_pass_loop` — *authoritative*. Passes taken here
+///   never reach a client, which is why `FullControl` has to live in engine
+///   state rather than in a frontend toggle: an auto-pass session installed by
+///   another player (Resolve All, CR 117.3d) drives this loop, and a
+///   client-only preference is invisible to it.
+///
+/// `Standard` is the meaningful-action-aware ladder. `SkipLowUseWindows` adds a
 /// narrow fast path for the active player's empty-stack Upkeep, Draw, and End
-/// priority windows; explicit phase stops, priority yields, and Full Control
-/// remain higher-authority user choices.
+/// windows. `FullControl` never auto-passes at all.
+///
+/// `FullControl` is deliberately NOT expressible as a `phase_stops` entry on
+/// every phase: `GameState::phase_stop_hit` is consulted only for empty-stack
+/// initial windows (`ai_support/mod.rs`), whereas Full Control must also hold a
+/// window while objects are on the stack.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Default, Serialize, Deserialize)]
 pub enum PriorityPassingMode {
     #[default]
     Standard,
     SkipLowUseWindows,
+    /// CR 117.1: hold every priority window this player receives. Outranks any
+    /// auto-pass session, including one another player installed.
+    FullControl,
 }
 
 /// CR 732.2a: user-controllable gate for the live combo (infinite-loop) detector.
@@ -36689,6 +36714,7 @@ mod tests {
         let run = ResolveAllConsentRun {
             epoch: 1,
             max_resolutions: StackResolutionBudget::Unlimited,
+            scope: ResolveAllScope::Own,
             priority_snapshot: ResolveAllPrioritySnapshot {
                 waiting_player: PlayerId(0),
                 priority_player: PlayerId(0),

--- a/crates/engine/tests/integration/precast_copy_shortcut.rs
+++ b/crates/engine/tests/integration/precast_copy_shortcut.rs
@@ -15,7 +15,7 @@ use engine::types::ability::{
     CardSelectionMode, ContinuousModification, CopyRetargetPermission, Effect, QuantityExpr,
     QuantityModification, ReplacementDefinition, ResolvedAbility, TargetFilter, TargetRef,
 };
-use engine::types::actions::{GameAction, PrecastCopyShortcutResponse};
+use engine::types::actions::{GameAction, PrecastCopyShortcutResponse, ResolveAllScope};
 use engine::types::card_type::CoreType;
 use engine::types::events::GameEvent;
 use engine::types::format::FormatConfig;
@@ -518,7 +518,10 @@ fn precast_shorten_requires_meaningful_divergence_before_manual_or_auto_pass() {
         .expect("shorten at the issued boundary");
 
     assert!(runner
-        .act(GameAction::BeginResolveAll { max_resolutions: 7 })
+        .act(GameAction::BeginResolveAll {
+            max_resolutions: 7,
+            scope: ResolveAllScope::Own
+        })
         .is_err());
     assert!(matches!(
         runner.state().waiting_for,

--- a/crates/engine/tests/integration/resolve_all_consent.rs
+++ b/crates/engine/tests/integration/resolve_all_consent.rs
@@ -22,12 +22,12 @@ use engine::types::ability::{
     ChoiceType, ControllerRef, CopyRetargetPermission, Effect, ResolvedAbility, TargetFilter,
     TargetRef, TargetSelectionMode, TypedFilter,
 };
-use engine::types::actions::{GameAction, ResolveAllConsentDecision};
+use engine::types::actions::{GameAction, ResolveAllConsentDecision, ResolveAllScope};
 use engine::types::card_type::CoreType;
 use engine::types::events::GameEvent;
 use engine::types::format::FormatConfig;
 use engine::types::game_state::{
-    AutoPassMode, GameState, PersistedGameState, StackEntry, StackEntryKind,
+    AutoPassMode, GameState, PersistedGameState, PriorityPassingMode, StackEntry, StackEntryKind,
     StackResolutionAutoPassOverlay, StackResolutionBudget, StackResolutionEntryFence,
     StackResolutionPolicy, StackResolutionSession, TurnBoundary, WaitingFor,
 };
@@ -52,7 +52,10 @@ fn begin(state: &mut GameState) -> u64 {
     apply(
         state,
         P0,
-        GameAction::BeginResolveAll { max_resolutions: 7 },
+        GameAction::BeginResolveAll {
+            max_resolutions: 7,
+            scope: ResolveAllScope::Shared,
+        },
     )
     .expect("priority holder may begin Resolve All consent");
     match &state.waiting_for {
@@ -171,6 +174,7 @@ fn browser_partial_priority_equip_grants_then_resolves_at_the_public_batch_seam(
         P0,
         GameAction::BeginResolveAll {
             max_resolutions: 100,
+            scope: ResolveAllScope::Shared,
         },
     )
     .expect("the human priority holder starts the browser Resolve All flow");
@@ -244,6 +248,7 @@ fn browser_partial_priority_equip_uses_the_shared_session_instead_of_a_prefix_pr
         P0,
         GameAction::BeginResolveAll {
             max_resolutions: 100,
+            scope: ResolveAllScope::Shared,
         },
     )
     .expect("the human priority holder starts Resolve All");
@@ -307,6 +312,100 @@ fn restored_mid_stack_priority_discards_an_orphaned_trigger_event_carrier() {
     assert!(restored.pending_trigger.is_none());
 }
 
+/// CR 117.3d: `ResolveAllScope::Own` binds the requester alone, so a table with
+/// AI seats can never park the requester on a consent prompt nobody answers.
+#[test]
+fn own_scope_resolves_without_asking_anyone() {
+    let mut state = GameState::new(FormatConfig::free_for_all(), 3, 0x5E55_1017);
+    state.active_player = P2;
+    state.priority_player = P0;
+    state.waiting_for = WaitingFor::Priority { player: P0 };
+    state.stack.push_back(no_op_entry(1, P2));
+    state.stack.push_back(no_op_entry(2, P2));
+
+    let result = apply(
+        &mut state,
+        P0,
+        GameAction::BeginResolveAll {
+            max_resolutions: 1,
+            scope: ResolveAllScope::Own,
+        },
+    )
+    .expect("the priority holder begins Resolve All without anyone else's consent");
+
+    assert!(
+        !matches!(
+            state.waiting_for,
+            WaitingFor::ResolveAllConsent { .. } | WaitingFor::ResolveAllReady { .. }
+        ),
+        "Own scope raises no consent prompt, got {:?}",
+        state.waiting_for
+    );
+    assert!(state.resolve_all_consent_run.is_none());
+    assert_eq!(
+        result
+            .events
+            .iter()
+            .filter(|event| matches!(event, GameEvent::EffectResolved { .. }))
+            .count(),
+        1,
+        "the requester's own session resolves under its cap with no second party"
+    );
+    assert_eq!(state.stack.len(), 1);
+    for viewer in [P0, P1, P2] {
+        assert!(
+            !legal_actions_for_viewer(&state, viewer)
+                .0
+                .iter()
+                .any(|action| matches!(
+                    action,
+                    GameAction::RespondResolveAllConsent { .. }
+                        | GameAction::RevokeResolveAllConsent { .. }
+                )),
+            "{viewer:?} must not be offered a consent response"
+        );
+    }
+}
+
+/// CR 117.1: Full Control is a standing refusal to give up any window, and it
+/// must survive a session ANOTHER player installed — those passes are taken
+/// inside `run_auto_pass_loop` and never reach a frontend, so a client-only
+/// toggle could not have stopped them.
+#[test]
+fn full_control_holds_a_window_against_another_players_resolve_all() {
+    let mut state = GameState::new(FormatConfig::free_for_all(), 3, 0xFC0_0DED);
+    state.active_player = P2;
+    state.priority_player = P0;
+    state.waiting_for = WaitingFor::Priority { player: P0 };
+    state.stack.push_back(no_op_entry(1, P2));
+    state.stack.push_back(no_op_entry(2, P2));
+    // P1 has nothing meaningful to do, so ONLY Full Control can hold their
+    // window — the meaningful-action gate would let the session pass them.
+    state
+        .priority_passing_modes
+        .insert(P1, PriorityPassingMode::FullControl);
+
+    apply(
+        &mut state,
+        P0,
+        GameAction::BeginResolveAll {
+            max_resolutions: 0,
+            scope: ResolveAllScope::Own,
+        },
+    )
+    .expect("P0 begins their own Resolve All");
+
+    assert!(
+        !state.stack.is_empty(),
+        "P1's Full Control must stop the session before it drains the stack"
+    );
+    assert!(
+        matches!(state.waiting_for, WaitingFor::Priority { player } if player == P1),
+        "the window belongs to the Full Control player, got {:?}",
+        state.waiting_for
+    );
+}
+
 #[test]
 fn final_grant_materializes_the_ordinary_session_without_a_ready_latch() {
     let mut state = GameState::new_two_player(42);
@@ -343,7 +442,10 @@ fn final_grant_transfers_the_requested_cap_zero_as_unlimited() {
         let epoch = apply(
             &mut state,
             P0,
-            GameAction::BeginResolveAll { max_resolutions },
+            GameAction::BeginResolveAll {
+                max_resolutions,
+                scope: ResolveAllScope::Shared,
+            },
         )
         .expect("priority holder begins")
         .waiting_for;
@@ -656,7 +758,10 @@ fn begin_resolve_all_refuses_to_replace_an_existing_resolution_session() {
     assert!(apply(
         &mut state,
         P0,
-        GameAction::BeginResolveAll { max_resolutions: 1 },
+        GameAction::BeginResolveAll {
+            max_resolutions: 1,
+            scope: ResolveAllScope::Shared
+        },
     )
     .is_err());
     assert_eq!(
@@ -869,7 +974,10 @@ fn decline_under_turn_control_restores_the_semantic_priority_snapshot() {
     apply(
         &mut state,
         P1,
-        GameAction::BeginResolveAll { max_resolutions: 7 },
+        GameAction::BeginResolveAll {
+            max_resolutions: 7,
+            scope: ResolveAllScope::Shared,
+        },
     )
     .expect("the controller may begin Resolve All for the controlled priority seat");
     let epoch = match state.waiting_for {
@@ -925,7 +1033,10 @@ fn eliminating_a_consent_representative_drops_the_run_and_restores_living_priori
     apply(
         &mut state,
         P0,
-        GameAction::BeginResolveAll { max_resolutions: 7 },
+        GameAction::BeginResolveAll {
+            max_resolutions: 7,
+            scope: ResolveAllScope::Shared,
+        },
     )
     .expect("priority holder may begin Resolve All consent");
     assert!(matches!(
@@ -1282,7 +1393,10 @@ fn ready_two_seat_state() -> GameState {
     apply(
         &mut state,
         P0,
-        GameAction::BeginResolveAll { max_resolutions: 1 },
+        GameAction::BeginResolveAll {
+            max_resolutions: 1,
+            scope: ResolveAllScope::Shared,
+        },
     )
     .expect("priority holder may begin Resolve All consent");
     let WaitingFor::ResolveAllConsent { epoch, .. } = state.waiting_for else {

--- a/crates/lobby-broker/src/protocol.rs
+++ b/crates/lobby-broker/src/protocol.rs
@@ -38,6 +38,11 @@ pub enum ServerErrorCode {
 /// rather than a parse error, and the handshake is the only place that pairing
 /// can be refused. See 24.
 ///
+/// 57 — `GameAction::BeginResolveAll` gained `scope: ResolveAllScope` (`Own`
+///      binds only the requester and resolves immediately; `Shared` opens the
+///      table-wide consent protocol), and `PriorityPassingMode` gained
+///      `FullControl`, which is now engine-authoritative rather than a
+///      frontend-only toggle.
 /// 56 — Host-only authoritative-state export request/response variants. Native
 ///      P2P host diagnostics must use a trusted server envelope rather than a
 ///      redacted player view. Lobby messages are unchanged.
@@ -263,7 +268,7 @@ pub enum ServerErrorCode {
 ///      payload; mulligan bottoming folded into a
 ///      `MulliganDecisionPhase::BottomCards` sub-phase on
 ///      `WaitingFor::MulliganDecision`.
-pub const PROTOCOL_VERSION: u32 = 56;
+pub const PROTOCOL_VERSION: u32 = 57;
 
 /// Minimum protocol version accepted by lobby-only brokers at the hello
 /// handshake **from clients that predate [`LOBBY_PROTOCOL_VERSION`]** — the

--- a/crates/lobby-broker/src/protocol.rs
+++ b/crates/lobby-broker/src/protocol.rs
@@ -1014,12 +1014,12 @@ mod tests {
 
     #[test]
     fn protocol_version_tracks_full_game_wire_additions() {
-        assert_eq!(PROTOCOL_VERSION, 56);
+        assert_eq!(PROTOCOL_VERSION, 57);
         // Lobby keeps its one-version rollout window; full-game servers stay
         // current-only (`server_core::MIN_SUPPORTED_PROTOCOL == PROTOCOL_VERSION`),
         // which is what refuses an older full-game peer whose GameState cannot
         // understand a success acknowledgment the submitting client awaits.
-        assert_eq!(MIN_SUPPORTED_PROTOCOL, 55);
+        assert_eq!(MIN_SUPPORTED_PROTOCOL, 56);
     }
 
     #[test]

--- a/crates/phase-ai/src/search.rs
+++ b/crates/phase-ai/src/search.rs
@@ -4517,6 +4517,7 @@ fn softmax_select_index(
 
 #[cfg(test)]
 mod tests {
+    use engine::types::actions::ResolveAllScope;
     use std::path::Path;
 
     use super::*;
@@ -5736,7 +5737,10 @@ mod tests {
         engine::game::engine::apply(
             &mut state,
             P0,
-            GameAction::BeginResolveAll { max_resolutions: 5 },
+            GameAction::BeginResolveAll {
+                max_resolutions: 5,
+                scope: ResolveAllScope::Shared,
+            },
         )
         .expect("the priority holder may propose Resolve All");
 
@@ -5761,7 +5765,10 @@ mod tests {
         engine::game::engine::apply(
             &mut state,
             P0,
-            GameAction::BeginResolveAll { max_resolutions: 5 },
+            GameAction::BeginResolveAll {
+                max_resolutions: 5,
+                scope: ResolveAllScope::Shared,
+            },
         )
         .expect("the priority holder may propose Resolve All");
 
@@ -5799,7 +5806,10 @@ mod tests {
         engine::game::engine::apply(
             &mut state,
             P0,
-            GameAction::BeginResolveAll { max_resolutions: 5 },
+            GameAction::BeginResolveAll {
+                max_resolutions: 5,
+                scope: ResolveAllScope::Shared,
+            },
         )
         .expect("the priority holder may propose Resolve All");
 

--- a/crates/phase-server/src/main.rs
+++ b/crates/phase-server/src/main.rs
@@ -10286,7 +10286,10 @@ mod state_transport_derived_tests {
             apply(
                 &mut session.state,
                 PlayerId(0),
-                GameAction::BeginResolveAll { max_resolutions: 1 },
+                GameAction::BeginResolveAll {
+                    max_resolutions: 1,
+                    scope: ResolveAllScope::Shared,
+                },
             )
             .expect("priority holder may start Resolve All consent");
             let epoch = match session.state.waiting_for {

--- a/crates/server-core/src/protocol.rs
+++ b/crates/server-core/src/protocol.rs
@@ -2953,8 +2953,8 @@ mod tests {
     }
 
     #[test]
-    fn protocol_version_is_56_for_authoritative_state_export() {
-        assert_eq!(PROTOCOL_VERSION, 56);
+    fn protocol_version_is_57_for_authoritative_state_export() {
+        assert_eq!(PROTOCOL_VERSION, 57);
     }
 
     /// The bump alone is inert — a version number nobody enforces prevents no
@@ -2965,7 +2965,7 @@ mod tests {
     ///
     /// REVERT-PROBE: relax to `PROTOCOL_VERSION - 1` — the exact regression
     /// this guards — and this test reds while
-    /// `protocol_version_is_56_for_authoritative_state_export` stays
+    /// `protocol_version_is_57_for_authoritative_state_export` stays
     /// green, which is why the two are separate assertions.
     #[test]
     fn full_game_floor_is_current_only_not_a_rollout_window() {

--- a/crates/server-core/src/session.rs
+++ b/crates/server-core/src/session.rs
@@ -2266,7 +2266,9 @@ mod tests {
     use engine::game::scenario::{GameRunner, GameScenario, P0, P1};
     use engine::game::scenario_db::GameScenarioDbExt;
     use engine::types::ability::{Effect, ResolvedAbility, TargetRef};
-    use engine::types::actions::{PrecastCopyShortcutResponse, ResolveAllConsentDecision};
+    use engine::types::actions::{
+        PrecastCopyShortcutResponse, ResolveAllConsentDecision, ResolveAllScope,
+    };
     use engine::types::card::CardFace;
     use engine::types::card_type::CardType;
     use engine::types::game_state::{
@@ -6799,10 +6801,12 @@ mod tests {
         (mgr, game_code, ai_player)
     }
 
-    /// A final AI consent grant enters the same fenced session used by direct
-    /// `UntilStackEmpty`, rather than creating a transport-owned Ready latch.
+    /// CR 117.3d: a human Resolve All at a table with AI seats enters the same
+    /// fenced session used by direct `UntilStackEmpty` without asking the AI for
+    /// anything. The AI seat owing a response is exactly what used to park the
+    /// human on a consent prompt they could not clear.
     #[test]
-    fn run_ai_advances_an_ai_granted_shared_session() {
+    fn resolve_all_at_an_ai_table_needs_no_ai_consent() {
         let (mut mgr, game_code, _ai_player) = ai_table_awaiting_one_consent();
         let session = mgr
             .sessions
@@ -6812,24 +6816,27 @@ mod tests {
         apply(
             &mut session.state,
             PlayerId(0),
-            GameAction::BeginResolveAll { max_resolutions: 1 },
+            GameAction::BeginResolveAll {
+                max_resolutions: 1,
+                scope: ResolveAllScope::Own,
+            },
         )
-        .expect("the priority holder may start Resolve All consent");
+        .expect("the priority holder may start Resolve All");
         assert!(
-            matches!(
+            !matches!(
                 session.state.waiting_for,
-                WaitingFor::ResolveAllConsent { .. }
+                WaitingFor::ResolveAllConsent { .. } | WaitingFor::ResolveAllReady { .. }
             ),
-            "the AI representative must still owe a consent response, got {:?}",
+            "the human must never be parked on an AI's consent, got {:?}",
             session.state.waiting_for
         );
-
-        let transitions = session.run_ai();
-
         assert!(
-            transitions.transitions.len() >= 2,
-            "the grant and session runner must each produce a transition"
+            session.state.resolve_all_consent_run.is_none(),
+            "the requester's single-participant run materializes immediately"
         );
+
+        session.run_ai();
+
         assert!(session.state.stack.is_empty());
         assert!(session.state.resolve_all_consent_run.is_none());
         assert!(session.state.stack_resolution_session.is_none());
@@ -6852,17 +6859,12 @@ mod tests {
         apply(
             &mut session.state,
             PlayerId(0),
-            GameAction::BeginResolveAll { max_resolutions: 1 },
+            GameAction::BeginResolveAll {
+                max_resolutions: 1,
+                scope: ResolveAllScope::Own,
+            },
         )
-        .expect("the priority holder may start Resolve All consent");
-        assert!(
-            matches!(
-                session.state.waiting_for,
-                WaitingFor::ResolveAllConsent { .. }
-            ),
-            "the AI representative must still owe a consent response, got {:?}",
-            session.state.waiting_for
-        );
+        .expect("the priority holder may start Resolve All");
 
         let transitions = session.run_ai();
 
@@ -6889,17 +6891,17 @@ mod tests {
         );
     }
 
-    /// A human final grant also enters the same engine-owned session; it does
-    /// not leave a Ready latch for a separate client transport action.
+    /// The same rule read from the other side: an AI seat's Resolve All is that
+    /// seat's own pre-commitment too, so it never interrupts the human for a
+    /// consent decision and never leaves a Ready latch behind.
     #[test]
-    fn human_final_grant_uses_the_shared_session() {
+    fn an_ai_resolve_all_does_not_prompt_the_human() {
         let (mut mgr, game_code, ai_player) = ai_table_awaiting_one_consent();
         let session = mgr
             .sessions
             .get_mut(&game_code)
             .expect("the game retains its session");
-        // Flip the roles: the AI opens the run (auto-granting itself) so the
-        // remaining representative is the human.
+        // Flip the roles: the AI seat is the one starting Resolve All.
         session.state.priority_player = ai_player;
         session.state.waiting_for = WaitingFor::Priority { player: ai_player };
         session.state.priority_passes.clear();
@@ -6908,44 +6910,27 @@ mod tests {
         apply(
             &mut session.state,
             ai_player,
-            GameAction::BeginResolveAll { max_resolutions: 1 },
-        )
-        .expect("the priority holder may start Resolve All consent");
-        let WaitingFor::ResolveAllConsent {
-            epoch,
-            representative,
-        } = session.state.waiting_for
-        else {
-            panic!(
-                "expected a pending consent prompt, got {:?}",
-                session.state.waiting_for
-            );
-        };
-        assert_eq!(
-            representative,
-            PlayerId(0),
-            "the human must be the outstanding representative"
-        );
-
-        apply(
-            &mut session.state,
-            PlayerId(0),
-            GameAction::RespondResolveAllConsent {
-                epoch,
-                decision: ResolveAllConsentDecision::Grant,
+            GameAction::BeginResolveAll {
+                max_resolutions: 1,
+                scope: ResolveAllScope::Own,
             },
         )
-        .expect("the human representative may grant");
+        .expect("the priority holder may start Resolve All");
+
+        assert!(
+            !matches!(
+                session.state.waiting_for,
+                WaitingFor::ResolveAllConsent { .. } | WaitingFor::ResolveAllReady { .. }
+            ),
+            "the human is never asked to approve another seat's Resolve All, got {:?}",
+            session.state.waiting_for
+        );
         assert!(
             session.state.resolve_all_consent_run.is_none(),
-            "the final grant transfers authorization to the shared session"
+            "the requester's single-participant run materializes immediately"
         );
         assert!(session.state.stack.is_empty());
         assert!(session.state.stack_resolution_session.is_none());
-        assert!(!matches!(
-            session.state.waiting_for,
-            WaitingFor::ResolveAllReady { .. }
-        ));
     }
 
     /// Generic reconstruction deliberately preserves a coherent automation
@@ -7058,12 +7043,18 @@ mod tests {
             .sessions
             .get_mut(&game_code)
             .expect("the game retains its session");
+        // `Shared` is the scope that still opens a consent queue; a missing
+        // baseline is then what identifies the run as the legacy encoding this
+        // migration path repairs.
         apply(
             &mut session.state,
             PlayerId(0),
-            GameAction::BeginResolveAll { max_resolutions: 1 },
+            GameAction::BeginResolveAll {
+                max_resolutions: 1,
+                scope: ResolveAllScope::Shared,
+            },
         )
-        .expect("the priority holder may start Resolve All consent");
+        .expect("the priority holder may start a shared Resolve All");
         let WaitingFor::ResolveAllConsent { epoch, .. } = session.state.waiting_for else {
             panic!("expected a pending consent prompt");
         };

--- a/crates/server-core/src/session.rs
+++ b/crates/server-core/src/session.rs
@@ -6877,10 +6877,24 @@ mod tests {
             session.state.resolve_all_consent_run.is_none(),
             "one run authorizes one batch and must not outlive it"
         );
+        // CR 117.3d: an `Own` run asks nobody, so the AI-grant round-trip that
+        // used to supply a second transition here no longer happens -- that
+        // round-trip is the defect this test's fixture reproduces. What must
+        // still hold is that the engine-owned runner published, and that no
+        // frame it published ever parked a player on a consent decision.
         assert!(
-            transitions.transitions.len() >= 2,
-            "expected the AI grant and session runner, got {}",
-            transitions.transitions.len()
+            !transitions.transitions.is_empty(),
+            "the engine-owned runner must publish the post-collapse state"
+        );
+        assert!(
+            transitions
+                .transitions
+                .iter()
+                .all(|(_, (broadcast_state, ..))| !matches!(
+                    broadcast_state.waiting_for,
+                    WaitingFor::ResolveAllConsent { .. } | WaitingFor::ResolveAllReady { .. }
+                )),
+            "a published frame parked a player on a Resolve All consent decision"
         );
         assert!(
             transitions

--- a/scripts/check-protocol-version.mjs
+++ b/scripts/check-protocol-version.mjs
@@ -3,7 +3,7 @@ import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
-const EXPECTED_PROTOCOL_VERSION = 56;
+const EXPECTED_PROTOCOL_VERSION = 57;
 // The LOBBY message-set version. Deliberately separate from the full-game
 // number above and deliberately NOT derived from it: a GameState-only bump must
 // not move the lobby's compatibility window. See the assertions at the bottom.
@@ -14,7 +14,7 @@ const EXPECTED_LOBBY_PROTOCOL_VERSION = 4;
 // here, so a full-game bump could ship with an unbumped P2P version and CI
 // stayed green — a v(n-1) host and a v(n) guest would then complete a
 // handshake and only fail when the incompatible payload arrived.
-const EXPECTED_WIRE_PROTOCOL_VERSION = 40;
+const EXPECTED_WIRE_PROTOCOL_VERSION = 41;
 
 function extractVersion(source, pattern, label) {
   const match = source.match(pattern);


### PR DESCRIPTION
Fixes the "fill with AI" multiplayer game that auto-passed the human and could not be cleared. Diagnosed from two authoritative state dumps.

## What went wrong

`BeginResolveAll` was a **table-wide proposal**: it froze every priority representative into a consent run and waited for each to answer. At a table filled with AI, that answer never came — so the requester parked on `WaitingFor::ResolveAllConsent` with no way out, while the resolution session that had already been installed kept passing their priority for them.

The dumps show it directly:
- `next_resolve_all_consent_epoch: 1` — an earlier Resolve All had already completed.
- Second dump is stopped on `ResolveAllConsent { epoch: 1, representative: 1 }`, human granted, both AI seats silent.

## The fix

CR 117.3d lets a player decline to take an action; it does not let one player's refusal bind another's. So the request is **parameterized**, not deleted:

```rust
BeginResolveAll { max_resolutions, scope: ResolveAllScope }
```

- **`Own`** — what the button now sends. Pre-commits only the requester, so no other seat can block or stall it.
- **`Shared`** — keeps the table-wide consent protocol reachable for engine-side stack compression.

The scope is stored **on the run**, because `resolve_all_consent_authority_matches_live` must check membership differently for each: an `Own` run has to be a *subset* of the live representatives, a `Shared` run must still match them *exactly* — otherwise a seat that joined the priority set after the snapshot would be bound by a consent it never gave (CR 117.4).

Inferring the scope from `participants.len() == 1` was considered and rejected: a one-seat game produces a single-participant `Shared` run too.

## Full Control is now engine state

`PriorityPassingMode::FullControl`. An auto-pass session another player installed runs inside the engine's own priority loop and never consults a client, so a purely local toggle could not stop it — which is why enabling Full Control only half-worked as a workaround.

Placement matters in two spots, both commented:
- **Above** the no-session `Exit` arm in `priority_auto_pass_decision` — `Exit` falls through to a pass whenever another player holds a live `UntilStackEmpty` session.
- **Above** the CR 117.3d yield rung in `ai_support`.

## Second defect, same investigation

The starting player's first turn never counted toward `turns_taken` (CR 103.8 + CR 500). Turn 1 is established inline by the game-start path rather than by `turns::start_next_turn`, so the starting player stayed permanently one turn behind every other seat, and `QuantityRef::TurnsTaken` read low for exactly the player who had taken the most turns.

Visible in both dumps under `seat_order: [2, 0, 1]`: `[1, 0, 0]` at turn 2, `[1, 1, 1]` at turn 4.

## Compatibility

- `ResolveAllScope` derives `Default = Own` and the field is `#[serde(default)]`, so a save written before this field existed cannot silently acquire table-wide authority.
- Wire protocol 40 → 41, lobby protocol 56 → 57. `scripts/check-protocol-version.mjs` passes (verified with a positive control — breaking the constant makes it exit 1).

## Tests

- `resolve_all_consent.rs`: an `Own` run at a table with AI seats resolves without asking anyone.
- `session.rs`: renamed and rewritten to assert the human is never parked on an AI seat's response.
- `engine_tests.rs`: starting player's first turn counts, for both possible starting seats.
- `useGameplayPreferencesSync.test.tsx`: Full Control projects onto the synced preference.
- `action_stable_order.rs`: `scope` participates in the stable ordering.

https://claude.ai/code/session_019UU2ujLnqEgwHRqUmYy1RF


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added **Full Control** priority mode, allowing a player to retain priority and prevent automatic passing.
  * Added **Own** and **Shared** scopes for Resolve All. Own resolves immediately for the requester; Shared uses table-wide consent.
* **Bug Fixes**
  * Starting players now correctly receive credit for their first turn.
  * Resolve All consent behavior now correctly reflects the selected scope.
* **Compatibility**
  * Updated game and peer-to-peer protocol versions to support these changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->