### PR TITLE
fix(engine): cite CR 117.3d, not CR 117.4, for Resolve All consent scope

### DIFF
--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -8918,7 +8918,7 @@ fn begin_resolve_all_consent(
     super::priority::pass_priority_legality(state, priority_player)?;
     let current_representative =
         super::topology::priority_pass_representative(state, priority_player);
-    // CR 117.3d / CR 117.4: `Own` binds the requester alone (no consent to ask,
+    // CR 117.3d: `Own` binds the requester alone (no consent to ask,
     // so nobody can block it); `Shared` opens the table-wide compression
     // proposal, rotated so the requester is first and self-granted. See
     // `ResolveAllScope`.

--- a/crates/engine/src/game/turn_control.rs
+++ b/crates/engine/src/game/turn_control.rs
@@ -412,7 +412,7 @@ pub(crate) fn resolve_all_consent_authority_matches_live(
         .into_iter()
         .collect();
 
-    // CR 117.4: a `Shared` run is a table-wide proposal, so a seat that became
+    // CR 117.3d: a `Shared` run is a table-wide proposal, so a seat that became
     // a priority participant after the snapshot would otherwise be bound by a
     // consent it never gave — the live set must match exactly. An `Own` run
     // binds only the requester and asks nobody, so it stays coherent as long as

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -2068,7 +2068,7 @@ pub struct ResolveAllConsentRun {
     /// live-authority check accepts them as a SUBSET of the current priority
     /// participants; a `Shared` run is a table-wide proposal and must still
     /// match the live set exactly, or a seat that became a participant after
-    /// the snapshot would be bound by a consent it never gave (CR 117.4).
+    /// the snapshot would be bound by a consent it never gave (CR 117.3d).
     /// Defaults to `Own` so a save written before this field existed cannot
     /// silently acquire table-wide authority.
     #[serde(default)]

--- a/crates/engine/tests/integration/resolve_all_consent.rs
+++ b/crates/engine/tests/integration/resolve_all_consent.rs
@@ -892,7 +892,7 @@ fn persisted_pending_consent_decline_restores_the_captured_baseline() {
     assert!(restored.auto_pass.is_empty());
 }
 
-/// CR 117.4: a save written before `ResolveAllScope` existed carries no `scope`
+/// CR 117.3d: a save written before `ResolveAllScope` existed carries no `scope`
 /// key at all, and `#[serde(default)]` must resolve that to `Own` -- the scope
 /// that binds only the requester. Defaulting a legacy run to `Shared` would
 /// silently hand it table-wide authority over seats that never consented, which


### PR DESCRIPTION
Addresses the Major finding CodeRabbit raised on #8350 (already merged, so it lands here).

## The mis-citation

CR 117.4 reads:

> If all players pass in succession (that is, if all players pass without taking any actions in between passing), the spell or ability on top of the stack resolves or, if the stack is empty, the phase or step ends.

That is **resolution on unanimous passes**. Four annotations added alongside `ResolveAllScope` used it for a different claim — *who a consent run binds* — which CR 117.4 does not govern. The reviewer was right.

CR 117.3d is the rule that does:

> If a player has priority and chooses not to take any actions, that player passes. If any mana is in that player's mana pool, they announce what mana is there. Then the next player in turn order receives priority.

Passing is an **individual** decision. That is precisely why one seat's consent cannot bind another, why `Own` asks nobody and cannot be blocked, and why a legacy save must default to `Own` rather than acquire table-wide authority.

## Corrected (4)

| file | site |
|---|---|
| `game/engine.rs:8921` | scope dispatch in `begin_resolve_all_consent` |
| `game/turn_control.rs:415` | live-authority membership check |
| `types/game_state.rs:2071` | `ResolveAllConsentRun::scope` field doc |
| `tests/integration/resolve_all_consent.rs:895` | migration test rationale |

## Deliberately NOT changed (2)

A citation fix is a deletion dressed as a substitution, so I checked what a blanket rewrite would have *dropped*. CR 117.4 is the correct rule at these, and both survive:

- `types/actions.rs:1014` — "so CR 117.4 still requires their real passes before anything resolves" is a direct statement of 117.4.
- `types/game_state.rs:15478` — "resolved by the normal CR 117.3d / CR 117.4 path" describes actual resolution.

## Verification

Both rule texts were grep-verified against `docs/MagicCompRules.txt` (lines 956 and 958) rather than recalled — per the repo's mandatory CR verification rule. Each of the four files' `CR 117.4` count dropped by exactly one, confirming no collateral rewrites.

Comment-only change: no code, no behaviour, no tests affected.

https://claude.ai/code/session_019UU2ujLnqEgwHRqUmYy1RF


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Corrected rule references for consent authority and priority-pass behavior from CR 117.4 to CR 117.3d.
  - Updated related test documentation to cite the correct rule.
  - No user-facing behavior or functionality changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->