### PR TITLE
fix(p2p): give every dial an ordered channel and drive redelivery off acceptance

### DIFF
--- a/client/src/adapter/__tests__/p2p-adapter-multiplayer.test.ts
+++ b/client/src/adapter/__tests__/p2p-adapter-multiplayer.test.ts
@@ -16,7 +16,7 @@ import { AdapterError, AdapterErrorCode, supportsAiDecisionDiagnostics, supports
 import type { WsAdapterEvent } from "../ws-adapter";
 import { FakeDataConnection } from "../../network/__tests__/fakeDataConnection";
 import { PEER_CONNECT_OPTIONS } from "../../network/connection";
-import { WIRE_PROTOCOL_VERSION } from "../../network/protocol";
+import { WIRE_PROTOCOL_VERSION, type P2PMessage } from "../../network/protocol";
 import { p2pFinalStateCommitment } from "../../services/p2pTerminalResult";
 import { ownsP2PHostLease } from "../../services/p2pSession";
 
@@ -480,6 +480,63 @@ class FakeOpenableConnection extends FakeDataConnection {
   }
   fireOpen() {
     for (const h of this.openHandlers) h();
+  }
+
+  /**
+   * Every `state_ack` this fake fed back to the host, in emission order.
+   * Harness-only bookkeeping: the host records nothing for an inbound ack,
+   * so this is the only observation point for the auto-ack behavior.
+   */
+  readonly acksSent: P2PMessage[] = [];
+
+  /**
+   * Stop auto-acking. Callable at any point — including before
+   * `initializeGame` — so a test can model a seat that never acknowledges
+   * anything, not merely one that stops mid-game.
+   */
+  stopAcking() {
+    this.acking = false;
+  }
+
+  /**
+   * Default ON: a real guest acks every state-bearing frame it applies, and a
+   * seat that never acks reads as permanently behind. Defaulting off would
+   * change behavior in tests that have nothing to do with acknowledgement.
+   */
+  private acking = true;
+
+  protected override onDecodedSend(msg: P2PMessage): void {
+    if (!this.acking) return;
+    // A decode `.then` from a pre-close send can settle AFTER
+    // `simulateClose()`; dispatching an ack into a torn-down session would
+    // model something a real guest never does.
+    if (!this.open) return;
+    if (msg.type !== "game_setup" && msg.type !== "state_update" && msg.type !== "reconnect_ack") {
+      return;
+    }
+    // `revision` is optional on `state_update` and `reconnect_ack`; only
+    // `game_setup` always carries one. An ack without a revision is not a
+    // frame a real guest could produce.
+    if (msg.revision == null) return;
+    const ack = {
+      type: "state_ack" as const,
+      revision: msg.revision,
+      // A real guest stamps `authority` on every outbound frame, so an
+      // unstamped ack would skip the host's pre-switch authority guard.
+      ...(msg.authority ? { authority: msg.authority } : {}),
+    };
+    this.acksSent.push(ack);
+    // Enqueue on the inherited drain so `getSentMessages()` reaches the
+    // fixed point: an ack can provoke host sends, which enqueue more decodes.
+    // The `.catch` prevents an unhandled rejection when a test never awaits
+    // `getSentMessages()`, but it must stay LOUD: a silently dropped ack makes
+    // a seat read as un-acked, which would let a redelivery test pass for the
+    // wrong reason.
+    this.pendingDecodes.push(
+      this.simulateData(ack).catch((e) => {
+        console.warn("[FakeOpenableConnection] auto-ack dispatch failed:", e);
+      }),
+    );
   }
 }
 
@@ -1665,6 +1722,56 @@ describe("P2PHostAdapter — 3-4p multiplayer", () => {
     expect(mockGetViewerSnapshot).toHaveBeenCalledTimes(2);
     expect(mockGetViewerSnapshot).toHaveBeenCalledWith(1);
     expect(mockGetViewerSnapshot).toHaveBeenCalledWith(2);
+  });
+
+  const isStateBearingWithRevision = (m: unknown): m is P2PMessage & { revision: number } =>
+    typeof m === "object"
+    && m !== null
+    && ["game_setup", "state_update", "reconnect_ack"].includes((m as { type: string }).type)
+    && typeof (m as { revision?: unknown }).revision === "number";
+
+  // Harness coverage for `FakeOpenableConnection`'s auto-ack. Nothing else in
+  // the suite observes it directly, so this test is the only thing standing
+  // between a silently-broken fake and every acceptance-semantics test built
+  // on top of it.
+  it("auto-acks every state-bearing frame the host sends, echoing its authority", async () => {
+    const { adapter, emitConnection } = makeHost(2);
+    await adapter.initialize();
+    const guest = await joinGuest(emitConnection, {
+      type: "guest_deck",
+      deckData: { player: { main_deck: [], sideboard: [] } },
+    });
+    await adapter.initializeGame();
+    await adapter.submitAction({ type: "PassPriority" }, 0);
+
+    const sent = await guest.getSentMessages();
+    const stateBearing = sent.filter(isStateBearingWithRevision);
+    // Both a `game_setup` and at least one `state_update` must have flowed,
+    // or the ack assertion below would be vacuously satisfiable.
+    expect(stateBearing.map((m) => m.type)).toEqual(
+      expect.arrayContaining(["game_setup", "state_update"]),
+    );
+    // One ack per state-bearing frame, in order, carrying that frame's
+    // revision and the host's authority stamp verbatim.
+    expect(guest.acksSent).toEqual(
+      stateBearing.map((m) => ({
+        type: "state_ack",
+        revision: m.revision,
+        authority: m.authority,
+      })),
+    );
+
+    // The knob silences it: further host state changes provoke no new ack.
+    guest.stopAcking();
+    const ackCount = guest.acksSent.length;
+    const stateBearingCount = stateBearing.length;
+    await adapter.submitAction({ type: "PassPriority" }, 0);
+    const afterStop = await guest.getSentMessages();
+    // Non-vacuity: the host really did send another state-bearing frame that
+    // the fake would have acked had the knob not been flipped.
+    expect(afterStop.filter(isStateBearingWithRevision).length).toBeGreaterThan(stateBearingCount);
+    expect(guest.acksSent).toHaveLength(ackCount);
+    adapter.dispose();
   });
 
   it("keeps a host zero-count debug create out of transition side effects", async () => {

--- a/client/src/adapter/__tests__/p2p-adapter-multiplayer.test.ts
+++ b/client/src/adapter/__tests__/p2p-adapter-multiplayer.test.ts
@@ -484,8 +484,9 @@ class FakeOpenableConnection extends FakeDataConnection {
 
   /**
    * Every `state_ack` this fake fed back to the host, in emission order.
-   * Harness-only bookkeeping: the host records nothing for an inbound ack,
-   * so this is the only observation point for the auto-ack behavior.
+   * Harness-only bookkeeping: the host's own record (`guestAckedRevisions`) is
+   * private, so this is the only direct observation point for what the seat
+   * acknowledged, as opposed to what the host did about it.
    */
   readonly acksSent: P2PMessage[] = [];
 
@@ -498,6 +499,12 @@ class FakeOpenableConnection extends FakeDataConnection {
     this.acking = false;
   }
 
+  /** Resume auto-acking after `stopAcking()`, so a test can show a seat that
+   *  missed a window and then recovers. */
+  resumeAcking() {
+    this.acking = true;
+  }
+
   /**
    * Default ON: a real guest acks every state-bearing frame it applies, and a
    * seat that never acks reads as permanently behind. Defaulting off would
@@ -505,7 +512,54 @@ class FakeOpenableConnection extends FakeDataConnection {
    */
   private acking = true;
 
+  /**
+   * The frame type after which this channel stops taking bytes, or `null`.
+   * Consumed once.
+   */
+  private refuseAfter: P2PMessage["type"] | null = null;
+
+  /**
+   * Model a channel that REFUSES bytes — `open = false`, so `PeerSession.send`
+   * resolves FALSE with no `close` event. `trySend` gates on `conn.open` both
+   * before and inside its queue and returns false at either gate without
+   * calling `handleDisconnect`, which is what makes this distinct from a `send`
+   * that THROWS (the only other failure the base fake can produce): a throw
+   * does call `handleDisconnect`, dropping the seat into `disconnectedSeats`
+   * where the sweep skips it — a different scenario entirely.
+   *
+   * What this is NOT is peerjs PARKING a frame past its buffered-amount
+   * budget. `_bufferedSend` returns `undefined` unconditionally and `trySend`
+   * returns `true` after any non-throwing `conn.send`, so a parked frame
+   * resolves TRUE and is indistinguishable from a delivered one at this
+   * boundary. That is exactly why the ADVANCE signal is the guest's own
+   * `state_ack` rather than the send result. The residual it leaves is
+   * `terminalDelivered`, which still records transmission: a parked terminal
+   * frame is recorded as delivered and the sweep stops nominating the seat.
+   * That residual is accepted (it is post-game, and acking it would need a
+   * second wire bump) and no test here covers it — this knob cannot produce
+   * it.
+   *
+   * The refusal starts AFTER the named frame has been sent and acked, so the
+   * seat is provably current on state when its next frame is refused.
+   * `reopen()` restores the channel.
+   */
+  refuseSendsAfter(type: P2PMessage["type"]) {
+    this.refuseAfter = type;
+  }
+
+  reopen() {
+    this.open = true;
+  }
+
   protected override onDecodedSend(msg: P2PMessage): void {
+    this.ackDecodedSend(msg);
+    if (this.refuseAfter !== null && this.refuseAfter === msg.type) {
+      this.refuseAfter = null;
+      this.open = false;
+    }
+  }
+
+  private ackDecodedSend(msg: P2PMessage): void {
     if (!this.acking) return;
     // A decode `.then` from a pre-close send can settle AFTER
     // `simulateClose()`; dispatching an ack into a torn-down session would
@@ -3130,10 +3184,10 @@ describe("P2PHostAdapter — 3-4p multiplayer", () => {
     });
     expect(await ackedRevisions()).toEqual([8, 9, 9]);
 
-    // A resumed session re-declares the seat's revision. No host consumes any
-    // `state_ack` yet — `handleGuestMessage` has no such case and falls to
-    // `default: break` — so this pins the guest half, which is the half this
-    // step owns.
+    // A resumed session re-declares the seat's revision. This test is the
+    // guest half only: it drives `P2PGuestAdapter` directly, with no host on
+    // the other end. The host half — `recordGuestAck` and the redelivery
+    // predicate it feeds — is pinned by the eventual-delivery block below.
     await conn.simulateData({
       type: "reconnect_ack",
       wireProtocolVersion: WIRE_PROTOCOL_VERSION,
@@ -3162,7 +3216,8 @@ describe("P2PHostAdapter — 3-4p multiplayer", () => {
     // subscriber unwinds the rest of the arm — here, only an ack placed after
     // the emit. It must already be on the wire: a resent EQUAL revision is not
     // `<` the cached one, so it re-enters this same arm and throws again, and
-    // once a host consumes acks that is a resend loop rather than a heal. The
+    // and since the host drives redelivery off these acks, that is a resend
+    // loop rather than a heal. The
     // seat itself is fine throughout; it holds the state and serves
     // `getState()`.
     adapter.onEvent((event) => {
@@ -4474,20 +4529,67 @@ describe("P2PHostAdapter — host emission precedes the guest fan-out", () => {
  * The immediate fan-out isolates a failed per-guest viewer read, but that
  * alone still strands the seat: its adapter cache never receives the applied
  * state, and the guest watchdog compares the screen against exactly that
- * cache. The host-side ledger (`guestDeliveredRevisions`) plus the 5s
- * redelivery sweep close the gap by resending the CURRENT authoritative
- * state until the channel accepts it.
+ * cache. Two host-side structures plus the 5s redelivery sweep close the gap:
+ * `guestAckedRevisions` (how far along each seat is) and `terminalDelivered`
+ * (whose statement reached the channel). `shouldRedeliver` reads both, and
+ * BOTH lag checks — the sweep's nomination and `redeliverGuestState`'s own
+ * re-check — go through it.
  *
- * Measured, so the claim stays honest: no-op'ing the sweep reds five of the
- * seven tests here. The two it leaves green are the setup pair, and each has a
- * probe of its own: dropping the rethrow after the setup loop reds both, and
- * dropping the create-guard in `markGuestBehind` reds the no-adoption one —
- * which is a NEGATIVE claim about the sweep and therefore trivially green
- * without it. The remaining guards likewise each have their own probe: the
- * ledger no longer recording accepted sends (the sweep then resends forever,
- * caught by the duplicate-frame assertion), a per-guest read failure still
- * aborting the fan-out, the per-seat isolation of the terminal close, and its
- * `markGuestBehind` handoff.
+ * `guestAckedRevisions` uses two different signals on purpose, because the two
+ * failure directions are not symmetric. It ADVANCES only on the seat's own
+ * `state_ack`: a `send` resolving true only means the bytes reached the
+ * channel (peerjs parks anything past its buffered-amount budget in a buffer
+ * `close()` discards), so a ledger that advanced on transmission marked a seat
+ * delivered while the host was still waiting on that seat to act, and the
+ * sweep skipped the very seat that deadlocked the match. It is CREATED on an
+ * accepted handshake send — `game_setup` or `reconnect_ack`, never
+ * `state_update` — because a seat with no entry is one the sweep can never
+ * nominate. The asymmetry is one-sided: a false negative disarms the sweep for
+ * good, while a false positive is merely no worse than the handshake never
+ * having been sent — a parked handshake never authenticates the guest, so the
+ * redelivered `state_update`s it would receive are discarded anyway.
+ *
+ * A consequence worth stating, because it changes what "duplicate frame"
+ * means here: a seat nominated ONLY by the terminal clause still runs the full
+ * `redeliverGuestState`, so it gets a state frame at its CURRENT revision
+ * before the terminal frame. That duplicate is expected and harmless — the
+ * guest's stale guard is a strict `<`, so an equal-revision frame passes
+ * through, settles `pendingResolve` and produces a fresh ack.
+ *
+ * Measured, so the claim stays honest. Each probe below was applied to
+ * `p2p-adapter.ts` alone and the whole frontend suite re-run; the counts are
+ * that run's, not an inference:
+ *
+ *   P1  no-op `queueLaggingRedeliveries`      → 10 of the 13 tests here red.
+ *       The three left green are the two setup tests and the
+ *       reconnect-stops-nominating one, all NEGATIVE claims about the sweep.
+ *   P2  drop the rethrow after the setup loop → both setup tests red.
+ *   P3  drop `shouldRedeliver`'s create-guard → "does not adopt a seat that
+ *       never took its game_setup" reds, and only it. That test's seat never
+ *       gets a `game_setup` send at all (its viewer read throws), so no
+ *       accepted send seeds it and the guard stays the only thing standing
+ *       between it and the terminal clause.
+ *   P4  leave `redeliverGuestState`'s own re-check on the lag-only inline
+ *       form                                  → the two terminal-clause tests
+ *       red ("heals a seat whose terminal-close viewer read rejected" and
+ *       "re-sends a terminal statement whose bytes never reached the
+ *       channel"): the seat is nominated and then returns before sending.
+ *   P5  restore TRANSMISSION semantics on the state fan-out (advance the
+ *       entry when `send` resolves true)      → 4 red: "resyncs a seat whose
+ *       channel took the frame but never applied it", "ignores a guest ack
+ *       claiming a revision the host never reached", and both new tests
+ *       below, each of which needs a seat that a true send does NOT make
+ *       current. This probe IS the shipped bug.
+ *   P6  drop the reconnect path's `terminalDelivered` write → "stops
+ *       nominating a seat that took its terminal result on reconnect" reds.
+ *   P7  drop `seedGuestEntry` from the setup fan-out → "heals a seat whose
+ *       handshake ack never reached the host" reds, and only it: with no
+ *       entry the create-guard disarms the sweep, and the seat cannot ack its
+ *       way back in because the frame that would let it never arrives.
+ *   P8  drop `recordGuestAck`'s `Number.isInteger` gate → "ignores a guest ack
+ *       whose revision is not a number" reds, and only it.
+ *
+ * Every test in this block is red under at least one probe.
  */
 describe("P2PHostAdapter — per-guest eventual state delivery", () => {
   beforeEach(() => {
@@ -4621,7 +4723,10 @@ describe("P2PHostAdapter — per-guest eventual state delivery", () => {
     const redelivered = statesSentTo((await guest.getSentMessages()).slice(before));
     expect(redelivered[0].state?.filteredFor).toBe(1);
 
-    // The accepted redelivery advanced the ledger: further sweeps stay quiet.
+    // The fake ACKED the redelivery, which is what advances the seat's entry
+    // to the authoritative revision: further sweeps stay quiet. (The send
+    // resolving true would not have been enough — this assertion depends on
+    // the harness's auto-ack, not on the redelivery alone.)
     await vi.advanceTimersByTimeAsync(5_000);
     // A negative ("nothing more went out") cannot be polled for, so cross the
     // real event loop the way this file already does elsewhere.
@@ -4671,7 +4776,7 @@ describe("P2PHostAdapter — per-guest eventual state delivery", () => {
   // The isolation half of the contract: seat 1's failed viewer read must not
   // abort seat 2's IMMEDIATE delivery (the pre-fix fan-out awaited the reads
   // serially, so one rejection starved every later seat). Seat 2's single
-  // frame also pins that a healthy broadcast advances the ledger — without
+  // frame also pins that a broadcast the seat ACKS leaves it current — without
   // that, the sweep would resend to a seat that missed nothing.
   it("serves the healthy seat immediately while the failed seat waits for the sweep", async () => {
     const { adapter, emitConnection } = makeHost(3, 5_000);
@@ -4718,9 +4823,9 @@ describe("P2PHostAdapter — per-guest eventual state delivery", () => {
 
   // The same isolation for the SETUP fan-out, which the sweep cannot repair.
   // Unisolated, one rejected read starved every LATER seat of its `game_setup`
-  // — permanently: such a seat has no ledger entry, so the sweep skips it by
-  // design, and a second start returns early because `gameStarted` is already
-  // true.
+  // — permanently: with no `game_setup` send there is nothing to seed the
+  // seat's entry, so the sweep skips it by design, and a second start returns
+  // early because `gameStarted` is already true.
   //
   // The isolation buys those later seats their frame. It must NOT also buy
   // silence: the seat whose own read failed waits on a promise that never
@@ -4750,22 +4855,30 @@ describe("P2PHostAdapter — per-guest eventual state delivery", () => {
     expect(await setupsFor(guestTwo)).toHaveLength(1);
     expect(await setupsFor(guestOne)).toHaveLength(0);
 
-    // The starved seat stays with the setup/reconnect path on purpose: without
-    // a `game_setup` it has no ledger entry, and a `state_update` cannot stand
-    // in for the handshake — a guest discards state frames it cannot
-    // authenticate. So the sweep must NOT adopt it.
+    // The starved seat stays with the setup/reconnect path on purpose: with no
+    // `game_setup` send there is no accepted handshake to seed its entry, and
+    // a `state_update` cannot stand in for the handshake — a guest discards
+    // state frames it cannot authenticate. So the sweep must NOT adopt it.
     await vi.advanceTimersByTimeAsync(5_000);
     await vi.advanceTimersByTimeAsync(0);
     expect(statesSentTo(await guestOne.getSentMessages())).toHaveLength(0);
     adapter.dispose();
   });
 
-  // `markGuestBehind` may LOWER a ledger entry, but must never CREATE one. A
-  // seat with no entry never took its `game_setup`, and the contract leaves it
-  // to the setup/reconnect path, because a `state_update` cannot stand in for
-  // the handshake — the guest discards state frames it cannot authenticate.
-  // Without the guard the terminal close adopts exactly such a seat, and the
-  // next sweep serves it a frame it never authenticated for.
+  // The create-guard: `shouldRedeliver` returns false for a seat with no
+  // `guestAckedRevisions` entry. Such a seat was never handed a handshake
+  // frame its channel accepted — here its viewer read throws, so no
+  // `game_setup` is ever sent and `seedGuestEntry` never runs — and the
+  // contract leaves it to the setup/reconnect path, because a `state_update`
+  // cannot stand in for the handshake (the guest discards state frames it
+  // cannot authenticate).
+  //
+  // The guard now gates BOTH clauses, and the terminal one is why it must be
+  // explicit: `undefined < N` is already false, so the lag clause was
+  // accidentally safe, but `terminalResult !== null && !terminalDelivered.has(pid)`
+  // is TRUE for exactly this seat once the game closes — the close ran, and
+  // this seat's terminal send never did. Dropping `acked === undefined` from
+  // `shouldRedeliver` is this test's probe.
   it("does not adopt a seat that never took its game_setup", async () => {
     const { adapter, emitConnection } = makeHost(3, 5_000);
     await adapter.initialize();
@@ -4777,8 +4890,8 @@ describe("P2PHostAdapter — per-guest eventual state delivery", () => {
       type: "guest_deck",
       deckData: { player: { main_deck: [], sideboard: [] } },
     });
-    // Seat 1 misses its setup frame, so it has no ledger entry. The host is
-    // told (see the test above); here only the ledger consequence matters.
+    // Seat 1's setup frame is never sent, so nothing seeds its entry. The host
+    // is told (see the test above); here only that consequence matters.
     const setupInjection = failNextViewerSnapshot();
     await expect(adapter.initializeGame()).rejects.toThrow("viewer snapshot failed");
     await flushPromises();
@@ -4829,8 +4942,9 @@ describe("P2PHostAdapter — per-guest eventual state delivery", () => {
   // The game-ending broadcast is the one delivery a seat cannot afford to
   // miss twice: the terminal fan-out is one-shot, and the guest refuses a
   // `terminal_result` whose revision it never received. The sweep therefore
-  // re-commits the terminal statement AFTER the healing state frame; the
-  // ledger advances only once both frames are accepted.
+  // re-commits the terminal statement AFTER the healing state frame. The two
+  // frames settle independently: the seat's ack clears the lag clause, and
+  // only an accepted terminal send clears `terminalDelivered`.
   it("re-commits the terminal result for the seat that missed the game-ending broadcast", async () => {
     const { adapter, emitConnection } = makeHost(2, 5_000);
     await adapter.initialize();
@@ -4968,6 +5082,357 @@ describe("P2PHostAdapter — per-guest eventual state delivery", () => {
       await p2pFinalStateCommitment(healing.state as unknown as GameState),
     );
     expect(afterSweep.indexOf(healing as never)).toBeLessThan(afterSweep.indexOf(terminals[0] as never));
+    adapter.dispose();
+  });
+
+  /** Keepalive `ping`s ride the same channel and land in `sent` whenever the
+   * fake clock crosses 5 s. They are transport, not delivery, so an
+   * exact-zero assertion about what a seat received must exclude them. */
+  function deliveryFramesIn(messages: unknown[]): unknown[] {
+    return messages.filter((m) => {
+      const type = (m as { type?: string }).type;
+      return type !== "ping" && type !== "pong";
+    });
+  }
+
+  // THE BUG. `send` resolving true only means the bytes reached the channel;
+  // peerjs parks anything past its buffered-amount budget in a buffer that
+  // `close()` discards. A ledger recording transmission therefore called this
+  // seat current while the host was still waiting on it to act — the sweep
+  // skipped it, the host could not advance its revision, and the match
+  // deadlocked. Acceptance semantics make the sweep the way out.
+  //
+  // `stopAcking()` models exactly that seat: every send succeeds, nothing is
+  // ever applied.
+  it("resyncs a seat whose channel took the frame but never applied it", async () => {
+    const { adapter, emitConnection } = makeHost(2, 5_000);
+    await adapter.initialize();
+    const guest = await joinGuest(emitConnection, {
+      type: "guest_deck",
+      deckData: { player: { main_deck: [], sideboard: [] } },
+    });
+    await adapter.initializeGame();
+    await flushPromises();
+
+    // The setup frame WAS applied, so the seat has an entry and the
+    // create-guard is not what this test measures.
+    expect(guest.acksSent).not.toHaveLength(0);
+    guest.stopAcking();
+    const before = (await guest.getSentMessages()).length;
+
+    await guest.simulateData({
+      type: "action",
+      senderPlayerId: 1,
+      action: { type: "PassPriority" },
+    });
+    await flushPromises();
+
+    // Non-vacuity: the fan-out succeeded. Every viewer read resolved and the
+    // channel took the bytes — a transmission ledger would record this seat as
+    // current here, and never send it anything again.
+    expect(mockSubmitAction).toHaveBeenCalledWith({ type: "PassPriority" }, 1);
+    expect(statesSentTo((await guest.getSentMessages()).slice(before))).toHaveLength(1);
+
+    // Acceptance semantics: no ack, so the seat is still behind and the sweep
+    // resends the current authoritative state.
+    await sweepAndWaitFor(async () => {
+      expect(statesSentTo((await guest.getSentMessages()).slice(before))).toHaveLength(2);
+    });
+    const resent = statesSentTo((await guest.getSentMessages()).slice(before));
+    expect(resent[1].state?.filteredFor).toBe(1);
+    adapter.dispose();
+  });
+
+  // `revision` crosses the trust boundary: `validateMessage` checks type
+  // membership only, and nothing on the decode path validates a field. An
+  // unclamped `1e9` makes the lag clause false forever, which strands the seat
+  // permanently — this bug's own symptom, reachable from one frame.
+  it("ignores a guest ack claiming a revision the host never reached", async () => {
+    const { adapter, emitConnection } = makeHost(2, 5_000);
+    await adapter.initialize();
+    const guest = await joinGuest(emitConnection, {
+      type: "guest_deck",
+      deckData: { player: { main_deck: [], sideboard: [] } },
+    });
+    await adapter.initializeGame();
+    await flushPromises();
+
+    guest.stopAcking();
+    await guest.simulateData({ type: "state_ack", revision: 1e9 });
+    const before = (await guest.getSentMessages()).length;
+
+    await guest.simulateData({
+      type: "action",
+      senderPlayerId: 1,
+      action: { type: "PassPriority" },
+    });
+    await flushPromises();
+    expect(statesSentTo((await guest.getSentMessages()).slice(before))).toHaveLength(1);
+
+    // Clamped to the host's own revision, so the seat is still behind.
+    await sweepAndWaitFor(async () => {
+      expect(statesSentTo((await guest.getSentMessages()).slice(before))).toHaveLength(2);
+    });
+    adapter.dispose();
+  });
+
+  // Terminal delivery gets its own bit rather than a revision, and this is
+  // why. Here the seat is FULLY current on state — its ack equals the
+  // authoritative revision — and must still be nominated, because its
+  // `terminal_result` never reached the channel. No revision ledger can
+  // express that, which is what the old ledger's `revision - 1` back-dating was
+  // simulating; and once the redelivered state frame is acked (the late ack),
+  // the simulation would be undone before the terminal frame ever went out.
+  it("re-sends a terminal statement whose bytes never reached the channel", async () => {
+    const { adapter, emitConnection } = makeHost(2, 5_000);
+    await adapter.initialize();
+    const guest = await joinGuest(emitConnection, {
+      type: "guest_deck",
+      deckData: { player: { main_deck: [], sideboard: [] } },
+    });
+    await adapter.initializeGame();
+    await flushPromises();
+
+    const before = (await guest.getSentMessages()).length;
+    (mockGetState as unknown as { mockResolvedValue: (v: unknown) => void }).mockResolvedValue({
+      players: [],
+      objects: {},
+      waiting_for: { type: "GameOver", data: { winner: 0 } },
+    });
+    (mockGetViewerSnapshot as unknown as {
+      mockImplementation: (implementation: (pid: number) => Promise<unknown>) => void;
+    }).mockImplementation(async (pid: number) => ({
+      state: { filteredFor: pid, players: [], waiting_for: { type: "GameOver", data: { winner: 0 } } },
+      actions: [],
+      autoPassRecommended: false,
+    }));
+    // The closing broadcast's state frame lands and is acked; the terminal
+    // frame that follows it finds a channel that cannot take bytes.
+    guest.refuseSendsAfter("state_update");
+
+    await guest.simulateData({
+      type: "action",
+      senderPlayerId: 1,
+      action: { type: "PassPriority" },
+    });
+    await flushPromises();
+
+    const immediate = (await guest.getSentMessages()).slice(before);
+    expect(statesSentTo(immediate)).toHaveLength(1);
+    expect(immediate.filter((m) => (m as { type?: string }).type === "terminal_result")).toHaveLength(0);
+    // The seat is provably current on state, so ONLY the terminal clause can
+    // nominate it below.
+    expect(guest.acksSent[guest.acksSent.length - 1])
+      .toMatchObject({ revision: statesSentTo(immediate)[0].revision });
+
+    guest.reopen();
+    await sweepAndWaitFor(async () => {
+      const sent = (await guest.getSentMessages()).slice(before);
+      expect(sent.filter((m) => (m as { type?: string }).type === "terminal_result")).toHaveLength(1);
+    });
+    const afterSweep = (await guest.getSentMessages()).slice(before);
+    const states = statesSentTo(afterSweep);
+    const terminals = afterSweep.filter((m) => (m as { type?: string }).type === "terminal_result") as
+      Array<{ result?: { recipient?: number; revision?: number } }>;
+    expect(states).toHaveLength(2);
+    expect(terminals[0].result?.recipient).toBe(1);
+    expect(terminals[0].result?.revision).toBe(states[1].revision);
+    expect(afterSweep.indexOf(states[1] as never)).toBeLessThan(afterSweep.indexOf(terminals[0] as never));
+
+    // And the flag terminates it: the delivered statement stops the sweep,
+    // even though `terminalResult` stays armed for the rest of the session.
+    await vi.advanceTimersByTimeAsync(5_000);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(deliveryFramesIn((await guest.getSentMessages()).slice(before)))
+      .toHaveLength(deliveryFramesIn(afterSweep).length);
+    adapter.dispose();
+  });
+
+  // `terminalResult` is never cleared for an adapter incarnation, so the
+  // terminal clause stays armed forever after a close. A seat that takes its
+  // statement on the reconnect path must therefore be recorded there too —
+  // otherwise it is nominated every 5 s for the life of the session, each tick
+  // costing a `reconnectHandoff` viewer-snapshot round trip plus a duplicate
+  // pair of frames.
+  //
+  // The FIRST tick is the measurement. Two ticks would not discriminate: the
+  // redelivery's own terminal write self-terminates the loop after one tick,
+  // so a missing reconnect-path write shows up as one duplicate pair and then
+  // silence.
+  it("stops nominating a seat that took its terminal result on reconnect", async () => {
+    const { adapter, emitConnection } = makeHost(2, 5_000);
+    await adapter.initialize();
+    const guest = await joinGuest(emitConnection, {
+      type: "guest_deck",
+      deckData: { player: { main_deck: [], sideboard: [] } },
+    });
+    await adapter.initializeGame();
+    await flushPromises();
+
+    const setup = (await guest.getSentMessages()).find(
+      (m): m is { type: "game_setup"; playerToken: string } =>
+        (m as { type?: string }).type === "game_setup",
+    );
+    const token = setup!.playerToken;
+
+    (mockGetState as unknown as { mockResolvedValue: (v: unknown) => void }).mockResolvedValue({
+      players: [],
+      objects: {},
+      waiting_for: { type: "GameOver", data: { winner: 0 } },
+    });
+    (mockGetViewerSnapshot as unknown as {
+      mockImplementation: (implementation: (pid: number) => Promise<unknown>) => void;
+    }).mockImplementation(async (pid: number) => ({
+      state: { filteredFor: pid, players: [], waiting_for: { type: "GameOver", data: { winner: 0 } } },
+      actions: [],
+      autoPassRecommended: false,
+    }));
+    // The one-shot terminal fan-out cannot reach this seat, so the reconnect
+    // path is the ONLY place it can be recorded as having taken its statement.
+    // (Disconnecting the seat BEFORE the close is not an option: a
+    // disconnected seat pauses the host and `submitAction` refuses.)
+    guest.refuseSendsAfter("state_update");
+    await guest.simulateData({
+      type: "action",
+      senderPlayerId: 1,
+      action: { type: "PassPriority" },
+    });
+    await flushPromises();
+    const closed = await guest.getSentMessages();
+    expect(closed.filter((m) => (m as { type?: string }).type === "terminal_result")).toHaveLength(0);
+
+    // Now the seat drops and comes back. The game is already terminal, so the
+    // seat is held without a grace timer.
+    guest.simulateClose();
+    const rejoin = await joinGuest(emitConnection, { type: "reconnect", playerToken: token });
+    // `handleFirstContact` fires the reconnect completion and forgets it, and
+    // the statement it commits crosses a real `crypto.subtle.digest`, so no
+    // microtask drain can await it. Poll, the way `sweepAndWaitFor` does — and
+    // well short of the 5 s sweep tick this test then fires deliberately.
+    await vi.waitFor(async () => {
+      const sent = await rejoin.getSentMessages();
+      expect(sent.filter((m) => (m as { type?: string }).type === "terminal_result")).toHaveLength(1);
+    }, { interval: 10, timeout: 2_000 });
+    const handshake = await rejoin.getSentMessages();
+    expect(handshake.filter((m) => (m as { type?: string }).type === "reconnect_ack")).toHaveLength(1);
+    // The seat is current on state because it acked the CLOSING `state_update`
+    // before it dropped, so its entry already equals `handoff.revision`. (Not
+    // because the reconnect ack was recorded: the host's real message handler
+    // is installed only after the `reconnect_ack` send, the seed, and the
+    // terminal send, and `peer.ts` buffers nothing while the drain handler is
+    // attached — so that ack races, and this test does not depend on it.)
+    // The lag clause is therefore provably false before the tick — exact zero
+    // assertion, not "no growth".
+    const before = handshake.length;
+
+    await vi.advanceTimersByTimeAsync(5_000);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(deliveryFramesIn((await rejoin.getSentMessages()).slice(before))).toHaveLength(0);
+    adapter.dispose();
+  });
+
+  // Why the ENTRY is created on transmission even though it ADVANCES on
+  // acceptance. The guest's ack is fire-and-forget — `P2PGuestAdapter.send`
+  // returns `void` and discards `trySend`'s boolean — so a handshake ack can
+  // be lost with nothing anywhere retrying it. Were the ack also the create,
+  // that single loss would disarm the sweep permanently: the host holds no
+  // entry, `shouldRedeliver` returns false at the create-guard, and the seat
+  // cannot produce another ack because every remaining ack site needs a frame
+  // the sweep will now never send. That is the reported deadlock verbatim — a
+  // guest stuck on "Waiting for another player to decide their opening hand"
+  // while the host waits on that same seat.
+  //
+  // `seedGuestEntry` closes it: the accepted `game_setup` send creates the
+  // entry at revision 1, so one revision later the lag clause is true and the
+  // sweep serves the seat the frame it needs to rejoin the conversation.
+  it("heals a seat whose handshake ack never reached the host", async () => {
+    const { adapter, emitConnection } = makeHost(2, 5_000);
+    await adapter.initialize();
+    const guest = await joinGuest(emitConnection, {
+      type: "guest_deck",
+      deckData: { player: { main_deck: [], sideboard: [] } },
+    });
+    // Every ack from this seat is lost, the handshake's included.
+    guest.stopAcking();
+    await adapter.initializeGame();
+    await flushPromises();
+
+    // Non-vacuity, and the line that separates this from the create-guard
+    // test: that seat's viewer read throws so no `game_setup` is ever sent,
+    // while this one WAS handed its frame and the channel took it.
+    const setups = (await guest.getSentMessages()).filter(
+      (m) => (m as { type?: string }).type === "game_setup",
+    );
+    expect(setups).toHaveLength(1);
+    expect(guest.acksSent).toHaveLength(0);
+
+    const before = (await guest.getSentMessages()).length;
+    await guest.simulateData({
+      type: "action",
+      senderPlayerId: 1,
+      action: { type: "PassPriority" },
+    });
+    await flushPromises();
+    expect(mockSubmitAction).toHaveBeenCalledWith({ type: "PassPriority" }, 1);
+    expect(statesSentTo((await guest.getSentMessages()).slice(before))).toHaveLength(1);
+
+    // Acks work again, but nothing on the guest side can restart the exchange:
+    // the host publishes no new revision while it waits on this seat, so the
+    // sweep is the only way out.
+    guest.resumeAcking();
+    await sweepAndWaitFor(async () => {
+      expect(statesSentTo((await guest.getSentMessages()).slice(before))).toHaveLength(2);
+    });
+    const resent = statesSentTo((await guest.getSentMessages()).slice(before));
+    expect(resent[1].state?.filteredFor).toBe(1);
+
+    // Healed, not merely retried: the resend was acked, so the next sweep is
+    // quiet rather than resending forever.
+    await vi.advanceTimersByTimeAsync(5_000);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(statesSentTo((await guest.getSentMessages()).slice(before))).toHaveLength(2);
+    adapter.dispose();
+  });
+
+  // `Number.isInteger`, which the `1e9` test above cannot reach: `1e9` IS an
+  // integer, so that test probes only the clamp. `Math.min` applies ToNumber,
+  // so a non-numeric revision yields `NaN`, and a stored `NaN` is the mirror
+  // image of an unclamped `1e9` — neither `undefined` (the create-guard lets
+  // it through) nor `< authoritativeRevision` (the lag clause is false
+  // forever). It is also self-sealing: `capped > NaN` is false for every
+  // later honest ack, and `seedGuestEntry` sees an entry already present, so
+  // nothing can ever overwrite it.
+  //
+  // Sent BEFORE the handshake on purpose. That is when the seat has no entry,
+  // which is the one branch that would store the `NaN`.
+  it("ignores a guest ack whose revision is not a number", async () => {
+    const { adapter, emitConnection } = makeHost(2, 5_000);
+    await adapter.initialize();
+    const guest = await joinGuest(emitConnection, {
+      type: "guest_deck",
+      deckData: { player: { main_deck: [], sideboard: [] } },
+    });
+    // `validateMessage` checks type membership only — no frame's fields are
+    // validated anywhere on the decode path — so this arrives verbatim.
+    await guest.simulateData({ type: "state_ack", revision: "not-a-number" });
+
+    await adapter.initializeGame();
+    await flushPromises();
+    guest.stopAcking();
+    const before = (await guest.getSentMessages()).length;
+
+    await guest.simulateData({
+      type: "action",
+      senderPlayerId: 1,
+      action: { type: "PassPriority" },
+    });
+    await flushPromises();
+    expect(statesSentTo((await guest.getSentMessages()).slice(before))).toHaveLength(1);
+
+    // Unpoisoned: the seat still reads as behind, so the sweep serves it.
+    await sweepAndWaitFor(async () => {
+      expect(statesSentTo((await guest.getSentMessages()).slice(before))).toHaveLength(2);
+    });
     adapter.dispose();
   });
 });

--- a/client/src/adapter/__tests__/p2p-adapter-multiplayer.test.ts
+++ b/client/src/adapter/__tests__/p2p-adapter-multiplayer.test.ts
@@ -15,6 +15,7 @@ import { P2PGuestAdapter, P2PHostAdapter, playerSlotsFromSeatView, type P2PAdapt
 import { AdapterError, AdapterErrorCode, supportsAiDecisionDiagnostics, supportsMatchConcede, type EngineSnapshot, type FormatConfig, type GameAction, type GameEvent, type GameLogEntry, type GameState, type PersistedGameState, type RestoredGameStateResult } from "../types";
 import type { WsAdapterEvent } from "../ws-adapter";
 import { FakeDataConnection } from "../../network/__tests__/fakeDataConnection";
+import { PEER_CONNECT_OPTIONS } from "../../network/connection";
 import { WIRE_PROTOCOL_VERSION } from "../../network/protocol";
 import { p2pFinalStateCommitment } from "../../services/p2pTerminalResult";
 import { ownsP2PHostLease } from "../../services/p2pSession";
@@ -3414,6 +3415,11 @@ describe("P2PHostAdapter — 3-4p multiplayer", () => {
     conn.simulateClose();
     await vi.advanceTimersByTimeAsync(1_000);
     expect(connect).toHaveBeenCalledOnce();
+    // The reconnect dial must carry the same options as the initial join.
+    // Without `reliable: true` PeerJS builds the channel `ordered: false`, and
+    // the guest's revision guards drop reordered frames rather than
+    // resequencing them.
+    expect(connect).toHaveBeenCalledWith("host-peer", PEER_CONNECT_OPTIONS);
 
     adapter.dispose();
     reconnectConn.fireOpen();

--- a/client/src/adapter/__tests__/p2p-adapter-multiplayer.test.ts
+++ b/client/src/adapter/__tests__/p2p-adapter-multiplayer.test.ts
@@ -2962,6 +2962,140 @@ describe("P2PHostAdapter — 3-4p multiplayer", () => {
     expect(emitted).not.toHaveBeenCalled();
   });
 
+  it("acks the revision the guest has applied, including the held one on a stale drop", async () => {
+    const { peer } = createFakePeer();
+    const conn = new FakeDataConnection();
+    const adapter = new P2PGuestAdapter(
+      { player: { main_deck: [], sideboard: [] } },
+      peer as unknown as Peer,
+      "host-peer",
+      conn as unknown as DataConnection,
+    );
+    await adapter.initialize();
+
+    const ackedRevisions = async (): Promise<number[]> => {
+      await flushPromises();
+      return (await conn.getSentMessages())
+        .filter(
+          (m): m is { type: "state_ack"; revision: number } =>
+            typeof m === "object" && m !== null && (m as { type: string }).type === "state_ack",
+        )
+        .map((m) => m.revision);
+    };
+
+    await conn.simulateData({
+      type: "game_setup",
+      wireProtocolVersion: WIRE_PROTOCOL_VERSION,
+      assignedPlayerId: 1,
+      playerToken: "seat-token",
+      revision: 8,
+      state: remoteState("setup"),
+      events: [],
+      legalActions: [],
+      autoPassRecommended: false,
+      manaPaymentShortcutActions: [],
+    });
+    await adapter.initializeGame();
+    expect(await ackedRevisions()).toEqual([8]);
+
+    await conn.simulateData({
+      type: "state_update",
+      revision: 9,
+      state: remoteState("current"),
+      events: [],
+      legalActions: [],
+      autoPassRecommended: false,
+      manaPaymentShortcutActions: [],
+    });
+    expect(await ackedRevisions()).toEqual([8, 9]);
+
+    // The stale frame is dropped, but the guest still answers — with the
+    // NEWER revision it holds. A host ledger that records transmission cannot
+    // observe this; the ack is the only way it learns the seat is ahead.
+    await conn.simulateData({
+      type: "state_update",
+      revision: 8,
+      state: remoteState("stale"),
+      events: [],
+      legalActions: [],
+      autoPassRecommended: false,
+      manaPaymentShortcutActions: [],
+    });
+    expect(await ackedRevisions()).toEqual([8, 9, 9]);
+
+    // A resumed session re-declares the seat's revision. No host consumes any
+    // `state_ack` yet — `handleGuestMessage` has no such case and falls to
+    // `default: break` — so this pins the guest half, which is the half this
+    // step owns.
+    await conn.simulateData({
+      type: "reconnect_ack",
+      wireProtocolVersion: WIRE_PROTOCOL_VERSION,
+      assignedPlayerId: 1,
+      revision: 12,
+      state: remoteState("resumed"),
+      legalActions: [],
+      autoPassRecommended: false,
+      manaPaymentShortcutActions: [],
+    });
+    expect(await ackedRevisions()).toEqual([8, 9, 9, 12]);
+  });
+
+  it("still acks an applied state_update when a stateChanged listener throws", async () => {
+    const { peer } = createFakePeer();
+    const conn = new FakeDataConnection();
+    const adapter = new P2PGuestAdapter(
+      { player: { main_deck: [], sideboard: [] } },
+      peer as unknown as Peer,
+      "host-peer",
+      conn as unknown as DataConnection,
+    );
+    await adapter.initialize();
+
+    // `P2PGuestAdapter.emit` does not wrap its listeners, so a throwing
+    // subscriber unwinds the rest of the arm — here, only an ack placed after
+    // the emit. It must already be on the wire: a resent EQUAL revision is not
+    // `<` the cached one, so it re-enters this same arm and throws again, and
+    // once a host consumes acks that is a resend loop rather than a heal. The
+    // seat itself is fine throughout; it holds the state and serves
+    // `getState()`.
+    adapter.onEvent((event) => {
+      if (event.type === "stateChanged") throw new Error("subscriber blew up");
+    });
+
+    await conn.simulateData({
+      type: "game_setup",
+      wireProtocolVersion: WIRE_PROTOCOL_VERSION,
+      assignedPlayerId: 1,
+      playerToken: "seat-token",
+      revision: 3,
+      state: remoteState("setup"),
+      events: [],
+      legalActions: [],
+      autoPassRecommended: false,
+      manaPaymentShortcutActions: [],
+    });
+    await adapter.initializeGame();
+
+    await conn.simulateData({
+      type: "state_update",
+      revision: 4,
+      state: remoteState("current"),
+      events: [],
+      legalActions: [],
+      autoPassRecommended: false,
+      manaPaymentShortcutActions: [],
+    });
+    await flushPromises();
+
+    const acked = (await conn.getSentMessages())
+      .filter(
+        (m): m is { type: "state_ack"; revision: number } =>
+          typeof m === "object" && m !== null && (m as { type: string }).type === "state_ack",
+      )
+      .map((m) => m.revision);
+    expect(acked).toEqual([3, 4]);
+  });
+
   it("guest receive path resolves action_noop without replacing its cached snapshot", async () => {
     const { peer } = createFakePeer();
     const conn = new FakeDataConnection();
@@ -3866,14 +4000,14 @@ describe("P2P wire-protocol version gate", () => {
   // Both halves stamp LITERALS. A frame built from WIRE_PROTOCOL_VERSION
   // cannot tell a bumped client from an unbumped one, which is why every
   // other handshake fixture in the suite is useless as an instrument for a
-  // bump. Revert 41 → 40 and BOTH halves red: the v40 frame stops being
-  // refused, and the v41 frame stops being admitted. The admitting half is
-  // the reach-guard — without it "refuses v40" is also satisfied by a client
+  // bump. Revert 42 → 41 and BOTH halves red: the v41 frame stops being
+  // refused, and the v42 frame stops being admitted. The admitting half is
+  // the reach-guard — without it "refuses v41" is also satisfied by a client
   // that refuses everything.
-  it("refuses the previous wire protocol (v40) and admits its own (v41)", async () => {
+  it("refuses the previous wire protocol (v41) and admits its own (v42)", async () => {
     const refusing = makeGuest();
     await refusing.adapter.initialize();
-    await refusing.conn.simulateData(setupFrameAt(40));
+    await refusing.conn.simulateData(setupFrameAt(41));
 
     await expect(refusing.adapter.initializeGame()).rejects.toMatchObject({
       code: "P2P_REJECTED",
@@ -3885,7 +4019,7 @@ describe("P2P wire-protocol version gate", () => {
 
     const admitting = makeGuest();
     await admitting.adapter.initialize();
-    await admitting.conn.simulateData(setupFrameAt(41));
+    await admitting.conn.simulateData(setupFrameAt(42));
 
     await expect(admitting.adapter.initializeGame()).resolves.toBeDefined();
     expect(admitting.emitted).not.toHaveBeenCalledWith(

--- a/client/src/adapter/__tests__/p2pDraftGuestHandshake.test.ts
+++ b/client/src/adapter/__tests__/p2pDraftGuestHandshake.test.ts
@@ -55,6 +55,7 @@ vi.mock("../../network/draftPeerSession", () => ({
 vi.mock("../../services/draftPersistence", () => persistenceState);
 
 import { P2PDraftGuest } from "../p2p-draft-guest";
+import { PEER_CONNECT_OPTIONS } from "../../network/connection";
 import { DRAFT_PROTOCOL_VERSION, validateDraftMessage } from "../../network/draftProtocol";
 
 const reconnectAck = {
@@ -710,5 +711,37 @@ describe("P2P draft guest handshake attempts", () => {
     sessionState.sessions[1]!.handler!(reconnectAck);
     await expect(second).resolves.toBeUndefined();
     expect(secondSettled).toBe(true);
+  });
+
+  it("dials the reconnect transport with the shared ordered-channel connect options", async () => {
+    // Unlike every other test here, this one needs a real `guestPeer`: the dial
+    // is `this.guestPeer.connect(...)`, which the shared `{} as never` peer
+    // cannot answer.
+    const connHandlers = new Map<string, (arg?: unknown) => void>();
+    const reconnectConn = {
+      on: vi.fn((event: string, handler: (arg?: unknown) => void) => {
+        connHandlers.set(event, handler);
+      }),
+    };
+    const connect = vi.fn(() => reconnectConn);
+    const guest = new P2PDraftGuest(
+      { connect } as never,
+      "phase2-ABCDE",
+      {} as never,
+      { kind: "reconnect", roomCode: "ABCDE", displayName: "Alice", draftToken: "opaque-token" },
+    );
+    const privateGuest = guest as unknown as {
+      openReconnectConnection: (signal?: AbortSignal) => Promise<unknown>;
+    };
+
+    const dial = privateGuest.openReconnectConnection();
+
+    // `reliable: true` is what PeerJS maps to `createDataChannel(…, { ordered
+    // }) `; an option-less dial silently yields an unordered channel that a
+    // TURN relay will actually reorder.
+    expect(connect).toHaveBeenCalledWith("phase2-ABCDE", PEER_CONNECT_OPTIONS);
+
+    connHandlers.get("open")!();
+    await expect(dial).resolves.toBe(reconnectConn);
   });
 });

--- a/client/src/adapter/__tests__/p2pDraftGuestOrdering.test.ts
+++ b/client/src/adapter/__tests__/p2pDraftGuestOrdering.test.ts
@@ -15,6 +15,7 @@ vi.mock("../../services/draftPersistence", () => persistence);
 
 import { EMPTY_DRAFT_POOL_GROUPS, type DraftPlayerView } from "../draft-adapter";
 import { P2PDraftGuest, type DraftGuestConnection, type DraftGuestEvent } from "../p2p-draft-guest";
+import { PEER_CONNECT_OPTIONS } from "../../network/connection";
 import { DRAFT_PROTOCOL_VERSION, decodeDraftWireMessage, type DraftP2PMessage } from "../../network/draftProtocol";
 import * as protocol from "../../network/draftProtocol";
 import { FakeDraftDataConnection } from "../../network/__tests__/fakeDraftDataConnection";
@@ -507,7 +508,7 @@ describe("P2P draft guest receive ordering", () => {
     vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
     conn.simulateClose();
     await vi.advanceTimersByTimeAsync(1000);
-    expect(connect).toHaveBeenCalledExactlyOnceWith("phase2-ABCDE");
+    expect(connect).toHaveBeenCalledExactlyOnceWith("phase2-ABCDE", PEER_CONNECT_OPTIONS);
     middleConn.simulateOpen();
     await vi.advanceTimersByTimeAsync(0);
     expect(middleConn.sentRaw).toHaveLength(1);
@@ -525,7 +526,7 @@ describe("P2P draft guest receive ordering", () => {
     middleConn.simulateClose();
     await vi.advanceTimersByTimeAsync(1000);
     expect(connect).toHaveBeenCalledTimes(2);
-    expect(connect).toHaveBeenNthCalledWith(2, "phase2-ABCDE");
+    expect(connect).toHaveBeenNthCalledWith(2, "phase2-ABCDE", PEER_CONNECT_OPTIONS);
     newestConn.simulateOpen();
     await vi.advanceTimersByTimeAsync(0);
     expect(newestConn.sentRaw).toHaveLength(1);

--- a/client/src/adapter/p2p-adapter.ts
+++ b/client/src/adapter/p2p-adapter.ts
@@ -38,6 +38,7 @@ import {
   type NativeAiSeat,
   type NativeSessionAttachment,
 } from "./ws-adapter";
+import { PEER_CONNECT_OPTIONS, RECONNECT_DIAL_TIMEOUT_MS } from "../network/connection";
 import { createPeerSession, type PeerSession } from "../network/peer";
 import type { P2PMessage } from "../network/protocol";
 import { WIRE_PROTOCOL_VERSION, legalActionsFromWire, legalActionsToWire } from "../network/protocol";
@@ -4159,9 +4160,16 @@ export class P2PGuestAdapter implements EngineAdapter {
     if (this.terminated) return;
 
     try {
-      const conn = this.hostPeer.connect(this.hostPeerId);
+      // `PEER_CONNECT_OPTIONS` is not optional: without `reliable: true` this
+      // reconnect channel comes up UNORDERED, and every revision guard
+      // downstream assumes ordered delivery. The initial `joinRoom` dial has
+      // always carried them; this one did not.
+      const conn = this.hostPeer.connect(this.hostPeerId, PEER_CONNECT_OPTIONS);
       await new Promise<void>((resolve, reject) => {
-        const timeout = setTimeout(() => reject(new Error("connect timed out")), 10_000);
+        const timeout = setTimeout(
+          () => reject(new Error("connect timed out")),
+          RECONNECT_DIAL_TIMEOUT_MS,
+        );
         conn.on("open", () => {
           clearTimeout(timeout);
           resolve();

--- a/client/src/adapter/p2p-adapter.ts
+++ b/client/src/adapter/p2p-adapter.ts
@@ -3648,6 +3648,66 @@ export class P2PGuestAdapter implements EngineAdapter {
     return this.snapshot;
   }
 
+  /** Report the highest revision this guest has actually APPLIED.
+   *
+   *  Called from every arm that accepts a state-bearing frame, and from the
+   *  stale-drop branch of `state_update`. A sender-side ledger records
+   *  TRANSMISSION — `send()` resolving true means the bytes reached the
+   *  channel, not that the guest ever applied them — so this is the only
+   *  frame that reports application. On the stale-drop branch `cachedRevision`
+   *  is still the NEWER revision the guest already holds, not the stale one it
+   *  just discarded, so the ack additionally reports being ahead of a resend.
+   *
+   *  Placement is NOT uniform and rests on no single criterion. `emit` does
+   *  not wrap its listeners in try/catch (unlike `peer.ts`, which wraps each
+   *  handler), so an ack sitting after an `emit` is suppressed by a throwing
+   *  subscriber — and whether that suppression is WANTED differs by arm.
+   *   - `state_update`: ack right after `cacheSnapshot`, before the emit. The
+   *     guest holds the state and serves `getState()` from there, so the ack
+   *     reports what the guest HAS, not what its UI has rendered. Acking after
+   *     the emit would be worse than merely late: a resent EQUAL revision is
+   *     not `<` the cached one, so it re-enters this same arm and throws
+   *     again — once a host consumes acks, that is a resend loop, not a heal.
+   *   - `game_setup` / `reconnect_ack`: ack AFTER `settleGameSetup`. Until
+   *     that promise settles `initializeGame()` has not resolved and the guest
+   *     cannot act at all, so here suppression is the wanted outcome: an
+   *     unacked seat is the honest report. Two limits on that, both real —
+   *     it covers only the setup frame itself, since a later `state_update`
+   *     acks from its own arm with no `gameSetupSettled` check; and a
+   *     redelivery rescues only a TRANSIENT throw, because a deterministic one
+   *     re-enters the same arm and throws again.
+   *
+   *  No-op when `cachedRevision` is null. Every host sender stamps `revision`
+   *  today, but the frame types declare it optional, so an unstamped
+   *  state-bearing frame would be applied and NOT acked, with no warning.
+   *
+   *  Authentication: all four call sites are on an authenticated session by
+   *  the time they reach here, but by two different routes.
+   *  `handleHostMessage`'s top-level guard already requires
+   *  `authenticatedSession === session` for every type except `game_setup`,
+   *  `reconnect_ack`, `reconnect_rejected`, `kick` and `host_left` — so the
+   *  two `state_update` sites are gated there before their arm is entered.
+   *  The other two arms are exempt from that guard precisely because they are
+   *  what ASSIGNS `authenticatedSession`, and each does so before its ack.
+   *
+   *  `send()` stamps `this.authority` when the guest holds one, so an ack
+   *  normally runs the host's `hasExactP2PAuthority` supersede check whose
+   *  failure path calls `rejectSuperseded` and closes the session. That is the
+   *  identical path an `action` already takes, so it is believed benign — but
+   *  it does mean this purely informational frame is capable of ending a
+   *  session, which is stated here rather than left latent. It also changes
+   *  the TIMING of that outcome: an `action` is user-driven, while an ack
+   *  rides every accepted broadcast, so a guest on a stale stamp would be
+   *  rejected on the next broadcast rather than on its next action. Both setup
+   *  arms refresh `this.authority` from the host's own frame before their ack
+   *  — conditionally, but the host stamps every outbound frame — so this is
+   *  not believed reachable.
+   */
+  private sendStateAck(): void {
+    if (this.cachedRevision === null) return;
+    this.send({ type: "state_ack", revision: this.cachedRevision });
+  }
+
   private async acceptTerminalResult(
     session: PeerSession,
     message: Extract<P2PMessage, { type: "terminal_result" }>,
@@ -3809,6 +3869,7 @@ export class P2PGuestAdapter implements EngineAdapter {
         this.cacheSnapshot(msg.state, legalActionsFromWire(msg));
         this.emit({ type: "playerIdentity", playerId: msg.assignedPlayerId, playerNames: msg.playerNames });
         this.settleGameSetup({ events: msg.events });
+        this.sendStateAck();
         break;
       }
       case "reconnect_ack": {
@@ -3836,6 +3897,7 @@ export class P2PGuestAdapter implements EngineAdapter {
         // a second time) are idempotent — the `gameSetupSettled` guard
         // prevents double-resolution.
         this.settleGameSetup({ events: [] });
+        this.sendStateAck();
         break;
       }
       case "reconnect_rejected": {
@@ -3891,10 +3953,14 @@ export class P2PGuestAdapter implements EngineAdapter {
           && this.cachedRevision !== null
           && msg.revision < this.cachedRevision
         ) {
+          // Ack the revision the guest HOLDS, not the one it just dropped, so
+          // the host learns this seat is ahead of what it resent.
+          this.sendStateAck();
           return;
         }
         this.cachedRevision = msg.revision ?? null;
         const updateSnapshot = this.cacheSnapshot(msg.state, legalActionsFromWire(msg));
+        this.sendStateAck();
         if (this.pendingResolve) {
           this.pendingResolve({ events: msg.events, log_entries: msg.logEntries });
           this.pendingResolve = null;

--- a/client/src/adapter/p2p-adapter.ts
+++ b/client/src/adapter/p2p-adapter.ts
@@ -806,17 +806,41 @@ export class P2PHostAdapter implements EngineAdapter {
    * with the local phase-server's revision before fan-out. */
   private authoritativeRevision = 0;
   /**
-   * Last revision each guest seat's channel ACCEPTED (`send` resolved true)
-   * from a state-bearing frame: `game_setup`, `state_update`, or
-   * `reconnect_ack`. A missing entry means the seat never took its setup
-   * frame; the redelivery sweep skips such seats, because a `state_update`
-   * cannot substitute for the setup handshake. Channel acceptance is the
-   * strongest per-frame signal the wire protocol offers (there is no
-   * state-update ack); a channel that dies after accepting is the
-   * keepalive's case, and its reconnect refreshes this ledger through
-   * `reconnect_ack`.
+   * How far along each guest seat is, on two different signals — because the
+   * two failure directions are not symmetric:
+   *
+   *  - ADVANCE is acceptance-only (`recordGuestAck`, driven by the seat's own
+   *    `state_ack`). A `send` resolving true only means the bytes reached the
+   *    channel, and peerjs parks anything past its buffered-amount budget in a
+   *    buffer that `close()` discards. A ledger that advanced on transmission
+   *    therefore marked a seat delivered while the host was still waiting on
+   *    that seat to act — the sweep skipped it and the match deadlocked.
+   *  - CREATE is transmission-only (`seedGuestEntry`, on an accepted
+   *    `game_setup` or `reconnect_ack` send). The asymmetry rests entirely on
+   *    the false-NEGATIVE side: a seat with no entry is one the sweep will
+   *    never nominate, so losing the create strands a seat that could have
+   *    been healed. A false POSITIVE is NOT self-healing — a parked handshake
+   *    never assigns the guest's `authenticatedSession`, so every redelivered
+   *    `state_update` is discarded unauthenticated — it is merely no worse
+   *    than the handshake never having been sent, which is already
+   *    unrecoverable.
+   *
+   * A missing entry therefore means the seat was never HANDED a handshake
+   * frame its channel accepted — no `game_setup`, no `reconnect_ack`. The
+   * redelivery sweep skips such seats, because a `state_update` cannot
+   * substitute for the setup handshake.
    */
-  private guestDeliveredRevisions = new Map<PlayerId, number>();
+  private guestAckedRevisions = new Map<PlayerId, number>();
+  /**
+   * Seats whose `terminal_result` reached the channel. Terminal delivery keeps
+   * transmission semantics — acking it would need a second wire bump, and it
+   * is post-game, so it cannot deadlock a live match. It gets its own bit so
+   * that a revision can no longer speak for it, which is exactly what the old
+   * ledger's `revision - 1` back-dating could not express: it simulated
+   * "still owes a frame" by corrupting a revision counter, so the next
+   * recorded delivery silently undid it.
+   */
+  private terminalDelivered = new Set<PlayerId>();
   private redeliveryTimer: ReturnType<typeof setInterval> | null = null;
   /** First committed terminal statement fences every subsequent action and
    * reconnect. Its id is immutable for this adapter incarnation. */
@@ -2092,13 +2116,13 @@ export class P2PHostAdapter implements EngineAdapter {
             events: result.events,
             playerNames: allNames,
             ...legalActionsToWire(snapshot),
-          }).then((delivered) => {
-            if (delivered) this.recordGuestDelivery(pid, revision);
+          }).then((accepted) => {
+            if (accepted) this.seedGuestEntry(pid, revision);
           });
         } catch (err) {
           // Isolate per seat. Unisolated, one rejected read left every LATER
           // seat without its setup frame — and those seats are then stuck for
-          // good: no `game_setup` means no ledger entry, so the sweep skips
+          // good: no `game_setup` means no entry to seed, so the sweep skips
           // them by design, and a second start returns early because
           // `gameStarted` is already true. The seat whose own read failed
           // still belongs to the setup/reconnect path, not to the sweep.
@@ -2197,7 +2221,7 @@ export class P2PHostAdapter implements EngineAdapter {
     if (revision < this.authoritativeRevision) return;
     this.authoritativeRevision = revision;
     const allNames = this.playerNamesForSeats();
-    const sends: Array<Promise<void>> = [];
+    const sends: Array<Promise<boolean>> = [];
     for (const [pid, session] of this.guestSessions) {
       const update = views.get(pid);
       if (!update || this.disconnectedSeats.has(pid)) continue;
@@ -2214,8 +2238,9 @@ export class P2PHostAdapter implements EngineAdapter {
           events: update.events,
           playerNames: allNames,
           ...legalActionsToWire(update.snapshot.legalResult),
-        }).then((delivered) => {
-          if (delivered) this.recordGuestDelivery(pid, revision);
+        }).then((accepted) => {
+          if (accepted) this.seedGuestEntry(pid, revision);
+          return accepted;
         }));
       } else {
         sends.push(this.send(session, {
@@ -2225,8 +2250,6 @@ export class P2PHostAdapter implements EngineAdapter {
           events: update.events,
           logEntries: update.logEntries,
           ...legalActionsToWire(update.snapshot.legalResult),
-        }).then((delivered) => {
-          if (delivered) this.recordGuestDelivery(pid, revision);
         }));
       }
     }
@@ -2291,12 +2314,13 @@ export class P2PHostAdapter implements EngineAdapter {
    * same rejection source as the state fan-out and is isolated the same way.
    * Unisolated, one rejected read cost the seat its statement, with no way
    * back — this function returns early once `this.terminalResult` is set; it
-   * cost that seat its sweep nomination too, whenever the state fan-out had
-   * already recorded it at this revision; and it cost the host its own
-   * `terminalResult` emit, which clears the prompt overlay, drops the
-   * resumable save and supplies the closing reason (the board itself already
-   * reads GameOver from the published snapshot). A failed seat is now pushed below the
-   * revision and the sweep heals it.
+   * cost that seat its sweep nomination too, whenever the seat had ACKED the
+   * state fan-out's frame at this revision, which leaves the lag clause false
+   * and `terminalDelivered` the only thing that can nominate it; and it cost
+   * the host its own `terminalResult` emit, which clears the prompt overlay,
+   * drops the resumable save and supplies the closing reason (the board
+   * already reads GameOver from the published snapshot). A failed seat never
+   * enters `terminalDelivered`, and the sweep heals it.
    */
   private async commitTerminalIfComplete(
     snapshot: EngineSnapshot,
@@ -2333,14 +2357,16 @@ export class P2PHostAdapter implements EngineAdapter {
           ? this.nativeBridge.viewerSnapshot(playerId)
           : await this.wasm.getViewerSnapshot(playerId);
         const recipientResult = await createResult(playerId, viewerSnapshot.state);
-        if (await this.send(session, { type: "terminal_result", result: recipientResult })) return;
+        if (await this.send(session, { type: "terminal_result", result: recipientResult })) {
+          this.terminalDelivered.add(playerId);
+          return;
+        }
       } catch (err) {
         console.error(`[P2PHost] terminal delivery for seat ${playerId} failed; the sweep resyncs it:`, err);
       }
-      // Same authority that heals a failed state fan-out: hand the seat to the
-      // ledger, and `redeliverGuestState` re-sends the final state plus a
+      // Nothing to record: leaving the seat out of `terminalDelivered` is what
+      // nominates it, and `redeliverGuestState` re-sends the final state plus a
       // freshly committed, recipient-bound statement on the next sweep.
-      this.markGuestBehind(playerId, revision);
     }));
     this.emit({ type: "terminalResult", result });
     return true;
@@ -2380,10 +2406,11 @@ export class P2PHostAdapter implements EngineAdapter {
    * actions from the engine-side viewer gate (`legal_actions_for_viewer`).
    * Skips disconnected seats (their state is delivered via `reconnect_ack`).
    *
-   * Delivery contract (#7924): an accepted send advances that seat's entry in
-   * `guestDeliveredRevisions`; a seat whose viewer read or send fails keeps
-   * its old entry and is resynchronized by the redelivery sweep below. One
-   * seat's failure aborts neither the other seats nor the terminal close.
+   * Delivery contract (#7924): only the recipient's own `state_ack` advances
+   * its entry in `guestAckedRevisions`. A seat whose viewer read or send
+   * fails — or which takes the bytes but never applies them — keeps its old
+   * entry and is resynchronized by the redelivery sweep below. One seat's
+   * failure aborts neither the other seats nor the terminal close.
    */
   private async broadcastStateUpdate(
     events: GameEvent[],
@@ -2401,7 +2428,7 @@ export class P2PHostAdapter implements EngineAdapter {
     if (!this.ownsAuthority()) return;
     if (this.nativeBridge) return;
     const revision = ++this.authoritativeRevision;
-    const sends: Array<Promise<void>> = [];
+    const sends: Array<Promise<boolean>> = [];
     for (const [pid, session] of this.guestSessions) {
       if (this.disconnectedSeats.has(pid)) continue;
       try {
@@ -2413,8 +2440,6 @@ export class P2PHostAdapter implements EngineAdapter {
           events,
           logEntries,
           ...legalActionsToWire(snapshot),
-        }).then((delivered) => {
-          if (delivered) this.recordGuestDelivery(pid, revision);
         }));
       } catch (err) {
         console.error(`[P2PHost] viewer snapshot for seat ${pid} failed; the redelivery sweep resyncs it:`, err);
@@ -2441,30 +2466,93 @@ export class P2PHostAdapter implements EngineAdapter {
   }
 
   /**
-   * Push a seat BELOW the authoritative revision so the sweep nominates it.
+   * Create-only seed: a seat that has been HANDED its handshake gets an entry,
+   * at the revision that handshake carried. Never advances an existing entry —
+   * `recordGuestAck` is the sole authority for that.
    *
-   * `recordGuestDelivery` is deliberately monotonic; this is the one caller
-   * allowed to lower an entry, and only where the seat provably did not
-   * receive this revision.
+   * Transmission is the right signal for the CREATE and acceptance for the
+   * ADVANCE, because the two failure directions are not symmetric: a false
+   * positive here (send resolved true, frame parked) leaves the seat entried at
+   * a stale revision, so the next revision makes `acked < authoritativeRevision`
+   * true and the sweep heals it. A false negative — no entry at all — disarms
+   * the sweep permanently, which is the deadlock this whole change exists to
+   * close: the guest's own ack is fire-and-forget (`P2PGuestAdapter.send`
+   * discards `trySend`'s boolean), so a lost ack would otherwise leave the host
+   * with nothing to nominate and the guest with no frame to ack against.
    *
-   * A seat with NO entry is left alone: a missing entry means the seat never
-   * took its `game_setup`, and that seat belongs to the setup/reconnect path
-   * (a `state_update` cannot substitute for the handshake). Creating an entry
-   * here would hand it a resync every tick that it discards unauthenticated.
-   * `Math.min` keeps the entry from claiming a revision the seat never had.
+   * Called only for `game_setup` and `reconnect_ack`, never `state_update`: an
+   * accepted state frame says nothing about whether the seat can authenticate
+   * it, and recording those was the shipped bug.
    */
-  private markGuestBehind(pid: PlayerId, revision: number): void {
-    const prior = this.guestDeliveredRevisions.get(pid);
-    if (prior === undefined) return;
-    this.guestDeliveredRevisions.set(pid, Math.min(prior, revision - 1));
+  private seedGuestEntry(pid: PlayerId, revision: number): void {
+    if (!this.guestAckedRevisions.has(pid)) {
+      this.guestAckedRevisions.set(pid, revision);
+    }
   }
 
-  /** Monotonic: a stale resync result must never roll a seat's entry back. */
-  private recordGuestDelivery(pid: PlayerId, revision: number): void {
-    const prior = this.guestDeliveredRevisions.get(pid);
-    if (prior === undefined || revision > prior) {
-      this.guestDeliveredRevisions.set(pid, revision);
-    }
+  /**
+   * Single authority for ADVANCING `guestAckedRevisions`. Monotonic, so a
+   * stale resync ack can never roll a seat back. It NEVER creates: an ack for
+   * a seat with no entry is dropped, because creating from one would hand the
+   * create-guard's invariant to a remote peer. `handleGuestMessage` is bound
+   * at lobby-join, long before any handshake, and the pre-switch authority
+   * check only inspects a stamp that is present — so an unsolicited
+   * `state_ack` would otherwise create an entry for a seat that never took a
+   * `game_setup`, and one carrying a negative revision would make that seat
+   * read as permanently lagging, costing a viewer-snapshot round trip and a
+   * discarded frame every tick for the life of the match.
+   *
+   * Dropping it costs nothing on the honest path: the seed is a microtask
+   * chained to the same `send` promise, while an ack must cross encode →
+   * channel → guest decode → guest handler → guest encode → host decode. The
+   * seed always lands first.
+   *
+   * `revision` arrives from a remote peer, so it is validated HERE, at the
+   * trust boundary: `validateMessage` checks only type membership, and no
+   * field on any frame is validated anywhere on the decode path. An
+   * unvalidated `1e9` would make the lag clause false forever and strand the
+   * seat permanently — this bug's own symptom from a single frame.
+   *
+   * `Number.isInteger` covers what the clamp cannot. A `"99"` is not a case:
+   * `Math.min` applies ToNumber and returns a Number, so nothing is ever
+   * stored as a string. Nor is `NaN` (from `"abc"` / `undefined`) once this
+   * never creates — `NaN > prior` is false, so it cannot be stored. What the
+   * guard is actually for is a FLOAT: `2.5` clamps and stores cleanly, and
+   * `2.5 < authoritativeRevision` then stays true for every integral revision
+   * the host will ever reach, so the seat is nominated every tick forever,
+   * each one costing a viewer-snapshot round trip and a duplicate frame.
+   *
+   * The clamp is safe because `authoritativeRevision` only ever rises within
+   * an incarnation, and `Math.min` can only LOWER a recorded ack — costing at
+   * most an extra redelivery, never a suppressed one.
+   */
+  private recordGuestAck(pid: PlayerId, revision: number): void {
+    if (!Number.isInteger(revision)) return;
+    const capped = Math.min(revision, this.authoritativeRevision);
+    const prior = this.guestAckedRevisions.get(pid);
+    if (prior === undefined) return;
+    if (capped > prior) this.guestAckedRevisions.set(pid, capped);
+  }
+
+  /**
+   * Whether the sweep owes this seat a resync. Both lag checks go through
+   * here — the nomination and `redeliverGuestState`'s own re-check — so the
+   * two can never disagree.
+   *
+   * The create-guard gates BOTH clauses. A seat with no entry was never
+   * handed a handshake frame its channel accepted — no `game_setup`, no
+   * `reconnect_ack` — and belongs to the setup/reconnect path because a
+   * `state_update` cannot stand in for the handshake (the guest discards
+   * state frames it cannot authenticate). `undefined < N` is already false,
+   * but the terminal clause would otherwise adopt exactly such a seat:
+   * `terminalResult` stays set for the rest of the incarnation, and that
+   * seat's terminal send never ran either.
+   */
+  private shouldRedeliver(pid: PlayerId): boolean {
+    const acked = this.guestAckedRevisions.get(pid);
+    if (acked === undefined) return false;
+    if (acked < this.authoritativeRevision) return true;
+    return this.terminalResult !== null && !this.terminalDelivered.has(pid);
   }
 
   private startRedeliverySweep(): void {
@@ -2480,8 +2568,7 @@ export class P2PHostAdapter implements EngineAdapter {
     if (this.disposed || !this.ownsAuthority()) return;
     for (const pid of this.guestSessions.keys()) {
       if (this.disconnectedSeats.has(pid)) continue;
-      const delivered = this.guestDeliveredRevisions.get(pid);
-      if (delivered === undefined || delivered >= this.authoritativeRevision) continue;
+      if (!this.shouldRedeliver(pid)) continue;
       void this.enqueueDelivery(() => this.redeliverGuestState(pid));
     }
   }
@@ -2497,15 +2584,14 @@ export class P2PHostAdapter implements EngineAdapter {
    * fan-out ran against the seat's stale revision, and `acceptTerminalResult`
    * refuses a revision mismatch, so without this the seat would hold the
    * final board but never a committed result. Never rejects: a failure
-   * leaves the ledger entry stale and the next sweep retries, for as long
-   * as the seat stays connected.
+   * leaves the seat behind and the next sweep retries, for as long as the
+   * seat stays connected.
    */
   private async redeliverGuestState(pid: PlayerId): Promise<void> {
     if (this.disposed || !this.ownsAuthority()) return;
     const session = this.guestSessions.get(pid);
     if (!session || this.disconnectedSeats.has(pid)) return;
-    const delivered = this.guestDeliveredRevisions.get(pid);
-    if (delivered === undefined || delivered >= this.authoritativeRevision) return;
+    if (!this.shouldRedeliver(pid)) return;
     try {
       const handoff = await this.reconnectHandoff(pid);
       const accepted = await this.send(session, {
@@ -2519,13 +2605,14 @@ export class P2PHostAdapter implements EngineAdapter {
       if (this.terminalResult !== null) {
         // Recipient-bound, like the reconnect path: `terminalResultForRecipient`
         // verifies the terminal revision against this handoff and throws
-        // otherwise — the catch below turns that into a retry. The ledger
-        // advances only once BOTH frames are accepted, so a refused or failed
-        // terminal send re-nominates the seat on the next sweep.
+        // otherwise — the catch below turns that into a retry. The state frame
+        // is settled by the seat's own ack; only the terminal frame needs a
+        // write here, so a refused or failed terminal send re-nominates the
+        // seat on the next sweep even after the state ack lands.
         const result = await this.terminalResultForRecipient(pid, handoff.snapshot.state, handoff.revision);
         if (!(await this.send(session, { type: "terminal_result", result }))) return;
+        this.terminalDelivered.add(pid);
       }
-      this.recordGuestDelivery(pid, handoff.revision);
     } catch (err) {
       console.warn(`[P2PHost] state redelivery for seat ${pid} failed; retrying on the next sweep:`, err);
     }
@@ -2539,7 +2626,7 @@ export class P2PHostAdapter implements EngineAdapter {
    * reject at its close: the host snapshot read feeding
    * `commitTerminalIfComplete`. The per-seat viewer reads on both sides of
    * that close — the fan-out's and the terminal commit's own recipient-bound
-   * ones — are caught per seat and settle into the delivery ledger. Emitting
+   * ones — are caught per seat and left to the redelivery sweep. Emitting
    * afterwards therefore makes the host's own screen depend on work done on
    * every guest's behalf — the host freezes on a board its own engine has
    * already advanced.
@@ -2729,7 +2816,8 @@ export class P2PHostAdapter implements EngineAdapter {
     this.guestDecks.clear();
     this.aiDecks.clear();
     this.nativeDeliveredViews.clear();
-    this.guestDeliveredRevisions.clear();
+    this.guestAckedRevisions.clear();
+    this.terminalDelivered.clear();
     if (this.redeliveryTimer !== null) {
       clearInterval(this.redeliveryTimer);
       this.redeliveryTimer = null;
@@ -3001,6 +3089,9 @@ export class P2PHostAdapter implements EngineAdapter {
         this.requestBoundMatchConcede(pid);
         break;
       }
+      case "state_ack":
+        this.recordGuestAck(pid, msg.revision);
+        break;
       default:
         break;
     }
@@ -3170,7 +3261,7 @@ export class P2PHostAdapter implements EngineAdapter {
         this.failPendingReconnect(pid, session, "Reconnect acknowledgement could not be delivered");
         return;
       }
-      this.recordGuestDelivery(pid, handoff.revision);
+      this.seedGuestEntry(pid, handoff.revision);
       if (this.pendingReconnectSessions.get(pid) !== session || !this.ownsAuthority()) return;
 
       if (this.deliveredNativeAiDriverFault !== null) {
@@ -3185,11 +3276,17 @@ export class P2PHostAdapter implements EngineAdapter {
       }
       if (this.terminalResult !== null) {
         const result = await this.terminalResultForRecipient(pid, handoff.snapshot.state, handoff.revision);
-        const terminalDelivered = await this.send(session, { type: "terminal_result", result });
-        if (!terminalDelivered) {
+        const terminalSent = await this.send(session, { type: "terminal_result", result });
+        if (!terminalSent) {
           this.failPendingReconnect(pid, session, "Reconnect terminal result could not be delivered");
           return;
         }
+        // `terminalResult` is never cleared for this incarnation, so the
+        // terminal clause stays armed for the rest of the session. Without
+        // this the seat would be nominated every tick forever, each one
+        // costing a `reconnectHandoff` viewer-snapshot round trip plus a
+        // duplicate pair of frames.
+        this.terminalDelivered.add(pid);
       }
       if (this.pendingReconnectSessions.get(pid) !== session || !this.ownsAuthority()) return;
 
@@ -3667,7 +3764,8 @@ export class P2PGuestAdapter implements EngineAdapter {
    *     reports what the guest HAS, not what its UI has rendered. Acking after
    *     the emit would be worse than merely late: a resent EQUAL revision is
    *     not `<` the cached one, so it re-enters this same arm and throws
-   *     again — once a host consumes acks, that is a resend loop, not a heal.
+   *     again, and since the host drives redelivery off these acks that is a
+   *     resend loop rather than a heal.
    *   - `game_setup` / `reconnect_ack`: ack AFTER `settleGameSetup`. Until
    *     that promise settles `initializeGame()` has not resolved and the guest
    *     cannot act at all, so here suppression is the wanted outcome: an
@@ -3948,6 +4046,16 @@ export class P2PGuestAdapter implements EngineAdapter {
         // reconnect can race a previously queued delivery. Never let that old
         // view overwrite a newer authority revision: it can leave two peers
         // each waiting for the other to act.
+        //
+        // The STRICT `<` is load-bearing, not stylistic: the host's redelivery
+        // sweep resends at its OWN `authoritativeRevision`, which equals this
+        // guest's cached revision whenever the terminal clause alone nominated
+        // the seat (a seat current on state but still owing a statement), and
+        // is strictly higher in the lag case. That equal-revision frame must
+        // fall through to settle `pendingResolve` below and produce a fresh
+        // ack. Widening this to `<=` would drop exactly the frame that breaks
+        // a stalled submission — silently reintroducing the deadlock the
+        // acceptance ledger exists to end.
         if (
           msg.revision !== undefined
           && this.cachedRevision !== null

--- a/client/src/adapter/p2p-draft-guest.ts
+++ b/client/src/adapter/p2p-draft-guest.ts
@@ -17,7 +17,11 @@ import {
   createDraftPeerSession,
   type DraftPeerSession,
 } from "../network/draftPeerSession";
-import { parseRoomCode } from "../network/connection";
+import {
+  PEER_CONNECT_OPTIONS,
+  RECONNECT_DIAL_TIMEOUT_MS,
+  parseRoomCode,
+} from "../network/connection";
 import {
   deckSubmissionFingerprint,
   DRAFT_PROTOCOL_VERSION,
@@ -102,6 +106,13 @@ type DraftGuestEventListener = (event: DraftGuestEvent) => void;
 
 const RECONNECT_BACKOFF_MS = [1_000, 2_000, 4_000, 8_000, 15_000, 30_000, 60_000];
 const RECONNECT_STEADY_STATE_MS = 60_000;
+/**
+ * Budget for the *post-open* application handshake — the wait for the host's
+ * `draft_welcome` / `draft_reconnect_ack` after `attachSession` on an already
+ * open, ordered channel. Its cost is one application round trip, so it is not
+ * ICE-sensitive and stays at 10s. The reconnect *dial* budget is a different
+ * quantity and lives in `RECONNECT_DIAL_TIMEOUT_MS`.
+ */
 const FIRST_CONTACT_TIMEOUT_MS = 10_000;
 const LEAVE_ACK_TIMEOUT_MS = 10_000;
 
@@ -908,9 +919,15 @@ export class P2PDraftGuest {
 
   private openReconnectConnection(signal?: AbortSignal): Promise<DataConnection> {
     if (signal?.aborted) return Promise.reject(abortError());
-    const conn = this.guestPeer.connect(this.hostPeerId);
+    // Ordered delivery is not the default: without `reliable: true` PeerJS
+    // builds this channel with `ordered: false`, which a TURN relay will
+    // actually exercise.
+    const conn = this.guestPeer.connect(this.hostPeerId, PEER_CONNECT_OPTIONS);
     return new Promise((resolve, reject) => {
-      const timeout = setTimeout(() => finish(() => reject(new Error("connect timed out"))), FIRST_CONTACT_TIMEOUT_MS);
+      const timeout = setTimeout(
+        () => finish(() => reject(new Error("connect timed out"))),
+        RECONNECT_DIAL_TIMEOUT_MS,
+      );
       const onAbort = () => finish(() => reject(abortError()));
       const onOpen = () => finish(() => resolve(conn));
       const onError = (err: Error) => finish(() => reject(err));

--- a/client/src/network/__tests__/connection.test.ts
+++ b/client/src/network/__tests__/connection.test.ts
@@ -1,6 +1,42 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
-import { logSelectedIceCandidate } from "../connection";
+// Shared with the hoisted `vi.mock("peerjs")` factory below so the dial made
+// inside `joinRoom` is observable. `vi.mock` is hoisted above imports, so the
+// factory cannot close over ordinary module scope.
+const peerState = vi.hoisted(() => ({
+  peersCreated: 0,
+  peerHandlers: new Map<string, (arg?: unknown) => void>(),
+  connHandlers: new Map<string, (arg?: unknown) => void>(),
+  dials: [] as Array<{ peerId: string; options: unknown }>,
+}));
+
+vi.mock("peerjs", () => {
+  class FakePeer {
+    constructor() {
+      peerState.peersCreated += 1;
+    }
+    on(event: string, handler: (arg?: unknown) => void): void {
+      peerState.peerHandlers.set(event, handler);
+    }
+    once(event: string, handler: (arg?: unknown) => void): void {
+      peerState.peerHandlers.set(event, handler);
+    }
+    off(): void {}
+    destroy(): void {}
+    connect(peerId: string, options: unknown): unknown {
+      peerState.dials.push({ peerId, options });
+      return {
+        open: false,
+        on: (event: string, handler: (arg?: unknown) => void) => {
+          peerState.connHandlers.set(event, handler);
+        },
+      };
+    }
+  }
+  return { default: FakePeer };
+});
+
+import { PEER_CONNECT_OPTIONS, joinRoom, logSelectedIceCandidate } from "../connection";
 
 // Fake RTCStatsReport: a Map<string, {type, ...}> with a forEach that matches
 // the browser API shape.
@@ -116,5 +152,50 @@ describe("logSelectedIceCandidate", () => {
     await promise;
 
     expect((console.log as ReturnType<typeof vi.fn>).mock.calls.length).toBe(0);
+  });
+});
+
+// Characterization: `joinRoom` has always passed these options. The test exists
+// so the guarantee is pinned rather than assumed — every revision guard
+// downstream depends on the channel being ordered, and the option that produces
+// that ordering is a single word inside an object literal.
+describe("joinRoom", () => {
+  beforeEach(() => {
+    peerState.peersCreated = 0;
+    peerState.peerHandlers.clear();
+    peerState.connHandlers.clear();
+    peerState.dials.length = 0;
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.spyOn(console, "debug").mockImplementation(() => {});
+    vi.stubGlobal("fetch", vi.fn(async () => ({
+      ok: true,
+      json: async () => ({ iceServers: [{ urls: "stun:stun.example:3478" }] }),
+    })));
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  // Real timers: `joinRoom` awaits the ICE-credential fetch before it ever
+  // constructs its `Peer`, so a macrotask hop is what flushes that chain.
+  const flush = () => new Promise((r) => setTimeout(r, 0));
+
+  it("dials the host peer with the shared ordered-channel connect options", async () => {
+    const joined = joinRoom("ABCDE");
+    await flush();
+
+    expect(peerState.peersCreated).toBe(1);
+    peerState.peerHandlers.get("open")!();
+
+    expect(peerState.dials).toEqual([
+      { peerId: "phase2-ABCDE", options: PEER_CONNECT_OPTIONS },
+    ]);
+    expect(PEER_CONNECT_OPTIONS.reliable).toBe(true);
+
+    peerState.connHandlers.get("open")!();
+    await expect(joined).resolves.toMatchObject({ conn: { open: false } });
   });
 });

--- a/client/src/network/__tests__/fakeDataConnection.ts
+++ b/client/src/network/__tests__/fakeDataConnection.ts
@@ -47,7 +47,13 @@ export class FakeDataConnection {
       const idx = this.sent.length;
       this.sent.push({ type: "__pending__" });
       const decodePromise = decodeWireMessage(data).then(
-        (msg) => { this.sent[idx] = msg; },
+        (msg) => {
+          this.sent[idx] = msg;
+          // Fire AFTER the backfill so a subclass reaction (e.g. an
+          // auto-ack) can never appear in `sent` before the frame that
+          // provoked it.
+          this.onDecodedSend(msg);
+        },
         (err) => { console.warn("[FakeDataConnection] decode failed:", err); },
       );
       this.pendingDecodes.push(decodePromise);
@@ -80,8 +86,21 @@ export class FakeDataConnection {
     return this.sent;
   }
 
-  /** Decode promises in flight from the most recent `send(Uint8Array)` calls. */
-  private pendingDecodes: Promise<void>[] = [];
+  /**
+   * Decode promises in flight from the most recent `send(Uint8Array)` calls.
+   * `protected` so subclasses that react to a decoded frame can enqueue their
+   * own follow-on work and have `getSentMessages()` drain it.
+   */
+  protected pendingDecodes: Promise<void>[] = [];
+
+  /**
+   * Hook fired once a sent frame has been decoded and backfilled into `sent`.
+   * Empty by default; subclasses override it to model peer behavior (e.g.
+   * feeding a `state_ack` back to the host). Overrides that start async work
+   * should push the resulting promise onto `pendingDecodes` so
+   * `getSentMessages()` awaits it.
+   */
+  protected onDecodedSend(_msg: P2PMessage): void {}
 
   close() {
     if (this.open) this.simulateClose();

--- a/client/src/network/__tests__/protocol.test.ts
+++ b/client/src/network/__tests__/protocol.test.ts
@@ -36,8 +36,8 @@ const viewerInteractionWithProducedMana = {
 } as never;
 
 describe("encodeWireMessage / decodeWireMessage", () => {
-  it("pins the P2P wire protocol to v41", () => {
-    expect(WIRE_PROTOCOL_VERSION).toBe(41);
+  it("pins the P2P wire protocol to v42", () => {
+    expect(WIRE_PROTOCOL_VERSION).toBe(42);
   });
 
   it("defaults shortcut actions for a legacy payload created before the additive field", () => {
@@ -88,6 +88,7 @@ describe("encodeWireMessage / decodeWireMessage", () => {
     { type: "lobby_progress", joined: 1, total: 3 },
     { type: "emote", emote: "🔥" },
     { type: "reconnect", playerToken: "token-123", wireProtocolVersion: WIRE_PROTOCOL_VERSION },
+    { type: "state_ack", revision: 17 },
     { type: "reconnect_rejected", reason: "Unknown token" },
     {
       type: "action_rejected",

--- a/client/src/network/connection.ts
+++ b/client/src/network/connection.ts
@@ -1,5 +1,5 @@
 import Peer from "peerjs";
-import type { DataConnection } from "peerjs";
+import type { DataConnection, PeerConnectOption } from "peerjs";
 
 /** Unambiguous characters -- no 0/O, 1/I/L confusion */
 const CODE_ALPHABET = "ABCDEFGHJKMNPQRSTUVWXYZ23456789";
@@ -30,6 +30,73 @@ export function stripPeerIdPrefix(peerId: string): string {
     ? peerId.slice(PEER_ID_PREFIX.length)
     : peerId;
 }
+
+/**
+ * The options **every** `peer.connect(...)` dial in the app must pass. Single
+ * authority — a dial that omits these is a defect, not a shortcut.
+ *
+ * - `serialization: "binary"` selects PeerJS's BinaryPack connection, which
+ *   packs our `Uint8Array` wire bytes through BinaryPack and applies its
+ *   `_sendChunks` chunker for SCTP fragmentation (max 16,300 B per frame) —
+ *   what carries our gzip-compressed `encodeWireMessage` payloads.
+ *   It is stated **explicitly rather than because it changes anything**:
+ *   `bundler.mjs:1463-1468` maps `binary`, `binary-utf8` AND `default` to that
+ *   same class, and `connect()` already defaults to `"default"`
+ *   (`bundler.mjs:1655-1658`), so passing it is a no-op documenting intent.
+ *   (It is NOT MsgPack — that is a separate class at `bundler.mjs:1851`,
+ *   reachable only via `options.serializers`.) The corollary matters for the
+ *   bug this constant fixes: the two dials that previously passed no options
+ *   were never on a different wire format, so the defect was ordering-only.
+ * - `reliable: true` is the option that actually changes behaviour — PeerJS
+ *   maps it to the data channel's **ordering**
+ *   guarantee: the originator stores it (`bundler.mjs:1160`) and the negotiator
+ *   passes it straight through as `createDataChannel(label, { ordered:
+ *   !!options.reliable })` (`bundler.mjs:741-743`). Omit it and the channel is
+ *   built UNORDERED — harmless on a direct path where reordering is rare, but
+ *   routinely wrong over a TURN relay, and silently assumed by every downstream
+ *   revision guard (which compares revisions and drops anything that looks
+ *   stale, so a reordered frame is *discarded*, not resequenced).
+ *
+ * The options live on `PeerConnectOption`, not `PeerOptions`; the host adopts
+ * whatever the dialing guest declares (verified at `peerjs/bundler.mjs:1597`).
+ */
+export const PEER_CONNECT_OPTIONS: PeerConnectOption = {
+  serialization: "binary",
+  reliable: true,
+};
+
+/**
+ * Budget for a first-contact dial (`joinRoom`). A relayed ICE negotiation —
+ * TURN allocation, candidate exchange, connectivity checks — routinely needs
+ * well over the ~2s a direct path takes, so this is deliberately generous.
+ *
+ * It does NOT slow down feedback for a mistyped room code: a nonexistent peer
+ * fails immediately via `peer-unavailable`, which the pre-open `peer.on("error")`
+ * handler below rejects on. This budget only applies once the peer exists and
+ * ICE is still negotiating.
+ */
+export const JOIN_CONNECT_TIMEOUT_MS = 30_000;
+
+/**
+ * Budget for a *reconnect* dial, shared by the game guest and the draft guest.
+ * Deliberately shorter than {@link JOIN_CONNECT_TIMEOUT_MS}, and sized against
+ * the tighter of the two consumers: the GAME host renders a
+ * `DisconnectChoiceDialog` counting down `DEFAULT_GRACE_PERIOD_MS` (30s), and a
+ * 30s reconnect dial would let attempt 1 consume the entire visible window.
+ * (The draft host's window is `DRAFT_GRACE_PERIOD_MS`, 60s, with no such
+ * dialog — it is the looser constraint, so it does not bind this value.)
+ * Not an auto-concede risk — the host arms
+ * `timer: null` and the dialog's expiry path dismisses without conceding — the
+ * cost is host *visibility*: the dialog closes before the guest's first attempt
+ * even finishes. With `RECONNECT_BACKOFF_MS = [1000, 2000, 4000, 8000, …]` a 15s
+ * budget puts attempt 1's completion at ~16s and attempt 2's at ~33s, i.e. one
+ * completed attempt plus one in flight inside the 30s dialog.
+ *
+ * Note this stretches the reconnect cadence generally: `RECONNECT_BACKOFF_MS`
+ * schedules the *gap between* attempts and was written when each attempt cost at
+ * most the old 10s budget, so total elapsed time per attempt grows by 5s.
+ */
+export const RECONNECT_DIAL_TIMEOUT_MS = 15_000;
 
 // ICE configuration. PeerJS's bundled TURN servers are broken, so we always
 // supply our own. Credentials are minted on demand (short-lived) by the lobby
@@ -441,9 +508,13 @@ export async function hostRoom(
  * Guest joins a room by code. Returns the `Peer` separately from the
  * `DataConnection` so the guest adapter can keep the `Peer` alive across
  * `DataConnection` drops and attempt auto-reconnect via
- * `peer.connect(hostPeerId)`.
+ * `peer.connect(hostPeerId, PEER_CONNECT_OPTIONS)`.
  */
-export async function joinRoom(code: string, signal?: AbortSignal, timeoutMs = 30_000): Promise<JoinResult> {
+export async function joinRoom(
+  code: string,
+  signal?: AbortSignal,
+  timeoutMs = JOIN_CONNECT_TIMEOUT_MS,
+): Promise<JoinResult> {
   if (signal?.aborted) throw new DOMException("Aborted", "AbortError");
   const config = await getPeerConfig();
   return new Promise((resolve, reject) => {
@@ -471,14 +542,7 @@ export async function joinRoom(code: string, signal?: AbortSignal, timeoutMs = 3
       }
       traceP2P("Guest", "peer-open", { peerId });
       console.log("[P2P Guest] registered on signaling server, connecting to:", peerId);
-      // `serialization: "binary"` switches PeerJS to its MsgPackBinaryConnection,
-      // which packs our `Uint8Array` wire bytes through BinaryPack (~3–6 byte
-      // msgpack envelope) and retains BinaryPack's `_sendChunks` chunker for
-      // SCTP fragmentation (max 16,300 B per frame). Required so we can send
-      // gzip-compressed `encodeWireMessage` payloads over the channel.
-      // The option lives on `PeerConnectOption`, not `PeerOptions`; host adopts
-      // whatever the guest declares (verified at peerjs/bundler.mjs:1597).
-      const conn = peer.connect(peerId, { serialization: "binary", reliable: true });
+      const conn = peer.connect(peerId, PEER_CONNECT_OPTIONS);
       traceP2P("Guest", "connect-called", { peerId, connOpen: conn.open });
 
       const timeout = setTimeout(() => {

--- a/client/src/network/protocol.ts
+++ b/client/src/network/protocol.ts
@@ -96,6 +96,25 @@ export function legalActionsFromWire(wire: LegalActionsWire): LegalActionsResult
  * seat or adopts reconnect state.
  *
  * Bumps to date:
+ *  42 — New guest → host `state_ack` frame, carrying the highest state
+ *       revision the guest has actually APPLIED — the fact a host ledger that
+ *       records TRANSMISSION cannot observe, since a send resolving true only
+ *       means the bytes reached the channel. On the stale-drop branch of
+ *       `state_update` it reports the NEWER revision the guest already holds,
+ *       not the stale one it just discarded. The guest emits it now; no host
+ *       consumes it yet. A v41 peer would not carry `state_ack` in
+ *       VALID_TYPES, so `validateMessage` would throw, the throw would
+ *       propagate out of `decodeWireMessage` into `peer.ts`'s catch, and
+ *       every ack would be dropped with a console warning — a capability
+ *       loss, not a parse break of the surrounding session, though unlike 24
+ *       it is a whole frame rejected rather than an accepted frame missing an
+ *       additive field. Since
+ *       game_setup and reconnect_ack carry the version, first contact rejects
+ *       the skew rather than allowing that loss, so the drop path above is
+ *       unreachable in practice; it is stated because it is what the
+ *       handshake exists to prevent. That check lives in
+ *       `P2PGuestAdapter.handleHostMessage`, not in `validateMessage` — see
+ *       the paragraph above.
  *  40 — DerivedViews.room_half_identities publishes both halves of every
  *       battlefield Room in printed order, resolved through the COPIED halves
  *       for a permanent that copies a Room (CR 709.5b + CR 707.2). The unlock
@@ -255,7 +274,7 @@ export function legalActionsFromWire(wire: LegalActionsWire): LegalActionsResult
  *       sub-phase on WaitingFor::MulliganDecision; the MulliganBottomCards
  *       variant was removed
  */
-export const WIRE_PROTOCOL_VERSION = 41 as const;
+export const WIRE_PROTOCOL_VERSION = 42 as const;
 
 export type P2PMessage = P2PAuthorityWire & (
   | {
@@ -285,6 +304,12 @@ export type P2PMessage = P2PAuthorityWire & (
       events: GameEvent[];
       logEntries?: GameLogEntry[];
     } & LegalActionsWire)
+  /** Guest → host: the highest state revision the guest has APPLIED, which a
+   * host ledger recording transmission cannot otherwise observe. Sent from
+   * every arm that accepts a state-bearing frame, and from the stale-drop
+   * branch of `state_update` — where it reports the newer revision the guest
+   * already holds, not the stale one it discarded. */
+  | { type: "state_ack"; revision: number }
   | { type: "action_rejected"; rejection: ActionRejection }
   | { type: "action_failed"; message: string }
   | { type: "action_noop" }
@@ -363,6 +388,7 @@ const VALID_TYPES = new Set([
   "interaction",
   "preview_mana_payment",
   "state_update",
+  "state_ack",
   "action_rejected",
   "action_failed",
   "action_noop",

--- a/client/src/network/protocol.ts
+++ b/client/src/network/protocol.ts
@@ -101,8 +101,10 @@ export function legalActionsFromWire(wire: LegalActionsWire): LegalActionsResult
  *       records TRANSMISSION cannot observe, since a send resolving true only
  *       means the bytes reached the channel. On the stale-drop branch of
  *       `state_update` it reports the NEWER revision the guest already holds,
- *       not the stale one it just discarded. The guest emits it now; no host
- *       consumes it yet. A v41 peer would not carry `state_ack` in
+ *       not the stale one it just discarded. The guest emits it and the host
+ *       ADVANCES each seat's redelivery entry off it (the entry is still
+ *       CREATED on an accepted handshake send, so a lost ack cannot disarm
+ *       the sweep). A v41 peer would not carry `state_ack` in
  *       VALID_TYPES, so `validateMessage` would throw, the throw would
  *       propagate out of `decodeWireMessage` into `peer.ts`'s catch, and
  *       every ack would be dropped with a console warning — a capability

--- a/client/src/providers/GameProvider.tsx
+++ b/client/src/providers/GameProvider.tsx
@@ -1004,7 +1004,12 @@ export function GameProvider({
             }
             // Dial target: `conn.peer` is the actual current host peer id;
             // reconnect reuses it rather than reconstructing a prefix.
-            const { conn, peer } = await joinRoom(code, signal, 10_000);
+            // No timeout override: `joinRoom`'s 30s default is sized for a
+            // relayed ICE negotiation. A 10s budget aborted TURN-relayed joins
+            // mid-negotiation, and it bought nothing for a mistyped code —
+            // that path rejects immediately on `peer-unavailable`, never on the
+            // timeout.
+            const { conn, peer } = await joinRoom(code, signal);
             hostPeerHandle = peer;
             signal.throwIfAborted();
             const adapter = new P2PGuestAdapter(

--- a/scripts/check-protocol-version.mjs
+++ b/scripts/check-protocol-version.mjs
@@ -14,7 +14,7 @@ const EXPECTED_LOBBY_PROTOCOL_VERSION = 4;
 // here, so a full-game bump could ship with an unbumped P2P version and CI
 // stayed green — a v(n-1) host and a v(n) guest would then complete a
 // handshake and only fail when the incompatible payload arrived.
-const EXPECTED_WIRE_PROTOCOL_VERSION = 41;
+const EXPECTED_WIRE_PROTOCOL_VERSION = 42;
 
 function extractVersion(source, pattern, label) {
   const match = source.match(pattern);


### PR DESCRIPTION
Users routed through the TURN relay could not reliably establish or hold a P2P
session: games started without all players, or a guest sat forever on
"Waiting for another player to decide their opening hand."

**Root cause, in two halves.**

`attemptReconnect` and the draft-guest reconnect dialed with no options, and
peerjs maps `reliable` straight onto the data channel's `ordered` flag — so the
first connection was ordered and *every reconnected one was unordered*. Over a
relay that made out-of-order delivery real, and a revision guard added days
earlier then silently dropped the older `state_update`.

That alone would self-heal, except the host's delivery ledger recorded
**transmission**, not acceptance. `send()` resolving true only means the bytes
reached the channel: peerjs's `_bufferedSend` parks anything past its 8MB budget
in a buffer that `close()` later discards. So the seat was already marked
current at a revision it never applied, the redelivery sweep skipped it — and
the host could not advance its own revision, because it was waiting on that very
seat.

**The fix, in four commits.**

1. **Ordered channels everywhere.** One `PEER_CONNECT_OPTIONS` for all three
   dials the app makes, plus relay-sized connect budgets (30s join, 15s
   reconnect) and the removal of a 10s join override that a relayed handshake
   routinely exceeds.
2. **A `state_ack { revision }` frame** the guest emits from every arm that
   accepts a state-bearing frame — and from the stale-drop branch, where it
   reports the *newer* revision it already holds, which is the one fact a
   sender-side ledger structurally cannot observe. Wire version 41 → 42. Lands
   with no host consumer, so it changes nothing on its own.
3. **Test-only:** the host-side fake can now acknowledge, so acceptance
   semantics are observable at all. Ships alone so its blast radius is measured
   rather than argued — turning it on across the suite reds nothing.
4. **The ledger swap.** A seat's entry is *created* when an accepted
   `game_setup`/`reconnect_ack` hands it its handshake, and *advanced* only by
   the guest's own ack. The signals differ by direction on purpose: losing a
   create disarms the sweep for a seat that could have been healed, while a
   create that proves false is no worse than a handshake never sent. Ack
   revisions are validated at the boundary — the ledger is now written from a
   remote peer's number, and an unvalidated one would strand a seat for the rest
   of the match. Terminal delivery gets its own bit instead of being simulated
   by back-dating a revision counter, and `markGuestBehind` is deleted rather
   than repaired.

**Ordering is now established rather than assumed** — guaranteed at the
transport for every dial, with the sweep as an explicit application-layer
tolerance path behind it.

**Verification.** Eight probes against the suite, each with a named failure:
every test in the eventual-delivery block reds under at least one, and both new
regression tests were confirmed red before green. The two behaviour claims that
matter — a seat whose frame was transmitted but never applied gets resynced, and
a seat whose handshake ack was lost still heals — each have a paired red run.

Knowingly left alone: terminal delivery keeps transmission semantics (post-game,
cannot deadlock a live match); a `game_setup` that is never sent or is parked
stays unrecoverable for that seat; redelivery is unbounded where it was
one-shot; and two pre-existing native-bridge hang paths are untouched.

peerjs itself is unchanged — only our use of it.

https://claude.ai/code/session_01R6awnc43C4YUnUsBFqujCx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved multiplayer state delivery, acknowledgements, reconnect ordering, and redelivery reliability.
  - Prevented stale, malformed, unauthenticated, or unacknowledged frames from corrupting game state.
  - Improved recovery and snapshot consistency for hosts and guests.

- **Network Improvements**
  - Updated the multiplayer protocol to version 42.
  - Added reliable, ordered connection handling with dedicated join and reconnect timeouts.
  - Extended the guest join timeout to support slower connection negotiations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->