### PR TITLE
fix(scripts): invoke the pinned wrangler through npx in lobby-servers.sh

### DIFF
--- a/scripts/lib/lobby_servers_tests.sh
+++ b/scripts/lib/lobby_servers_tests.sh
@@ -9,8 +9,13 @@
 # `--env preview` that is not forwarded edits PRODUCTION. None of those
 # produces an error anywhere — the listing is just quietly wrong.
 #
-# `wrangler` and `curl` are stubbed on a narrowed PATH and record their argv,
-# so the assertions are about what the script WOULD send, not about Cloudflare.
+# `npx`, `wrangler` and `curl` are stubbed on a narrowed PATH and record their
+# argv, so the assertions are about what the script WOULD send, not about
+# Cloudflare. `npx` is stubbed because the script invokes `npx wrangler` rather
+# than a bare `wrangler` (the pinned binary lives in lobby-worker/node_modules
+# and is not on an operator's PATH). Without the shim the narrowed PATH has no
+# `npx` at all and every wrangler assertion below fails at exit 127 — measured,
+# not hypothesised.
 # jq's real directory is added to that PATH: the script parses `kv key list`
 # output with it, and stubbing a JSON parser would test the stub.
 #
@@ -39,6 +44,7 @@ ok()   { printf '  ok: %s\n' "$1";     PASS=$((PASS + 1)); }
 make_fixture() {
   FIXTURE="$(mktemp -d)"
   mkdir -p "$FIXTURE/bin"
+  : > "$FIXTURE/npx.log"
   : > "$FIXTURE/wrangler.log"
   : > "$FIXTURE/curl.log"
   : > "$FIXTURE/kv_list.json"
@@ -55,6 +61,17 @@ esac
 exit 0
 STUB
 
+  # Transparent shim: `npx <cmd> ...` runs the stubbed <cmd> from this same
+  # bin/, so every assertion below still reads the argv the script built. An
+  # unstubbed <cmd> execs nothing and exits 127, which is the honest signal.
+  cat > "$FIXTURE/bin/npx" <<STUB
+#!/bin/sh
+printf '%s\n' "\$*" >> "$FIXTURE/npx.log"
+CMD="\$1"
+shift
+exec "$FIXTURE/bin/\$CMD" "\$@"
+STUB
+
   cat > "$FIXTURE/bin/curl" <<STUB
 #!/bin/sh
 printf '%s\n' "\$*" >> "$FIXTURE/curl.log"
@@ -62,7 +79,7 @@ cat "$FIXTURE/info.json"
 exit 0
 STUB
 
-  chmod +x "$FIXTURE/bin/wrangler" "$FIXTURE/bin/curl"
+  chmod +x "$FIXTURE/bin/npx" "$FIXTURE/bin/wrangler" "$FIXTURE/bin/curl"
 }
 
 run_script() { # $@ = script args; stdout captured in OUT, exit in STATUS
@@ -95,6 +112,17 @@ fi
 make_fixture
 run_script add "wss://play.example.com/ws" --env preview
 if [ "$STATUS" -eq 0 ]; then ok "add exits 0"; else fail "add exits 0 (got $STATUS)"; fi
+
+# The wrangler stub sits on PATH, so a silent revert to a bare `wrangler` would
+# satisfy every argv assertion below and change nothing here. This is the only
+# line that fails on that revert — and it matters because a bare `wrangler` is
+# not on an operator's PATH at all: the pinned binary lives in
+# lobby-worker/node_modules and `npx`, run from that directory, is what resolves
+# it.
+case "$(cat "$FIXTURE/npx.log")" in
+  wrangler\ kv*) ok "add reaches wrangler through npx" ;;
+  *) fail "add reaches wrangler through npx (npx argv: $(cat "$FIXTURE/npx.log"))" ;;
+esac
 
 PUT_LINE="$(grep '^kv key put' "$FIXTURE/wrangler.log" || true)"
 case "$PUT_LINE" in

--- a/scripts/lobby-servers.sh
+++ b/scripts/lobby-servers.sh
@@ -29,7 +29,9 @@
 # sentinels in lobby-worker/wrangler.toml. Until that is done every command
 # here fails at wrangler, and the Worker deploys with an empty directory.
 #
-# Requires: wrangler (the pinned one in lobby-worker/node_modules), jq, curl.
+# Requires: node (for `npx`), jq, curl. Every wrangler call goes through `npx`
+# from lobby-worker/, which resolves the PINNED wrangler in that package's
+# node_modules/.bin — a bare `wrangler` is not on an operator's PATH.
 # Tests: scripts/lib/lobby_servers_tests.sh (Tilt resource `lobby-servers`,
 # label 'lint' — local-only, not CI).
 set -euo pipefail
@@ -95,7 +97,7 @@ wrangler_kv() {
   # Run from lobby-worker/ so wrangler finds its config, and always against
   # REMOTE storage: this script manages the deployed allowlist, never a local
   # simulator.
-  (cd "$ROOT/lobby-worker" && wrangler kv "$@" --binding "$BINDING" --remote \
+  (cd "$ROOT/lobby-worker" && npx wrangler kv "$@" --binding "$BINDING" --remote \
     ${ENV_ARGS[@]+"${ENV_ARGS[@]}"})
 }
 


### PR DESCRIPTION
A bare `wrangler` is not on an operator's PATH — the pinned binary lives in
lobby-worker/node_modules, which is why the header's namespace-create steps
already said `npx wrangler`. `wrangler_kv` did not, so every allowlist command
failed at "command not found" unless the operator had a global install.

Running it through npx from lobby-worker/ resolves node_modules/.bin ahead of
PATH, so the version that edits the deployed allowlist is the pinned one.

The test harness stubs `wrangler` on a narrowed PATH that has no `npx` at all,
so the change alone took the suite from 39 green to 8 passed / 31 failed, every
failure an exit 127. Add a transparent `npx` shim to the fixture: it logs its
argv, shifts off the command name, and execs the stubbed binary from the same
bin/, leaving every existing argv assertion reading exactly what it read before.

Also pin the npx-ness itself. The wrangler stub sits on PATH, so a silent revert
to a bare `wrangler` would satisfy all 39 other assertions unchanged — and this
file exists precisely because every failure mode of this script is silent.
Verified non-vacuous: under that revert exactly one assertion fails.

Claude-Session: https://claude.ai/code/session_01RtBf74gnapvcsEqQiPnjmC

https://claude.ai/code/session_01RtBf74gnapvcsEqQiPnjmC
