### PR TITLE
fix(client): drop the wire-assigned seat when a game session tears down

### DIFF
--- a/client/src/providers/GameProvider.tsx
+++ b/client/src/providers/GameProvider.tsx
@@ -179,6 +179,29 @@ function setupDraftMatchAvatars(seed: string) {
   });
 }
 
+/**
+ * Drop this client's wire-assigned seat when a game session tears down.
+ *
+ * `activePlayerId` is written only from a wire (`playerIdentity`, P2P
+ * `game_setup`, `setupDraftMatchAvatars`) and had no clear, so it outlived the
+ * game that assigned it. Two consecutive wire-assigned games therefore shared
+ * one value: until the second game's assignment arrived, `resolveLocalSeat`
+ * handed out the FIRST game's seat. `SeatSource` does not cover this — it is
+ * keyed on mode (`"seat-zero"` makes a solo game ignore the field), not on
+ * session, so online → online reads the stale seat.
+ *
+ * Safe against a remount (React StrictMode double-mounts in dev) because every
+ * wire-assigned mode re-establishes the seat when its effect re-runs:
+ * draft-match re-runs `setupDraftMatchAvatars`, and a fresh WS/P2P-guest
+ * adapter re-emits `playerIdentity` from `GameStarted` / `reconnect_ack`. The
+ * P2P HOST is the one path with no re-emit (it emits only from its game-start
+ * flow) — it is unaffected because the host is always seat 0, which is exactly
+ * what `resolveLocalSeat` falls back to.
+ */
+function clearWireAssignedSeat(): void {
+  useMultiplayerStore.getState().setActivePlayerId(null);
+}
+
 function playerNamesRecordToMap(playerNames: Record<number, string>): Map<number, string> {
   const names = new Map<number, string>();
   for (const [playerId, name] of Object.entries(playerNames)) {
@@ -720,6 +743,7 @@ export function GameProvider({
       return () => {
         audioManager.setContext("menu");
         clearPromptOverlayState();
+        clearWireAssignedSeat();
       };
     }
 
@@ -1055,6 +1079,7 @@ export function GameProvider({
         if (p2pAdapter) p2pAdapter.dispose();
         audioManager.setContext("menu");
         clearPromptOverlayState();
+        clearWireAssignedSeat();
         reset();
       };
     }
@@ -1356,6 +1381,7 @@ export function GameProvider({
         useMultiplayerStore.getState().setSpectators([]);
         audioManager.setContext("menu");
         clearPromptOverlayState();
+        clearWireAssignedSeat();
         reset();
       };
     }

--- a/client/src/providers/__tests__/GameProvider.nativeEngine.test.tsx
+++ b/client/src/providers/__tests__/GameProvider.nativeEngine.test.tsx
@@ -155,6 +155,7 @@ const {
   const multiplayerState = {
     displayName: "Player",
     setActionPending: vi.fn(),
+    setActivePlayerId: vi.fn(),
     setConnectionStatus: vi.fn(),
     setIsSpectator: vi.fn(),
     setLatency: vi.fn(),
@@ -749,6 +750,27 @@ describe("GameProvider native AI routing", () => {
     view.unmount();
 
     expect(clearPromptOverlayState).toHaveBeenCalledOnce();
+  });
+
+  // `activePlayerId` is written only from a wire and had no clear, so it
+  // outlived the game that assigned it and the NEXT wire-assigned game read the
+  // previous game's seat until its own assignment landed. `SeatSource` does not
+  // cover this: it is keyed on mode, not on session.
+  it("drops the wire-assigned seat when a draft match unmounts", () => {
+    gameStoreState.gameId = "draft-match";
+    gameStoreState.adapter = {} as never;
+    gameStoreState.gameState = {} as never;
+
+    const view = render(
+      <GameProvider gameId="draft-match" mode="draft-match">
+        <div />
+      </GameProvider>,
+    );
+
+    multiplayerState.setActivePlayerId.mockClear();
+    view.unmount();
+
+    expect(multiplayerState.setActivePlayerId).toHaveBeenCalledWith(null);
   });
 });
 


### PR DESCRIPTION
Second of the two multiplayer bugs reported alongside #8346. This is a real latent defect found while investigating the "both players see *Opponent is deciding their opening hand…*" report — it is **not** confirmed to be that bug's cause, and I am not claiming it is.

## The defect

`activePlayerId` is written only from a wire — `playerIdentity`, the P2P `game_setup` frame, and `setupDraftMatchAvatars` — and **nothing ever cleared it**. It was write-once per page load and outlived the game that assigned it.

So two consecutive wire-assigned games shared one value: until the second game's assignment arrived, `resolveLocalSeat` handed out the **first game's seat**.

## Why `SeatSource` doesn't already cover this

`gameStore.ts` already documents the hazard — "a stale `activePlayerId` left behind by an earlier online game must not be read" — but `SeatSource` is keyed on **mode**, not on session. `"seat-zero"` makes a solo game ignore the field entirely, so it covers online → solo and leaves **online → online** exposed. That is the gap this closes.

## Remount safety

Clearing on teardown is only safe if a remount re-establishes the seat, and React StrictMode double-mounts in dev, so cleanup runs against live games routinely. Each path was checked:

| path | re-establishes on remount? |
|---|---|
| draft-match | yes — `setupDraftMatchAvatars` runs unconditionally in the effect body |
| WS | yes — a fresh adapter re-emits `playerIdentity` from `GameStarted` |
| P2P guest | yes — `reconnect_ack` re-emits it |
| **P2P host** | **no** — both emissions live in game-start flows only |

The P2P host survives only because it is always seat 0, which is exactly what `resolveLocalSeat` falls back to. That is accidental correctness, so it is recorded on the helper rather than left for the next person to rediscover.

## Not placed in `gameStore.reset()`

All three cleanups call `reset()`, but `gameStore` does not import `multiplayerStore`, and this would be the first cross-store write there. The three explicit calls sit alongside the existing `setIsSpectator(false)` / `setSpectators([])` resets in the same blocks.

## Tests

New regression test asserting the draft-match unmount clears the seat. Probed for non-vacuity: removing the draft-match call reds exactly that test, restoring it greens. Also fixed a mock gap in `GameProvider.nativeEngine.test.tsx`, which stubbed `useMultiplayerStore` without `setActivePlayerId`.

Verified on this branch's exact content: 28 passed across `src/providers/__tests__` and `usePlayerId.test.ts`.

https://claude.ai/code/session_019UU2ujLnqEgwHRqUmYy1RF
