### PR TITLE
fix(client): cache mana pips offline and make Prepare for Offline mean it

### DIFF
--- a/client/src/components/mana/ManaGlyphPresentation.tsx
+++ b/client/src/components/mana/ManaGlyphPresentation.tsx
@@ -1,8 +1,5 @@
-import {
-  useManaSymbolImage,
-  type ManaSymbolShard,
-} from "../../hooks/useFixedVisualImage.ts";
-import { manaSymbolSourceUrl } from "../../services/scryfall.ts";
+import { useManaSymbolImage } from "../../hooks/useFixedVisualImage.ts";
+import { manaSymbolSourceUrl, type ManaSymbolShard } from "../../services/scryfall.ts";
 
 interface ManaGlyphPresentationProps {
   shard: ManaSymbolShard | null;

--- a/client/src/components/mana/ManaSymbol.tsx
+++ b/client/src/components/mana/ManaSymbol.tsx
@@ -1,5 +1,5 @@
 import { ManaGlyphPresentation } from "./ManaGlyphPresentation.tsx";
-import type { ManaSymbolShard } from "../../hooks/useFixedVisualImage.ts";
+import { isManaSymbolShard } from "../../services/scryfall.ts";
 
 interface ManaSymbolProps {
   shard: string;
@@ -13,30 +13,6 @@ export const MANA_SYMBOL_SIZE_CLASSES = {
   md: "w-6 h-6",
   lg: "w-8 h-8",
 } as const;
-
-const SINGLE_SYMBOL_CODES = new Set([
-  "W", "U", "B", "R", "G", "C", "S", "T", "Q", "E", "P", "X", "Y", "Z", "A", "∞", "½", "CHAOS",
-]);
-const COMPOSITE_SYMBOL_CODES = new Set([
-  "W/U", "W/B", "U/B", "U/R", "B/R", "B/G", "R/W", "R/G", "G/W", "G/U",
-  "2/W", "2/U", "2/B", "2/R", "2/G",
-  "W/P", "U/P", "B/P", "R/P", "G/P",
-  "W/U/P", "W/B/P", "U/B/P", "U/R/P", "B/R/P", "B/G/P", "R/W/P", "R/G/P", "G/W/P", "G/U/P",
-  "C/W", "C/U", "C/B", "C/R", "C/G",
-]);
-
-const FINITE_NUMERIC_SYMBOL_CODES = new Set([
-  ...Array.from({ length: 21 }, (_, value) => String(value)),
-  "100",
-  "1000000",
-]);
-
-/** True when `shard` has a corresponding Scryfall card-symbol SVG. */
-export function isManaSymbolShard(shard: string): shard is ManaSymbolShard {
-  return FINITE_NUMERIC_SYMBOL_CODES.has(shard)
-    || SINGLE_SYMBOL_CODES.has(shard)
-    || COMPOSITE_SYMBOL_CODES.has(shard);
-}
 
 export function ManaSymbol({
   shard,

--- a/client/src/components/mana/RichLabel.tsx
+++ b/client/src/components/mana/RichLabel.tsx
@@ -1,4 +1,5 @@
-import { isManaSymbolShard, ManaSymbol } from "./ManaSymbol.tsx";
+import { isManaSymbolShard } from "../../services/scryfall.ts";
+import { ManaSymbol } from "./ManaSymbol.tsx";
 
 interface RichLabelProps {
   text: string;

--- a/client/src/components/settings/OfflinePreparationSection.tsx
+++ b/client/src/components/settings/OfflinePreparationSection.tsx
@@ -8,6 +8,7 @@ import {
 } from "../../services/offlinePreparation.ts";
 import { useConnectivityStore, useEffectiveOffline } from "../../stores/connectivityStore.ts";
 import { ConfirmDialog } from "../ui/ConfirmDialog.tsx";
+import { packLabel } from "./visual-packs/packLabels.ts";
 
 const CAPABILITIES: readonly OfflinePreparationCapabilityName[] = [
   "appShell",
@@ -16,6 +17,7 @@ const CAPABILITIES: readonly OfflinePreparationCapabilityName[] = [
   "preconCatalog",
   "bundledAiCatalog",
   "deckLibrary",
+  "coreVisuals",
   "nativeEngine",
 ];
 
@@ -31,9 +33,10 @@ function reconnectRequiredResult(): OfflinePreparationResult {
       preconCatalog: { status: "not-ready" },
       bundledAiCatalog: { status: "not-ready" },
       deckLibrary: { status: "not-ready" },
+      coreVisuals: { status: "not-ready" },
       nativeEngine: { status: "not-applicable" },
     },
-    visualPacks: { status: "not-installed" },
+    visualPacks: { status: "not-installed", installedPacks: [] },
     requiredGaps: [],
   };
 }
@@ -101,6 +104,7 @@ export function OfflinePreparationSection({ nativeEngineEnabled }: { nativeEngin
 
   const statusKey = preparing ? "preparing" : result?.status ?? "needs-preparation";
   const requiredGaps = result?.requiredGaps ?? [];
+  const installedArt = result?.visualPacks.installedPacks ?? [];
 
   return (
     <section className="rounded-[20px] border border-white/10 bg-black/18 p-4 shadow-[0_18px_54px_rgba(0,0,0,0.18)] backdrop-blur-md sm:p-5">
@@ -144,8 +148,22 @@ export function OfflinePreparationSection({ nativeEngineEnabled }: { nativeEngin
               </li>
             ))}
           </ul>
+          {/* Card art is reported, never required — a deck plays correctly with
+              none installed. Saying so plainly is the point: this panel used to
+              render nothing at all in the "not-installed" case, so a device with
+              zero images cached still read as ready. */}
+          {result.visualPacks.status === "not-installed" && (
+            <p className="mt-3 text-xs text-amber-200">{t("offlinePreparation.cardArtMissing")}</p>
+          )}
           {result.visualPacks.status === "warning" && (
             <p className="mt-3 text-xs text-amber-200">{t("offlinePreparation.visualWarning")}</p>
+          )}
+          {result.visualPacks.status === "ready" && installedArt.length > 0 && (
+            <p className="mt-3 text-xs text-slate-400">
+              {t("offlinePreparation.cardArtInstalled", {
+                packs: installedArt.map((pack) => packLabel(pack, t)).join(", "),
+              })}
+            </p>
           )}
         </>
       )}

--- a/client/src/components/settings/PreferencesModal.tsx
+++ b/client/src/components/settings/PreferencesModal.tsx
@@ -808,7 +808,13 @@ export function PreferencesModal({
 
               {activeTab === "data" && (
         <>
-          {isDesktopTauri() && <OfflinePreparationSection nativeEngineEnabled={nativeEngineEnabled} />}
+          {/* Not gated on the desktop shell. The service worker precaches the
+              app shell, engine WASM and card data for the browser too, so a
+              readiness checklist is meaningful there — and the browser is where
+              a player is most likely to be surprised by a broken offline
+              session. The native-engine row reports "not applicable" off
+              desktop, which is exactly what it is. */}
+          <OfflinePreparationSection nativeEngineEnabled={nativeEngineEnabled} />
           <VisualPackManager />
           <CloudSyncSection />
           <DataSection />

--- a/client/src/components/settings/__tests__/OfflinePreparationSection.test.tsx
+++ b/client/src/components/settings/__tests__/OfflinePreparationSection.test.tsx
@@ -21,9 +21,10 @@ const ready = {
     preconCatalog: { status: "ready" as const },
     bundledAiCatalog: { status: "ready" as const },
     deckLibrary: { status: "not-installed" as const },
+    coreVisuals: { status: "ready" as const },
     nativeEngine: { status: "not-applicable" as const },
   },
-  visualPacks: { status: "not-installed" as const },
+  visualPacks: { status: "not-installed" as const, installedPacks: [] },
   requiredGaps: [],
 };
 
@@ -244,6 +245,40 @@ describe("OfflinePreparationSection", () => {
     fireEvent.click(screen.getByRole("button", { name: "Prepare for Offline" }));
 
     await screen.findByText("This device is ready for offline local play.");
+  });
+
+  /** The gap this panel used to have: with nothing cached it rendered no card
+   *  image line at all, so a device with zero art still read as ready. */
+  it("warns when no card images are cached", async () => {
+    render(<OfflinePreparationSection nativeEngineEnabled={false} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Prepare for Offline" }));
+
+    await screen.findByText(/No card images are installed/);
+  });
+
+  it("names the card image packs that are cached", async () => {
+    mocks.prepare.mockResolvedValue({
+      ...ready,
+      visualPacks: { status: "ready" as const, installedPacks: ["curated", "deck_library"] },
+    });
+    render(<OfflinePreparationSection nativeEngineEnabled={false} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Prepare for Offline" }));
+
+    const cached = await screen.findByText(/Card images cached/);
+    expect(cached).toHaveTextContent("One image per card");
+    expect(cached).toHaveTextContent("Deck library");
+    expect(screen.queryByText(/No card images are installed/)).not.toBeInTheDocument();
+  });
+
+  it("lists the core visuals row in the readiness checklist", async () => {
+    render(<OfflinePreparationSection nativeEngineEnabled={false} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Prepare for Offline" }));
+
+    const checklist = await screen.findByRole("list", { name: "Offline readiness checklist" });
+    expect(checklist).toHaveTextContent("Card back and mana symbols");
   });
 
   it.each([

--- a/client/src/components/settings/__tests__/PreferencesModal.offline.test.tsx
+++ b/client/src/components/settings/__tests__/PreferencesModal.offline.test.tsx
@@ -55,7 +55,7 @@ afterEach(() => {
 });
 
 describe("PreferencesModal offline cloud controls", () => {
-  it("places desktop offline preparation first in Data and hides it on web", () => {
+  it("places offline preparation first in Data, on web as well as desktop", () => {
     platform.desktop = true;
     renderPreferences();
 
@@ -67,10 +67,13 @@ describe("PreferencesModal offline cloud controls", () => {
     expect(visualPacks.compareDocumentPosition(cloudSync) & Node.DOCUMENT_POSITION_FOLLOWING).not.toBe(0);
     expect(cloudSync.compareDocumentPosition(data) & Node.DOCUMENT_POSITION_FOLLOWING).not.toBe(0);
 
+    // The browser needs this panel more than the desktop shell does, not less:
+    // it is where a player is most likely to enable Work Offline without ever
+    // having cached the images the board draws.
     cleanup();
     platform.desktop = false;
     renderPreferences();
-    expect(screen.queryByRole("heading", { name: "Offline preparation" })).not.toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Offline preparation" })).toBeInTheDocument();
   });
 
   it("shows paused state and disables signed-out provider actions without invoking them", () => {

--- a/client/src/hooks/useFixedVisualImage.ts
+++ b/client/src/hooks/useFixedVisualImage.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
-import { manaSymbolSourceUrl } from "../services/scryfall.ts";
+import { manaSymbolSourceUrl, type ManaSymbolShard } from "../services/scryfall.ts";
 import { manaSymbolCandidate } from "../services/visualPacks/candidateKeys.ts";
 import { visualPackRepository } from "../services/visualPacks/repository.ts";
 import type {
@@ -16,9 +16,6 @@ export interface UseFixedVisualImageResult {
   source: CardImageSource | null;
   advanceFailedSource(failedSrc: string): void;
 }
-
-declare const manaSymbolShardBrand: unique symbol;
-export type ManaSymbolShard = string & { readonly [manaSymbolShardBrand]: true };
 
 /** Resolve one fixed visual without synthesizing responsive companion rungs. */
 export function useFixedVisualImage(

--- a/client/src/i18n/locales/de/settings.json
+++ b/client/src/i18n/locales/de/settings.json
@@ -404,17 +404,19 @@
   },
   "offlinePreparation": {
     "title": "Offline-Vorbereitung",
-    "description": "Bereite diesen Desktop auf lokales Offline-Spiel vor, bevor Offline arbeiten aktiviert wird.",
+    "description": "Bereite dieses Gerät auf lokales Offline-Spiel vor, bevor Offline arbeiten aktiviert wird.",
     "prepare": "Für Offline vorbereiten",
     "preparing": "Wird vorbereitet…",
     "workOffline": "Offline arbeiten",
     "checklistLabel": "Offline-Bereitschaftsliste",
     "visualWarning": "Installierte Bildpakete benötigen Aufmerksamkeit. Öffne Bildpakete zur Reparatur; lokales Spiel bleibt verfügbar.",
+    "cardArtMissing": "Es sind keine Kartenbilder installiert. Karten werden offline ohne Artwork dargestellt – installiere unten unter Bildpakete ein Paket.",
+    "cardArtInstalled": "Zwischengespeicherte Kartenbilder: {{packs}}",
     "incompleteTitle": "Offline-Vorbereitung ist unvollständig",
     "incompleteMessage": "Fehlt: {{capabilities}}. Offline arbeiten trotzdem aktivieren?",
     "confirmOffline": "Offline arbeiten aktivieren",
     "states": { "needs-preparation": "Bereite dieses Gerät vor dem Offline-Arbeiten vor.", "preparing": "Lokale Spielfunktionen werden vorbereitet…", "ready": "Dieses Gerät ist für lokales Offline-Spiel bereit.", "failed": "Einige erforderliche Funktionen sind nicht bereit.", "reconnect-required": "Stelle die Verbindung wieder her, bevor du Offline-Spiel vorbereitest.", "reload-or-relaunch-required": "Lade die App neu oder starte den Desktop neu und bereite erneut vor." },
-    "capabilities": { "appShell": "App-Shell", "browserEngine": "Browser-Engine und Kartendatenbank", "scryfallSearch": "Kartensuchdaten", "preconCatalog": "Vorgefertigte Decks", "bundledAiCatalog": "KI-Deckkatalog", "deckLibrary": "Installierte Deckbibliothek", "nativeEngine": "Native Engine" },
+    "capabilities": { "appShell": "App-Shell", "browserEngine": "Browser-Engine und Kartendatenbank", "scryfallSearch": "Kartensuchdaten", "preconCatalog": "Vorgefertigte Decks", "bundledAiCatalog": "KI-Deckkatalog", "deckLibrary": "Installierte Deckbibliothek", "coreVisuals": "Kartenrückseite und Manasymbole", "nativeEngine": "Native Engine" },
     "capabilityStates": { "ready": "Bereit", "not-ready": "Nicht bereit", "reload-required": "Neuladen erforderlich", "not-applicable": "Nicht anwendbar", "not-installed": "Nicht installiert" }
   },
   "artChain": {

--- a/client/src/i18n/locales/en/settings.json
+++ b/client/src/i18n/locales/en/settings.json
@@ -227,7 +227,7 @@
     },
     "selector": {
       "title": "Download selection",
-      "core": "Card back",
+      "core": "Card back and mana symbols",
       "printing": "Set printings",
       "complete": "All current English card images",
       "curated": "One image per card",
@@ -347,7 +347,7 @@
       "catalog_state": "Historical catalog state could not be reclaimed"
     },
     "packs": {
-      "core": "Card back",
+      "core": "Card back and mana symbols",
       "complete": "All current English card images",
       "curated": "One image per card",
       "deckLibrary": "Deck library",
@@ -408,12 +408,14 @@
   },
   "offlinePreparation": {
     "title": "Offline preparation",
-    "description": "Prepare this desktop for cold-launch local play before enabling Work Offline.",
+    "description": "Prepare this device for cold-launch local play before enabling Work Offline.",
     "prepare": "Prepare for Offline",
     "preparing": "Preparing…",
     "workOffline": "Work Offline",
     "checklistLabel": "Offline readiness checklist",
     "visualWarning": "Installed visual packs need attention. Open Visual Packs to repair them; local play remains available.",
+    "cardArtMissing": "No card images are installed. Cards will render without art offline — install a pack in Visual Packs below.",
+    "cardArtInstalled": "Card images cached: {{packs}}",
     "incompleteTitle": "Offline preparation is incomplete",
     "incompleteMessage": "Missing: {{capabilities}}. Enable Work Offline anyway?",
     "confirmOffline": "Enable Work Offline",
@@ -432,6 +434,7 @@
       "preconCatalog": "Generated preconstructed decks",
       "bundledAiCatalog": "Bundled AI deck catalog",
       "deckLibrary": "Installed Deck Library",
+      "coreVisuals": "Card back and mana symbols",
       "nativeEngine": "Native engine"
     },
     "capabilityStates": {

--- a/client/src/i18n/locales/es/settings.json
+++ b/client/src/i18n/locales/es/settings.json
@@ -223,7 +223,7 @@
     },
     "selector": {
       "title": "Selección de catálogo",
-      "core": "Reverso de carta",
+      "core": "Reverso de carta y símbolos de maná",
       "printing": "Impresiones de la colección",
       "complete": "Todas las imágenes actuales de cartas en inglés",
       "curated": "Una imagen por carta",
@@ -343,7 +343,7 @@
       "catalog_state": "No se pudo recuperar el estado del catálogo histórico"
     },
     "packs": {
-      "core": "Reverso de carta",
+      "core": "Reverso de carta y símbolos de maná",
       "complete": "Todas las imágenes actuales de cartas en inglés",
       "curated": "Una imagen por carta",
       "deckLibrary": "Biblioteca de mazos",
@@ -404,17 +404,19 @@
   },
   "offlinePreparation": {
     "title": "Preparación sin conexión",
-    "description": "Prepara este escritorio para juego local sin conexión antes de activar Trabajar sin conexión.",
+    "description": "Prepara este dispositivo para juego local sin conexión antes de activar Trabajar sin conexión.",
     "prepare": "Preparar sin conexión",
     "preparing": "Preparando…",
     "workOffline": "Trabajar sin conexión",
     "checklistLabel": "Lista de preparación sin conexión",
     "visualWarning": "Los paquetes visuales instalados necesitan atención. Ábrelos para repararlos; el juego local sigue disponible.",
+    "cardArtMissing": "No hay imágenes de cartas instaladas. Las cartas se mostrarán sin ilustración sin conexión: instala un paquete en Paquetes visuales, abajo.",
+    "cardArtInstalled": "Imágenes de cartas en caché: {{packs}}",
     "incompleteTitle": "La preparación sin conexión está incompleta",
     "incompleteMessage": "Falta: {{capabilities}}. ¿Activar Trabajar sin conexión de todos modos?",
     "confirmOffline": "Activar Trabajar sin conexión",
     "states": { "needs-preparation": "Prepara este dispositivo antes de trabajar sin conexión.", "preparing": "Preparando capacidades de juego local…", "ready": "Este dispositivo está listo para jugar sin conexión.", "failed": "Algunas capacidades necesarias no están listas.", "reconnect-required": "Vuelve a conectarte antes de preparar el juego sin conexión.", "reload-or-relaunch-required": "Recarga la aplicación o reinicia el escritorio y vuelve a preparar." },
-    "capabilities": { "appShell": "Aplicación", "browserEngine": "Motor y base de cartas", "scryfallSearch": "Datos de búsqueda", "preconCatalog": "Mazos preconstruidos", "bundledAiCatalog": "Catálogo de mazos de IA", "deckLibrary": "Biblioteca de mazos instalada", "nativeEngine": "Motor nativo" },
+    "capabilities": { "appShell": "Aplicación", "browserEngine": "Motor y base de cartas", "scryfallSearch": "Datos de búsqueda", "preconCatalog": "Mazos preconstruidos", "bundledAiCatalog": "Catálogo de mazos de IA", "deckLibrary": "Biblioteca de mazos instalada", "coreVisuals": "Reverso de carta y símbolos de maná", "nativeEngine": "Motor nativo" },
     "capabilityStates": { "ready": "Listo", "not-ready": "No listo", "reload-required": "Debe recargarse", "not-applicable": "No aplicable", "not-installed": "No instalado" }
   },
   "artChain": {

--- a/client/src/i18n/locales/fr/settings.json
+++ b/client/src/i18n/locales/fr/settings.json
@@ -404,17 +404,19 @@
   },
   "offlinePreparation": {
     "title": "Préparation hors ligne",
-    "description": "Préparez ce bureau pour le jeu local hors ligne avant d’activer le travail hors ligne.",
+    "description": "Préparez cet appareil pour le jeu local hors ligne avant d’activer le travail hors ligne.",
     "prepare": "Préparer hors ligne",
     "preparing": "Préparation…",
     "workOffline": "Travailler hors ligne",
     "checklistLabel": "Liste de préparation hors ligne",
     "visualWarning": "Les packs visuels installés nécessitent une attention. Ouvrez-les pour les réparer ; le jeu local reste disponible.",
+    "cardArtMissing": "Aucune image de carte n’est installée. Les cartes s’afficheront sans illustration hors ligne — installez un pack dans Packs visuels ci-dessous.",
+    "cardArtInstalled": "Images de cartes en cache : {{packs}}",
     "incompleteTitle": "La préparation hors ligne est incomplète",
     "incompleteMessage": "Manquant : {{capabilities}}. Activer le travail hors ligne quand même ?",
     "confirmOffline": "Activer le travail hors ligne",
     "states": { "needs-preparation": "Préparez cet appareil avant de travailler hors ligne.", "preparing": "Préparation des capacités de jeu local…", "ready": "Cet appareil est prêt pour le jeu local hors ligne.", "failed": "Certaines capacités requises ne sont pas prêtes.", "reconnect-required": "Reconnectez-vous avant de préparer le jeu hors ligne.", "reload-or-relaunch-required": "Rechargez l’application ou relancez le bureau, puis réessayez." },
-    "capabilities": { "appShell": "Application", "browserEngine": "Moteur navigateur et base de cartes", "scryfallSearch": "Données de recherche", "preconCatalog": "Decks préconstruits", "bundledAiCatalog": "Catalogue de decks IA", "deckLibrary": "Bibliothèque de decks installée", "nativeEngine": "Moteur natif" },
+    "capabilities": { "appShell": "Application", "browserEngine": "Moteur navigateur et base de cartes", "scryfallSearch": "Données de recherche", "preconCatalog": "Decks préconstruits", "bundledAiCatalog": "Catalogue de decks IA", "deckLibrary": "Bibliothèque de decks installée", "coreVisuals": "Dos de carte et symboles de mana", "nativeEngine": "Moteur natif" },
     "capabilityStates": { "ready": "Prêt", "not-ready": "Non prêt", "reload-required": "Rechargement requis", "not-applicable": "Non applicable", "not-installed": "Non installé" }
   },
   "artChain": {

--- a/client/src/i18n/locales/it/settings.json
+++ b/client/src/i18n/locales/it/settings.json
@@ -223,7 +223,7 @@
     },
     "selector": {
       "title": "Selezione del catalogo",
-      "core": "Retro della carta",
+      "core": "Retro della carta e simboli di mana",
       "printing": "Stampe del set",
       "complete": "Tutte le immagini attuali delle carte inglesi",
       "curated": "Un'immagine per carta",
@@ -343,7 +343,7 @@
       "catalog_state": "Impossibile recuperare lo stato del catalogo storico"
     },
     "packs": {
-      "core": "Retro della carta",
+      "core": "Retro della carta e simboli di mana",
       "complete": "Tutte le immagini attuali delle carte inglesi",
       "curated": "Un'immagine per carta",
       "deckLibrary": "Raccolta mazzi",
@@ -404,17 +404,19 @@
   },
   "offlinePreparation": {
     "title": "Preparazione offline",
-    "description": "Prepara questo desktop per il gioco locale offline prima di attivare Lavora offline.",
+    "description": "Prepara questo dispositivo per il gioco locale offline prima di attivare Lavora offline.",
     "prepare": "Prepara per offline",
     "preparing": "Preparazione…",
     "workOffline": "Lavora offline",
     "checklistLabel": "Elenco di preparazione offline",
     "visualWarning": "I pacchetti visivi installati richiedono attenzione. Apri Pacchetti visivi per ripararli; il gioco locale resta disponibile.",
+    "cardArtMissing": "Nessuna immagine delle carte installata. Le carte verranno mostrate senza illustrazione offline: installa un pacchetto in Pacchetti visivi, qui sotto.",
+    "cardArtInstalled": "Immagini delle carte in cache: {{packs}}",
     "incompleteTitle": "La preparazione offline è incompleta",
     "incompleteMessage": "Manca: {{capabilities}}. Attivare Lavora offline comunque?",
     "confirmOffline": "Attiva Lavora offline",
     "states": { "needs-preparation": "Prepara questo dispositivo prima di lavorare offline.", "preparing": "Preparazione delle capacità di gioco locale…", "ready": "Questo dispositivo è pronto per il gioco locale offline.", "failed": "Alcune capacità richieste non sono pronte.", "reconnect-required": "Riconnettiti prima di preparare il gioco offline.", "reload-or-relaunch-required": "Ricarica l’app o riavvia il desktop, quindi riprova." },
-    "capabilities": { "appShell": "App", "browserEngine": "Motore browser e database carte", "scryfallSearch": "Dati di ricerca", "preconCatalog": "Mazzi precostruiti", "bundledAiCatalog": "Catalogo mazzi IA", "deckLibrary": "Libreria mazzi installata", "nativeEngine": "Motore nativo" },
+    "capabilities": { "appShell": "App", "browserEngine": "Motore browser e database carte", "scryfallSearch": "Dati di ricerca", "preconCatalog": "Mazzi precostruiti", "bundledAiCatalog": "Catalogo mazzi IA", "deckLibrary": "Libreria mazzi installata", "coreVisuals": "Retro della carta e simboli di mana", "nativeEngine": "Motore nativo" },
     "capabilityStates": { "ready": "Pronto", "not-ready": "Non pronto", "reload-required": "Ricaricamento richiesto", "not-applicable": "Non applicabile", "not-installed": "Non installato" }
   },
   "artChain": {

--- a/client/src/i18n/locales/pl/settings.json
+++ b/client/src/i18n/locales/pl/settings.json
@@ -404,17 +404,19 @@
   },
   "offlinePreparation": {
     "title": "Przygotowanie offline",
-    "description": "Przygotuj ten komputer do lokalnej gry offline przed włączeniem pracy offline.",
+    "description": "Przygotuj to urządzenie do lokalnej gry offline przed włączeniem pracy offline.",
     "prepare": "Przygotuj do pracy offline",
     "preparing": "Przygotowywanie…",
     "workOffline": "Pracuj offline",
     "checklistLabel": "Lista gotowości offline",
     "visualWarning": "Zainstalowane pakiety wizualne wymagają uwagi. Otwórz Pakiety wizualne, aby je naprawić; gra lokalna pozostaje dostępna.",
+    "cardArtMissing": "Nie zainstalowano żadnych obrazów kart. Karty będą wyświetlane offline bez grafiki — zainstaluj pakiet w Pakietach wizualnych poniżej.",
+    "cardArtInstalled": "Zapisane obrazy kart: {{packs}}",
     "incompleteTitle": "Przygotowanie offline jest niepełne",
     "incompleteMessage": "Brakuje: {{capabilities}}. Mimo to włączyć pracę offline?",
     "confirmOffline": "Włącz pracę offline",
     "states": { "needs-preparation": "Przygotuj to urządzenie przed pracą offline.", "preparing": "Przygotowywanie możliwości gry lokalnej…", "ready": "To urządzenie jest gotowe do lokalnej gry offline.", "failed": "Niektóre wymagane możliwości nie są gotowe.", "reconnect-required": "Połącz się ponownie przed przygotowaniem gry offline.", "reload-or-relaunch-required": "Odśwież aplikację lub uruchom ponownie desktop, a następnie spróbuj ponownie." },
-    "capabilities": { "appShell": "Powłoka aplikacji", "browserEngine": "Silnik przeglądarki i baza kart", "scryfallSearch": "Dane wyszukiwania", "preconCatalog": "Wygenerowane talie", "bundledAiCatalog": "Katalog talii SI", "deckLibrary": "Zainstalowana biblioteka talii", "nativeEngine": "Silnik natywny" },
+    "capabilities": { "appShell": "Powłoka aplikacji", "browserEngine": "Silnik przeglądarki i baza kart", "scryfallSearch": "Dane wyszukiwania", "preconCatalog": "Wygenerowane talie", "bundledAiCatalog": "Katalog talii SI", "deckLibrary": "Zainstalowana biblioteka talii", "coreVisuals": "Rewers karty i symbole many", "nativeEngine": "Silnik natywny" },
     "capabilityStates": { "ready": "Gotowe", "not-ready": "Nie gotowe", "reload-required": "Wymagane odświeżenie", "not-applicable": "Nie dotyczy", "not-installed": "Nie zainstalowano" }
   },
   "artChain": {

--- a/client/src/i18n/locales/pt/settings.json
+++ b/client/src/i18n/locales/pt/settings.json
@@ -404,17 +404,19 @@
   },
   "offlinePreparation": {
     "title": "Preparação offline",
-    "description": "Prepare este desktop para jogo local offline antes de ativar Trabalhar offline.",
+    "description": "Prepare este dispositivo para jogo local offline antes de ativar Trabalhar offline.",
     "prepare": "Preparar para offline",
     "preparing": "Preparando…",
     "workOffline": "Trabalhar offline",
     "checklistLabel": "Lista de preparação offline",
     "visualWarning": "Os pacotes visuais instalados precisam de atenção. Abra Pacotes visuais para repará-los; o jogo local continua disponível.",
+    "cardArtMissing": "Nenhuma imagem de carta instalada. As cartas serão exibidas sem arte offline — instale um pacote em Pacotes visuais, abaixo.",
+    "cardArtInstalled": "Imagens de cartas em cache: {{packs}}",
     "incompleteTitle": "A preparação offline está incompleta",
     "incompleteMessage": "Falta: {{capabilities}}. Ativar Trabalhar offline mesmo assim?",
     "confirmOffline": "Ativar Trabalhar offline",
     "states": { "needs-preparation": "Prepare este dispositivo antes de trabalhar offline.", "preparing": "Preparando capacidades de jogo local…", "ready": "Este dispositivo está pronto para jogo local offline.", "failed": "Algumas capacidades necessárias não estão prontas.", "reconnect-required": "Reconecte-se antes de preparar o jogo offline.", "reload-or-relaunch-required": "Recarregue o aplicativo ou reinicie o desktop e tente novamente." },
-    "capabilities": { "appShell": "Aplicativo", "browserEngine": "Motor do navegador e banco de cartas", "scryfallSearch": "Dados de busca", "preconCatalog": "Decks pré-construídos", "bundledAiCatalog": "Catálogo de decks de IA", "deckLibrary": "Biblioteca de decks instalada", "nativeEngine": "Motor nativo" },
+    "capabilities": { "appShell": "Aplicativo", "browserEngine": "Motor do navegador e banco de cartas", "scryfallSearch": "Dados de busca", "preconCatalog": "Decks pré-construídos", "bundledAiCatalog": "Catálogo de decks de IA", "deckLibrary": "Biblioteca de decks instalada", "coreVisuals": "Verso da carta e símbolos de mana", "nativeEngine": "Motor nativo" },
     "capabilityStates": { "ready": "Pronto", "not-ready": "Não pronto", "reload-required": "Recarga necessária", "not-applicable": "Não aplicável", "not-installed": "Não instalado" }
   },
   "artChain": {

--- a/client/src/services/__tests__/offlinePreparation.test.ts
+++ b/client/src/services/__tests__/offlinePreparation.test.ts
@@ -21,6 +21,7 @@ vi.mock("../nativeEngine.ts", () => ({
 }));
 
 import { prepareForOffline } from "../offlinePreparation.ts";
+import { MANA_SYMBOL_SHARDS } from "../scryfall.ts";
 
 const assetsReady = {
   status: "ready",
@@ -32,6 +33,30 @@ const assetsReady = {
     deckLibrary: { status: "not-installed" },
   },
 } as const;
+
+/**
+ * A visual-pack backend whose core install succeeds, so that a test about ART
+ * reporting is not also a test about the core pack.
+ *
+ * `start` answers `healthy` — the backend's own "already installed, nothing to
+ * do" reply — which is the shortest path through `installCorePack` and needs no
+ * progress events. Tests that care about the install itself override it.
+ */
+function visualBackend(overrides: Record<string, unknown> = {}) {
+  return {
+    catalogStatus: vi.fn(async () => ({ status: "ready", summary: { installedPacks: [{ packId: "core" }] } })),
+    verify: vi.fn(async () => ({ issues: [] })),
+    subscribeProgress: vi.fn(async () => () => undefined),
+    start: vi.fn(async () => ({ status: "healthy" })),
+    operationStatus: vi.fn(async () => ({ state: "completed" })),
+    ...overrides,
+  };
+}
+
+/** `catalogStatus` reporting exactly these packs as installed. */
+function installed(...packIds: string[]) {
+  return vi.fn(async () => ({ status: "ready", summary: { installedPacks: packIds.map((packId) => ({ packId })) } }));
+}
 
 describe("prepareForOffline", () => {
   beforeEach(() => {
@@ -68,16 +93,19 @@ describe("prepareForOffline", () => {
       calls.push("assets");
       return assetsReady;
     });
-    const visual = {
+    // Core is already installed, so this stays a test of ORDER rather than of
+    // the install. The catalog is read twice on purpose: once to decide whether
+    // core needs installing, then again for the art inventory afterwards.
+    const visual = visualBackend({
       catalogStatus: vi.fn(async () => {
         calls.push("catalog");
-        return { status: "ready", summary: { installedPacks: [{}] } };
+        return { status: "ready", summary: { installedPacks: [{ packId: "core" }, { packId: "curated" }] } };
       }),
       verify: vi.fn(async () => {
         calls.push("verify");
         return { issues: [] };
       }),
-    };
+    });
     mocks.loadVisual.mockImplementation(async () => {
       calls.push("visual");
       return visual;
@@ -91,7 +119,7 @@ describe("prepareForOffline", () => {
 
     await expect(prepareForOffline({ nativeEngineEnabled: true })).resolves.toMatchObject({ status: "ready" });
 
-    expect(calls).toEqual(["shell", "assets", "visual", "catalog", "verify", "native", "shell"]);
+    expect(calls).toEqual(["shell", "assets", "visual", "catalog", "catalog", "verify", "native", "shell"]);
     expect(mocks.prepareNative).toHaveBeenCalledWith({ release: { version: "1.0.0" } });
   });
 
@@ -109,10 +137,10 @@ describe("prepareForOffline", () => {
   });
 
   it("keeps optional visual verification issues visible without blocking ready local play", async () => {
-    mocks.loadVisual.mockResolvedValue({
-      catalogStatus: vi.fn(async () => ({ status: "ready", summary: { installedPacks: [{}] } })),
+    mocks.loadVisual.mockResolvedValue(visualBackend({
+      catalogStatus: installed("core", "curated"),
       verify: vi.fn(async () => ({ issues: [{ kind: "missing_object" }] })),
-    });
+    }));
 
     await expect(prepareForOffline({ nativeEngineEnabled: false })).resolves.toMatchObject({
       status: "ready",
@@ -148,11 +176,12 @@ describe("prepareForOffline", () => {
 
   it.each([
     ["no backend", null, { status: "not-installed" }],
-    ["empty catalog", { catalogStatus: vi.fn(async () => ({ status: "empty" })) }, { status: "not-installed" }],
-    ["invalid catalog", { catalogStatus: vi.fn(async () => ({ status: "invalid" })) }, { status: "warning", issueKinds: ["invalid-catalog"] }],
-    ["no installed packs", { catalogStatus: vi.fn(async () => ({ status: "ready", summary: { installedPacks: [] } })) }, { status: "not-installed" }],
+    ["empty catalog", visualBackend({ catalogStatus: vi.fn(async () => ({ status: "empty" })) }), { status: "not-installed" }],
+    ["invalid catalog", visualBackend({ catalogStatus: vi.fn(async () => ({ status: "invalid" })) }), { status: "warning", issueKinds: ["invalid-catalog"] }],
+    ["no installed packs", visualBackend({ catalogStatus: installed() }), { status: "not-installed" }],
+    ["only the core pack", visualBackend({ catalogStatus: installed("core") }), { status: "not-installed" }],
   ] as const)("reports optional visual %s without verification", async (_label, backend, visualPacks) => {
-    mocks.loadVisual.mockResolvedValueOnce(backend);
+    mocks.loadVisual.mockResolvedValue(backend);
 
     await expect(prepareForOffline({ nativeEngineEnabled: false })).resolves.toMatchObject({
       status: "ready",
@@ -161,21 +190,94 @@ describe("prepareForOffline", () => {
   });
 
   it("reports healthy installed visual packs and catches visual backend failures as optional warnings", async () => {
-    const healthy = {
-      catalogStatus: vi.fn(async () => ({ status: "ready" as const, summary: { installedPacks: [{}] } })),
-      verify: vi.fn(async () => ({ issues: [] })),
-    };
-    mocks.loadVisual.mockResolvedValueOnce(healthy);
+    const healthy = visualBackend({ catalogStatus: installed("core", "curated") });
+    mocks.loadVisual.mockResolvedValue(healthy);
     await expect(prepareForOffline({ nativeEngineEnabled: false })).resolves.toMatchObject({
       status: "ready",
-      visualPacks: { status: "ready" },
+      visualPacks: { status: "ready", installedPacks: ["curated"] },
     });
     expect(healthy.verify).toHaveBeenCalledWith("full");
 
+    // A backend that fails to LOAD leaves art as an optional warning, but core
+    // — the card back and mana symbols — is genuinely absent and cannot be
+    // installed, so overall readiness is not "ready". That distinction is the
+    // whole point of core being a required capability rather than an advisory.
     mocks.loadVisual.mockRejectedValueOnce(new Error("adapter unavailable"));
     await expect(prepareForOffline({ nativeEngineEnabled: false })).resolves.toMatchObject({
-      status: "ready",
+      status: "failed",
+      requiredGaps: ["coreVisuals"],
       visualPacks: { status: "warning", issueKinds: ["unavailable"] },
+    });
+  });
+
+  it("installs the core pack when it is missing, rather than only reporting it", async () => {
+    // Installed only AFTER the install runs, which is what makes this a test of
+    // the install rather than of the report: the first read finds no core.
+    const catalogStatus = vi.fn()
+      .mockResolvedValueOnce({ status: "ready", summary: { installedPacks: [] } })
+      .mockResolvedValue({ status: "ready", summary: { installedPacks: [{ packId: "core" }] } });
+    const backend = visualBackend({ catalogStatus });
+    mocks.loadVisual.mockResolvedValue(backend);
+
+    await expect(prepareForOffline({ nativeEngineEnabled: false })).resolves.toMatchObject({
+      status: "ready",
+      capabilities: { coreVisuals: { status: "ready" } },
+    });
+    expect(backend.start).toHaveBeenCalledWith({
+      kind: "install",
+      selector: { kind: "core" },
+      // Derived, not a literal: a hardcoded count would silently go stale the
+      // day a mana shard is added to the catalog.
+      objectEstimate: 1 + MANA_SYMBOL_SHARDS.length,
+    });
+  });
+
+  it("does not reinstall the core pack when it is already on disk", async () => {
+    const backend = visualBackend({ catalogStatus: installed("core") });
+    mocks.loadVisual.mockResolvedValue(backend);
+
+    await expect(prepareForOffline({ nativeEngineEnabled: false })).resolves.toMatchObject({
+      capabilities: { coreVisuals: { status: "ready" } },
+    });
+    expect(backend.start).not.toHaveBeenCalled();
+  });
+
+  it("holds readiness back when the core install fails", async () => {
+    const backend = visualBackend({
+      catalogStatus: installed(),
+      start: vi.fn(async () => { throw new Error("network"); }),
+    });
+    mocks.loadVisual.mockResolvedValue(backend);
+
+    await expect(prepareForOffline({ nativeEngineEnabled: false })).resolves.toMatchObject({
+      status: "failed",
+      requiredGaps: ["coreVisuals"],
+      capabilities: { coreVisuals: { status: "not-ready" } },
+    });
+  });
+
+  it("waits for a started core install to reach a terminal progress event", async () => {
+    let emit: ((event: unknown) => void) | null = null;
+    const backend = visualBackend({
+      catalogStatus: installed(),
+      subscribeProgress: vi.fn(async (listener: (event: unknown) => void) => {
+        emit = listener;
+        return () => undefined;
+      }),
+      start: vi.fn(async () => ({ status: "started", operationId: "op-7" })),
+      // Still downloading at the post-start read, so only the event can settle it.
+      operationStatus: vi.fn(async () => ({ state: "downloading" })),
+    });
+    mocks.loadVisual.mockResolvedValue(backend);
+
+    const preparation = prepareForOffline({ nativeEngineEnabled: false });
+    await vi.waitFor(() => { expect(emit).not.toBeNull(); });
+    // An event for a DIFFERENT operation must not settle this wait.
+    emit!({ phase: "completed", operation: { operationId: "op-other" } });
+    emit!({ phase: "completed", operation: { operationId: "op-7" } });
+
+    await expect(preparation).resolves.toMatchObject({
+      capabilities: { coreVisuals: { status: "ready" } },
     });
   });
 

--- a/client/src/services/offlinePreparation.ts
+++ b/client/src/services/offlinePreparation.ts
@@ -1,8 +1,25 @@
 import { canAttemptNativeEngine, nativeEngineKeyForCurrentOrigin, prepareNativeEngineForOffline } from "./nativeEngine.ts";
 import { prepareOfflineAssets, type OfflineAssetsReadiness } from "./offlineAssets.ts";
 import { loadVisualPackBackend } from "./platform.ts";
+import { MANA_SYMBOL_SHARDS } from "./scryfall.ts";
+import type { VisualPackBackend } from "./visualPacks/backend.ts";
+import { packId, type CatalogStatus, type OperationId, type PackId } from "./visualPacks/types.ts";
 import { checkAppShellReadiness, type AppShellReadiness } from "../pwa/registerServiceWorker.ts";
 import { getEffectiveOffline } from "../stores/connectivityStore.ts";
+
+const CORE_PACK = packId("core");
+
+/**
+ * How many objects a core install writes: the card back plus one SVG per mana
+ * shard, matching `coreDescriptors()` in `visualPacks/browser/scryfallBulk.ts`.
+ *
+ * Only a progress hint — the install derives the real membership itself, and
+ * nothing validates this figure. It is computed rather than written as a
+ * literal so the symbol half cannot drift; `estimateInstall` is deliberately
+ * NOT the source, because every count it returns is a pre-rendered display
+ * string that can legitimately read "unknown".
+ */
+const CORE_OBJECT_ESTIMATE = 1 + MANA_SYMBOL_SHARDS.length;
 
 export type OfflinePreparationStatus =
   | "ready"
@@ -17,6 +34,7 @@ export type OfflinePreparationCapabilityName =
   | "preconCatalog"
   | "bundledAiCatalog"
   | "deckLibrary"
+  | "coreVisuals"
   | "nativeEngine";
 
 export type OfflinePreparationCapabilityStatus =
@@ -30,9 +48,21 @@ export interface OfflinePreparationCapability {
   readonly status: OfflinePreparationCapabilityStatus;
 }
 
+/**
+ * The state of the installed CARD ART, which is reported but never required.
+ *
+ * Deliberately excludes the `core` pack, which is a required capability of its
+ * own above: core is chrome every game screen draws, whereas art is a
+ * preference — a deck plays correctly with no art installed, it just renders
+ * without it. Folding the two together is what let this panel report "ready"
+ * while nothing at all was cached.
+ */
 export interface OfflinePreparationVisualCapability {
   readonly status: "ready" | "not-installed" | "warning";
   readonly issueKinds?: readonly string[];
+  /** The art packs on disk, so the panel can name what is cached rather than
+   *  only whether something is. Never includes `core`. */
+  readonly installedPacks?: readonly PackId[];
 }
 
 export interface OfflinePreparationResult {
@@ -51,6 +81,7 @@ function unavailableCapabilities(): Record<OfflinePreparationCapabilityName, Off
     preconCatalog: { status: "not-ready" },
     bundledAiCatalog: { status: "not-ready" },
     deckLibrary: { status: "not-ready" },
+    coreVisuals: { status: "not-ready" },
     nativeEngine: { status: "not-applicable" },
   };
 }
@@ -71,7 +102,7 @@ function shellResult(readiness: AppShellReadiness, final = false): OfflinePrepar
 }
 
 function assetCapabilities(readiness: OfflineAssetsReadiness): Record<
-  Exclude<OfflinePreparationCapabilityName, "appShell" | "nativeEngine">,
+  Exclude<OfflinePreparationCapabilityName, "appShell" | "coreVisuals" | "nativeEngine">,
   OfflinePreparationCapability
 > {
   return {
@@ -83,20 +114,118 @@ function assetCapabilities(readiness: OfflineAssetsReadiness): Record<
   };
 }
 
-async function prepareVisualPacks(): Promise<OfflinePreparationVisualCapability> {
+/** The installed packs that carry card art. `core` is excluded: it is chrome,
+ *  and it is reported by its own required capability. */
+function cardArtPacks(catalog: CatalogStatus): readonly PackId[] {
+  if (catalog.status !== "ready") return [];
+  return catalog.summary.installedPacks
+    .map((pack) => pack.packId)
+    .filter((pack) => pack !== CORE_PACK);
+}
+
+/**
+ * How this platform's visual-pack backend answered when asked for.
+ *
+ * `absent` and `unavailable` are deliberately separate: a platform with no
+ * backend at all is not a gap a user can close, while one whose backend failed
+ * to load is an error that a retry may fix. Collapsing them would either
+ * mark healthy platforms permanently unready or hide a real failure.
+ */
+type VisualPackAccess =
+  | { readonly kind: "backend"; readonly backend: VisualPackBackend }
+  | { readonly kind: "absent" }
+  | { readonly kind: "unavailable" };
+
+async function accessVisualPacks(): Promise<VisualPackAccess> {
   try {
     const backend = await loadVisualPackBackend();
-    if (!backend) return { status: "not-installed" };
+    return backend ? { kind: "backend", backend } : { kind: "absent" };
+  } catch {
+    return { kind: "unavailable" };
+  }
+}
+
+async function prepareVisualPacks(access: VisualPackAccess): Promise<OfflinePreparationVisualCapability> {
+  if (access.kind === "unavailable") return { status: "warning", issueKinds: ["unavailable"] };
+  if (access.kind === "absent") return { status: "not-installed", installedPacks: [] };
+  const backend = access.backend;
+  try {
     const catalog = await backend.catalogStatus();
-    if (catalog.status === "empty") return { status: "not-installed" };
     if (catalog.status === "invalid") return { status: "warning", issueKinds: ["invalid-catalog"] };
-    if (catalog.summary.installedPacks.length === 0) return { status: "not-installed" };
+    const installedPacks = cardArtPacks(catalog);
+    if (installedPacks.length === 0) return { status: "not-installed", installedPacks: [] };
     const verification = await backend.verify("full");
     return verification.issues.length === 0
-      ? { status: "ready" }
-      : { status: "warning", issueKinds: verification.issues.map((issue) => issue.kind) };
+      ? { status: "ready", installedPacks }
+      : { status: "warning", issueKinds: verification.issues.map((issue) => issue.kind), installedPacks };
   } catch {
     return { status: "warning", issueKinds: ["unavailable"] };
+  }
+}
+
+/**
+ * Drives a core install to a terminal state.
+ *
+ * The subscription is opened BEFORE `start()`, so no event of this operation
+ * can be emitted before there is a listener for it; events belonging to other
+ * operations (a concurrent deck-library reconcile) are filtered by id. The
+ * single `operationStatus` read after `start()` closes the remaining window —
+ * `start()` launches `run()` without awaiting it, so an install that finished
+ * between the two would otherwise leave this waiting on an event already sent.
+ */
+async function installCorePack(backend: VisualPackBackend): Promise<OfflinePreparationCapability> {
+  let operation: OperationId | null = null;
+  let settle: (capability: OfflinePreparationCapability) => void = () => undefined;
+  const settled = new Promise<OfflinePreparationCapability>((resolve) => { settle = resolve; });
+  const unsubscribe = await backend.subscribeProgress((event) => {
+    if (operation === null || event.operation.operationId !== operation) return;
+    if (event.phase === "completed") settle({ status: "ready" });
+    if (event.phase === "failed" || event.phase === "cancelled") settle({ status: "not-ready" });
+  });
+  try {
+    const response = await backend.start({
+      kind: "install",
+      selector: { kind: "core" },
+      objectEstimate: CORE_OBJECT_ESTIMATE,
+    });
+    if (response.status === "healthy") return { status: "ready" };
+    operation = response.operationId;
+    const current = await backend.operationStatus(operation);
+    if (current.state === "completed") return { status: "ready" };
+    if (current.state === "cancelled") return { status: "not-ready" };
+    return await settled;
+  } finally {
+    unsubscribe();
+  }
+}
+
+/**
+ * Ensures the core visual pack — the card back and every mana symbol — is on
+ * disk, and reports whether it is.
+ *
+ * The one capability here that INSTALLS a visual pack rather than only
+ * inspecting one, and required rather than advisory, because core is what
+ * every game screen draws regardless of deck or set: a mana cost with no pips
+ * is unreadable, and no other pack carries them. It is also small enough
+ * (~77 files) that routing the user to the Visual Packs panel to choose it
+ * would be ceremony rather than consent — the same judgement `prepareOffline`
+ * already makes for the native engine and the deck-library pack.
+ */
+async function prepareCoreVisuals(access: VisualPackAccess): Promise<OfflinePreparationCapability> {
+  // No backend at all is not a gap the user can close, so it must not hold
+  // offline preparation permanently red. A backend that failed to LOAD is a
+  // different answer: core is genuinely absent and a retry may fix it.
+  if (access.kind === "absent") return { status: "not-applicable" };
+  if (access.kind === "unavailable") return { status: "not-ready" };
+  const backend = access.backend;
+  try {
+    const catalog = await backend.catalogStatus();
+    if (catalog.status === "ready" && catalog.summary.installedPacks.some((pack) => pack.packId === CORE_PACK)) {
+      return { status: "ready" };
+    }
+    return await installCorePack(backend);
+  } catch {
+    return { status: "not-ready" };
   }
 }
 
@@ -112,13 +241,19 @@ function requiredGaps(
 /**
  * Runs the existing, release-specific preparation authorities once and reports
  * their fresh result. It deliberately never writes connectivity policy.
+ *
+ * "Prepare" means prepare: like the native engine and the deck-library pack,
+ * the core visual pack is INSTALLED here when missing rather than merely
+ * reported, so that a green checklist means the next offline session actually
+ * works. Card art is the one thing left to the user, and it is now named
+ * rather than silently omitted.
  */
 export async function prepareForOffline({ nativeEngineEnabled }: { nativeEngineEnabled: boolean }): Promise<OfflinePreparationResult> {
   if (getEffectiveOffline()) {
     return {
       status: "reconnect-required",
       capabilities: unavailableCapabilities(),
-      visualPacks: { status: "not-installed" },
+      visualPacks: { status: "not-installed", installedPacks: [] },
       requiredGaps: [],
     };
   }
@@ -127,7 +262,12 @@ export async function prepareForOffline({ nativeEngineEnabled }: { nativeEngineE
   if (initialShell) return initialShell;
 
   const assets = await prepareOfflineAssets();
-  const visualPacks = await prepareVisualPacks();
+  // One backend for both, and core FIRST: the art inventory must be read after
+  // the core install, or a first preparation reports the art state of a catalog
+  // it is about to change.
+  const visualPackAccess = await accessVisualPacks();
+  const coreVisuals = await prepareCoreVisuals(visualPackAccess);
+  const visualPacks = await prepareVisualPacks(visualPackAccess);
   let nativeEngine: OfflinePreparationCapability = (() => {
     if (!nativeEngineEnabled || !canAttemptNativeEngine(true)) return { status: "not-applicable" };
     return { status: "not-ready" };
@@ -149,6 +289,7 @@ export async function prepareForOffline({ nativeEngineEnabled }: { nativeEngineE
   const capabilities: Record<OfflinePreparationCapabilityName, OfflinePreparationCapability> = {
     appShell: { status: "ready" },
     ...assetCapabilities(assets),
+    coreVisuals,
     nativeEngine,
   };
   const finalShell = await checkAppShellReadiness();

--- a/client/src/services/scryfall.ts
+++ b/client/src/services/scryfall.ts
@@ -40,14 +40,56 @@ interface ScryfallDataEntry {
 export const CARD_BACK_URL =
   "https://backs.scryfall.io/normal/0/a/0aeebaf5-8c7d-4636-9e82-8c27447861f7.jpg";
 
-/** Build the authoritative Scryfall source URL for an admitted mana shard. */
-export function manaSymbolSourceUrl(shard: string): string {
-  const code = shard === "∞"
+declare const manaSymbolShardBrand: unique symbol;
+/** A mana shard string admitted by the finite Scryfall card-symbol catalog. */
+export type ManaSymbolShard = string & { readonly [manaSymbolShardBrand]: true };
+
+const SINGLE_MANA_SYMBOL_SHARDS = [
+  "W", "U", "B", "R", "G", "C", "S", "T", "Q", "E", "P", "X", "Y", "Z", "A", "∞", "½", "CHAOS",
+] as const;
+const COMPOSITE_MANA_SYMBOL_SHARDS = [
+  "W/U", "W/B", "U/B", "U/R", "B/R", "B/G", "R/W", "R/G", "G/W", "G/U",
+  "2/W", "2/U", "2/B", "2/R", "2/G",
+  "W/P", "U/P", "B/P", "R/P", "G/P",
+  "W/U/P", "W/B/P", "U/B/P", "U/R/P", "B/R/P", "B/G/P", "R/W/P", "R/G/P", "G/W/P", "G/U/P",
+  "C/W", "C/U", "C/B", "C/R", "C/G",
+] as const;
+const FINITE_NUMERIC_MANA_SYMBOL_SHARDS: readonly string[] = [
+  ...Array.from({ length: 21 }, (_, value) => String(value)),
+  "100",
+  "1000000",
+];
+const MANA_SYMBOL_SHARD_SET = new Set<string>([
+  ...SINGLE_MANA_SYMBOL_SHARDS,
+  ...COMPOSITE_MANA_SYMBOL_SHARDS,
+  ...FINITE_NUMERIC_MANA_SYMBOL_SHARDS,
+]);
+
+/** True when `shard` has a corresponding Scryfall card-symbol SVG. */
+export function isManaSymbolShard(shard: string): shard is ManaSymbolShard {
+  return MANA_SYMBOL_SHARD_SET.has(shard);
+}
+
+/** Every admitted mana shard, for callers that must enumerate the whole
+ *  finite catalog (e.g. pre-caching every symbol for offline play). */
+export const MANA_SYMBOL_SHARDS: readonly ManaSymbolShard[] =
+  Array.from(MANA_SYMBOL_SHARD_SET) as ManaSymbolShard[];
+
+/** The URL- and asset-key-safe code for an admitted mana shard: strips the
+ *  hybrid/Phyrexian slash separators and spells out the two symbols with no
+ *  ASCII representation, matching Scryfall's `card-symbols` filenames. Also
+ *  usable verbatim as an `[A-Za-z0-9_-]+` visual-pack asset-key suffix. */
+export function manaSymbolCode(shard: string): string {
+  return shard === "∞"
     ? "INFINITY"
     : shard === "½"
       ? "HALF"
       : shard.replace(/\//g, "");
-  return `https://svgs.scryfall.io/card-symbols/${encodeURIComponent(code)}.svg`;
+}
+
+/** Build the authoritative Scryfall source URL for an admitted mana shard. */
+export function manaSymbolSourceUrl(shard: string): string {
+  return `https://svgs.scryfall.io/card-symbols/${encodeURIComponent(manaSymbolCode(shard))}.svg`;
 }
 
 export interface PrintingEntry {

--- a/client/src/services/visualPacks/browser/__tests__/coreDescriptors.test.ts
+++ b/client/src/services/visualPacks/browser/__tests__/coreDescriptors.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+
+import { CARD_BACK_URL, MANA_SYMBOL_SHARDS, manaSymbolSourceUrl } from "../../../scryfall.ts";
+import { manaSymbolCandidate } from "../../candidateKeys.ts";
+import { catalogRoot, packId } from "../../types.ts";
+import { countScryfallAssets, forEachScryfallAsset, type ScryfallAssetDescriptor, type ScryfallBulkSource } from "../scryfallBulk.ts";
+
+// The `core` arm of both functions is planned entirely from local constants —
+// it never opens the bulk stream — so this source is only there to satisfy the
+// signature, and a fetch that reached the network would fail the run.
+const UNUSED_SOURCE: ScryfallBulkSource = Object.freeze({
+  root: catalogRoot("a".repeat(64)),
+  downloadUrl: "https://data.scryfall.io/all-cards.jsonl.gz",
+  updatedAt: "2026-08-01T00:00:00.000Z",
+  compressedBytes: 1,
+});
+
+const unreachableFetch = (async () => {
+  throw new Error("the core selector must not fetch");
+}) as unknown as typeof fetch;
+
+async function coreDescriptors(): Promise<ScryfallAssetDescriptor[]> {
+  const descriptors: ScryfallAssetDescriptor[] = [];
+  await forEachScryfallAsset(
+    UNUSED_SOURCE,
+    { kind: "core" },
+    new AbortController().signal,
+    (descriptor) => { descriptors.push(descriptor); },
+    unreachableFetch,
+  );
+  return descriptors;
+}
+
+describe("the core visual pack", () => {
+  it("installs the card back and every finite mana symbol", async () => {
+    const descriptors = await coreDescriptors();
+    const sources = descriptors.map((descriptor) => descriptor.sourceUrl);
+
+    expect(sources).toContain(CARD_BACK_URL);
+    expect(sources).toEqual(expect.arrayContaining(MANA_SYMBOL_SHARDS.map(manaSymbolSourceUrl)));
+    expect(descriptors).toHaveLength(1 + MANA_SYMBOL_SHARDS.length);
+    expect(descriptors.every((descriptor) => descriptor.packId === packId("core"))).toBe(true);
+  });
+
+  /** The contract that actually makes an installed symbol reachable: the key
+   *  the installer writes must be the key `useManaSymbolImage` looks up. A
+   *  mismatch caches every pip and renders none of them. */
+  it("keys each mana symbol under the candidate the renderer resolves", async () => {
+    const byCandidate = new Map(
+      (await coreDescriptors()).flatMap((descriptor) =>
+        descriptor.candidateKeys.map((key) => [key, descriptor] as const)),
+    );
+
+    for (const shard of MANA_SYMBOL_SHARDS) {
+      const descriptor = byCandidate.get(manaSymbolCandidate(shard));
+      expect(descriptor, `no core descriptor for {${shard}}`).toBeDefined();
+      expect(descriptor?.sourceUrl).toBe(manaSymbolSourceUrl(shard));
+      // Scryfall serves these as SVG, and `fetchImage` rejects any response
+      // whose Content-Type disagrees with the descriptor's declared media.
+      expect(descriptor?.media).toBe("image/svg+xml");
+    }
+  });
+
+  /** `manaSymbolCode` strips the hybrid/Phyrexian slashes, so two distinct
+   *  shards could collide into one asset key and silently install 75 of 76. */
+  it("gives every asset a distinct key", async () => {
+    const keys = (await coreDescriptors()).map((descriptor) => descriptor.assetKey);
+    expect(new Set(keys).size).toBe(keys.length);
+  });
+
+  it("counts exactly what it installs", async () => {
+    const counted = await countScryfallAssets(
+      UNUSED_SOURCE,
+      { kind: "core" },
+      new AbortController().signal,
+      undefined,
+      unreachableFetch,
+    );
+    expect(counted).toBe((await coreDescriptors()).length);
+  });
+});

--- a/client/src/services/visualPacks/browser/__tests__/curatedDelta.test.ts
+++ b/client/src/services/visualPacks/browser/__tests__/curatedDelta.test.ts
@@ -7,7 +7,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { STORAGE_KEY_PREFIX } from "../../../../constants/storage.ts";
 import { usePreferencesStore, type ArtChainEntry, type CardArtOverride } from "../../../../stores/preferencesStore.ts";
 import type { DeckEntry } from "../../../deckParser.ts";
-import { CARD_BACK_URL, loadScryfallData, type PrintingEntry } from "../../../scryfall.ts";
+import { CARD_BACK_URL, MANA_SYMBOL_SHARDS, loadScryfallData, type PrintingEntry } from "../../../scryfall.ts";
 import { assetKey, packId } from "../../types.ts";
 import type { AssetKey, CatalogRoot, CuratedDrift, InstallSelector, OperationId, ProgressEvent, ResolutionResponse } from "../../types.ts";
 import type { ScryfallAssetDescriptor } from "../descriptors.ts";
@@ -199,17 +199,25 @@ function imageResponse(source: string): Response {
   return new Response(new TextEncoder().encode(source), { status: 200, headers: { "Content-Type": "image/jpeg" } });
 }
 
+/** `fetchImage` rejects a response whose Content-Type doesn't match the
+ *  descriptor's declared media, so mana-symbol SVGs need their own stub. */
+function svgResponse(source: string): Response {
+  return new Response(new TextEncoder().encode(source), { status: 200, headers: { "Content-Type": "image/svg+xml" } });
+}
+
 const fetchStub = vi.fn(async (input: RequestInfo | URL): Promise<Response> => {
   const source = String(input);
   requested.push(source);
   if (source === BULK_INDEX_URL) return jsonResponse({ data: [BULK_RECORD] });
   if (source === "/scryfall-data.json") return jsonResponse(CARDS);
   if (source === "/scryfall-printings.json") return jsonResponse(PRINTINGS);
-  // The `core` pack's only image, served with the SAME bytes as Bolt's newest
-  // normal rung. Content addressing then gives both packs one cache entry, so
-  // "an image another pack still uses" is a real shared path rather than a
-  // claim about one.
+  // The card back, served with the SAME bytes as Bolt's newest normal rung.
+  // Content addressing then gives both packs one cache entry, so "an image
+  // another pack still uses" is a real shared path rather than a claim about
+  // one.
   if (source === CARD_BACK_URL) return imageResponse(url(BOLT_NEW.id, "normal"));
+  // The `core` pack's other constituent: every finite mana-symbol SVG.
+  if (source.startsWith("https://svgs.scryfall.io/card-symbols/")) return svgResponse(source);
   if (source.startsWith("https://cards.scryfall.io/")) {
     if (held?.matches(source)) await held.gate;
     if (failImages || imagesServed >= imageBudget) return new Response("", { status: 503 });
@@ -325,10 +333,10 @@ async function failures(backend: ScryfallBrowserVisualPackBackend): Promise<Prog
   return events;
 }
 
-async function settle(backend: ScryfallBrowserVisualPackBackend, operation: OperationId): Promise<void> {
+async function settle(backend: ScryfallBrowserVisualPackBackend, operation: OperationId, timeout = 5000): Promise<void> {
   await vi.waitFor(async () => {
     expect((await backend.operationStatus(operation)).state).toBe("completed");
-  }, { timeout: 5000 });
+  }, { timeout });
 }
 
 async function startCurated(backend: ScryfallBrowserVisualPackBackend): Promise<{
@@ -357,9 +365,13 @@ async function installCurated(backend: ScryfallBrowserVisualPackBackend): Promis
 }
 
 async function installCore(backend: ScryfallBrowserVisualPackBackend): Promise<void> {
-  const response = await backend.start({ kind: "install", selector: { kind: "core" }, objectEstimate: 1 });
+  const objectEstimate = 1 + MANA_SYMBOL_SHARDS.length;
+  const response = await backend.start({ kind: "install", selector: { kind: "core" }, objectEstimate });
   if (response.status !== "started") throw new Error("core install did not start");
-  await settle(backend, response.operationId);
+  // The card back plus every finite mana-symbol SVG — an order of magnitude
+  // more objects than the 5s default budgets for, so this settle gets its own
+  // allowance rather than raising the shared default other callers rely on.
+  await settle(backend, response.operationId, 10000);
 }
 
 /** Every installed object a render-time asset lookup can actually reach. */
@@ -593,7 +605,7 @@ describe("curated delta install", () => {
     expect(cache.entries.has(soloPath)).toBe(false);
     const back = await backend.resolve([{ kind: "asset", key: assetKey("asset:v1:card_back:default") }]);
     expect(back.entries[0].matches).toHaveLength(1);
-  });
+  }, 10000);
 
   it("sweeps identically when a pack is removed rather than replaced", async () => {
     const backend = await ScryfallBrowserVisualPackBackend.create();
@@ -618,7 +630,7 @@ describe("curated delta install", () => {
     expect(await resolvedAssets(backend, first.descriptors)).toHaveLength(0);
     const back = await backend.resolve([{ kind: "asset", key: assetKey("asset:v1:card_back:default") }]);
     expect(back.entries[0].matches).toHaveLength(1);
-  });
+  }, 10000);
 
   it("clears rows and images stranded at a cancelled install's digest", async () => {
     const backend = await ScryfallBrowserVisualPackBackend.create();
@@ -724,7 +736,7 @@ describe("curated delta install", () => {
     } finally {
       restore();
     }
-  });
+  }, 10000);
 
   it("adopts content from a pack that is not curated", async () => {
     const backend = await ScryfallBrowserVisualPackBackend.create();

--- a/client/src/services/visualPacks/browser/__tests__/curatedSelector.test.tsx
+++ b/client/src/services/visualPacks/browser/__tests__/curatedSelector.test.tsx
@@ -8,7 +8,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { VisualPackManager } from "../../../../components/settings/visual-packs/VisualPackManager.tsx";
 import { useVisualPackManager } from "../../../../components/settings/visual-packs/useVisualPackManager.ts";
 import { usePreferencesStore, type ArtChainEntry } from "../../../../stores/preferencesStore.ts";
-import type { PrintingEntry } from "../../../scryfall.ts";
+import { MANA_SYMBOL_SHARDS, type PrintingEntry } from "../../../scryfall.ts";
 import { packId } from "../../types.ts";
 import type { CatalogRoot, InstallSelector, OperationId, ProgressEvent, ResolutionResponse } from "../../types.ts";
 import type { ScryfallAssetDescriptor } from "../descriptors.ts";
@@ -135,6 +135,12 @@ function imageResponse(source: string): Response {
   return new Response(new TextEncoder().encode(source), { status: 200, headers: { "Content-Type": "image/jpeg" } });
 }
 
+/** `fetchImage` rejects a response whose Content-Type doesn't match the
+ *  descriptor's declared media, so mana-symbol SVGs need their own stub. */
+function svgResponse(source: string): Response {
+  return new Response(new TextEncoder().encode(source), { status: 200, headers: { "Content-Type": "image/svg+xml" } });
+}
+
 /** A transient image outage: `fetchImage` rejects a non-200 as `network`. */
 let failImages = false;
 let holdLaterImages = false;
@@ -147,6 +153,10 @@ const fetchStub = vi.fn(async (input: RequestInfo | URL): Promise<Response> => {
   if (source === BULK_INDEX_URL) return jsonResponse({ data: [BULK_RECORD] });
   if (source === "/scryfall-data.json") return jsonResponse(CARDS);
   if (source === "/scryfall-printings.json") return jsonResponse(PRINTINGS);
+  if (source.startsWith("https://svgs.scryfall.io/card-symbols/")) {
+    if (holdLaterImages && imageRequests().length > 1) await heldImages;
+    return failImages ? new Response("", { status: 503 }) : svgResponse(source);
+  }
   if (source.startsWith("https://cards.scryfall.io/") || source.startsWith("https://backs.scryfall.io/")) {
     if (holdLaterImages && imageRequests().length > 1) await heldImages;
     return failImages ? new Response("", { status: 503 }) : imageResponse(source);
@@ -205,10 +215,10 @@ async function operationRecords(): Promise<unknown[]> {
   return records;
 }
 
-async function settle(backend: ScryfallBrowserVisualPackBackend, operation: OperationId): Promise<void> {
+async function settle(backend: ScryfallBrowserVisualPackBackend, operation: OperationId, timeout = 5000): Promise<void> {
   await vi.waitFor(async () => {
     expect((await backend.operationStatus(operation)).state).toBe("completed");
-  }, { timeout: 5000 });
+  }, { timeout });
 }
 
 async function installCurated(backend: ScryfallBrowserVisualPackBackend): Promise<{
@@ -572,17 +582,21 @@ describe("curated install selector", () => {
 
   it("keeps a non-curated pack on the bulk catalog root", async () => {
     const backend = await ScryfallBrowserVisualPackBackend.create();
-    const response = await backend.start({ kind: "install", selector: { kind: "core" }, objectEstimate: 1 });
+    const objectEstimate = 1 + MANA_SYMBOL_SHARDS.length;
+    const response = await backend.start({ kind: "install", selector: { kind: "core" }, objectEstimate });
     if (response.status !== "started") throw new Error("core install did not start");
-    await settle(backend, response.operationId);
+    // The card back plus every finite mana-symbol SVG — an order of magnitude
+    // more objects than the 5s default budgets for, so this settle gets its
+    // own allowance rather than raising the shared default other callers rely on.
+    await settle(backend, response.operationId, 20000);
 
     const summary = await backend.catalogSummary();
     expect(summary.installedPacks).toEqual([{ packId: packId("core"), catalogRoot: summary.catalogRoot }]);
     expect(response.catalogRoot).toBe(summary.catalogRoot);
     // The restructured installed-filter must still short-circuit a re-install.
-    expect(await backend.start({ kind: "install", selector: { kind: "core" }, objectEstimate: 1 }))
+    expect(await backend.start({ kind: "install", selector: { kind: "core" }, objectEstimate }))
       .toEqual({ status: "healthy" });
-  });
+  }, 10000);
 
   it("replaces the membership wholesale when the art chain changes the digest", async () => {
     const backend = await ScryfallBrowserVisualPackBackend.create();

--- a/client/src/services/visualPacks/browser/scryfallBulk.ts
+++ b/client/src/services/visualPacks/browser/scryfallBulk.ts
@@ -1,13 +1,13 @@
 import { Gunzip } from "fflate";
 
 import { VisualPackBackendError } from "../backend.ts";
-import { cardBackCandidate, cardCandidateGroups, setIconCandidate } from "../candidateKeys.ts";
+import { cardBackCandidate, cardCandidateGroups, manaSymbolCandidate, setIconCandidate } from "../candidateKeys.ts";
 import { curatedDescriptors } from "../curatedPack.ts";
 import { planDeckLibraryPack } from "../deckLibraryPack.ts";
 import { assetKey, catalogRoot, packId, type CatalogRoot, type CatalogScanProgress, type InstallSelector, type PackId } from "../types.ts";
 import { descriptor, englishDescriptors } from "./descriptors.ts";
 import type { CardIdentity, ScryfallAssetDescriptor } from "./descriptors.ts";
-import { CARD_BACK_URL } from "../../scryfall.ts";
+import { CARD_BACK_URL, MANA_SYMBOL_SHARDS, manaSymbolCode, manaSymbolSourceUrl } from "../../scryfall.ts";
 
 // `ScryfallAssetDescriptor` moved to `descriptors.ts` alongside the builders
 // that produce it; re-exported so existing importers of this module are
@@ -149,14 +149,30 @@ function imageCount(card: CardIdentity, faceLimit = card.faces.length): number {
   return count;
 }
 
-function coreDescriptors(): ScryfallAssetDescriptor[] {
-  return [{
+/** Every finite mana-shard SVG (`{W}`, `{2/U}`, `{∞}`, …) — set- and
+ *  deck-independent, so it belongs in `core` alongside the card back rather
+ *  than any per-printing pack. */
+function manaSymbolDescriptors(): ScryfallAssetDescriptor[] {
+  return MANA_SYMBOL_SHARDS.map((shard) => ({
     packId: packId("core"),
-    assetKey: assetKey("asset:v1:card_back:default"),
-    candidateKeys: [cardBackCandidate()],
-    sourceUrl: CARD_BACK_URL,
-    media: "image/jpeg",
-  }];
+    assetKey: assetKey(`asset:v1:mana_symbol:${manaSymbolCode(shard)}`),
+    candidateKeys: [manaSymbolCandidate(shard)],
+    sourceUrl: manaSymbolSourceUrl(shard),
+    media: "image/svg+xml",
+  }));
+}
+
+function coreDescriptors(): ScryfallAssetDescriptor[] {
+  return [
+    {
+      packId: packId("core"),
+      assetKey: assetKey("asset:v1:card_back:default"),
+      candidateKeys: [cardBackCandidate()],
+      sourceUrl: CARD_BACK_URL,
+      media: "image/jpeg",
+    },
+    ...manaSymbolDescriptors(),
+  ];
 }
 
 function setIconDescriptor(selectedPack: PackId, set: string): ScryfallAssetDescriptor {

--- a/client/src/services/visualPacks/types.ts
+++ b/client/src/services/visualPacks/types.ts
@@ -325,9 +325,17 @@ const CHEAPEST_IMAGE_BYTES = Math.min(...RUNG_MEDIANS);
  * which is NOT measured here; a set of records skewed entirely onto one rung
  * would be overstated ~3.8x (all `small`) or understated ~1.6x (all `normal`).
  *
- * `core` and `printing` also contribute a card back and a set icon, which are
- * not card art at all. One and one per pack against tens of thousands of card
- * images, so they are counted at the same weight rather than modelled.
+ * `printing` also contributes a set icon, which is not card art at all. One per
+ * pack against tens of thousands of card images, so it is counted at the same
+ * weight rather than modelled.
+ *
+ * `core` no longer fits that reasoning and is OVERSTATED here by roughly 20x:
+ * it is a card back plus every finite mana-symbol SVG (~77 records), of which
+ * none are card art and nearly all are 1-2 KB vectors — so a real ~230 KB
+ * download is quoted at ~4.9 MB. Nothing refuses on this figure
+ * (`reserveStorage` gates on `minimumImageBytes`), so the cost is a misleading
+ * label rather than a blocked install. Modelling it needs a per-media weight,
+ * which this signature — a bare record COUNT — cannot express.
  */
 export function estimatedImageBytes(imageRecords: number): number {
   return Math.round(imageRecords * MEAN_IMAGE_BYTES);


### PR DESCRIPTION
Mana cost pips are the one visual the app neither bundles nor service-worker caches: they are per-symbol SVGs from `svgs.scryfall.io`, deliberately excluded from the Workbox runtime rules (see the CORS note in `vite.config.ts`), so their only offline path is the visual-pack Cache Storage system. `mana_symbol` was defined as an asset and candidate kind there, but nothing ever emitted a descriptor for it — so the pips were never installed and every mana cost fell back to bare text offline.

Keyword and player-HUD icons were never affected: they are glyphs from the bundled `mana-font` woff2, which Workbox already precaches.

## The fix

`coreDescriptors()` now emits one descriptor per shard in the finite Scryfall symbol catalog, alongside the card back. `core` is the right home — mana symbols are set- and deck-independent, unlike set icons, which stay attached to their per-set printing packs. The catalog itself moves to `services/scryfall.ts` next to `manaSymbolSourceUrl`, since it was duplicated between `ManaSymbol.tsx` and `useFixedVisualImage.ts` and the installer now needs it too.

## Prepare for Offline

That fix alone only reached users who had installed `core` themselves, so Prepare for Offline now installs it:

- **`coreVisuals` is a required capability that Prepare INSTALLS when missing**, the way it already prepares the native engine and the deck library. A failed install holds readiness back instead of reporting green.
- **Card art is reported rather than silently omitted.** The panel names the installed packs, or warns when there are none. The `not-installed` case previously rendered nothing at all, so a device with zero images cached still read "ready for offline local play" — `visualPacks` sat beside `capabilities` and was structurally unable to enter the verdict.
- **Core and card art are now distinct concepts.** Core is chrome every board draws (required); card art is a preference (advisory) — a deck plays correctly with none installed.
- **The panel is no longer gated on the desktop shell.** The service worker precaches the app shell, engine WASM and card data for the browser too, and the browser is where a player is most likely to enable Work Offline having cached nothing.

Also corrects the `core` pack's en/es/it label, which still read "Card back", and the `estimatedImageBytes` doc comment, whose justification for weighting non-card-art assets at card-art size no longer holds for core (it now overstates core by ~20x; `reserveStorage` gates on `minimumImageBytes`, so nothing refuses on it).

## Testing

- New `coreDescriptors.test.ts` (4 tests): count, per-shard candidate-key agreement between the installer and `useManaSymbolImage`, `media: "image/svg+xml"`, asset-key uniqueness, and `countScryfallAssets` agreement. Drives the real `forEachScryfallAsset` core arm with a throwing fetcher, so a future regression that opens the bulk stream for `core` fails rather than passing slowly.
- Four new `offlinePreparation` tests: install-when-missing, skip-when-present, hold-back-on-failure, and the terminal-event wait (including that another operation's event must not settle it).
- Three new UI tests: the no-images warning, the named-packs line, and the core row in the checklist.
- Non-vacuity verified by reverting each production change and confirming the new tests go red.
- All 76 symbol URLs probed live at HTTP 200. Worth noting: a 404 now fails the whole core install, where previously a bad symbol URL only degraded one glyph to text.

https://claude.ai/code/session_01RtBf74gnapvcsEqQiPnjmC


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Offline preparation now works in browser and desktop settings.
  - Automatically prepares essential visuals, including card backs and mana symbols.
  - Shows whether card artwork is unavailable or which artwork packs are installed.
  - Improved mana-symbol handling and rendering consistency.

- **Localization**
  - Updated offline-preparation labels and guidance across supported languages.

- **Tests**
  - Added coverage for visual readiness, core assets, cached artwork, and browser availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->