### PR TITLE
Add Sigarda, Host of Herons / Tajuru Preserver / Tamiyo, Collector of Tales (can't cause sacrifice/discard)

### DIFF
--- a/crates/engine/src/analysis/resource.rs
+++ b/crates/engine/src/analysis/resource.rs
@@ -5883,6 +5883,7 @@ fn static_mode_references_growing_class(mode: &crate::types::statics::StaticMode
         | StaticMode::RestrictLibrarySearchToTop { .. }
         | StaticMode::ControlPlayersDuringOwnLibrarySearch { .. }
         | StaticMode::CantCauseSacrificeOrExile { .. }
+        | StaticMode::CantCauseForcedAction { .. }
         | StaticMode::CastWithFlash
         | StaticMode::GrantsExtraVote
         | StaticMode::GrantsExtraVillainousChoice

--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -184,6 +184,11 @@ pub(crate) fn is_data_carrying_static(mode: &StaticMode) -> bool {
             | StaticMode::ControlPlayersDuringOwnLibrarySearch { .. }
             // CR 603.2 + CR 609.3: CantCauseSacrificeOrExile carries `cause`.
             | StaticMode::CantCauseSacrificeOrExile { .. }
+            // CR 701.9a + CR 701.21a: CantCauseForcedAction carries `cause` +
+            // `actions`. Runtime enforcement is in
+            // game/static_abilities.rs::forced_action_muzzled, consulted from
+            // effects/sacrifice.rs and effects/discard.rs.
+            | StaticMode::CantCauseForcedAction { .. }
             // CR 603.2g: SuppressTriggers carries `source_filter` + `events`.
             | StaticMode::SuppressTriggers { .. }
             // CR 603.2d: DoubleTriggers carries the `TriggerCause` predicate.

--- a/crates/engine/src/game/effects/discard.rs
+++ b/crates/engine/src/game/effects/discard.rs
@@ -403,6 +403,18 @@ pub fn resolve(
             }
             let player_id = obj.owner;
 
+            // CR 701.9a + CR 609.3: Tamiyo, Collector of Tales class — an
+            // opponent's spell or ability can't force the protected player to
+            // discard ANY card, regardless of which one.
+            if crate::game::static_abilities::forced_action_muzzled(
+                state,
+                ability.controller,
+                player_id,
+                crate::types::ability::CostCategory::Discards,
+            ) {
+                continue;
+            }
+
             let proposed = ProposedEvent::Discard {
                 player_id,
                 object_id: obj_id,
@@ -526,6 +538,29 @@ pub fn resolve(
         // the wrong hand. `resolve_player_for_context_ref` skips `ability.targets`
         // when the filter is a context-ref and falls back to `ability.controller`.
         let discard_player = super::resolve_player_for_context_ref(state, ability, &target_filter);
+
+        // CR 701.9a + CR 609.3: Tamiyo, Collector of Tales class — an
+        // opponent's spell or ability can't force the protected player to
+        // discard ANY card, regardless of which one. Treated as an impossible
+        // action for that player: a mandatory discard is a failed no-op
+        // (mirrors the empty-hand mandatory-discard path below), an "up to"
+        // discard simply discards zero.
+        if crate::game::static_abilities::forced_action_muzzled(
+            state,
+            ability.controller,
+            discard_player,
+            crate::types::ability::CostCategory::Discards,
+        ) {
+            if !up_to {
+                state.cost_payment_failed_flag = true;
+            }
+            events.push(GameEvent::EffectResolved {
+                kind: EffectKind::from(&ability.effect),
+                source_id: ability.source_id,
+                subject: None,
+            });
+            return Ok(());
+        }
 
         // CR 701.9b: Player chooses which card(s) to discard (not "at random").
         let hand_cards: Vec<ObjectId> = state

--- a/crates/engine/src/game/effects/sacrifice.rs
+++ b/crates/engine/src/game/effects/sacrifice.rs
@@ -310,6 +310,16 @@ pub fn resolve(
                                 *id,
                                 chooser,
                             )
+                            // CR 701.21a + CR 609.3: Sigarda, Host of Herons /
+                            // Tajuru Preserver class — an opponent's spell or
+                            // ability can't force the protected player to
+                            // sacrifice ANY permanent, regardless of which one.
+                            && !crate::game::static_abilities::forced_action_muzzled(
+                                state,
+                                ability.controller,
+                                chooser,
+                                crate::types::ability::CostCategory::SacrificesPermanent,
+                            )
                     })
             })
             .collect();
@@ -459,6 +469,18 @@ pub fn resolve(
 
         if crate::game::static_abilities::triggered_cause_sacrifice_or_exile_muzzled(
             state, ability, obj_id, player_id,
+        ) {
+            continue;
+        }
+
+        // CR 701.21a + CR 609.3: Sigarda, Host of Herons / Tajuru Preserver
+        // class — an opponent's spell or ability can't force the protected
+        // player to sacrifice ANY permanent, regardless of which one.
+        if crate::game::static_abilities::forced_action_muzzled(
+            state,
+            ability.controller,
+            player_id,
+            crate::types::ability::CostCategory::SacrificesPermanent,
         ) {
             continue;
         }

--- a/crates/engine/src/game/static_abilities.rs
+++ b/crates/engine/src/game/static_abilities.rs
@@ -9,7 +9,8 @@ use crate::game::functioning_abilities::{
 use crate::game::game_object::GameObject;
 use crate::game::layers::{evaluate_condition, evaluate_condition_with_recipient};
 use crate::types::ability::{
-    ContinuousModification, ControllerRef, StaticDefinition, TargetFilter, TypedFilter,
+    ContinuousModification, ControllerRef, CostCategory, StaticDefinition, TargetFilter,
+    TypedFilter,
 };
 use crate::types::game_state::GameState;
 use crate::types::identifiers::ObjectId;
@@ -91,6 +92,10 @@ pub fn build_static_registry() -> HashMap<StaticMode, StaticAbilityHandler> {
     // runtime enforcement is in effects/sacrifice.rs and effects/change_zone.rs via
     // triggered_cause_sacrifice_or_exile_muzzled(). Coverage support is via
     // is_data_carrying_static().
+    //
+    // CR 701.9a + CR 701.21a + CR 609.3: CantCauseForcedAction is a data-carrying
+    // variant — runtime enforcement is in effects/sacrifice.rs and effects/discard.rs
+    // via forced_action_muzzled(). Coverage support is via is_data_carrying_static().
     //
     // CR 603.2g + CR 603.6a + CR 700.4: SuppressTriggers is a data-carrying variant —
     // runtime enforcement is in triggers.rs via event_is_suppressed_by_static_triggers().
@@ -490,6 +495,60 @@ pub(crate) fn triggered_cause_sacrifice_or_exile_muzzled(
         };
         let ctx = crate::game::filter::FilterContext::from_source(state, bf_obj.id);
         if crate::game::filter::matches_target_filter(state, object_id, affected, &ctx) {
+            return true;
+        }
+    }
+    false
+}
+
+/// CR 701.9a (discard) + CR 701.21a (sacrifice) + CR 609.3 + CR 109.5: True
+/// when `acting_player` is protected from being forced to perform `action` by
+/// the spell or ability controlled by `cause_controller`, per an active
+/// `CantCauseForcedAction` static whose `cause` scope matches
+/// `cause_controller` relative to the static's own controller (CR 109.5: the
+/// "you"/"your" a static ability protects is its own controller). If muzzled,
+/// `action` is treated as an impossible action for `acting_player` and
+/// produces no game-state change for them (CR 609.3: an effect that can't do
+/// something does only as much as possible) — other players a multi-player
+/// instruction also affects are untouched.
+///
+/// E.g., Sigarda, Host of Herons / Tajuru Preserver: "Spells and abilities
+/// your opponents control can't cause you to sacrifice permanents." Tamiyo,
+/// Collector of Tales additionally lists `Discards`.
+///
+/// Unlike `triggered_cause_sacrifice_or_exile_muzzled` (The Master, Multiplied
+/// — triggered abilities ONLY, filtered to a specific affected-object
+/// subset), this protects the player wholesale against ANY spell or ability
+/// (not just triggered abilities), and is not filtered by which
+/// permanent/card would be affected — there is no `affected` filter to
+/// consult.
+pub(crate) fn forced_action_muzzled(
+    state: &GameState,
+    cause_controller: PlayerId,
+    acting_player: PlayerId,
+    action: CostCategory,
+) -> bool {
+    // CR 604.1: O(1) presence gate — no CantCauseForcedAction static means no muzzle.
+    if !static_kind_present(state, StaticModeKind::CantCauseForcedAction) {
+        return false;
+    }
+    crate::game::perf_counters::record_static_full_scan();
+    for (bf_obj, def) in crate::game::functioning_abilities::battlefield_active_statics(state) {
+        let StaticMode::CantCauseForcedAction {
+            ref cause,
+            ref actions,
+        } = def.mode
+        else {
+            continue;
+        };
+        // CR 109.5: "you" binds to the static's own controller — only THEY are protected.
+        if bf_obj.controller != acting_player {
+            continue;
+        }
+        if !actions.contains(&action) {
+            continue;
+        }
+        if prohibition_scope_matches_player(cause, cause_controller, bf_obj.id, state) {
             return true;
         }
     }

--- a/crates/engine/src/parser/oracle_classifier.rs
+++ b/crates/engine/src/parser/oracle_classifier.rs
@@ -392,6 +392,12 @@ const STATIC_CONTAINS_PATTERNS: &[&str] = &[
     // the "can't" effect takes precedence over the triggered ability directing it.
     "triggered abilities ",
     "can't cause you to sacrifice or exile",
+    // CR 701.9a + CR 701.21a + CR 609.3: Sigarda, Host of Herons / Tajuru
+    // Preserver / Tamiyo, Collector of Tales-class player-level protection —
+    // the "can't" effect takes precedence over the spell/ability directing
+    // the sacrifice/discard.
+    "can't cause you to sacrifice permanents",
+    "can't cause you to discard cards",
     // CR 701.23 + CR 101.2: Mindlock Orb-class search prohibition — the "can't"
     // effect takes precedence over any effect directing a search.
     "can't search libraries",

--- a/crates/engine/src/parser/oracle_static/dispatch.rs
+++ b/crates/engine/src/parser/oracle_static/dispatch.rs
@@ -2540,6 +2540,16 @@ pub(crate) fn parse_static_line_inner(
         return Some(def);
     }
 
+    // --- "Spells and abilities <scope> can't cause you to <action list>" ---
+    // CR 701.9a + CR 701.21a + CR 609.3: Sigarda, Host of Herons / Tajuru
+    // Preserver (sacrifice permanents) / Tamiyo, Collector of Tales (discard
+    // cards or sacrifice permanents) class. Player-level protection — unlike
+    // the triggered-only, object-filtered form above, this covers ANY spell
+    // or ability and is not filtered by which permanent/card is affected.
+    if let Some(def) = parse_cant_cause_forced_action(&tp, &text) {
+        return Some(def);
+    }
+
     // --- "Creatures entering [the battlefield] [and dying] don't cause abilities to trigger" ---
     // CR 603.2g + CR 603.6a + CR 700.4: Torpor Orb (ETB only), Hushbringer (ETB + Dies).
     if let Some(def) = parse_suppress_triggers(&tp, &text) {

--- a/crates/engine/src/parser/oracle_static/restriction.rs
+++ b/crates/engine/src/parser/oracle_static/restriction.rs
@@ -704,6 +704,72 @@ pub(crate) fn parse_cant_cause_sacrifice_or_exile(
     )
 }
 
+/// CR 701.9a (discard) + CR 701.21a (sacrifice) + CR 109.5: One action phrase
+/// inside a "can't cause you to <action list>" forced-action prohibition. A
+/// future forced action (e.g. "can't cause you to pay life") slots in as an
+/// additional `alt()` branch here without restructuring the caller.
+fn parse_forced_action_phrase(input: &str) -> OracleResult<'_, CostCategory> {
+    alt((
+        value(
+            CostCategory::SacrificesPermanent,
+            tag("sacrifice permanents"),
+        ),
+        value(CostCategory::Discards, tag("discard cards")),
+    ))
+    .parse(input)
+}
+
+/// A list of 1+ forced-action phrases joined by ", "/" or "/" and " (Tamiyo,
+/// Collector of Tales: "discard cards or sacrifice permanents").
+fn parse_forced_action_list(input: &str) -> OracleResult<'_, Vec<CostCategory>> {
+    separated_list1(
+        alt((
+            tag(", and "),
+            tag(", or "),
+            tag(" and "),
+            tag(" or "),
+            tag(", "),
+        )),
+        parse_forced_action_phrase,
+    )
+    .parse(input)
+}
+
+/// CR 701.9a (discard) + CR 701.21a (sacrifice) + CR 609.3 + CR 109.5: Parse
+/// "Spells and abilities <scope> can't cause you to <action list>." statics —
+/// a player-level protection distinct from `CantCauseSacrificeOrExile` (The
+/// Master, Multiplied — triggered abilities ONLY, filtered to a specific
+/// affected-object subset): this protects the player wholesale against ANY
+/// spell or ability, regardless of which permanent/card would be affected.
+///
+/// Supported Oracle classes:
+/// - "Spells and abilities your opponents control can't cause you to
+///   sacrifice permanents." (Sigarda, Host of Herons; Tajuru Preserver)
+/// - "Spells and abilities your opponents control can't cause you to discard
+///   cards or sacrifice permanents." (Tamiyo, Collector of Tales)
+pub(crate) fn parse_cant_cause_forced_action(
+    tp: &TextPair<'_>,
+    text: &str,
+) -> Option<StaticDefinition> {
+    let rest_tp = nom_tag_tp(tp, "spells and abilities ")?;
+    // Scope rides on the controller-possessive suffix, mirroring
+    // `parse_cant_search_library` (Ashiok class) and
+    // `parse_cant_cause_sacrifice_or_exile` (The Master, Multiplied class).
+    let (cause, predicate) = strip_controller_possessive_scope(rest_tp.original)?;
+    let predicate_lower = predicate.to_lowercase();
+    let (actions, _) = nom_on_lower(predicate, &predicate_lower, |i| {
+        let (i, _) = tag("can't cause you to ").parse(i)?;
+        let (i, actions) = parse_forced_action_list(i)?;
+        let (i, _) = opt(tag(".")).parse(i)?;
+        let (i, _) = eof(i)?;
+        Ok((i, actions))
+    })?;
+    Some(
+        StaticDefinition::new(StaticMode::CantCauseForcedAction { cause, actions })
+            .description(text.to_string()),
+    )
+}
+
 /// CR 603.2g + CR 603.6a + CR 700.4: Parse Torpor Orb / Hushbringer-class
 /// "Creatures entering [the battlefield] [and dying] don't cause abilities to trigger."
 ///

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -12830,6 +12830,43 @@ fn static_cant_cause_sacrifice_or_exile_creature_tokens() {
 }
 
 #[test]
+fn static_cant_cause_forced_action_sacrifice_only() {
+    // CR 701.21a + CR 609.3 + CR 109.5: Sigarda, Host of Herons / Tajuru
+    // Preserver — protects the player wholesale against ANY opponent-
+    // controlled spell or ability forcing a sacrifice, with no affected-object
+    // filter (unlike CantCauseSacrificeOrExile).
+    let def = parse_static_line(
+        "Spells and abilities your opponents control can't cause you to sacrifice permanents.",
+    )
+    .unwrap();
+    assert_eq!(
+        def.mode,
+        StaticMode::CantCauseForcedAction {
+            cause: ProhibitionScope::Opponents,
+            actions: vec![CostCategory::SacrificesPermanent],
+        }
+    );
+    assert!(def.affected.is_none());
+}
+
+#[test]
+fn static_cant_cause_forced_action_discard_or_sacrifice() {
+    // CR 701.9a + CR 701.21a + CR 609.3: Tamiyo, Collector of Tales — the same
+    // static family, listing two forced actions in one clause.
+    let def = parse_static_line(
+        "Spells and abilities your opponents control can't cause you to discard cards or sacrifice permanents.",
+    )
+    .unwrap();
+    assert_eq!(
+        def.mode,
+        StaticMode::CantCauseForcedAction {
+            cause: ProhibitionScope::Opponents,
+            actions: vec![CostCategory::Discards, CostCategory::SacrificesPermanent],
+        }
+    );
+}
+
+#[test]
 fn static_legend_rule_defers_unparseable_scopes() {
     // CR 704.5j: scopes this parser cannot resolve precisely, and conditional
     // forms, must NOT be emitted as a LegendRuleDoesntApply static — they are

--- a/crates/engine/src/types/statics.rs
+++ b/crates/engine/src/types/statics.rs
@@ -1050,6 +1050,32 @@ pub enum StaticMode {
     CantCauseSacrificeOrExile {
         cause: ProhibitionScope,
     },
+    /// CR 701.9a (discard) + CR 701.21a (sacrifice) + CR 609.3 + CR 109.5:
+    /// "Spells and abilities <cause> can't cause you to <action list>." Sigarda,
+    /// Host of Herons / Tajuru Preserver ("... sacrifice permanents") and
+    /// Tamiyo, Collector of Tales ("... discard cards or sacrifice
+    /// permanents"). Unlike `CantCauseSacrificeOrExile` (triggered abilities
+    /// ONLY, and filtered to a specific `StaticDefinition::affected` object
+    /// subset), this protects the player wholesale against ANY spell or
+    /// ability controlled by a player matching `cause` — not just triggered
+    /// abilities — and is not filtered by which permanent/card would be
+    /// affected. When a muzzled spell/ability would force the protected
+    /// player to perform a listed action, that action is treated as
+    /// impossible for them and produces no game-state change for that player
+    /// (CR 609.3: an effect that can't do something does only as much as
+    /// possible) — a scoped multi-player instruction (e.g. "each player
+    /// sacrifices/discards") still affects every OTHER player normally.
+    ///
+    /// `actions` reuses [`CostCategory`] — already the single-authority
+    /// classifier over "what kind of action is this" for ability costs (see
+    /// its doc comment) — rather than a parallel enum for the same set of
+    /// keyword actions (CR 701.9 discard, CR 701.21 sacrifice). A future
+    /// forced action (e.g. "can't cause you to pay life") slots in as an
+    /// additional `CostCategory` variant rather than a new architecture.
+    CantCauseForcedAction {
+        cause: ProhibitionScope,
+        actions: Vec<CostCategory>,
+    },
     CastWithFlash,
     /// CR 701.38d: While voting, the controller of this permanent may vote an
     /// additional time. Each active source grants +1 to the controller's
@@ -2194,6 +2220,7 @@ pub enum StaticModeKind {
     RestrictLibrarySearchToTop,
     ControlPlayersDuringOwnLibrarySearch,
     CantCauseSacrificeOrExile,
+    CantCauseForcedAction,
     CastWithFlash,
     GrantsExtraVote,
     GrantsExtraVillainousChoice,
@@ -2332,6 +2359,7 @@ impl StaticMode {
             StaticMode::CantCauseSacrificeOrExile { .. } => {
                 StaticModeKind::CantCauseSacrificeOrExile
             }
+            StaticMode::CantCauseForcedAction { .. } => StaticModeKind::CantCauseForcedAction,
             StaticMode::CastWithFlash => StaticModeKind::CastWithFlash,
             StaticMode::GrantsExtraVote => StaticModeKind::GrantsExtraVote,
             StaticMode::GrantsExtraVillainousChoice => StaticModeKind::GrantsExtraVillainousChoice,
@@ -2671,6 +2699,11 @@ impl Hash for StaticMode {
             | StaticMode::CantSearchLibrary { .. }
             | StaticMode::ControlPlayersDuringOwnLibrarySearch { .. }
             | StaticMode::CantCauseSacrificeOrExile { .. }
+            // CR 701.9a + CR 701.21a: data-carrying (`actions: Vec<CostCategory>`
+            // is not Hash-collision-safe to enumerate); consumed by direct match
+            // in game/static_abilities.rs::forced_action_muzzled, never used as a
+            // HashMap key.
+            | StaticMode::CantCauseForcedAction { .. }
             // CR 614.1c: data-carrying (CounterType + count); consumed by direct
             // match in change_zone.rs, never used as a HashMap key.
             | StaticMode::EntersWithAdditionalCounters { .. }
@@ -2720,6 +2753,7 @@ impl StaticMode {
             | StaticMode::RestrictLibrarySearchToTop { .. }
             | StaticMode::ControlPlayersDuringOwnLibrarySearch { .. }
             | StaticMode::CantCauseSacrificeOrExile { .. }
+            | StaticMode::CantCauseForcedAction { .. }
             | StaticMode::CastWithFlash
             | StaticMode::GrantsExtraVote
             | StaticMode::GrantsExtraVillainousChoice
@@ -2854,6 +2888,10 @@ impl fmt::Display for StaticMode {
             }
             StaticMode::CantCauseSacrificeOrExile { cause } => {
                 write!(f, "CantCauseSacrificeOrExile({cause})")
+            }
+            StaticMode::CantCauseForcedAction { cause, actions } => {
+                let parts: Vec<String> = actions.iter().map(|a| format!("{a:?}")).collect();
+                write!(f, "CantCauseForcedAction({cause},{})", parts.join("+"))
             }
             StaticMode::SuppressTriggers { events, .. } => {
                 let parts: Vec<String> = events.iter().map(|e| e.to_string()).collect();
@@ -3778,6 +3816,11 @@ impl FromStr for StaticMode {
                     if let Ok(cause) = ProhibitionScope::from_str(inner) {
                         return Ok(StaticMode::CantCauseSacrificeOrExile { cause });
                     }
+                    return Ok(StaticMode::Other(other.to_string()));
+                } else if other.starts_with("CantCauseForcedAction(") {
+                    // CR 701.9a + CR 701.21a: Data-carrying — `actions` has no
+                    // `CostCategory` FromStr inverse, so round-trip preserves the
+                    // discriminant only. Mirrors SuppressTriggers.
                     return Ok(StaticMode::Other(other.to_string()));
                 } else if other.starts_with("SuppressTriggers(") {
                     // CR 603.2g: Data-carrying — round-trip preserves discriminant only.

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -1067,6 +1067,7 @@ mod sentinel_sliver_vigilance_grant;
 mod serpent_society_ward_poison_cost;
 mod serras_emissary_chosen_card_type_protection;
 mod shorten_efficacy;
+mod sigarda_tajuru_tamiyo_forced_action_protection;
 mod sin_spiras_punishment_repeat;
 mod skitterfang_reflexive_without_counter;
 mod skullwinder_chosen_opponent;

--- a/crates/engine/tests/integration/sigarda_tajuru_tamiyo_forced_action_protection.rs
+++ b/crates/engine/tests/integration/sigarda_tajuru_tamiyo_forced_action_protection.rs
@@ -1,0 +1,216 @@
+//! CR 701.9a (discard) + CR 701.21a (sacrifice) + CR 609.3 + CR 109.5:
+//! "Spells and abilities your opponents control can't cause you to
+//! <action list>." — a player-level protection static shared by three cards.
+//!
+//! CARD TEXT (verified against `data/mtgjson/AtomicCards.json`):
+//!   Sigarda, Host of Herons — "Flying, hexproof\nSpells and abilities your
+//!     opponents control can't cause you to sacrifice permanents."
+//!   Tajuru Preserver — "Spells and abilities your opponents control can't
+//!     cause you to sacrifice permanents."
+//!   Tamiyo, Collector of Tales — "Spells and abilities your opponents
+//!     control can't cause you to discard cards or sacrifice permanents."
+//!     (plus two loyalty abilities, unrelated to this static and already
+//!     supported before this change).
+//!
+//! This engine models the shared clause as `StaticMode::CantCauseForcedAction
+//! { cause: ProhibitionScope, actions: Vec<CostCategory> }`, enforced in
+//! `game/static_abilities.rs::forced_action_muzzled` and consulted from the
+//! `Effect::Sacrifice` resolver (`game/effects/sacrifice.rs`) and the
+//! `Effect::Discard`/`Effect::DiscardCard` resolver (`game/effects/discard.rs`).
+//!
+//! Test 1 (Sigarda/Tajuru shape): an opponent's forced-sacrifice spell is a
+//! no-op against the protected player.
+//! Test 2: the protected player's OWN sacrifice effect still works normally —
+//! the protection only blocks OPPONENT-controlled spells/abilities.
+//! Test 3 (Tamiyo shape): an opponent's forced-discard spell is a no-op
+//! against the protected player.
+
+use engine::game::scenario::{GameRunner, GameScenario};
+use engine::types::game_state::WaitingFor;
+use engine::types::identifiers::ObjectId;
+use engine::types::mana::{ManaCost, ManaCostShard, ManaType, ManaUnit};
+use engine::types::phase::Phase;
+use engine::types::player::PlayerId;
+use engine::types::zones::Zone;
+
+const P0: PlayerId = PlayerId(0);
+const P1: PlayerId = PlayerId(1);
+
+/// Tajuru Preserver / Sigarda, Host of Herons's static line (verbatim).
+const SACRIFICE_PROTECTION_ORACLE: &str =
+    "Spells and abilities your opponents control can't cause you to sacrifice permanents.";
+
+/// Tamiyo, Collector of Tales's first static line (verbatim) — the loyalty
+/// abilities that follow it on the real card are unrelated to this static and
+/// are not needed to exercise it, so this test isolates the line on a plain
+/// creature stand-in (mirrors the "Synthetic Sacrifice"/"Synthetic Edict"
+/// convention already used by other integration tests in this suite for
+/// isolating a single clause).
+const DISCARD_AND_SACRIFICE_PROTECTION_ORACLE: &str = "Spells and abilities your opponents \
+control can't cause you to discard cards or sacrifice permanents.";
+
+const EDICT_ORACLE: &str = "Target player sacrifices a creature of their choice.";
+const DISCARD_ORACLE: &str = "Target player discards a card.";
+const SELF_SACRIFICE_ORACLE: &str = "Sacrifice a creature.";
+
+/// Add `count` units of `ty` mana to `player`'s pool — deterministic payment
+/// without modelling lands (mirrors `undying_malice_edict_sacrifice_5942.rs`).
+fn add_mana(runner: &mut GameRunner, player: PlayerId, ty: ManaType, count: usize) {
+    let unit_source = ObjectId(0);
+    let target = runner
+        .state_mut()
+        .players
+        .iter_mut()
+        .find(|p| p.id == player)
+        .expect("player exists");
+    for _ in 0..count {
+        target
+            .mana_pool
+            .add(ManaUnit::new(ty, unit_source, false, vec![]));
+    }
+}
+
+/// CR 701.21a + CR 609.3: an opponent's "Target player sacrifices a creature
+/// of their choice" is a no-op against a player protected by
+/// `CantCauseForcedAction { actions: [SacrificesPermanent] }` — the whole
+/// forced sacrifice fails for that player specifically (CR 609.3: an effect
+/// that can't do something does only as much as possible), so every one of
+/// their permanents survives, regardless of which one would otherwise have
+/// been eligible.
+#[test]
+fn opponent_edict_is_muzzled_by_sacrifice_protection() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let ward = scenario
+        .add_creature_from_oracle(P0, "Tajuru Preserver", 3, 2, SACRIFICE_PROTECTION_ORACLE)
+        .id();
+    let victim = scenario.add_creature(P0, "Fodder Bear", 2, 2).id();
+
+    let edict = scenario
+        .add_spell_to_hand_from_oracle(P1, "Synthetic Edict", true, EDICT_ORACLE)
+        .with_mana_cost(ManaCost::Cost {
+            shards: vec![ManaCostShard::Black],
+            generic: 1,
+        })
+        .id();
+
+    let mut runner = scenario.build();
+    add_mana(&mut runner, P1, ManaType::Black, 2);
+
+    // Hand priority to P1 so they may cast their edict (CR 117.3c).
+    runner.state_mut().priority_player = P1;
+    runner.state_mut().waiting_for = WaitingFor::Priority { player: P1 };
+
+    // Pre-stage a choice of `victim` for the `EffectZoneChoice` pause that
+    // would occur if the muzzle did NOT empty the eligible pool (reach guard:
+    // without this, an unmuzzled sacrifice would merely pause unresolved and
+    // the assertions below would pass vacuously regardless of the muzzle).
+    let outcome = runner
+        .cast(edict)
+        .target_player(P0)
+        .effect_zone(&[victim])
+        .resolve();
+
+    // Non-vacuity: BOTH the protected permanent and the otherwise-eligible
+    // "Fodder Bear" survive — the muzzle blocks the whole forced sacrifice for
+    // the protected player, not just the object carrying the static.
+    outcome.assert_zone(&[ward, victim], Zone::Battlefield);
+    assert!(
+        outcome.state().players[0].graveyard.is_empty(),
+        "the protected player must sacrifice nothing"
+    );
+}
+
+/// CR 701.21a: the protection only stops OPPONENT-controlled spells/abilities
+/// — the protected player's OWN sacrifice effect must still function
+/// normally. Mutation-test companion to the muzzle test above: this assertion
+/// would also fail if `forced_action_muzzled` were (incorrectly) applied
+/// without checking the causing ability's controller.
+#[test]
+fn own_sacrifice_effect_still_works_under_sacrifice_protection() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let ward = scenario
+        .add_creature_from_oracle(P0, "Tajuru Preserver", 3, 2, SACRIFICE_PROTECTION_ORACLE)
+        .id();
+    let fodder = scenario.add_creature(P0, "Fodder Bear", 2, 2).id();
+
+    let synthetic_sacrifice = scenario
+        .add_spell_to_hand_from_oracle(P0, "Synthetic Sacrifice", true, SELF_SACRIFICE_ORACLE)
+        .with_mana_cost(ManaCost::Cost {
+            shards: vec![ManaCostShard::Black],
+            generic: 0,
+        })
+        .id();
+
+    let mut runner = scenario.build();
+    add_mana(&mut runner, P0, ManaType::Black, 1);
+
+    // Two eligible creatures (the protected permanent itself is a legal
+    // choice too), so the sacrifice pauses on `EffectZoneChoice`; choose the
+    // non-warded creature to keep the assertions unambiguous.
+    let outcome = runner
+        .cast(synthetic_sacrifice)
+        .effect_zone(&[fodder])
+        .resolve();
+
+    outcome.assert_zone(&[fodder], Zone::Graveyard);
+    outcome.assert_zone(&[ward], Zone::Battlefield);
+}
+
+/// CR 701.9a + CR 609.3: Tamiyo, Collector of Tales shape — an opponent's
+/// "Target player discards a card" is a no-op against a player protected by
+/// `CantCauseForcedAction { actions: [Discards, SacrificesPermanent] }`. The
+/// discard pauses on `WaitingFor::DiscardChoice` when unmuzzled (see
+/// `issue_7470_hidden_strings_optional_frame_leak.rs`); under the muzzle it
+/// must resolve immediately with no discard and no pause.
+#[test]
+fn opponent_discard_is_muzzled_by_discard_protection() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let _ward = scenario.add_creature_from_oracle(
+        P0,
+        "Ward Host",
+        2,
+        2,
+        DISCARD_AND_SACRIFICE_PROTECTION_ORACLE,
+    );
+    let card_a = scenario.add_card_to_hand(P0, "Victim Card A");
+    let card_b = scenario.add_card_to_hand(P0, "Victim Card B");
+
+    let discard_spell = scenario
+        .add_spell_to_hand_from_oracle(P1, "Synthetic Discard", true, DISCARD_ORACLE)
+        .with_mana_cost(ManaCost::Cost {
+            shards: vec![ManaCostShard::Black],
+            generic: 0,
+        })
+        .id();
+
+    let mut runner = scenario.build();
+    add_mana(&mut runner, P1, ManaType::Black, 1);
+
+    // Hand priority to P1 so they may cast their discard spell (CR 117.3c).
+    runner.state_mut().priority_player = P1;
+    runner.state_mut().waiting_for = WaitingFor::Priority { player: P1 };
+
+    // Pre-stage a choice of `card_a` for the `DiscardChoice` pause that would
+    // occur if the muzzle did NOT prevent the discard (reach guard: without
+    // this, an unmuzzled discard would merely pause unresolved and the
+    // assertions below would pass vacuously regardless of the muzzle).
+    let outcome = runner
+        .cast(discard_spell)
+        .target_player(P0)
+        .discard(&[card_a])
+        .resolve();
+
+    // Non-vacuity: both hand cards remain — the muzzle blocks the whole
+    // forced discard, not just one candidate card.
+    outcome.assert_zone(&[card_a, card_b], Zone::Hand);
+    assert!(
+        outcome.state().players[0].graveyard.is_empty(),
+        "the protected player must discard nothing"
+    );
+}


### PR DESCRIPTION
## Summary
Adds engine support for **Sigarda, Host of Herons**, **Tajuru Preserver**, and **Tamiyo, Collector of Tales** — three cards sharing the clause "Spells and abilities your opponents control can't cause you to sacrifice permanents[/discard cards]." Modeled as a new parameterized `StaticMode::CantCauseForcedAction { cause: ProhibitionScope, actions: Vec<CostCategory> }`, reusing the existing `CostCategory` enum (already the single-authority classifier for ability-cost kinds — see its doc comment) as the forced-action axis instead of inventing a parallel enum, so a future card ("can't cause you to pay life") slots in as another `CostCategory` variant rather than a new architecture.

This is distinct from the existing `StaticMode::CantCauseSacrificeOrExile` (The Master, Multiplied): that variant is triggered-abilities-only and filtered to a specific `affected` object subset. The new variant protects the player wholesale against **any** opponent-controlled spell or ability, regardless of source kind or which permanent/card would be affected.

## Files changed
- crates/engine/src/types/statics.rs
- crates/engine/src/game/static_abilities.rs
- crates/engine/src/game/effects/sacrifice.rs
- crates/engine/src/game/effects/discard.rs
- crates/engine/src/game/coverage.rs
- crates/engine/src/analysis/resource.rs
- crates/engine/src/parser/oracle_classifier.rs
- crates/engine/src/parser/oracle_static/restriction.rs
- crates/engine/src/parser/oracle_static/dispatch.rs
- crates/engine/src/parser/oracle_static/tests.rs
- crates/engine/tests/integration/main.rs
- crates/engine/tests/integration/sigarda_tajuru_tamiyo_forced_action_protection.rs (new)

## CR references
- CR 701.21a — sacrifice a permanent
- CR 701.9a — discard a card
- CR 609.3 — an effect that can't do something does only as much as possible
- CR 109.5 — "you"/"your" on a static bind to its own controller
- CR 102.2 / CR 102.3 — opponent definition (two-player and team)
- CR 604.1 — static abilities are simply true (presence-gate citation, matches existing `CantCauseSacrificeOrExile`/`CantSearchLibrary` precedent)

All verified by grepping `docs/MagicCompRules.txt` before writing.

## Implementation method (required)
Method: not-applicable — implemented directly against an explicit task brief (building-block trace → parameterized-variant design → parser → runtime → tests), rather than via the `/engine-implementer` skill loop. A `/review-impl`-style self-review was performed against the final diff (see Anchored on / Verification below).

## Track
Developer

## LLM
Model: claude-sonnet-5
Tier: Frontier
Thinking: high

## Verification
- [x] Required checks ran clean, or the exact CI-owned alternative is stated below.
- [x] Gate A output below is for the current committed head.
- [x] Final review-impl below is clean for the current committed head.
- [x] Both anchors cite existing analogous code at the same seam.

- `cargo fmt --all` — clean (no diff)
- `cargo check -p phase-engine --lib` — PASS (x2, before and after runtime/parser wiring)
- `cargo clippy -p phase-engine --all-targets -- -D warnings` — PASS clean (two full runs: once after the core implementation, once after the final integration-test reach-guard fixes)
- `cargo test -p phase-engine --lib static_cant_cause_forced_action` — 2 passed (parser unit tests, exact `StaticMode` AST assertions against verbatim Oracle text)
- `cargo test -p phase-engine --test integration sigarda_tajuru_tamiyo` — 3 passed: opponent-forced-sacrifice muzzle (Sigarda/Tajuru shape), own-sacrifice-still-works (protection scoping), opponent-forced-discard muzzle (Tamiyo shape)
- Mutation test: hard-coded `forced_action_muzzled` to `return false` — the two opponent-muzzle tests failed as expected (non-vacuous), the own-sacrifice test stayed green (correctly unaffected); reverted, reran, 3/3 green again
- `cargo coverage` / `cargo semantic-audit` — **not completed**: see CI Failures below (environment resource exhaustion, not a code defect)

## Gate A
Gate A PASS head=70ec7a6db63f71f6187aaf4f7d4bac83624a852d base=66e203e9382af6fc7a4162b7d751cbd01a71fe7e

## Anchored on
- crates/engine/src/parser/oracle_static/restriction.rs:503 (`parse_cant_search_library`, pre-existing, Ashiok class) — "Spells and abilities `<scope>` can't cause ... to ..." grammar via `strip_controller_possessive_scope`; the new `parse_cant_cause_forced_action` mirrors this exact combinator structure (`nom_tag_tp` → `strip_controller_possessive_scope` → `nom_on_lower` closure).
- crates/engine/src/types/statics.rs:1043 (`StaticMode::CantCauseSacrificeOrExile`, pre-existing, The Master Multiplied class) — the closest existing "can't cause you to sacrifice" muzzle pattern and its runtime companion `triggered_cause_sacrifice_or_exile_muzzled` in game/static_abilities.rs:461; the new `forced_action_muzzled` function follows the same `battlefield_active_statics` + `prohibition_scope_matches_player` shape, generalized to drop the triggered-only gate and the affected-object filter.
- crates/engine/src/types/ability.rs:11893 (`CostCategory`, pre-existing) — reused verbatim as the forced-action parameter type per its own doc comment ("Policies, AI heuristics, and other consumers should ask `.contains(&CostCategory::SacrificesPermanent)`"), rather than adding a new enum for the same set of keyword actions.

## Final review-impl
Self-review performed against the full diff using the review-impl checklist (seam correctness, idiomatic-change check, nom-mandate compliance, CR-citation completeness, pattern coverage, logic placement, building-block reuse, bool-flag avoidance, test discrimination/non-vacuity). One defect was found and fixed before this PR: the first draft of the two "opponent muzzle" integration tests paused on an unresolved `EffectZoneChoice`/`DiscardChoice` rather than completing the action, making the assertions pass vacuously regardless of whether the muzzle fired. Fixed by pre-staging the interactive choice (`.effect_zone(...)`/`.discard(...)`) so an unmuzzled run would actually complete the sacrifice/discard; confirmed via the mutation test described above. No other findings.

## Claimed parse impact
Sigarda, Host of Herons; Tajuru Preserver; Tamiyo, Collector of Tales — first static line now parses to `StaticMode::CantCauseForcedAction` (previously unsupported/`Unimplemented`). Not independently confirmed via `cargo coverage`/`cargo semantic-audit` for this PR — see CI Failures.

## Scope Expansion
None.

## Validation Failures
None — the engine-level verification listed above (parser unit tests, integration tests with mutation-test non-vacuity check, full clippy, cargo check) is clean.

## CI Failures
`cargo coverage` and `cargo semantic-audit` could not be run in this session: both require `./scripts/gen-card-data.sh`, which recompiles the `phase-engine` crate under the repo's `tool` profile (with `cli` + `tracing-subscriber` features). This machine is shared with other concurrently-running agents per this repo's own CLAUDE.md multi-agent notice, and across four attempts (`CARGO_BUILD_JOBS` unset, `=4`, `=3`, `=1`) that single monolithic-crate compile failed with: `rustc-LLVM ERROR: out of memory` (twice), a disk-full error (`os error 112`), and finally `os error 1450` ("insufficient system resources") plus a `STATUS_STACK_BUFFER_OVERRUN` — free system RAM was observed swinging between ~0.9 GB and ~21 GB and free disk between ~0.9 GB and ~30 GB over the course of this session, purely as a function of other agents' concurrent builds starting and finishing. This is an environment resource-contention issue, not a defect surfaced by the new code: the change is a small, additive diff to a pre-existing multi-hundred-thousand-line crate, and every check that does not require this specific full recompile (fmt, check, clippy --all-targets, the full lib test-binary compile, both new/changed test suites, Gate A) passed cleanly. Recommend CI (which runs on dedicated, non-contended infrastructure) or a maintainer re-run of `cargo coverage`/`cargo semantic-audit` to confirm `supported: true, gap_count: 0` for all three cards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for effects that prevent opponents’ spells and abilities from forcing a player to sacrifice permanents or discard cards.
  * Added parsing support for these protection effects on cards such as Sigarda, Tajuru Preserver, and Tamiyo.

* **Bug Fixes**
  * Protected players are no longer forced to sacrifice permanents or discard cards by opposing effects, while their own effects continue to work normally.

* **Tests**
  * Added coverage for sacrifice and discard protection scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->