### PR TITLE
fix(client): bound every net-boundary promise that can freeze the board

### DIFF
--- a/client/src/adapter/__tests__/p2p-adapter-multiplayer.test.ts
+++ b/client/src/adapter/__tests__/p2p-adapter-multiplayer.test.ts
@@ -561,6 +561,12 @@ class FakeOpenableConnection extends FakeDataConnection {
   }
 
   protected override onDecodedSend(msg: P2PMessage): void {
+    // `FakeDataConnection.onDecodedSend` documents that an override MUST call
+    // super, so the base keep-alive `pong` reply survives. No test in this file
+    // currently fails without it — no seat here holds an open channel for a
+    // full 10s of fake time — but an override that silently models a dead peer
+    // is a trap for the next test that does.
+    super.onDecodedSend(msg);
     this.ackDecodedSend(msg);
     if (this.refuseAfter !== null && this.refuseAfter === msg.type) {
       this.refuseAfter = null;
@@ -3316,6 +3322,101 @@ describe("P2PHostAdapter — 3-4p multiplayer", () => {
     expect(emitted).not.toHaveBeenCalledWith(
       expect.objectContaining({ type: "stateChanged" }),
     );
+  });
+
+  /** A guest adapter past its `game_setup` handshake, ready to submit. */
+  async function joinedGuest(): Promise<{ adapter: P2PGuestAdapter; conn: FakeDataConnection }> {
+    const { peer } = createFakePeer();
+    const conn = new FakeDataConnection();
+    const adapter = new P2PGuestAdapter(
+      { player: { main_deck: [], sideboard: [] } },
+      peer as unknown as Peer,
+      "host-peer",
+      conn as unknown as DataConnection,
+    );
+    await adapter.initialize();
+    await conn.simulateData({
+      type: "game_setup",
+      wireProtocolVersion: WIRE_PROTOCOL_VERSION,
+      assignedPlayerId: 1,
+      playerToken: "seat-token",
+      state: remoteState("setup"),
+      events: [],
+      legalActions: [],
+      autoPassRecommended: false,
+      manaPaymentShortcutActions: [],
+    });
+    await adapter.initializeGame();
+    return { adapter, conn };
+  }
+
+  it("guest submission the host never answers rejects at the timeout instead of parking forever", async () => {
+    const { adapter, conn } = await joinedGuest();
+
+    // The host lease fence applies the action and then sends NOTHING: no
+    // `state_update` (so no ack, no ledger entry, no redelivery sweep), and no
+    // `action_rejected`/`action_failed` either. The channel stays open and
+    // healthy — a liveness detector has nothing to find here.
+    const stranded = adapter.submitAction({ type: "PassPriority" }, 1);
+    let settled = false;
+    void stranded.catch(() => {
+      settled = true;
+    });
+
+    await vi.advanceTimersByTimeAsync(29_000);
+    expect(settled).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    await expect(stranded).rejects.toMatchObject({
+      code: "P2P_ERROR",
+      recoverable: true,
+    });
+    // The host is silent, not gone: nothing was sent after the action frame.
+    expect((await conn.getSentMessages()).filter(
+      (message) => (message as { type?: string }).type === "action",
+    )).toHaveLength(1);
+  });
+
+  it("guest settles an action submission displaced by an interaction submission", async () => {
+    const { adapter, conn } = await joinedGuest();
+
+    // `dispatchInteraction` never touches `isAnimating`/`inFlightLocalAction`
+    // while `dispatchActionInternal` does, so an interaction submit can overlap
+    // an action submit and take the single slot from under it.
+    const displaced = adapter.submitAction({ type: "PassPriority" }, 1);
+    const displacing = adapter.submitInteraction({} as never, 1);
+
+    await expect(displaced).rejects.toMatchObject({
+      code: "P2P_ERROR",
+      recoverable: true,
+    });
+
+    // The displacing submission still settles normally off the next reply. The
+    // slot remains single and unkeyed: this does NOT make reply routing correct
+    // after a displacement, it only stops the displaced caller from parking.
+    await conn.simulateData({ type: "action_noop" });
+    await expect(displacing).resolves.toEqual({ events: [], log_entries: [] });
+  });
+
+  it("guest timeout from a settled submission never rejects a later, unrelated one", async () => {
+    const { adapter, conn } = await joinedGuest();
+
+    const first = adapter.submitAction({ type: "PassPriority" }, 1);
+    await conn.simulateData({ type: "action_noop" });
+    await expect(first).resolves.toEqual({ events: [], log_entries: [] });
+
+    // Sit just short of the FIRST submission's original 30s deadline, then park
+    // a second submission. A timeout armed on park but cleared only in the
+    // teardown helper survives the successful settle and fires below — against
+    // a submission the host has had barely a second to answer. The slot is
+    // unkeyed, so that rejection would hit whatever is parked, breaking normal
+    // play rather than fixing the freeze.
+    await vi.advanceTimersByTimeAsync(29_000);
+    const second = adapter.submitInteraction({} as never, 1);
+    await vi.advanceTimersByTimeAsync(2_000);
+
+    await conn.simulateData({ type: "action_noop" });
+    await expect(second).resolves.toEqual({ events: [], log_entries: [] });
   });
 
   it("guest preserves a structured stale engine rejection from the host", async () => {

--- a/client/src/adapter/__tests__/server-draft-adapter.test.ts
+++ b/client/src/adapter/__tests__/server-draft-adapter.test.ts
@@ -59,6 +59,35 @@ async function completeHandshake(): Promise<MockWebSocket> {
   return ws;
 }
 
+/**
+ * Starts observing `promise` immediately and returns a reader that yields the
+ * rejection reason — or the string `"never settled"` if the promise is still
+ * pending.
+ *
+ * Observation has to start before the first `await` so an already-rejected
+ * promise is handled in the same tick, and the drain is what turns an orphaned
+ * promise — the exact defect these settlement fixes prevent — into a readable
+ * assertion failure instead of a suite timeout.
+ *
+ * The reader yields a MACROTASK turn (`setTimeout(…, 0)`), not a microtask
+ * drain: that is strictly more generous than the settlement paths need, since
+ * both `dispose()` and `onclose` reject synchronously. The cost is that it
+ * couples the reader to real timers — a caller running it under
+ * `vi.useFakeTimers()` would hang. No current caller does; the only fake-timer
+ * scope in these suites is closed by a `finally { vi.useRealTimers(); }`.
+ */
+function trackRejection(promise: Promise<unknown>): () => Promise<unknown> {
+  let outcome: unknown = "never settled";
+  void promise.then(
+    (value) => { outcome = { resolvedWith: value }; },
+    (error) => { outcome = error; },
+  );
+  return async () => {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    return outcome;
+  };
+}
+
 function createMockDraftView(overrides: Partial<DraftPlayerView> = {}): DraftPlayerView {
   return {
     status: "Drafting",
@@ -660,6 +689,40 @@ describe("ServerDraftAdapter", () => {
     expect(adapter.playerId).toBeNull();
     expect(adapter.currentDraftView).toBeNull();
     expect(adapter.currentMatchId).toBeNull();
+  });
+
+  // `dispose()` used to null all three handle pairs instead of rejecting them,
+  // so every caller awaiting a server reply was orphaned — and a gameplay
+  // caller holds the module-level dispatch mutex while it waits.
+  it("dispose rejects the in-flight submit, draft and init promises", async () => {
+    ws.dispatchSynthetic(
+      "message",
+      JSON.stringify({
+        type: "DraftMatchStart",
+        data: {
+          match_id: "r1-t0",
+          round: 1,
+          game_code: "GAME01",
+          player_token: "gametok",
+          your_player: 0,
+          opponent_name: "Bob",
+        },
+      }),
+    );
+
+    const submit = trackRejection(adapter.submitAction({ type: "PassPriority" }, 0));
+    const pick = trackRejection(adapter.submitPick("card-1"));
+    const reconnect = trackRejection(adapter.reconnectDraft());
+
+    adapter.dispose();
+
+    // Asserted as one tuple rather than three statements: a per-leg assertion
+    // would abort on the first orphan and leave the other two unprobeable.
+    expect([await submit(), await pick(), await reconnect()]).toMatchObject([
+      { code: "WS_CLOSED", message: "Adapter disposed during action", recoverable: true },
+      { code: "WS_CLOSED", message: "Adapter disposed during draft operation", recoverable: true },
+      { code: "WS_CLOSED", message: "Adapter disposed before draft started", recoverable: true },
+    ]);
   });
 
   it("DraftOver sets phase to complete", () => {

--- a/client/src/adapter/__tests__/ws-adapter.test.ts
+++ b/client/src/adapter/__tests__/ws-adapter.test.ts
@@ -88,6 +88,35 @@ async function completeHandshake(adapter: WebSocketAdapter): Promise<MockWebSock
   return (adapter as unknown as { ws: MockWebSocket }).ws;
 }
 
+/**
+ * Starts observing `promise` immediately and returns a reader that yields the
+ * rejection reason — or the string `"never settled"` if the promise is still
+ * pending.
+ *
+ * Observation has to start before the first `await` so an already-rejected
+ * promise is handled in the same tick, and the drain is what turns an orphaned
+ * promise — the exact defect these settlement fixes prevent — into a readable
+ * assertion failure instead of a suite timeout.
+ *
+ * The reader yields a MACROTASK turn (`setTimeout(…, 0)`), not a microtask
+ * drain: that is strictly more generous than the settlement paths need, since
+ * both `dispose()` and `onclose` reject synchronously. The cost is that it
+ * couples the reader to real timers — a caller running it under
+ * `vi.useFakeTimers()` would hang. No current caller does; the only fake-timer
+ * scope in these suites is closed by a `finally { vi.useRealTimers(); }`.
+ */
+function trackRejection(promise: Promise<unknown>): () => Promise<unknown> {
+  let outcome: unknown = "never settled";
+  void promise.then(
+    (value) => { outcome = { resolvedWith: value }; },
+    (error) => { outcome = error; },
+  );
+  return async () => {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    return outcome;
+  };
+}
+
 // Shared session service relies on localStorage in test environments.
 vi.stubGlobal("localStorage", {
   getItem: vi.fn(() => null),
@@ -1745,6 +1774,51 @@ describe("WebSocketAdapter", () => {
       });
       expect(listener).toHaveBeenCalledWith({ type: "actionPendingChanged", pending: false });
       expect(listener).toHaveBeenCalledWith(expect.objectContaining({ type: "aiDriverFault" }));
+    });
+
+    // `dispose()` used to null the submission handles instead of rejecting
+    // them, so the caller — which holds the module-level dispatch mutex —
+    // waited forever on a reply the closed socket could never deliver.
+    it("rejects an in-flight submitAction when the adapter is disposed", async () => {
+      const pending = trackRejection(adapter.submitAction({ type: "PassPriority" }, 0));
+
+      adapter.dispose();
+
+      expect(await pending()).toMatchObject({
+        code: "WS_CLOSED",
+        message: "Adapter disposed during action",
+        recoverable: true,
+      });
+    });
+
+    // The `sessionIdentityRejected` guard used to sit ABOVE the pending
+    // submission block in `onclose`, so a close taken on the identity-rejected
+    // path abandoned an in-flight submission.
+    it("settles the pending submission on close even after session identity is rejected", async () => {
+      ws.dispatchSynthetic(
+        "message",
+        JSON.stringify({
+          type: "GameCreated",
+          data: {
+            game_code: "ABCD",
+            player_token: "tok",
+            // generation < 1 is rejected by `acceptFullSessionKey`, latching
+            // `sessionIdentityRejected`.
+            full_key: { game_code: "ABCD", generation: 0 },
+          },
+        }),
+      );
+      // Reach-guard: the latch really is set, otherwise this test would pass
+      // against the unguarded close path and prove nothing.
+      await expect(adapter.exportPersistenceState()).rejects.toThrow("Session identity rejected");
+
+      const pending = trackRejection(adapter.submitAction({ type: "PassPriority" }, 0));
+      ws.dispatchSynthetic("close");
+
+      expect(await pending()).toMatchObject({
+        code: "WS_CLOSED",
+        message: "Connection closed during action",
+      });
     });
 
     it("emits an error instead of throwing when a fire-and-forget send hits a closed socket", () => {

--- a/client/src/adapter/p2p-adapter.ts
+++ b/client/src/adapter/p2p-adapter.ts
@@ -558,6 +558,85 @@ const DEFAULT_GRACE_PERIOD_MS = 30_000;
  */
 const RECONNECT_BACKOFF_MS = [1_000, 2_000, 4_000, 8_000, 15_000, 30_000, 60_000];
 const RECONNECT_STEADY_STATE_MS = 60_000;
+
+/**
+ * Budget for a guest's in-flight submission — the window between sending an
+ * `action`/`interaction` frame and the host reply that settles it.
+ *
+ * Sizing input is host turnaround: a WASM engine submit plus a per-guest
+ * viewer snapshot, on a possibly-mobile host with a large Commander board.
+ * 30s is chosen so a merely slow host is never failed. The timer is a bound on
+ * an unanswerable wait; it is deliberately too coarse to be a latency signal.
+ *
+ * One legitimate wait can still exceed it: the host answers a guest action
+ * before `runAiLoop()`, but `runAiLoop` drives the SAME engine-worker client,
+ * and a long WASM AI search blocks that worker's event loop. A guest action
+ * arriving during one queues behind it, and a multi-minute Commander decision
+ * is on record. The degradation there is graceful rather than lossy — the guest
+ * gets a recoverable toast, and the late `state_update` still lands and
+ * resyncs through `processRemoteUpdate`.
+ *
+ * ## Why a timer at all
+ *
+ * The #8360 acceptance ledger covers ONE of the four frame types that settle a
+ * guest submission. `state_update` is acked (`sendStateAck`), tracked
+ * (`recordGuestAck`) and resent by the host's redelivery sweep.
+ * `action_rejected` and `action_failed` have no ack, no ledger entry and no
+ * redelivery — `redeliverGuestState` sends only `state_update` and
+ * `terminal_result` — and the host's `send` returns `Promise<boolean>` without
+ * throwing, a boolean the `action_*` dispatch sites discard. (`action_noop` is
+ * uncovered too, but it is debug-only — `isZeroCountDebugCreate` — so there are
+ * two reachable uncovered classes, not three.)
+ *
+ * The primary measured route is the host lease fence. `ownsAuthority()` is
+ * `ownsP2PHostLease()` plus a trace, and `ownsP2PHostLease`
+ * (`services/p2pSession.ts`) re-reads the lease on EVERY call, so it can flip
+ * during an await; on `false` it only traces and never closes the channel. So
+ * the guest's action APPLIES, and then `broadcastStateUpdateInner` bails on
+ * `!ownsAuthority()` before `++authoritativeRevision`, with
+ * `queueLaggingRedeliveries`, `redeliverGuestState` and `send()` fenced by the
+ * same predicate. The action has applied, but no frame goes out and the
+ * revision never rises, so the sweep is disarmed and the channel stays healthy
+ * and ponging. A liveness detector therefore has nothing to find, and the guest
+ * waits forever while holding the module-level dispatch mutex.
+ *
+ * Reachability precondition: tab A's PeerJS SIGNALING socket must have dropped
+ * (freeing the peer id) while its WebRTC DataConnections stay up. That state is
+ * durable — no `peer.on("disconnected")` handler and no `.reconnect()` call
+ * exists repo-wide — and is produced by sleep, a network change, or mobile
+ * backgrounding. Opening a second tab does NOT reach it on its own: `hostRoom`
+ * opens the peer before the adapter is constructed, so tab B fails
+ * `unavailable-id` and never reaches `claimP2PHostLease`. The lease flip must
+ * land inside the `submitAction` → `broadcastStateUpdateInner` window, so
+ * exactly ONE in-flight submission is stranded — matching a game that freezes
+ * once, mid-match.
+ *
+ * ## Why reject, when this repo's convention for gameplay round-trips is notify
+ *
+ * `engine-worker-client.ts` deliberately went the other way:
+ * `ENGINE_REQUEST_TIMEOUT_MS = 60_000` with `RequestTimeoutBehavior` defaulting
+ * to `"notify"` for gameplay, `"reject"` reserved for init, after
+ * reject-on-timer for gameplay was walked back. P2P differs in the one way that
+ * matters: after this rejection `pendingResolve` is null, so a late
+ * `state_update` still lands — the handler emits `stateChanged`, which
+ * `GameProvider` routes into `processRemoteUpdate`. The late reply is NOT lost.
+ * At the worker boundary it would have been, which is exactly why "notify" won
+ * there.
+ *
+ * The code is `P2P_ERROR`, not `ENGINE_UNRESPONSIVE`: the latter is suppressed
+ * by `shouldShowActionError` in `dispatch.ts` and routes to `notifyEngineLost`,
+ * the wrong surface for a peer that may simply be gone.
+ *
+ * ## Honest residual
+ *
+ * Rejecting UNFREEZES the client but does not RESYNC it. On the lease-fence
+ * route the guest's cached state is STALE — the action applied on a host that
+ * then sent nothing — so a post-timeout retry re-submits against a board the
+ * guest has wrong; the user's recovery is a reload, not a retry. The
+ * stale-state watchdog cannot help: for a guest, the adapter cache and the
+ * screen go stale together, so the fingerprints match and its check returns.
+ */
+const SUBMISSION_TIMEOUT_MS = 30_000;
 // A stale proposal leaves the prompt unchanged, so cap retries to prevent a
 // persistent authority race from becoming a tight host-loop spin.
 const MAX_AI_PROPOSAL_STALE_RETRIES = 3;
@@ -3607,6 +3686,15 @@ export class P2PHostAdapter implements EngineAdapter {
 }
 
 /**
+ * How a parked guest submission is being settled. A typed union rather than a
+ * pair of methods so that BOTH arms are forced through the single settlement
+ * path that clears the slot handles and the submission timeout together.
+ */
+type PendingSubmissionOutcome =
+  | { kind: "resolve"; result: SubmitResult }
+  | { kind: "reject"; error: Error };
+
+/**
  * Guest-side P2P adapter. Maintains the `Peer` reference for auto-reconnect,
  * persists session token to `sessionStorage` (via `p2pSession` service), and
  * applies host-broadcasted state updates locally.
@@ -3624,6 +3712,9 @@ export class P2PGuestAdapter implements EngineAdapter {
   private listeners: P2PAdapterEventListener[] = [];
   private pendingResolve: ((result: SubmitResult) => void) | null = null;
   private pendingReject: ((error: Error) => void) | null = null;
+  /** Armed with the slot in `parkPendingSubmission`, cleared only by
+   *  `settlePendingSubmission` — see `SUBMISSION_TIMEOUT_MS`. */
+  private pendingSubmissionTimer: ReturnType<typeof setTimeout> | null = null;
   private nextManaPaymentPreviewRequestId = 1;
   private pendingManaPaymentPreviews = new Map<
     number,
@@ -3766,8 +3857,7 @@ export class P2PGuestAdapter implements EngineAdapter {
     // action before touching the engine.
     this.requireAuthenticatedSession();
     return new Promise<SubmitResult>((resolve, reject) => {
-      this.pendingResolve = resolve;
-      this.pendingReject = reject;
+      this.parkPendingSubmission(resolve, reject);
       this.send({
         type: "action",
         senderPlayerId: this.assignedPlayerId!,
@@ -3782,8 +3872,7 @@ export class P2PGuestAdapter implements EngineAdapter {
   ): Promise<SubmitResult> {
     this.requireAuthenticatedSession();
     return new Promise<SubmitResult>((resolve, reject) => {
-      this.pendingResolve = resolve;
-      this.pendingReject = reject;
+      this.parkPendingSubmission(resolve, reject);
       this.send({
         type: "interaction",
         senderPlayerId: this.assignedPlayerId!,
@@ -4164,11 +4253,11 @@ export class P2PGuestAdapter implements EngineAdapter {
         this.cachedRevision = msg.revision ?? null;
         const updateSnapshot = this.cacheSnapshot(msg.state, legalActionsFromWire(msg));
         this.sendStateAck();
-        if (this.pendingResolve) {
-          this.pendingResolve({ events: msg.events, log_entries: msg.logEntries });
-          this.pendingResolve = null;
-          this.pendingReject = null;
-        } else {
+        const settled = this.settlePendingSubmission({
+          kind: "resolve",
+          result: { events: msg.events, log_entries: msg.logEntries },
+        });
+        if (!settled) {
           this.emit({
             type: "stateChanged",
             snapshot: updateSnapshot,
@@ -4186,31 +4275,23 @@ export class P2PGuestAdapter implements EngineAdapter {
             "Host sent an invalid action rejection",
             true,
           );
-        if (this.pendingReject) {
-          this.pendingReject(error);
-          this.pendingResolve = null;
-          this.pendingReject = null;
-        } else {
+        if (!this.settlePendingSubmission({ kind: "reject", error })) {
           this.emit({ type: "error", message: error.message });
         }
         break;
       }
       case "action_failed": {
-        if (this.pendingReject) {
-          this.pendingReject(new AdapterError("P2P_ERROR", msg.message, true));
-          this.pendingResolve = null;
-          this.pendingReject = null;
-        } else {
+        const failure = new AdapterError("P2P_ERROR", msg.message, true);
+        if (!this.settlePendingSubmission({ kind: "reject", error: failure })) {
           this.emit({ type: "error", message: msg.message });
         }
         break;
       }
       case "action_noop": {
-        if (this.pendingResolve) {
-          this.pendingResolve({ events: [], log_entries: [] });
-          this.pendingResolve = null;
-          this.pendingReject = null;
-        }
+        this.settlePendingSubmission({
+          kind: "resolve",
+          result: { events: [], log_entries: [] },
+        });
         break;
       }
       case "mana_payment_preview": {
@@ -4352,10 +4433,91 @@ export class P2PGuestAdapter implements EngineAdapter {
     this.pendingInteractionPreviews.clear();
   }
 
-  private rejectPendingSubmission(error: Error): void {
-    this.pendingReject?.(error);
+  /**
+   * The SINGLE settlement path for the parked submission slot. Every site that
+   * finishes a guest submission routes through here — the four inbound reply
+   * frames (`state_update`, `action_rejected`, `action_failed`, `action_noop`),
+   * `rejectPendingSubmission` (attach/disconnect/terminate), the submission
+   * timeout, and a displacement — so the two slot handles and the timeout are
+   * cleared together, in one place.
+   *
+   * A settlement path that bypassed this would be a NEW bug, not a missing
+   * tidy-up: the timer would survive a SUCCESSFUL submit and, because the slot
+   * is unkeyed, fire `SUBMISSION_TIMEOUT_MS` later against whatever unrelated
+   * submission happened to be parked by then.
+   *
+   * Returns whether a submission was actually parked, so callers can fall back
+   * to their unsolicited-frame behaviour (`stateChanged` / `error`).
+   */
+  private settlePendingSubmission(outcome: PendingSubmissionOutcome): boolean {
+    if (this.pendingSubmissionTimer !== null) {
+      clearTimeout(this.pendingSubmissionTimer);
+      this.pendingSubmissionTimer = null;
+    }
+    const resolve = this.pendingResolve;
+    const reject = this.pendingReject;
     this.pendingResolve = null;
     this.pendingReject = null;
+    if (outcome.kind === "resolve") {
+      if (!resolve) return false;
+      resolve(outcome.result);
+      return true;
+    }
+    if (!reject) return false;
+    reject(outcome.error);
+    return true;
+  }
+
+  /**
+   * Take the single submission slot for a new caller and arm its timeout.
+   *
+   * A submission parked while one is already pending SETTLES the displaced one
+   * (retryable rejection) instead of dropping the reference and leaving that
+   * caller's promise parked forever. Displacement is reachable:
+   * `dispatchInteraction` never touches `isAnimating`/`inFlightLocalAction`
+   * while `dispatchActionInternal` does, so an interaction submit can overlap
+   * an action submit, and two concurrent `dispatchInteraction` calls can
+   * displace each other.
+   *
+   * The slot deliberately stays single and unkeyed, and it still MIS-ROUTES
+   * after a displacement: whichever reply arrives first settles the SECOND
+   * submission, because no reply frame carries anything to correlate against.
+   * That is pre-existing and is NOT fixed here — a correct fix needs a
+   * wire-level correlation id, which means a `WIRE_PROTOCOL_VERSION` bump
+   * (currently 44) and is deferred. Nothing here makes the slot correct; it
+   * only stops the displaced caller from waiting on a promise that can never
+   * settle. A keyed map would not help: it cannot route replies that carry no
+   * id.
+   */
+  private parkPendingSubmission(
+    resolve: (result: SubmitResult) => void,
+    reject: (error: Error) => void,
+  ): void {
+    this.settlePendingSubmission({
+      kind: "reject",
+      error: new AdapterError(
+        "P2P_ERROR",
+        "Superseded by a later submission before the host replied",
+        true,
+      ),
+    });
+    this.pendingResolve = resolve;
+    this.pendingReject = reject;
+    this.pendingSubmissionTimer = setTimeout(() => {
+      this.pendingSubmissionTimer = null;
+      this.settlePendingSubmission({
+        kind: "reject",
+        error: new AdapterError(
+          "P2P_ERROR",
+          "The host did not answer this action in time",
+          true,
+        ),
+      });
+    }, SUBMISSION_TIMEOUT_MS);
+  }
+
+  private rejectPendingSubmission(error: Error): void {
+    this.settlePendingSubmission({ kind: "reject", error });
   }
 
   private acceptsHostAuthority(msg: P2PMessage): boolean {

--- a/client/src/adapter/server-draft-adapter.ts
+++ b/client/src/adapter/server-draft-adapter.ts
@@ -1013,18 +1013,33 @@ export class ServerDraftAdapter implements EngineAdapter {
     this.draftView = null;
     this.seatIndex = null;
     this.activeMatchId = null;
-    this.pendingResolve = null;
-    this.pendingReject = null;
+    if (this.pendingReject) {
+      this.pendingReject(
+        new AdapterError("WS_CLOSED", "Adapter disposed during action", true),
+      );
+      this.pendingResolve = null;
+      this.pendingReject = null;
+    }
     this.rejectPendingManaPaymentPreviews(
       new AdapterError("WS_CLOSED", "Adapter disposed during mana-payment preview", true),
     );
     this.rejectPendingInteractionPreviews(
       new AdapterError("WS_CLOSED", "Adapter disposed during interaction preview", true),
     );
-    this.draftResolve = null;
-    this.draftReject = null;
-    this.initResolve = null;
-    this.initReject = null;
+    if (this.draftReject) {
+      this.draftReject(
+        new AdapterError("WS_CLOSED", "Adapter disposed during draft operation", true),
+      );
+      this.draftResolve = null;
+      this.draftReject = null;
+    }
+    if (this.initReject) {
+      this.initReject(
+        new AdapterError("WS_CLOSED", "Adapter disposed before draft started", true),
+      );
+      this.initResolve = null;
+      this.initReject = null;
+    }
     this._serverInfo = null;
     this.emit({ type: "actionPendingChanged", pending: false });
     this.listeners = [];

--- a/client/src/adapter/ws-adapter.ts
+++ b/client/src/adapter/ws-adapter.ts
@@ -1027,12 +1027,9 @@ export class WebSocketAdapter implements EngineAdapter {
         clearInterval(this.pingInterval);
         this.pingInterval = null;
       }
-      if (this.sessionIdentityRejected) return;
-      // Clear the "host waiting for opponent" latch on socket close —
-      // otherwise a host who received GameCreated, disconnected before
-      // GameStarted, and then reconnected through a different path would
-      // fire `opponentJoined` spuriously on the replayed GameStarted.
-      this.hostWaitingForOpponent = false;
+      // Settled above the identity-rejection guard: a close that arrives
+      // while the latch is set must still settle the caller's promise, or
+      // the submission hangs forever holding the dispatch mutex.
       if (this.pendingReject) {
         this.emit({ type: "actionPendingChanged", pending: false });
         this.pendingReject(
@@ -1041,6 +1038,16 @@ export class WebSocketAdapter implements EngineAdapter {
         this.pendingResolve = null;
         this.pendingReject = null;
       }
+      // Deliberately scoped to the submission slot. The seven reject helpers
+      // below still skip on the identity-rejected path; none of them holds the
+      // dispatch mutex, so none can freeze the board the way a parked
+      // submission does. Widening the hoist is a separate judgement.
+      if (this.sessionIdentityRejected) return;
+      // Clear the "host waiting for opponent" latch on socket close —
+      // otherwise a host who received GameCreated, disconnected before
+      // GameStarted, and then reconnected through a different path would
+      // fire `opponentJoined` spuriously on the replayed GameStarted.
+      this.hostWaitingForOpponent = false;
       this.rejectPendingManaPaymentPreviews(
         new AdapterError("WS_CLOSED", "Connection closed during mana-payment preview", true),
       );
@@ -1324,8 +1331,13 @@ export class WebSocketAdapter implements EngineAdapter {
     this.playerToken = null;
     this._gameCode = null;
     this.fullSessionKey = null;
-    this.pendingResolve = null;
-    this.pendingReject = null;
+    if (this.pendingReject) {
+      this.pendingReject(
+        new AdapterError("WS_CLOSED", "Adapter disposed during action", true),
+      );
+      this.pendingResolve = null;
+      this.pendingReject = null;
+    }
     this.rejectPendingManaPaymentPreviews(
       new AdapterError("WS_CLOSED", "Adapter disposed during mana-payment preview", true),
     );

--- a/client/src/game/__tests__/dispatchRemoteUpdate.test.ts
+++ b/client/src/game/__tests__/dispatchRemoteUpdate.test.ts
@@ -132,11 +132,11 @@ describe("processRemoteUpdate", () => {
     });
 
     // NOT TESTED HERE: that a *superseded* update declines to write. The
-    // generation is bumped only by `abandonDispatchesForStateRestore`
-    // (reachable via `restoreGameState`), and an event-free update runs to
-    // completion synchronously, so there is no window in which to supersede it
-    // from this harness. The property is structural instead: the write sits
-    // immediately after `processRemoteUpdateInner`'s second
+    // generation is bumped only by `abandonPendingDispatches` (reachable via
+    // `restoreGameState` and `clearPromptOverlayState`), and an event-free
+    // update runs to completion synchronously, so there is no window in which
+    // to supersede it from this harness. The property is structural instead:
+    // the write sits immediately after `processRemoteUpdateInner`'s second
     // `isCurrentDispatchGeneration` guard, next to `commitEngineSnapshot`, and
     // is the reason the list is threaded through dispatch rather than written
     // from `GameProvider`. A `reset()`-based version of this test passes

--- a/client/src/game/__tests__/dispatchTimeout.test.ts
+++ b/client/src/game/__tests__/dispatchTimeout.test.ts
@@ -11,7 +11,7 @@ import {
   buildPlayer,
   buildPriorityWaitingFor,
 } from "../../test/factories/gameStateFactory";
-import { dispatchAction, dispatchInteraction } from "../dispatch";
+import { dispatchAction, dispatchInteraction, isDispatchIdle } from "../dispatch";
 
 // Spy on the recovery escalation so we can assert the dispatch.ts branch that
 // fires `notifyEngineLost` on ENGINE_UNRESPONSIVE actually runs. Without this
@@ -102,6 +102,38 @@ describe("dispatchAction recovery on ENGINE_UNRESPONSIVE", () => {
     });
 
     expect(submitAction).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns the pipeline to idle when a P2P guest submission times out", async () => {
+    // What `P2PGuestAdapter`'s submission timeout rejects with. Before it
+    // existed the promise never settled, so `dispatchAction` never reached its
+    // `finally` and the module-level mutex stayed held — every later click was
+    // silently queued and the client sat frozen on a stale board.
+    const timeout = new AdapterError(
+      "P2P_ERROR",
+      "The host did not answer this action in time",
+      true,
+    );
+    const submitAction = vi.fn<EngineAdapter["submitAction"]>().mockRejectedValue(timeout);
+
+    useGameStore.setState({
+      adapter: buildEngineAdapterMock(emptyState, { submitAction }),
+      gameState: emptyState,
+      gameMode: "online",
+    });
+
+    await expect(dispatchAction({ type: "PassPriority", data: {} } as GameAction, 0)).rejects.toBe(
+      timeout,
+    );
+
+    expect(isDispatchIdle()).toBe(true);
+    // `P2P_ERROR`, not `ENGINE_UNRESPONSIVE`: the timeout must surface as a
+    // normal action error, never route to the engine-lost recovery prompt —
+    // the host may simply be gone, and the local engine is fine.
+    expect(notifyEngineLost).not.toHaveBeenCalled();
+    expect(useAppNotificationStore.getState().notification).toMatchObject({
+      description: timeout.message,
+    });
   });
 
   it("shows a clear toast when a normal game action fails", async () => {

--- a/client/src/game/__tests__/sessionCleanup.test.ts
+++ b/client/src/game/__tests__/sessionCleanup.test.ts
@@ -1,8 +1,11 @@
-import { beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import type { EngineAdapter, GameAction, SubmitResult } from "../../adapter/types";
+import { abandonPendingDispatches, dispatchAction, isDispatchIdle } from "../dispatch";
 import { clearPromptOverlayState } from "../sessionCleanup";
 import { useGameStore } from "../../stores/gameStore";
 import { useUiStore } from "../../stores/uiStore";
+import { buildEngineAdapterMock } from "../../test/factories/engineAdapterFactory";
 import { buildGameState, buildManaPaymentWaitingFor } from "../../test/factories/gameStateFactory";
 
 describe("clearPromptOverlayState", () => {
@@ -114,5 +117,90 @@ describe("clearPromptOverlayState", () => {
     clearPromptOverlayState();
 
     expect(useUiStore.getState().scryOutcome).toBeNull();
+  });
+});
+
+/**
+ * The dispatch mutex (`isAnimating` in dispatch.ts) is module-level and shared
+ * by local dispatches and inbound remote updates. A submit promise that never
+ * settles holds it forever, so before this wiring one wedged dispatch froze the
+ * whole page session — including the NEXT game, from its first click.
+ */
+describe("clearPromptOverlayState dispatch-pipeline recovery", () => {
+  const passPriority = { type: "PassPriority", data: {} } as unknown as GameAction;
+  const concede = { type: "Concede", data: { player_id: 0 } } as unknown as GameAction;
+
+  beforeEach(() => {
+    useGameStore.getState().reset();
+  });
+
+  afterEach(() => {
+    // These tests deliberately leave an unsettled submit holding the mutex.
+    // Release it so the wedge cannot leak into a later test in this file.
+    abandonPendingDispatches();
+  });
+
+  it("releases a dispatch mutex wedged by an unsettled submit, so the next session's first action runs", () => {
+    // A submit that never settles: `dispatchActionInternal`'s `finally` never
+    // runs, so `isAnimating` stays held with nothing to release it.
+    const submitAction = vi.fn<EngineAdapter["submitAction"]>(
+      () => new Promise<SubmitResult>(() => {}),
+    );
+    const state = buildGameState({ stack: [], players: [] });
+    useGameStore.setState({
+      adapter: buildEngineAdapterMock(state, { submitAction }),
+      gameState: state,
+      gameMode: "ai",
+    });
+
+    void dispatchAction(passPriority, 0);
+    expect(submitAction).toHaveBeenCalledTimes(1);
+    expect(isDispatchIdle()).toBe(false);
+
+    clearPromptOverlayState();
+
+    expect(isDispatchIdle()).toBe(true);
+
+    // Discriminating: with the mutex still held, a distinct action is pushed
+    // onto `pendingQueue` and `submitAction` is never reached a second time.
+    void dispatchAction(concede, 0);
+    expect(submitAction).toHaveBeenCalledTimes(2);
+  });
+
+  it("drops a commit that was in flight when the boundary fired, so it cannot re-populate prompts", async () => {
+    let releaseSubmit!: (result: SubmitResult) => void;
+    const submitAction = vi.fn<EngineAdapter["submitAction"]>(
+      () => new Promise<SubmitResult>((resolve) => {
+        releaseSubmit = resolve;
+      }),
+    );
+    const state = buildGameState({ stack: [], players: [] });
+    useGameStore.setState({
+      adapter: buildEngineAdapterMock(state, { submitAction }),
+      gameState: state,
+      gameMode: "ai",
+    });
+
+    const inFlight = dispatchAction(passPriority, 0);
+    expect(submitAction).toHaveBeenCalledTimes(1);
+
+    // The session boundary lands while the engine round-trip is outstanding.
+    clearPromptOverlayState();
+    expect(useGameStore.getState().waitingFor).toBeNull();
+
+    releaseSubmit({ events: [] });
+    await inFlight;
+
+    // The commit's generation is now stale, so `isDispatchContextCurrent`
+    // declines it rather than writing the prompt back over the cleared state.
+    expect(useGameStore.getState().waitingFor).toBeNull();
+
+    // Control: the same harness DOES commit a prompt when no boundary
+    // intervenes, so the assertions above are not vacuously green.
+    const uninterrupted = dispatchAction(concede, 0);
+    releaseSubmit({ events: [] });
+    await uninterrupted;
+
+    expect(useGameStore.getState().waitingFor).toEqual(state.waiting_for);
   });
 });

--- a/client/src/game/controllers/__tests__/gameLoopController.test.ts
+++ b/client/src/game/controllers/__tests__/gameLoopController.test.ts
@@ -80,6 +80,9 @@ describe("gameLoopController auto-pass authorization", () => {
   beforeEach(() => {
     vi.useFakeTimers();
     dispatchAction.mockReset();
+    // The real `dispatchAction` returns a promise and the auto-pass beat now
+    // attaches a rejection handler to it, so the mock must be promise-shaped.
+    dispatchAction.mockResolvedValue(undefined);
     dispatchResolveAll.mockReset();
     waitingForSubscriber = null;
     animationSpeedMultiplier = 1.0;
@@ -227,6 +230,40 @@ describe("gameLoopController auto-pass authorization", () => {
     // Zero multiplier collapses the beat to 0ms but must still dispatch the pass.
     await vi.advanceTimersByTimeAsync(0);
     expect(dispatchAction).toHaveBeenCalledWith({ type: "PassPriority" });
+    controller.dispose();
+  });
+
+  it("attaches a rejection handler to the auto-pass dispatch", async () => {
+    // The auto-pass beat is a `dispatchAction` call site with no caller to
+    // propagate to. A P2P guest sitting in auto-pass now rejects on the guest
+    // adapter's submission timeout as well as on `action_rejected` /
+    // `action_failed` / host disconnect, so every beat must swallow its own
+    // failure.
+    const rejected = Promise.reject(new Error("The host did not answer this action in time"));
+    // Keep the probe itself from leaking a rejection regardless of what the
+    // controller does; `catch` is spied only afterwards, so this handler is not
+    // counted.
+    rejected.catch(() => undefined);
+    const attachedHandler = vi.spyOn(rejected, "catch");
+    dispatchAction.mockReturnValueOnce(rejected);
+    const waitingFor = priority(1);
+    storeState = {
+      waitingFor,
+      gameState: stateFor(waitingFor, 0),
+      autoPassRecommended: true,
+    };
+
+    const controller = createGameLoopController({ mode: "online" });
+    controller.start();
+
+    await vi.advanceTimersByTimeAsync(200);
+    expect(dispatchAction).toHaveBeenCalledWith({ type: "PassPriority" });
+
+    // The beat must attach its own rejection handler. Asserting on the absence
+    // of a `process` "unhandledRejection" event cannot see this: vitest's spy
+    // machinery observes the promise it returns, which marks the rejection
+    // handled no matter what the caller does.
+    expect(attachedHandler).toHaveBeenCalled();
     controller.dispose();
   });
 

--- a/client/src/game/controllers/gameLoopController.ts
+++ b/client/src/game/controllers/gameLoopController.ts
@@ -107,7 +107,13 @@ export function createGameLoopController(config: GameLoopConfig): GameLoopContro
       ) {
         return;
       }
-      dispatchAction({ type: "PassPriority" });
+      // The auto-pass beat has no caller to propagate to, and `dispatchAction`
+      // already surfaces the failure itself through `reportActionError`. Every
+      // rejecting submission path therefore has to be absorbed here or it
+      // escapes as an unhandled rejection: a P2P guest sitting in auto-pass now
+      // rejects on `action_rejected` / `action_failed` / host disconnect AND on
+      // the guest adapter's submission timeout (`SUBMISSION_TIMEOUT_MS`).
+      void dispatchAction({ type: "PassPriority" }).catch(() => undefined);
     }, beat);
   }
 

--- a/client/src/game/dispatch.ts
+++ b/client/src/game/dispatch.ts
@@ -104,8 +104,10 @@ const pendingQueue: PendingWork[] = [];
 
 /**
  * Identifies the game state for which the current dispatch pipeline is valid.
- * Restoring a saved game replaces the engine state wholesale, so work queued
- * for the old state must neither run nor release a newer dispatch's mutex.
+ * Restoring a saved game replaces the engine state wholesale, and a game-session
+ * boundary abandons it outright, so work queued for the old state must neither
+ * run nor release a newer dispatch's mutex. Bumped only by
+ * `abandonPendingDispatches`.
  */
 let dispatchGeneration = 0;
 
@@ -153,8 +155,22 @@ function sameBoundGameSession(
   return a?.adapter === b?.adapter && a?.generation === b?.generation;
 }
 
-/** Discard dispatch work that belongs to the game state being replaced. */
-function abandonDispatchesForStateRestore(): void {
+/**
+ * Discard every queued and in-flight dispatch and release the mutex.
+ *
+ * Two callers, both of which abandon the game the pending work belongs to:
+ * `restoreGameState` (the engine state is replaced wholesale) and
+ * `clearPromptOverlayState` (a game-session boundary). Bumping
+ * `dispatchGeneration` makes every downstream `isDispatchContextCurrent` guard
+ * decline, so a `processAction` continuation still in flight can neither commit
+ * nor release a newer dispatch's mutex. That covers the dispatch pipeline only:
+ * `dispatchInteraction` and `restoreGameState` commit without capturing the
+ * generation, so they are unaffected by the bump and can still write.
+ * Queued work is *resolved*, not rejected: a caller
+ * awaiting an action in an abandoned game has nothing to recover from and
+ * must not see a spurious rejection.
+ */
+export function abandonPendingDispatches(): void {
   dispatchGeneration += 1;
   inFlightLocalAction = null;
   isAnimating = false;
@@ -980,7 +996,7 @@ export async function restoreGameState(
   const { adapter, gameId } = useGameStore.getState();
   if (!adapter) return "No adapter available";
 
-  abandonDispatchesForStateRestore();
+  abandonPendingDispatches();
   try {
     await adapter.restoreState(state);
   } catch (err) {

--- a/client/src/game/sessionCleanup.ts
+++ b/client/src/game/sessionCleanup.ts
@@ -1,3 +1,4 @@
+import { abandonPendingDispatches } from "./dispatch.ts";
 import { useGameStore } from "../stores/gameStore.ts";
 import { useUiStore } from "../stores/uiStore.ts";
 
@@ -7,14 +8,28 @@ import { useUiStore } from "../stores/uiStore.ts";
  * deferred store resets or async `initGame` cannot leave `ManaPayment`,
  * `pendingAbilityChoice`, or a roll animation bleeding into the next session.
  *
- * Documented exemption from the `commitEngineSnapshot` single-writer invariant:
- * this is a session-boundary CLEAR, not a live-game commit. It writes the prompt
- * + legal-action fields without advancing `lastCommittedSeq`, so a commit already
- * in flight can re-populate the prompts it just cleared. That race pre-dates this
- * mechanism and is neither worsened nor fixed by it — the clear has no snapshot to
- * gate on, and gating it would require inventing an epoch it doesn't have.
+ * Abandoning the dispatch pipeline is part of the boundary, not an errand on the
+ * side. `isAnimating` is a module-level mutex shared by local dispatches and
+ * inbound remote updates, so a submit promise that never settles holds it for the
+ * rest of the page session — the *next* game is then unresponsive from its first
+ * click. `abandonPendingDispatches` releases it and resolves the queue.
+ *
+ * The generation it bumps is also an epoch this clear can lean on — partially.
+ * The clear writes the prompt + legal-action fields without advancing
+ * `lastCommittedSeq`, so a commit landing afterwards still wins the store's own
+ * `seq` gate. Of the four `commitEngineSnapshot` call sites in `dispatch.ts`, two
+ * capture the generation and decline once it is bumped: `processAction` (via
+ * `isDispatchContextCurrent`) and `processRemoteUpdateInner` (via
+ * `isCurrentDispatchGeneration`). Those can no longer re-populate the prompts this
+ * function just cleared.
+ *
+ * `dispatchInteraction` and `restoreGameState` commit outside the generation gate
+ * and still can. That race pre-dates this mechanism and is not fixed here; closing
+ * it means threading the generation through those two paths, which is a change to
+ * the single-writer invariant rather than to this boundary.
  */
 export function clearPromptOverlayState(): void {
+  abandonPendingDispatches();
   useGameStore.setState({
     waitingFor: null,
     legalActions: [],

--- a/client/src/network/__tests__/fakeDataConnection.ts
+++ b/client/src/network/__tests__/fakeDataConnection.ts
@@ -95,12 +95,29 @@ export class FakeDataConnection {
 
   /**
    * Hook fired once a sent frame has been decoded and backfilled into `sent`.
-   * Empty by default; subclasses override it to model peer behavior (e.g.
-   * feeding a `state_ack` back to the host). Overrides that start async work
+   * Subclasses override it to model peer behavior (e.g. feeding a `state_ack`
+   * back to the host); an override MUST call `super.onDecodedSend(msg)` so the
+   * base keep-alive reply below survives — unless it is deliberately modelling
+   * a peer that has stopped responding, as `SilentPeerConnection` in
+   * `peer.test.ts` does. Nothing enforces this. Overrides that start async work
    * should push the resulting promise onto `pendingDecodes` so
    * `getSentMessages()` awaits it.
+   *
+   * Default behavior: answer `ping` with `pong`. A live channel always does,
+   * and `peer.ts` now disconnects a session that sees no pong for 10s — so a
+   * fake that never ponged would model a DEAD peer, which is not what any
+   * caller of this class means by "a connection". The reply goes out through
+   * `simulateData` into the session's receive path, so it never appears in
+   * `sent`; tests asserting on `sent` are unaffected.
    */
-  protected onDecodedSend(_msg: P2PMessage): void {}
+  protected onDecodedSend(msg: P2PMessage): void {
+    if (msg.type !== "ping" || !this.open) return;
+    this.pendingDecodes.push(
+      this.simulateData({ type: "pong", timestamp: msg.timestamp }).catch((e) => {
+        console.warn("[FakeDataConnection] pong dispatch failed:", e);
+      }),
+    );
+  }
 
   close() {
     if (this.open) this.simulateClose();

--- a/client/src/network/__tests__/peer.test.ts
+++ b/client/src/network/__tests__/peer.test.ts
@@ -276,3 +276,93 @@ describe("PeerSession", () => {
     session.close();
   });
 });
+
+/**
+ * A channel whose peer never answers a ping — i.e. a HALF-OPEN channel:
+ * `open` stays true, `conn.on("close")` never fires, and nothing comes back.
+ * The keep-alive silence check is the only thing that can detect it.
+ */
+class SilentPeerConnection extends FakeDataConnection {
+  protected override onDecodedSend(): void {}
+}
+
+// Fake timers are scoped per-test: the rest of this file runs on real timers
+// and would be slowed (or made order-dependent) by a suite-wide fake clock.
+//
+// `ping`/`pong` are far below `WIRE_COMPRESSION_THRESHOLD`, so they take the
+// raw envelope path — no `CompressionStream`, which is what lets the real
+// protocol module run under fake timers here.
+describe("PeerSession keep-alive", () => {
+  it("disconnects a peer that stops answering pings", async () => {
+    vi.useFakeTimers();
+    try {
+      const conn = new SilentPeerConnection();
+      const session = createPeerSession(conn as never);
+      const onDisconnect = vi.fn();
+      session.onDisconnect(onDisconnect);
+
+      // First tick: a ping goes out, but only 5s of silence has accrued.
+      await vi.advanceTimersByTimeAsync(5_000);
+      expect(onDisconnect).not.toHaveBeenCalled();
+
+      // Second tick: 10s with no pong, and the inter-tick gap is a healthy 5s,
+      // so the silence is real evidence.
+      await vi.advanceTimersByTimeAsync(5_000);
+      expect(onDisconnect).toHaveBeenCalledWith("Ping timeout");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("keeps a ponging peer connected indefinitely", async () => {
+    vi.useFakeTimers();
+    try {
+      const conn = new FakeDataConnection();
+      const session = createPeerSession(conn as never);
+      const onDisconnect = vi.fn();
+      session.onDisconnect(onDisconnect);
+
+      // Six ticks' worth — three times the silence budget.
+      await vi.advanceTimersByTimeAsync(30_000);
+
+      expect(onDisconnect).not.toHaveBeenCalled();
+      // The pongs are real: they arrived over the wire in response to pings.
+      const sent = await conn.getSentMessages();
+      expect(sent.filter((m) => (m as P2PMessage).type === "ping").length).toBe(6);
+      session.close();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not disconnect a healthy peer across a suspend/resume clock jump", async () => {
+    vi.useFakeTimers();
+    try {
+      const conn = new FakeDataConnection();
+      const session = createPeerSession(conn as never);
+      const onDisconnect = vi.fn();
+      session.onDisconnect(onDisconnect);
+
+      await vi.advanceTimersByTimeAsync(10_000);
+      expect(onDisconnect).not.toHaveBeenCalled();
+
+      // Suspend: move the wall clock five minutes WITHOUT running the
+      // interval. `setSystemTime` shifts pending timers' deadlines along with
+      // the clock, so no tick fires — which is what a frozen tab looks like.
+      // `advanceTimersByTime(300_000)` would instead run sixty ticks that each
+      // observe a healthy 5s gap, and would pass against any implementation.
+      vi.setSystemTime(Date.now() + 300_000);
+
+      // Resume: the next tick observes a 305s gap since its predecessor. A
+      // bare `now - lastPongAt` check cannot tell that from 305s of real
+      // silence and would disconnect here; the inter-tick gap can, and
+      // re-baselines instead.
+      await vi.advanceTimersByTimeAsync(5_000);
+
+      expect(onDisconnect).not.toHaveBeenCalled();
+      session.close();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/client/src/network/peer.ts
+++ b/client/src/network/peer.ts
@@ -48,13 +48,26 @@ export function createPeerSession(
 
   const pendingMessages: P2PMessage[] = [];
 
-  // Ping/pong keep-alive
+  // Ping/pong keep-alive. We probe every `PING_INTERVAL_MS`; a channel that
+  // has produced no pong for `PONG_TIMEOUT_MS` is declared dead. This is the
+  // only detector for a HALF-OPEN channel — one where `conn.open` is still
+  // true and `conn.on("close")` will never fire because nothing ever formally
+  // closed.
+  const PING_INTERVAL_MS = 5_000;
+  const PONG_TIMEOUT_MS = 10_000;
+
   let pingInterval: ReturnType<typeof setInterval> | null = null;
-  let pongTimeout: ReturnType<typeof setTimeout> | null = null;
+  // `Date.now()` of the most recent pong, and of the previous interval tick.
+  // Wall clock specifically because it is the clock a test can move
+  // independently of the timer queue (`vi.setSystemTime`), which is what makes
+  // the suspend discriminator below observable at all. Whether
+  // `performance.now()` also advances across a suspend is browser-dependent and
+  // is deliberately NOT the reason stated here.
+  let lastPongAt = 0;
+  let lastTickAt = 0;
 
   const clearKeepAlive = () => {
     if (pingInterval !== null) { clearInterval(pingInterval); pingInterval = null; }
-    if (pongTimeout !== null) { clearTimeout(pongTimeout); pongTimeout = null; }
   };
 
   // FIFO send queue. Compression is async (CompressionStream), so two rapid
@@ -106,26 +119,64 @@ export function createPeerSession(
   };
 
   const startKeepAlive = () => {
+    lastPongAt = lastTickAt = Date.now();
     pingInterval = setInterval(() => {
       if (!conn.open) return;
 
-      if (pongTimeout !== null) { clearTimeout(pongTimeout); pongTimeout = null; }
+      const now = Date.now();
+      const sinceLastTick = now - lastTickAt;
+      lastTickAt = now;
+
+      // Suspend discriminator. A bare `now - lastPongAt` is NOT enough: a tab
+      // frozen for five minutes and a channel silent for five minutes produce
+      // the identical gap, and disconnecting every resumed tab (routine on
+      // mobile) is worse than missing a dead channel. The gap since the
+      // PREVIOUS TICK is what tells them apart — a tick that arrives a whole
+      // silence budget after its predecessor did not observe the interval it
+      // was scheduled for, so the elapsed time is no evidence about the peer.
+      // Re-baseline and start measuring again.
+      //
+      // ACCEPTED CONSEQUENCE: re-baselining disables this detector for as long
+      // as ticks keep arriving a full budget apart, and it does NOT distinguish
+      // WHY they do. Any cause counts — a frozen tab, Chrome's intensive
+      // throttling tier (hidden >= 5 min, ~1 tick/minute), or a long
+      // synchronous WASM engine call blocking a FOREGROUNDED main thread. Note
+      // ordinary hidden-tab throttling (~1/sec) does not delay a 5s interval at
+      // all, so a merely-backgrounded tab usually keeps detecting normally.
+      // Detection resumes two ticks after normal 5s pacing returns.
+      //
+      // The symmetric case is the PEER's, and this change newly reaches it: a
+      // foregrounded tab sees healthy 5s gaps, so it never re-baselines, and it
+      // will drop a peer whose page the browser has frozen for a whole budget.
+      // Two things bound the damage. Pong replies ride `conn.on("data")`
+      // rather than a timer, so ordinary hidden-tab throttling never silences a
+      // peer; and a dropped peer auto-reconnects inside the host's 30s
+      // `DEFAULT_GRACE_PERIOD_MS` (p2p-adapter.ts). A device locked past that
+      // grace now loses the seat where it previously survived until ICE failed.
+      //
+      // That is the intended trade. The alternative — concluding silence from a
+      // gap the tick cannot explain — false-disconnects a healthy peer, which
+      // is the harm this whole branch exists to prevent.
+      if (sinceLastTick >= PONG_TIMEOUT_MS) {
+        lastPongAt = now;
+      } else if (now - lastPongAt >= PONG_TIMEOUT_MS) {
+        handleDisconnect("Ping timeout");
+        return;
+      }
 
       // Fire-and-forget: real `conn.send` failures fire `handleDisconnect`
-      // from inside the queue's catch; the 10s pong-timeout below bounds
+      // from inside the queue's catch; the silence check above bounds
       // detection latency for everything else.
-      void trySend({ type: "ping", timestamp: Date.now() });
-
-      pongTimeout = setTimeout(() => {
-        if (!closed) handleDisconnect("Ping timeout");
-      }, 10_000);
-    }, 5_000);
+      void trySend({ type: "ping", timestamp: now });
+    }, PING_INTERVAL_MS);
   };
 
   const beforeUnloadHandler = () => {
     // Best-effort farewell over the queued path. Compression is async, so the
-    // message may not flush before the tab is torn down; the 10s pong-timeout
-    // is the reliable disconnect detection on the remote side regardless.
+    // message may not flush before the tab is torn down. If it doesn't, the
+    // remote side falls back to its own keep-alive silence check (~10s), which
+    // covers a foregrounded peer but is deliberately inert while that peer's
+    // tab is backgrounded — see `startKeepAlive`.
     if (!closed && conn.open) void trySend({ type: "disconnect", reason: "Page closed" });
   };
   window.addEventListener("beforeunload", beforeUnloadHandler);
@@ -203,7 +254,8 @@ export function createPeerSession(
       }
 
       if (msg.type === "pong") {
-        if (pongTimeout !== null) { clearTimeout(pongTimeout); pongTimeout = null; }
+        // Sole liveness evidence the keep-alive tick reads.
+        lastPongAt = Date.now();
         return;
       }
 


### PR DESCRIPTION
A P2P guest could park a submission promise that nothing would ever
settle. `isAnimating` in `dispatch.ts` is a module-level mutex shared by
local dispatches and inbound remote updates, so one unsettled promise
froze the board *and* stopped inbound state from applying. The
stale-state watchdog bails while `!isDispatchIdle()`, so the one
self-healing path was disabled by exactly the condition it exists to
heal.

Four settlement guarantees, each with regression coverage that fails
without it:

- `abandonPendingDispatches()` now runs at game-session boundaries via
  `clearPromptOverlayState`, so a wedged mutex cannot poison the next
  game for the rest of the page session.
- `peer.ts` keep-alive actually detects a quiet channel. The 5s tick
  cleared the 10s pong timeout every time, so `handleDisconnect("Ping
  timeout")` was unreachable while `conn.open` — with two comments
  asserting it worked. Now tracks `lastPongAt`/`lastTickAt`, with a
  re-baseline guard so a suspended tab is not read as a dead peer.
- `P2PGuestAdapter` bounds an in-flight submission with
  `SUBMISSION_TIMEOUT_MS`, routing every settlement through a single
  `settlePendingSubmission` so the timer is armed and disarmed in one
  place and a stale timer cannot reject a later, unrelated submission.
- `WsAdapter.dispose()` and `ServerDraftAdapter.dispose()` reject their
  in-flight promises instead of nulling them, and the ws `onclose`
  settlement is hoisted above the identity-rejection guard.

Rejecting unfreezes the guest without resyncing it: on the host-lease
route the action applied on a host that will never broadcast again, so
recovery is a reload. That residual is documented at
`SUBMISSION_TIMEOUT_MS` rather than papered over.

The same freeze remains reachable on the WebSocket transport, and it
cannot be fixed by mirroring this change: `handle_client_message`
answers `Ping` on the same task that runs `run_ai` inline, so a client
timer cannot tell a busy server from a dead one. Tracked separately.

Claude-Session: https://claude.ai/code/session_01SKXMrb8mH6tLbz7U8keCE5


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Guest action and interaction submissions now time out after 30 seconds instead of remaining pending indefinitely.
  - Displaced, interrupted, or closed submissions now settle with clear, retryable errors.
  - Session changes and cleanup reliably release blocked action processing.
  - Auto-pass failures no longer create unhandled errors.
  - Peer connections now detect silent or half-open channels and disconnect appropriately.
  - Healthy peers remain connected across temporary tab suspension or throttling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->