### PR TITLE
fix(client): re-baseline the keep-alive across a backward clock step

### DIFF
--- a/client/src/adapter/p2p-adapter.ts
+++ b/client/src/adapter/p2p-adapter.ts
@@ -635,6 +635,18 @@ const RECONNECT_STEADY_STATE_MS = 60_000;
  * guest has wrong; the user's recovery is a reload, not a retry. The
  * stale-state watchdog cannot help: for a guest, the adapter cache and the
  * screen go stale together, so the fingerprints match and its check returns.
+ *
+ * A SECOND residual is new here, and it belongs to the single unkeyed pending
+ * slot. Once this timer has rejected submission A, a retry B parks in that same
+ * slot, and A's late `state_update` settles B: its revision is NEWER than the
+ * guest's cached one, so the stale-revision guard above does not drop it. B's
+ * own frame then arrives, finds nothing pending, and emits `stateChanged`, so
+ * the board still converges — the cost is one early resolve carrying another
+ * action's events. Routing replies correctly needs a wire request id echoed on
+ * every settlement frame, i.e. a `WIRE_PROTOCOL_VERSION` bump, and is deferred.
+ * Do NOT instead widen the revision guard to drop such frames: dropping the
+ * frame that reports application is the deadlock the acceptance ledger exists
+ * to end.
  */
 const SUBMISSION_TIMEOUT_MS = 30_000;
 // A stale proposal leaves the prompt unchanged, so cap retries to prevent a

--- a/client/src/network/__tests__/peer.test.ts
+++ b/client/src/network/__tests__/peer.test.ts
@@ -365,4 +365,33 @@ describe("PeerSession keep-alive", () => {
       vi.useRealTimers();
     }
   });
+
+  it("re-baselines after the wall clock moves backward", async () => {
+    vi.useFakeTimers();
+    try {
+      const conn = new SilentPeerConnection();
+      const session = createPeerSession(conn as never);
+      const onDisconnect = vi.fn();
+      session.onDisconnect(onDisconnect);
+
+      // One healthy tick: 5s of silence, not yet the budget.
+      await vi.advanceTimersByTimeAsync(5_000);
+      expect(onDisconnect).not.toHaveBeenCalled();
+
+      // The wall clock steps BACKWARD a minute (NTP correction, manual clock
+      // change, VM restore). `setSystemTime` moves pending deadlines with it,
+      // so ticks keep their 5s spacing — only `Date.now()` jumps.
+      vi.setSystemTime(Date.now() - 60_000);
+
+      // The peer has never ponged, so it must still be declared dead. Without
+      // the negative-gap re-baseline, `lastPongAt` is stranded a minute in the
+      // future and `now - lastPongAt` stays negative, so this detector would
+      // stay disabled until the clock caught up — the failure this guards.
+      await vi.advanceTimersByTimeAsync(20_000);
+
+      expect(onDisconnect).toHaveBeenCalledWith("Ping timeout");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });

--- a/client/src/network/peer.ts
+++ b/client/src/network/peer.ts
@@ -157,7 +157,14 @@ export function createPeerSession(
       // That is the intended trade. The alternative — concluding silence from a
       // gap the tick cannot explain — false-disconnects a healthy peer, which
       // is the harm this whole branch exists to prevent.
-      if (sinceLastTick >= PONG_TIMEOUT_MS) {
+      // `Date.now()` is wall-clock, so it can also move BACKWARD (an NTP step,
+      // a manual clock change, a VM restore). That strands `lastPongAt` in the
+      // future, and every later comparison then reads as "answered recently"
+      // until the clock catches up — the detector silently disables itself for
+      // the width of the jump. A negative gap is a discontinuity for the same
+      // reason an oversized one is: the tick observed no interval it can vouch
+      // for, so the elapsed time is no evidence about the peer. Re-baseline.
+      if (sinceLastTick >= PONG_TIMEOUT_MS || sinceLastTick < 0) {
         lastPongAt = now;
       } else if (now - lastPongAt >= PONG_TIMEOUT_MS) {
         handleDisconnect("Ping timeout");


### PR DESCRIPTION
`Date.now()` is wall-clock, so it can move backward (an NTP step, a
manual clock change, a VM restore). The keep-alive treated only an
oversized inter-tick gap as a discontinuity, so a backward step left
`lastPongAt` stranded in the future: every later `now - lastPongAt`
read as "answered recently", and the detector silently disabled itself
for the width of the jump — on a channel that may genuinely be dead.

Treat a negative gap as the same class of discontinuity as an oversized
one, for the same reason: the tick observed no interval it can vouch
for, so the elapsed time is no evidence about the peer. The regression
test fails without the guard (1 failed / 18 passed) and passes with it
(19 passed).

Also records the second residual of the single unkeyed pending slot,
which the 30s timeout makes newly reachable: after a timeout rejects
submission A, a retry B parks in the same slot and A's late
`state_update` settles B, because A's revision is newer than the guest's
cached one and so survives the stale-revision guard. The board still
converges when B's own frame emits `stateChanged`; routing replies
correctly needs a wire request id and stays deferred.

Both raised by CodeRabbit on #8365.

Claude-Session: https://claude.ai/code/session_01SKXMrb8mH6tLbz7U8keCE5
