### PR TITLE
fix(client): complete the mana symbol catalog and verify core bytes

### DIFF
--- a/client/src/components/settings/OfflinePreparationSection.tsx
+++ b/client/src/components/settings/OfflinePreparationSection.tsx
@@ -119,7 +119,7 @@ export function OfflinePreparationSection({ nativeEngineEnabled }: { nativeEngin
           type="button"
           onClick={() => { void prepare("prepare"); }}
           disabled={preparing}
-          className="rounded-[14px] border border-sky-400/40 bg-sky-500/14 px-4 py-2 text-sm font-medium text-sky-100 transition hover:bg-sky-500/25 disabled:cursor-not-allowed disabled:opacity-60"
+          className="min-h-11 rounded-[14px] border border-sky-400/40 bg-sky-500/14 px-4 py-2 text-sm font-medium text-sky-100 transition hover:bg-sky-500/25 disabled:cursor-not-allowed disabled:opacity-60"
         >
           {preparing ? t("offlinePreparation.preparing") : t("offlinePreparation.prepare")}
         </button>

--- a/client/src/services/__tests__/manaSymbolCatalog.test.ts
+++ b/client/src/services/__tests__/manaSymbolCatalog.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  isManaSymbolShard,
+  manaSymbolCode,
+  manaSymbolSourceUrl,
+  MANA_SYMBOL_SHARDS,
+} from "../scryfall.ts";
+
+/**
+ * Every symbol Scryfall's `/symbology` endpoint publishes, transcribed here as
+ * a literal on 2026-09-04 (84 entries, each with an `svg_uri`).
+ *
+ * WRITTEN OUT rather than derived, and that is the entire point of this file.
+ * The catalog decides two things at once: whether `RichLabel` renders a glyph
+ * or literal brace text, and whether `coreDescriptors()` installs the SVG for
+ * offline play. An omission is therefore invisible to any test that iterates
+ * `MANA_SYMBOL_SHARDS` to build its own expectation — it would simply check a
+ * smaller set against itself and pass. Only an independently-sourced list can
+ * see a missing symbol.
+ *
+ * When Scryfall adds a symbol this test fails, which is the intended signal:
+ * refresh from `https://api.scryfall.com/symbology` and add it to the catalog.
+ */
+const SCRYFALL_SYMBOLOGY: readonly string[] = [
+  "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "A", "B", "C", "D", "E", "G", "H", "L", "P",
+  "Q", "R", "S", "T", "U", "W", "X", "Y", "Z", "½", "∞", "10", "11", "12", "13", "14", "15",
+  "16", "17", "18", "19", "20", "HR", "HW", "PW", "TK", "100", "2/B", "2/G", "2/R", "2/U",
+  "2/W", "B/G", "B/P", "B/R", "C/B", "C/G", "C/P", "C/R", "C/U", "C/W", "G/P", "G/U", "G/W",
+  "R/G", "R/P", "R/W", "U/B", "U/P", "U/R", "W/B", "W/P", "W/U", "B/G/P", "B/R/P", "CHAOS",
+  "G/U/P", "G/W/P", "R/G/P", "R/W/P", "U/B/P", "U/R/P", "W/B/P", "W/U/P", "1000000",
+];
+
+describe("the mana symbol catalog", () => {
+  it("admits exactly the symbols Scryfall publishes", () => {
+    expect([...MANA_SYMBOL_SHARDS].sort()).toEqual([...SCRYFALL_SYMBOLOGY].sort());
+  });
+
+  it("admits every published symbol through the render-time guard", () => {
+    const rejected = SCRYFALL_SYMBOLOGY.filter((symbol) => !isManaSymbolShard(symbol));
+    expect(rejected).toEqual([]);
+  });
+
+  it("rejects notation that has no Scryfall symbol", () => {
+    // Guards the negative direction: a guard that returned true for everything
+    // would satisfy the assertion above and admit garbage into the installer.
+    for (const notation of ["", "WW", "21", "W/", "/W", "{W}", "w", "FOO", "1/2"]) {
+      expect(isManaSymbolShard(notation), `expected {${notation}} to be rejected`).toBe(false);
+    }
+  });
+
+  /** The codes are the last path segment of an SVG URL and the suffix of a
+   *  visual-pack asset key, so a collision would silently install one symbol's
+   *  art under another's identity. */
+  it("maps every symbol to a distinct URL-safe code", () => {
+    const codes = MANA_SYMBOL_SHARDS.map(manaSymbolCode);
+    expect(new Set(codes).size).toBe(codes.length);
+    expect(codes.filter((code) => !/^[A-Za-z0-9_-]+$/.test(code))).toEqual([]);
+  });
+
+  it("builds the documented Scryfall URL, spelling out the two non-ASCII symbols", () => {
+    expect(manaSymbolSourceUrl("W")).toBe("https://svgs.scryfall.io/card-symbols/W.svg");
+    expect(manaSymbolSourceUrl("2/W")).toBe("https://svgs.scryfall.io/card-symbols/2W.svg");
+    expect(manaSymbolSourceUrl("C/P")).toBe("https://svgs.scryfall.io/card-symbols/CP.svg");
+    expect(manaSymbolSourceUrl("∞")).toBe("https://svgs.scryfall.io/card-symbols/INFINITY.svg");
+    expect(manaSymbolSourceUrl("½")).toBe("https://svgs.scryfall.io/card-symbols/HALF.svg");
+  });
+});

--- a/client/src/services/__tests__/offlinePreparation.test.ts
+++ b/client/src/services/__tests__/offlinePreparation.test.ts
@@ -318,21 +318,6 @@ describe("prepareForOffline", () => {
     });
   });
 
-  it("does not hang when operationStatus already reports failed", async () => {
-    const backend = visualBackend({
-      catalogStatus: installed(),
-      resolve: resolvesCore(false),
-      start: vi.fn(async () => ({ status: "started", operationId: "op-failed" })),
-      operationStatus: vi.fn(async () => ({ state: "failed" })),
-    });
-    mocks.loadVisual.mockResolvedValue(backend);
-
-    await expect(prepareForOffline({ nativeEngineEnabled: false })).resolves.toMatchObject({
-      status: "failed",
-      requiredGaps: ["coreVisuals"],
-      capabilities: { coreVisuals: { status: "not-ready" } },
-    });
-  });
 
   it("holds readiness back when the core install fails", async () => {
     const backend = visualBackend({

--- a/client/src/services/__tests__/offlinePreparation.test.ts
+++ b/client/src/services/__tests__/offlinePreparation.test.ts
@@ -318,6 +318,22 @@ describe("prepareForOffline", () => {
     });
   });
 
+  it("does not hang when operationStatus already reports failed", async () => {
+    const backend = visualBackend({
+      catalogStatus: installed(),
+      resolve: resolvesCore(false),
+      start: vi.fn(async () => ({ status: "started", operationId: "op-failed" })),
+      operationStatus: vi.fn(async () => ({ state: "failed" })),
+    });
+    mocks.loadVisual.mockResolvedValue(backend);
+
+    await expect(prepareForOffline({ nativeEngineEnabled: false })).resolves.toMatchObject({
+      status: "failed",
+      requiredGaps: ["coreVisuals"],
+      capabilities: { coreVisuals: { status: "not-ready" } },
+    });
+  });
+
   it("holds readiness back when the core install fails", async () => {
     const backend = visualBackend({
       catalogStatus: installed(),

--- a/client/src/services/__tests__/offlinePreparation.test.ts
+++ b/client/src/services/__tests__/offlinePreparation.test.ts
@@ -49,8 +49,29 @@ function visualBackend(overrides: Record<string, unknown> = {}) {
     subscribeProgress: vi.fn(async () => () => undefined),
     start: vi.fn(async () => ({ status: "healthy" })),
     operationStatus: vi.fn(async () => ({ state: "completed" })),
+    remove: vi.fn(async () => ({ removed: [], revision: "1", cleanupIssues: [] })),
+    resolve: resolvesCore(true),
     ...overrides,
   };
+}
+
+/**
+ * A `resolve` answering that every requested candidate either is or is not
+ * backed by cached bytes in `core`.
+ *
+ * The real `resolve` admits an object only when `cache.match(path)` succeeds,
+ * so `matches: []` is exactly how an evicted or corrupt cache presents itself
+ * while the pack receipt is still on disk.
+ */
+function resolvesCore(present: boolean) {
+  return vi.fn(async (keys: { kind: string; key: string }[]) => ({
+    revision: "1",
+    entries: keys.map((key, ordinal) => ({
+      ordinal,
+      key,
+      matches: present ? [{ packId: "core", assetKey: `asset:${key.key}` }] : [],
+    })),
+  }));
 }
 
 /** `catalogStatus` reporting exactly these packs as installed. */
@@ -93,9 +114,9 @@ describe("prepareForOffline", () => {
       calls.push("assets");
       return assetsReady;
     });
-    // Core is already installed, so this stays a test of ORDER rather than of
-    // the install. The catalog is read twice on purpose: once to decide whether
-    // core needs installing, then again for the art inventory afterwards.
+    // Core resolves cleanly, so this stays a test of ORDER rather than of the
+    // install. The catalog is read once, by the art inventory: core is gated on
+    // `resolve`, and only consults the catalog when something is missing.
     const visual = visualBackend({
       catalogStatus: vi.fn(async () => {
         calls.push("catalog");
@@ -119,7 +140,7 @@ describe("prepareForOffline", () => {
 
     await expect(prepareForOffline({ nativeEngineEnabled: true })).resolves.toMatchObject({ status: "ready" });
 
-    expect(calls).toEqual(["shell", "assets", "visual", "catalog", "catalog", "verify", "native", "shell"]);
+    expect(calls).toEqual(["shell", "assets", "visual", "catalog", "verify", "native", "shell"]);
     expect(mocks.prepareNative).toHaveBeenCalledWith({ release: { version: "1.0.0" } });
   });
 
@@ -211,12 +232,12 @@ describe("prepareForOffline", () => {
   });
 
   it("installs the core pack when it is missing, rather than only reporting it", async () => {
-    // Installed only AFTER the install runs, which is what makes this a test of
-    // the install rather than of the report: the first read finds no core.
-    const catalogStatus = vi.fn()
-      .mockResolvedValueOnce({ status: "ready", summary: { installedPacks: [] } })
-      .mockResolvedValue({ status: "ready", summary: { installedPacks: [{ packId: "core" }] } });
-    const backend = visualBackend({ catalogStatus });
+    // Nothing resolves until the install has run, which is what makes this a
+    // test of the install rather than of the report.
+    const resolve = vi.fn()
+      .mockImplementationOnce(resolvesCore(false))
+      .mockImplementation(resolvesCore(true));
+    const backend = visualBackend({ catalogStatus: installed(), resolve });
     mocks.loadVisual.mockResolvedValue(backend);
 
     await expect(prepareForOffline({ nativeEngineEnabled: false })).resolves.toMatchObject({
@@ -232,7 +253,7 @@ describe("prepareForOffline", () => {
     });
   });
 
-  it("does not reinstall the core pack when it is already on disk", async () => {
+  it("does not reinstall the core pack when its assets are already drawable", async () => {
     const backend = visualBackend({ catalogStatus: installed("core") });
     mocks.loadVisual.mockResolvedValue(backend);
 
@@ -242,9 +263,65 @@ describe("prepareForOffline", () => {
     expect(backend.start).not.toHaveBeenCalled();
   });
 
+  /**
+   * The receipt outliving the bytes is the case a catalog-only check cannot
+   * see: Cache Storage was evicted, so `core` is installed and undrawable.
+   *
+   * The recovery must DROP the receipt first. Both `start()` paths key on that
+   * receipt standing at the current root — an install short-circuits to
+   * `healthy` and a repair filters its own selector out — so an install issued
+   * while it stands would report success and download nothing. That is
+   * recorded as MEASURED in `scryfallBackend.ts`, and asserting the order here
+   * is what stops the recovery from silently regressing into a no-op.
+   */
+  it("drops the stale receipt before reinstalling core when its cached bytes are gone", async () => {
+    const resolve = vi.fn()
+      .mockImplementationOnce(resolvesCore(false))
+      .mockImplementation(resolvesCore(true));
+    const order: string[] = [];
+    const backend = visualBackend({
+      catalogStatus: installed("core"),
+      resolve,
+      remove: vi.fn(async () => { order.push("remove"); return { removed: [], revision: "1", cleanupIssues: [] }; }),
+      start: vi.fn(async () => { order.push("start"); return { status: "healthy" }; }),
+    });
+    mocks.loadVisual.mockResolvedValue(backend);
+
+    await expect(prepareForOffline({ nativeEngineEnabled: false })).resolves.toMatchObject({
+      capabilities: { coreVisuals: { status: "ready" } },
+    });
+    expect(backend.remove).toHaveBeenCalledWith({ kind: "packs", packIds: ["core"] }, "reject_dependents");
+    expect(order).toEqual(["remove", "start"]);
+  });
+
+  it("does not drop a receipt that does not exist when first installing core", async () => {
+    const resolve = vi.fn()
+      .mockImplementationOnce(resolvesCore(false))
+      .mockImplementation(resolvesCore(true));
+    const backend = visualBackend({ catalogStatus: installed(), resolve, remove: vi.fn() });
+    mocks.loadVisual.mockResolvedValue(backend);
+
+    await expect(prepareForOffline({ nativeEngineEnabled: false })).resolves.toMatchObject({
+      capabilities: { coreVisuals: { status: "ready" } },
+    });
+    expect(backend.remove).not.toHaveBeenCalled();
+  });
+
+  it("stays not-ready when core assets are still missing after the operation", async () => {
+    const backend = visualBackend({ catalogStatus: installed("core"), resolve: resolvesCore(false) });
+    mocks.loadVisual.mockResolvedValue(backend);
+
+    await expect(prepareForOffline({ nativeEngineEnabled: false })).resolves.toMatchObject({
+      status: "failed",
+      requiredGaps: ["coreVisuals"],
+      capabilities: { coreVisuals: { status: "not-ready" } },
+    });
+  });
+
   it("holds readiness back when the core install fails", async () => {
     const backend = visualBackend({
       catalogStatus: installed(),
+      resolve: resolvesCore(false),
       start: vi.fn(async () => { throw new Error("network"); }),
     });
     mocks.loadVisual.mockResolvedValue(backend);
@@ -260,6 +337,9 @@ describe("prepareForOffline", () => {
     let emit: ((event: unknown) => void) | null = null;
     const backend = visualBackend({
       catalogStatus: installed(),
+      // Missing before the install, present after — otherwise the install path
+      // is never entered and there is no progress event to wait on.
+      resolve: vi.fn().mockImplementationOnce(resolvesCore(false)).mockImplementation(resolvesCore(true)),
       subscribeProgress: vi.fn(async (listener: (event: unknown) => void) => {
         emit = listener;
         return () => undefined;

--- a/client/src/services/offlinePreparation.ts
+++ b/client/src/services/offlinePreparation.ts
@@ -226,7 +226,7 @@ async function runCoreInstall(backend: VisualPackBackend): Promise<void> {
     if (response.status === "healthy") return;
     operation = response.operationId;
     const current = await backend.operationStatus(operation);
-    if (current.state === "completed" || current.state === "cancelled" || current.state === "failed") return;
+    if (current.state === "completed" || current.state === "cancelled") return;
     await settled;
   } finally {
     unsubscribe();

--- a/client/src/services/offlinePreparation.ts
+++ b/client/src/services/offlinePreparation.ts
@@ -3,7 +3,14 @@ import { prepareOfflineAssets, type OfflineAssetsReadiness } from "./offlineAsse
 import { loadVisualPackBackend } from "./platform.ts";
 import { MANA_SYMBOL_SHARDS } from "./scryfall.ts";
 import type { VisualPackBackend } from "./visualPacks/backend.ts";
-import { packId, type CatalogStatus, type OperationId, type PackId } from "./visualPacks/types.ts";
+import { cardBackCandidate, manaSymbolCandidate } from "./visualPacks/candidateKeys.ts";
+import {
+  packId,
+  type CatalogStatus,
+  type OperationId,
+  type PackId,
+  type ResolutionKey,
+} from "./visualPacks/types.ts";
 import { checkAppShellReadiness, type AppShellReadiness } from "../pwa/registerServiceWorker.ts";
 import { getEffectiveOffline } from "../stores/connectivityStore.ts";
 
@@ -163,8 +170,37 @@ async function prepareVisualPacks(access: VisualPackAccess): Promise<OfflinePrep
   }
 }
 
+/** Every candidate key a board draws from the core pack, in the same form
+ *  `useManaSymbolImage` and the card-back hook look them up by. */
+function coreCandidateKeys(): ResolutionKey[] {
+  return [
+    { kind: "candidate", key: cardBackCandidate() },
+    ...MANA_SYMBOL_SHARDS.map((shard) => ({ kind: "candidate" as const, key: manaSymbolCandidate(shard) })),
+  ];
+}
+
 /**
- * Drives a core install to a terminal state.
+ * The core assets a board would fail to draw right now.
+ *
+ * `catalogStatus()` reports the pack RECEIPT, which survives Cache Storage
+ * eviction and corruption — so a receipt alone cannot say the pips are
+ * actually there. `resolve()` can: it admits an object only when
+ * `cache.match(object.path)` succeeds, and each match carries its `packId`,
+ * which is the pack-scoped integrity answer `verify()` does not give.
+ */
+async function missingCoreAssets(backend: VisualPackBackend): Promise<number> {
+  const keys = coreCandidateKeys();
+  const resolution = await backend.resolve(keys);
+  const resolved = new Set(
+    resolution.entries
+      .filter((entry) => entry.matches.some((match) => match.packId === CORE_PACK))
+      .map((entry) => entry.key.key),
+  );
+  return keys.length - resolved.size;
+}
+
+/**
+ * Drives a core install or repair to a terminal state.
  *
  * The subscription is opened BEFORE `start()`, so no event of this operation
  * can be emitted before there is a listener for it; events belonging to other
@@ -173,14 +209,13 @@ async function prepareVisualPacks(access: VisualPackAccess): Promise<OfflinePrep
  * `start()` launches `run()` without awaiting it, so an install that finished
  * between the two would otherwise leave this waiting on an event already sent.
  */
-async function installCorePack(backend: VisualPackBackend): Promise<OfflinePreparationCapability> {
+async function runCoreInstall(backend: VisualPackBackend): Promise<void> {
   let operation: OperationId | null = null;
-  let settle: (capability: OfflinePreparationCapability) => void = () => undefined;
-  const settled = new Promise<OfflinePreparationCapability>((resolve) => { settle = resolve; });
+  let settle: () => void = () => undefined;
+  const settled = new Promise<void>((resolve) => { settle = resolve; });
   const unsubscribe = await backend.subscribeProgress((event) => {
     if (operation === null || event.operation.operationId !== operation) return;
-    if (event.phase === "completed") settle({ status: "ready" });
-    if (event.phase === "failed" || event.phase === "cancelled") settle({ status: "not-ready" });
+    if (event.phase === "completed" || event.phase === "failed" || event.phase === "cancelled") settle();
   });
   try {
     const response = await backend.start({
@@ -188,12 +223,11 @@ async function installCorePack(backend: VisualPackBackend): Promise<OfflinePrepa
       selector: { kind: "core" },
       objectEstimate: CORE_OBJECT_ESTIMATE,
     });
-    if (response.status === "healthy") return { status: "ready" };
+    if (response.status === "healthy") return;
     operation = response.operationId;
     const current = await backend.operationStatus(operation);
-    if (current.state === "completed") return { status: "ready" };
-    if (current.state === "cancelled") return { status: "not-ready" };
-    return await settled;
+    if (current.state === "completed" || current.state === "cancelled") return;
+    await settled;
   } finally {
     unsubscribe();
   }
@@ -207,9 +241,13 @@ async function installCorePack(backend: VisualPackBackend): Promise<OfflinePrepa
  * inspecting one, and required rather than advisory, because core is what
  * every game screen draws regardless of deck or set: a mana cost with no pips
  * is unreadable, and no other pack carries them. It is also small enough
- * (~77 files) that routing the user to the Visual Packs panel to choose it
+ * (~85 files) that routing the user to the Visual Packs panel to choose it
  * would be ceremony rather than consent — the same judgement `prepareOffline`
  * already makes for the native engine and the deck-library pack.
+ *
+ * The verdict is decided by `missingCoreAssets`, NOT by the pack receipt, and
+ * both before and after any work: a receipt outlives the bytes it describes,
+ * so "installed" and "drawable offline" are different questions.
  */
 async function prepareCoreVisuals(access: VisualPackAccess): Promise<OfflinePreparationCapability> {
   // No backend at all is not a gap the user can close, so it must not hold
@@ -219,11 +257,22 @@ async function prepareCoreVisuals(access: VisualPackAccess): Promise<OfflinePrep
   if (access.kind === "unavailable") return { status: "not-ready" };
   const backend = access.backend;
   try {
-    const catalog = await backend.catalogStatus();
-    if (catalog.status === "ready" && catalog.summary.installedPacks.some((pack) => pack.packId === CORE_PACK)) {
-      return { status: "ready" };
+    if (await missingCoreAssets(backend) > 0) {
+      const catalog = await backend.catalogStatus();
+      const receipt = catalog.status === "ready"
+        && catalog.summary.installedPacks.some((pack) => pack.packId === CORE_PACK);
+      // A receipt whose bytes are gone cannot be refilled through `start()`:
+      // BOTH an install and a repair key on that receipt standing at the
+      // current root, so the install short-circuits to `healthy` and the
+      // repair filters its own selector out — see the `cacheContains` note in
+      // scryfallBackend.ts, which records this as MEASURED. Dropping the
+      // receipt first is the recovery that note prescribes, and it costs the
+      // same ~85 small files the install downloads anyway. Nothing declares a
+      // dependency on `core`, so the removal cannot be rejected.
+      if (receipt) await backend.remove({ kind: "packs", packIds: [CORE_PACK] }, "reject_dependents");
+      await runCoreInstall(backend);
     }
-    return await installCorePack(backend);
+    return await missingCoreAssets(backend) === 0 ? { status: "ready" } : { status: "not-ready" };
   } catch {
     return { status: "not-ready" };
   }

--- a/client/src/services/offlinePreparation.ts
+++ b/client/src/services/offlinePreparation.ts
@@ -226,7 +226,7 @@ async function runCoreInstall(backend: VisualPackBackend): Promise<void> {
     if (response.status === "healthy") return;
     operation = response.operationId;
     const current = await backend.operationStatus(operation);
-    if (current.state === "completed" || current.state === "cancelled") return;
+    if (current.state === "completed" || current.state === "cancelled" || current.state === "failed") return;
     await settled;
   } finally {
     unsubscribe();

--- a/client/src/services/scryfall.ts
+++ b/client/src/services/scryfall.ts
@@ -44,8 +44,22 @@ declare const manaSymbolShardBrand: unique symbol;
 /** A mana shard string admitted by the finite Scryfall card-symbol catalog. */
 export type ManaSymbolShard = string & { readonly [manaSymbolShardBrand]: true };
 
+/**
+ * The catalog below is the COMPLETE set published by Scryfall's `/symbology`
+ * endpoint — all 84 symbols, every one of which has an SVG asset.
+ *
+ * "Complete" is the definition on purpose, rather than "the ones we happen to
+ * have needed". A symbol missing from here is not merely un-rendered: it is
+ * also never installed by `coreDescriptors()`, so it breaks offline in exactly
+ * the way this catalog exists to prevent. `manaSymbolCatalog.test.ts` pins the
+ * full expected set against an independently-authored literal, because a test
+ * that derives its expectation from `MANA_SYMBOL_SHARDS` cannot see an omission.
+ */
 const SINGLE_MANA_SYMBOL_SHARDS = [
   "W", "U", "B", "R", "G", "C", "S", "T", "Q", "E", "P", "X", "Y", "Z", "A", "∞", "½", "CHAOS",
+  // One colored mana or two life, one-half white/red mana, one mana from a
+  // legendary source, one potential land drop, planeswalker, ticket counter.
+  "H", "HW", "HR", "L", "D", "PW", "TK",
 ] as const;
 const COMPOSITE_MANA_SYMBOL_SHARDS = [
   "W/U", "W/B", "U/B", "U/R", "B/R", "B/G", "R/W", "R/G", "G/W", "G/U",
@@ -53,6 +67,8 @@ const COMPOSITE_MANA_SYMBOL_SHARDS = [
   "W/P", "U/P", "B/P", "R/P", "G/P",
   "W/U/P", "W/B/P", "U/B/P", "U/R/P", "B/R/P", "B/G/P", "R/W/P", "R/G/P", "G/W/P", "G/U/P",
   "C/W", "C/U", "C/B", "C/R", "C/G",
+  // Colorless Phyrexian: one colorless mana or two life.
+  "C/P",
 ] as const;
 const FINITE_NUMERIC_MANA_SYMBOL_SHARDS: readonly string[] = [
   ...Array.from({ length: 21 }, (_, value) => String(value)),


### PR DESCRIPTION
Follow-up to #8366, addressing the three CodeRabbit review threads. They could not go on that PR — it was already in the merge queue and push-locked by the time the fixes were ready.

### 1. Complete the symbol catalog (`scryfall.ts`)

The review named `{C/P}`, `{H}`, `{HW}` and `{HR}`. Diffing the catalog against Scryfall's `/symbology` found **four more** it did not name — `{D}`, `{L}`, `{PW}` and `{TK}` — so all eight are added. The catalog is now exactly the 84 symbols Scryfall publishes.

All 84 URLs were probed at HTTP 200, with the URL list dumped from `manaSymbolSourceUrl` itself rather than re-deriving the transform, so the probe covers the code path the installer actually uses. This matters now that a single 404 fails the whole core install.

### 2. Pin the catalog against an independent list (`manaSymbolCatalog.test.ts`)

The sharpest part of that finding was about test design. The existing tests derived their expectations from `MANA_SYMBOL_SHARDS`, so they checked a smaller set against itself and could not detect an omission by construction. The new test transcribes `/symbology` as a literal, and covers the negative direction so a guard that admitted everything would not pass. Verified by deleting `{TK}` and watching it go red.

### 3. Verify core bytes, not the receipt (`offlinePreparation.ts`)

Agreed with the finding; implemented differently than proposed. Extending `verify()` with pack scope is not needed: `resolve()` already admits an object only when `cache.match(path)` succeeds, and returns `packId` per match, so a pack-scoped integrity check needs no new backend surface.

The recovery is the subtle half. The first draft called `start({kind: "repair"})`, which reads as obviously correct and is a silent no-op: with the receipt standing at the current root, an install short-circuits to `healthy` and a repair filters its own selector out — recorded as MEASURED in `scryfallBackend.ts`. So it would have reported success having downloaded nothing. Recovery now drops the stale receipt before reinstalling, and the test asserts `remove`-then-`start` ordering so the no-op cannot creep back.

### 4. 44pt touch target (`OfflinePreparationSection.tsx`)

Removing the desktop-only gate in #8366 put this panel in front of browser and touch users, where `text-sm` + `py-2` is under the minimum. `min-h-11` matches the sibling `<label>` and 42 other files.

### Verification

- `check-frontend` (protocol check + `tsc -b --noEmit` + lint): ok, fresh
- `test-frontend`: ok — 469 files passed, 2 skipped; log grepped for OOM/`ELIFECYCLE` since a vitest OOM can report green
- All 84 symbol URLs: HTTP 200

This round also fixed a defect in the round-1 tests: `visualBackend(overrides: Record<string, unknown>)` contributed nothing to the inferred return type, so tests that did not override `remove` were calling `undefined(...)` and reaching their `not-ready` assertion through a caught `TypeError` rather than the path they name. `remove` now lives in the mock's base literal.

https://claude.ai/code/session_01RtBf74gnapvcsEqQiPnjmC


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the complete set of Scryfall mana symbols, including additional shard, hybrid, infinity, half, and Phyrexian symbols.
  * Improved offline preparation to detect missing cached assets and recover from stale installation data.

* **Bug Fixes**
  * Offline preparation now verifies asset availability before reporting readiness.
  * Improved handling of reinstallations, incomplete asset downloads, and failed preparation operations.

* **Style**
  * Updated the offline preparation button height to match the adjacent toggle control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->