### PR TITLE
fix(engine,client): re-anchor life-magnitude citations and tighten shortcut guards

### DIFF
--- a/client/src/adapter/__tests__/server-draft-adapter.test.ts
+++ b/client/src/adapter/__tests__/server-draft-adapter.test.ts
@@ -5,7 +5,12 @@ import { ServerDraftAdapter } from "../server-draft-adapter";
 import { PROTOCOL_VERSION } from "../ws-adapter";
 import type { DraftPlayerView } from "../draft-adapter";
 import type { GameLogEntry, GameState, LegalActionsResult, ObjectAction } from "../types";
-import type { InteractionPreviewRequest } from "../generated/interaction";
+import type {
+  InteractionChoiceId,
+  InteractionId,
+  InteractionPreviewRequest,
+  PreviewRequestId,
+} from "../generated/interaction";
 
 // ── MockWebSocket (copied from ws-adapter.test.ts) ─────────────────────
 
@@ -832,25 +837,26 @@ describe("ServerDraftAdapter", () => {
      * NOT the candidate publication order, so a sort or a canonicalisation in
      * the adapter layer is caught rather than coinciding.
      */
+    const cid = (id: string) => id as InteractionChoiceId;
     const previewRequest = {
-      requestId: "preview-req-1",
-      interactionId: "interaction-1",
+      requestId: "preview-req-1" as PreviewRequestId,
+      interactionId: "interaction-1" as InteractionId,
       response: {
         type: "shortcut",
         data: {
           decision: { type: "fixed", data: { iterations: 6 } },
           pins: [{
             group: 0,
-            choiceIds: ["choice-c", "choice-a", "choice-b"],
+            choiceIds: [cid("choice-c"), cid("choice-a"), cid("choice-b")],
             amounts: [
-              { choiceId: "choice-c", amount: 3 },
-              { choiceId: "choice-a", amount: 1 },
-              { choiceId: "choice-b", amount: 2 },
+              { choiceId: cid("choice-c"), amount: 3 },
+              { choiceId: cid("choice-a"), amount: 1 },
+              { choiceId: cid("choice-b"), amount: 2 },
             ],
           }],
         },
       },
-    } as never as InteractionPreviewRequest;
+    } satisfies InteractionPreviewRequest;
 
     const previewAnswer = (requestId: string) => ({
       requestId,
@@ -902,7 +908,7 @@ describe("ServerDraftAdapter", () => {
     it("rejects in-flight previews on socket close, keeping answered ones", async () => {
       const answered = adapter.previewInteraction(previewRequest, 0);
       const unanswered = adapter.previewInteraction(
-        { ...previewRequest, requestId: "preview-req-2" } as InteractionPreviewRequest,
+        { ...previewRequest, requestId: "preview-req-2" as PreviewRequestId },
         0,
       );
 

--- a/client/src/adapter/__tests__/ws-adapter.test.ts
+++ b/client/src/adapter/__tests__/ws-adapter.test.ts
@@ -7,7 +7,12 @@ import {
 } from "../ws-adapter";
 import { AdapterError, supportsMatchConcede, supportsServerRewind } from "../types";
 import type { FormatConfig, GameState } from "../types";
-import type { InteractionPreviewRequest } from "../generated/interaction";
+import type {
+  InteractionChoiceId,
+  InteractionId,
+  InteractionPreviewRequest,
+  PreviewRequestId,
+} from "../generated/interaction";
 import type { PhaseSocketTransport } from "../../services/openPhaseSocket";
 
 // Minimal mock WebSocket. Latest-constructed instance is exposed via
@@ -1765,25 +1770,26 @@ describe("WebSocketAdapter", () => {
      * NOT the candidate publication order, so a sort or a canonicalisation
      * anywhere in the adapter layer is caught rather than coinciding.
      */
+    const cid = (id: string) => id as InteractionChoiceId;
     const request = {
-      requestId: "preview-req-1",
-      interactionId: "interaction-1",
+      requestId: "preview-req-1" as PreviewRequestId,
+      interactionId: "interaction-1" as InteractionId,
       response: {
         type: "shortcut",
         data: {
           decision: { type: "fixed", data: { iterations: 6 } },
           pins: [{
             group: 0,
-            choiceIds: ["choice-c", "choice-a", "choice-b"],
+            choiceIds: [cid("choice-c"), cid("choice-a"), cid("choice-b")],
             amounts: [
-              { choiceId: "choice-c", amount: 3 },
-              { choiceId: "choice-a", amount: 1 },
-              { choiceId: "choice-b", amount: 2 },
+              { choiceId: cid("choice-c"), amount: 3 },
+              { choiceId: cid("choice-a"), amount: 1 },
+              { choiceId: cid("choice-b"), amount: 2 },
             ],
           }],
         },
       },
-    } as never as InteractionPreviewRequest;
+    } satisfies InteractionPreviewRequest;
 
     const answer = (requestId: string) => ({
       requestId,
@@ -1813,18 +1819,22 @@ describe("WebSocketAdapter", () => {
       const frame = sentPreviewFrame();
       expect(frame.type).toBe("PreviewInteraction");
       expect(frame.data.request).toEqual(request);
-      const pins = (frame.data.request.response as never as {
-        data: { pins: { choiceIds: string[]; amounts: { choiceId: string; amount: number }[] }[] };
-      }).data.pins;
+      const response = frame.data.request.response;
+      if (response.type !== "shortcut") throw new Error(`not a shortcut: ${response.type}`);
+      const pins = response.data.pins;
+      const amounts = pins[0].amounts;
+      // `amounts` is OPTIONAL on the wire, so its presence is an assertion rather than a shape
+      // the narrow gives for free.
+      if (amounts === undefined) throw new Error("the sent pin carries no amounts");
       // Reach guard: the asserted allocation has more than one segment, so an
       // adapter that dropped all but the first could not pass.
-      expect(pins[0].amounts.length).toBeGreaterThan(1);
-      expect(pins[0].amounts).toEqual([
+      expect(amounts.length).toBeGreaterThan(1);
+      expect(amounts).toEqual([
         { choiceId: "choice-c", amount: 3 },
         { choiceId: "choice-a", amount: 1 },
         { choiceId: "choice-b", amount: 2 },
       ]);
-      expect(pins[0].amounts.map((a) => a.choiceId)).toEqual(pins[0].choiceIds);
+      expect(amounts.map((a) => a.choiceId)).toEqual(pins[0].choiceIds);
 
       ws.dispatchSynthetic(
         "message",
@@ -1888,7 +1898,7 @@ describe("WebSocketAdapter", () => {
     it("rejects every in-flight preview when the socket closes, keeping answered ones", async () => {
       const answered = adapter.previewInteraction(request, 0);
       const unanswered = adapter.previewInteraction(
-        { ...request, requestId: "preview-req-2" } as InteractionPreviewRequest,
+        { ...request, requestId: "preview-req-2" as PreviewRequestId },
         0,
       );
 

--- a/client/src/adapter/generated/interaction/index.ts
+++ b/client/src/adapter/generated/interaction/index.ts
@@ -111,7 +111,7 @@ export type InteractionShortcutPreview = { count: number, entries: Array<Interac
  * never empty — and NOT necessarily positive, since a step starting exactly at the count
  * takes a zero-length segment.
  *
- * CR 704.5a: `entries` follow this allocation ONLY when the period's life map names
+ * CR 119.3: `entries` follow this allocation ONLY when the period's life map names
  * exactly one losing seat that this allocation itself announces and the slot's announced
  * magnitude is the whole of that seat's per-period loss, which is what makes it positive —
  * per-seat life magnitudes are then this split multiplied by that rate, and they still

--- a/client/src/components/modal/LoopShortcutModal.tsx
+++ b/client/src/components/modal/LoopShortcutModal.tsx
@@ -468,14 +468,19 @@ function DeclareShortcutOffer({
     // to leak onto. `amounts` is always written explicitly. CR 732.2c: `null` on an unselected
     // subject is the same type-level refusal arm the count uses above, so the dispatched id is
     // the SELECTED value rather than an assertion, a default, a clamp or a fallback.
-    const pinFor = (p: InteractionShortcutPoint): InteractionShortcutPin | null =>
-      p.kind === "mayChoice"
-        ? { group: p.group, choiceIds: [mayPicks[p.group]], amounts: [] }
-        : targetsControl?.kind === "allocation"
-          ? { group: p.group, choiceIds: effective.map((a) => a.choiceId), amounts: effective }
-          : subject === null
-            ? null
-            : { group: p.group, choiceIds: [subject], amounts: [] };
+    const pinFor = (p: InteractionShortcutPoint): InteractionShortcutPin | null => {
+      if (p.kind === "mayChoice") {
+        // An unanswered group takes that same refusal arm, so an unset pick is unrepresentable
+        // in a pin rather than shipped as `[undefined]`.
+        const pick = mayPicks[p.group];
+        return pick === undefined ? null : { group: p.group, choiceIds: [pick], amounts: [] };
+      }
+      return targetsControl?.kind === "allocation"
+        ? { group: p.group, choiceIds: effective.map((a) => a.choiceId), amounts: effective }
+        : subject === null
+          ? null
+          : { group: p.group, choiceIds: [subject], amounts: [] };
+    };
 
     const pins = points.filter((p) => !p.readOnly).map(pinFor);
     if (pins.includes(null)) return null;
@@ -789,11 +794,32 @@ export function RespondToShortcutModal() {
   const allocationGroup = spec?.allocationGroup ?? null;
   const orderPoints = points.filter((p) => p.kind === "targets" && p.group !== allocationGroup);
   const allocation = declared?.allocation ?? [];
-  const mayPoints = points.filter((p) => p.kind === "mayChoice");
+  // One authority for whether a may row exists, so the panel's predicate and its render cannot
+  // drift: a point this modal has no wording for contributes neither a row nor a title.
+  const mayRows = points
+    .filter((p) => p.kind === "mayChoice")
+    .flatMap((point) => {
+      // The engine publishes EXACTLY TWO candidate ids on a `mayChoice` statement point,
+      // read in order as SUBJECT then ANSWER; a decision whose subject cannot be minted
+      // publishes no point at all, so this positional read is total over what arrives.
+      const [subjectId, answerId] = point.candidateIds;
+      if (subjectId === undefined || answerId === undefined) return [];
+      const answer = mayCandidate(candidates, answerId);
+      // A whitelist, deliberately: an answer this modal has no wording for renders
+      // nothing rather than a raw lookup key.
+      if (answer !== "take" && answer !== "decline") return [];
+      return [
+        <p key={point.group} className="text-sm text-slate-200">
+          {t(`comboShortcut.respondDecision.${answer}`, {
+            subject: candidateLabel(t, candidates, subjectId),
+          })}
+        </p>,
+      ];
+    });
   const showsDeclaration =
     allocation.length > 0 ||
     orderPoints.some((p) => p.candidateIds.length > 0) ||
-    mayPoints.length > 0;
+    mayRows.length > 0;
 
   const footer = (
     <div className="flex flex-col gap-3 sm:flex-row sm:justify-end">
@@ -853,24 +879,7 @@ export function RespondToShortcutModal() {
                 </p>
               )),
             )}
-            {mayPoints.map((point) => {
-              // The engine publishes EXACTLY TWO candidate ids on a `mayChoice` statement point,
-              // read in order as SUBJECT then ANSWER; a decision whose subject cannot be minted
-              // publishes no point at all, so this positional read is total over what arrives.
-              const [subjectId, answerId] = point.candidateIds;
-              if (subjectId === undefined || answerId === undefined) return null;
-              const answer = mayCandidate(candidates, answerId);
-              // A whitelist, deliberately: an answer this modal has no wording for renders
-              // nothing rather than a raw lookup key.
-              if (answer !== "take" && answer !== "decline") return null;
-              return (
-                <p key={point.group} className="text-sm text-slate-200">
-                  {t(`comboShortcut.respondDecision.${answer}`, {
-                    subject: candidateLabel(t, candidates, subjectId),
-                  })}
-                </p>
-              );
-            })}
+            {mayRows}
           </div>
         )}
       </div>

--- a/client/src/components/modal/__tests__/LoopShortcutModal.test.tsx
+++ b/client/src/components/modal/__tests__/LoopShortcutModal.test.tsx
@@ -258,21 +258,20 @@ function objectCandidate(id: string, name: string | null, reference: string): In
   };
 }
 
+/** One published option, its `value` surface stated by the caller — the axis the modal's
+ *  wording whitelist reads. */
+function mayAnswer(id: string, value: string): InteractionChoice {
+  return {
+    id: cid(id),
+    surfaces: [{ type: "value", data: { role: "accept", index: null, value } }],
+    status: { type: "available" },
+  };
+}
+
 /** A may point's two published options. The control reads the `value` surface these carry —
  *  never the index. */
 function mayCandidates(takeId: string, declineId: string): InteractionChoice[] {
-  return [
-    {
-      id: cid(takeId),
-      surfaces: [{ type: "value", data: { role: "accept", index: null, value: "take" } }],
-      status: { type: "available" },
-    },
-    {
-      id: cid(declineId),
-      surfaces: [{ type: "value", data: { role: "accept", index: null, value: "decline" } }],
-      status: { type: "available" },
-    },
-  ];
+  return [mayAnswer(takeId, "take"), mayAnswer(declineId, "decline")];
 }
 
 function element(
@@ -987,6 +986,39 @@ describe("LoopShortcutModal", () => {
     expect(screen.getByText("Sue Storm — taken each iteration")).toBeInTheDocument();
     expect(screen.getByText("Reed Richards — taken each iteration")).toBeInTheDocument();
     expect(screen.queryByText(/declined each iteration/)).not.toBeInTheDocument();
+  });
+
+  // Hostile: the ONLY declaration content is a may point whose answer this modal has no wording
+  // for, so every row it could render is dropped and the box would be a title over nothing.
+  it("omits the declaration panel when no may row survives", () => {
+    seed(
+      buildRespondToShortcutWaitingFor(),
+      {},
+      respondInteraction({ points: [statementMayPoint(0, "s0", "a0")] }, [
+        objectCandidate("s0", "Sue Storm", "402"),
+        mayAnswer("a0", "abstain"),
+      ]),
+    );
+    render(<RespondToShortcutModal />);
+
+    expect(screen.queryByText("Proposed declaration:")).not.toBeInTheDocument();
+  });
+
+  // The paired positive, one literal apart: the same fixture with a whitelisted answer keeps the
+  // title AND its row, so a renderer that dropped the panel unconditionally fails here.
+  it("keeps the declaration panel when its one may row survives", () => {
+    seed(
+      buildRespondToShortcutWaitingFor(),
+      {},
+      respondInteraction({ points: [statementMayPoint(0, "s0", "a0")] }, [
+        objectCandidate("s0", "Sue Storm", "402"),
+        mayAnswer("a0", "take"),
+      ]),
+    );
+    render(<RespondToShortcutModal />);
+
+    expect(screen.getByText("Proposed declaration:")).toBeInTheDocument();
+    expect(screen.getByText("Sue Storm — taken each iteration")).toBeInTheDocument();
   });
 
   // T6 (non-vacuity): both modals self-gate — a non-matching waitingFor.type

--- a/crates/engine/src/game/interaction.rs
+++ b/crates/engine/src/game/interaction.rs
@@ -2667,7 +2667,7 @@ fn shortcut_preview_entries(
 /// interior is thinned by a stride wide enough that the whole sample fits under
 /// `MAX_SHORTCUT_PREVIEW_ELEMENTS`; the length guard, not the stride, is what enforces the cap.
 ///
-/// `k` starts at 1 rather than 0 deliberately: at 0 the loop regenerates `min` itself, and the
+/// `step` starts at 1 rather than 0 deliberately: at 0 the loop regenerates `min` itself, and the
 /// explicit `min` seed would then be unfalsifiable.
 ///
 /// The exhaustive match is also the offer's single finite-count gate — `UntilLethal` names no

--- a/crates/engine/src/game/interaction.rs
+++ b/crates/engine/src/game/interaction.rs
@@ -2635,7 +2635,7 @@ fn shortcut_preview_entries(
             .into_iter()
             .map(|(key, per_cycle)| (key, per_cycle.saturating_mul(i64::from(count))))
             .collect();
-    // CR 704.5a: the announced slot charges a LIFE magnitude, so the re-attribution moves the
+    // CR 119.3: the announced slot charges a LIFE magnitude, so the re-attribution moves the
     // `Life` family and nothing else. `DamageDealt`, `LibraryDelta` and `Poison` are seat-keyed
     // by `payload_seat` too, and keep the seat it gave them.
     if let Some(split) = victim {
@@ -2734,7 +2734,7 @@ fn canonical_allocation(ids: &[InteractionChoiceId], count: u32) -> Vec<AmountAs
         .collect()
 }
 
-/// CR 704.5a: the life magnitude one repetition charges through an announced slot, and the
+/// CR 119.3: the life magnitude one repetition charges through an announced slot, and the
 /// single seat that magnitude currently lands on.
 #[derive(Debug, Clone, Copy)]
 struct VictimCharge {
@@ -2742,7 +2742,7 @@ struct VictimCharge {
     seat: PlayerId,
 }
 
-/// CR 704.5a: what the period charges through THIS announced slot, or `None` when the period
+/// CR 119.3: what the period charges through THIS announced slot, or `None` when the period
 /// does not say.
 ///
 /// **A `victim_slot` magnitude is an aggregate, not a per-slot charge.** Every entry carries
@@ -2771,7 +2771,7 @@ struct VictimCharge {
 /// the charged seat's life by dropping that axis and re-adding `rate` once per allocated cycle.
 /// The substitution preserves the period's life total exactly when `rate` is the seat's whole
 /// loss; under any other charge the published magnitudes total less than the drain the
-/// declaration takes, and CR 704.5a is the number the player is deciding on. The equality is
+/// declaration takes, and CR 119.3 is the number the player is deciding on. The equality is
 /// tested on the already-identified seat rather than used to pick one — filtering the life map
 /// by it would name whichever seat happened to match the aggregate.
 fn victim_charge(
@@ -2794,7 +2794,7 @@ fn victim_charge(
         .then_some(VictimCharge { rate, seat: *seat })
 }
 
-/// CR 704.5a: how one element's count spreads the charged life magnitude over the seats the
+/// CR 119.3: how one element's count spreads the charged life magnitude over the seats the
 /// declaration allocates it to.
 ///
 /// `cycles` is never empty — the one constructor filters that case away — so "a split with no
@@ -2854,7 +2854,7 @@ fn allocation_point<'a>(
     Some((u32::try_from(index).ok()?, point))
 }
 
-/// CR 704.5a: the seats a point's candidates name, in published order, or `None` when any
+/// CR 119.3: the seats a point's candidates name, in published order, or `None` when any
 /// candidate is not a player.
 ///
 /// Exhaustive over the candidate kinds so a new one must decide for itself rather than being
@@ -3397,7 +3397,7 @@ fn declared_sequence_preview(
         })
         .collect();
 
-    // CR 704.5a: the period charges this announced slot's life to whoever the DECLARATION names.
+    // CR 119.3: the period charges this announced slot's life to whoever the DECLARATION names.
     //
     // `victim_charge` refuses for FOUR reasons: no `victim_slot` entry for this point's slot; a
     // life map naming zero or several losing seats; a losing seat the seats-in-hand do not name;
@@ -3480,20 +3480,19 @@ fn loop_shortcut_projection(
     }
     let count = match schema.iteration_count {
         crate::analysis::decision_template::IterationCount::Fixed(suggested) => {
-            // CR 732.2a (MagicCompRules.txt:6372): the picker's ceiling is the offer's own
-            // CR 704 bound, never the raw global safety limit — a count above it would
-            // specify a sequence containing an elimination, which is a conditional action.
-            // The engine owns this number; the frontend renders it. An unnarrowed offer
-            // states `MAX_SHORTCUT_CYCLES`; a bounded offer states less. Either way this is
-            // the offer's own bound, clamped at the same authority.
+            // CR 732.2a: the picker's ceiling is the offer's own CR 704 bound, never the raw
+            // global safety limit — a count above it would specify a sequence containing an
+            // elimination, which is a conditional action. The engine owns this number; the
+            // frontend renders it. An unnarrowed offer states `MAX_SHORTCUT_CYCLES`; a bounded
+            // offer states less. Either way this is the offer's own bound, clamped at the same
+            // authority.
             //
-            // CR 704.5a (MagicCompRules.txt:5492): `elimination_bounds` returns `0` to
-            // mean "no legal repetition exists and the caller must not offer". A
-            // published offer carrying
-            // `0` is an authority violation, not a number to repair — clamping it to `1`
-            // renders a one-iteration offer whose single iteration eliminates a player
-            // mid-proposal. Reject it in EVERY build: a `debug_assert!` disappears from
-            // release, which is precisely where the clamp is what the player sees.
+            // CR 704.5a: `elimination_bounds` returns `0` to mean "no legal repetition exists and
+            // the caller must not offer". A published offer carrying `0` is an authority
+            // violation, not a number to repair — clamping it to `1` renders a one-iteration
+            // offer whose single iteration eliminates a player mid-proposal. Reject it in EVERY
+            // build: a `debug_assert!` disappears from release, which is precisely where the
+            // clamp is what the player sees.
             //
             // THIS GUARD IS ALSO LOAD-BEARING AGAINST A PANIC, not merely against a bad
             // offer. With the lower clamp replaced by `.min(MAX_SHORTCUT_CYCLES)` below,

--- a/crates/engine/src/game/interaction.rs
+++ b/crates/engine/src/game/interaction.rs
@@ -10260,7 +10260,14 @@ fn materialize_loop_shortcut_response(
                     .iter()
                     .map(|index| match &projection.candidates[*index] {
                         LoopShortcutCandidateValue::Mode(mode) => Ok(*mode),
-                        _ => Err(InteractionReasonCode::InvalidAuthorityState),
+                        LoopShortcutCandidateValue::Target(TargetRef::Player(_))
+                        | LoopShortcutCandidateValue::Target(TargetRef::Object(_))
+                        | LoopShortcutCandidateValue::ConvokeObject(_)
+                        | LoopShortcutCandidateValue::May(_)
+                        | LoopShortcutCandidateValue::Unless(_)
+                        | LoopShortcutCandidateValue::ManaColor(_) => {
+                            Err(InteractionReasonCode::InvalidAuthorityState)
+                        }
                     })
                     .collect::<Result<Vec<_>, _>>()?;
                 decisions.push(PinnedDecision::Mode {

--- a/crates/engine/src/game/interaction.rs
+++ b/crates/engine/src/game/interaction.rs
@@ -10395,7 +10395,13 @@ fn shortcut_announcement_subject(
                 },
             ))
         }
-        _ => Err(InteractionReasonCode::InvalidAuthorityState),
+        LoopShortcutCandidateValue::ConvokeObject(_)
+        | LoopShortcutCandidateValue::Mode(_)
+        | LoopShortcutCandidateValue::May(_)
+        | LoopShortcutCandidateValue::Unless(_)
+        | LoopShortcutCandidateValue::ManaColor(_) => {
+            Err(InteractionReasonCode::InvalidAuthorityState)
+        }
     }
 }
 

--- a/crates/engine/src/game/visibility.rs
+++ b/crates/engine/src/game/visibility.rs
@@ -209,9 +209,9 @@ fn pins_name_hidden_source(
     };
     // A `Scheduled` step carries a whole `Ranking`, so the walk descends one level further
     // than the pin: EVERY subject in every step is inspected, not just the head the current
-    // episode would resolve. The tail is a pre-declaration the responder receives now (it is
-    // part of the proposal they accept or shorten under CR 732.2b), so a hidden identity in
-    // the tail is a leak on exactly the same footing as one in the head.
+    // episode would resolve. The whole ranking travels with the projected declaration the
+    // responder receives under CR 732.2b even though the drive resolves only the head, so a
+    // hidden identity in the tail is a leak on exactly the same footing as one in the head.
     //
     // Wildcard-free over `AnnouncementSubject`: a future subject kind gets a compile-time
     // visit here. The `Seat` arm is `false` for the SEAT reason given above — seat identity is
@@ -7555,9 +7555,9 @@ mod tests {
     /// hidden one; this is a public *subject* ahead of a hidden one inside a single pin —
     /// which the `Ranking` parameterization newly makes possible. The redaction walk must
     /// descend into every subject of every step, not stop at the head the current episode
-    /// would resolve: the tail is a pre-declaration the responder receives NOW, as part of
-    /// the proposal CR 732.2b lets them accept or shorten, so a hidden identity there leaks
-    /// on exactly the same footing as one in the head.
+    /// would resolve: the whole ranking travels with the projected declaration CR 732.2b
+    /// lets the responder accept or shorten even though the drive resolves only the head, so
+    /// a hidden identity there leaks on exactly the same footing as one in the head.
     ///
     /// # Coverage this row creates rather than repeats
     ///

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -36632,8 +36632,8 @@ mod tests {
     ///   head-only shape `evaluate_schedule` uses to RESOLVE, and therefore the plausible
     ///   wrong reading ⇒ arm (b)'s same-head/different-tail pair compares EQUAL ⇒ no latch ⇒
     ///   **arm (b) FAILS while arms (a) and (c) stay green**, because (a)'s heads already
-    ///   differ. The tail is the NEXT episode's pre-declaration, so two proposals agreeing
-    ///   only about this episode are not the same answer;
+    ///   differ. The recorded answer is the whole announcement sequence, so two proposals
+    ///   agreeing only on the head are not the same answer;
     /// * hand-write `impl PartialEq for AnnouncementSubject` with `(Seat(_), Seat(_)) => true`
     ///   ⇒ two DIFFERENT seats compare equal ⇒ arm (a)'s own reach-guard fires first and
     ///   names the vacuity by hand, which is the reach-guard doing its job rather than the
@@ -36687,8 +36687,8 @@ mod tests {
 
         // ── (b) SAME head, DIFFERENT tail ⇒ still Conflicted ──
         //
-        // The tail is a pre-declaration for the NEXT episode (CR 732.2a), not decoration, so
-        // two proposals that agree only about this episode are not the same answer. This is
+        // The recorded answer is the whole announcement sequence (CR 732.2a), not just the
+        // head, so two proposals that agree only on the head are not the same answer. This is
         // the arm a head-only equality would lose.
         let slot_b = DecisionSlot::target(journal_source(914));
         let head1_tail2 = ranked(vec![seat(1), seat(2)]);
@@ -36703,8 +36703,8 @@ mod tests {
         assert_eq!(
             state.loop_answer(&slot_b, PlayerId(0)),
             Some(LoopAnswer::Conflicted),
-            "equality over a `Ranking` is STRUCTURAL, not head-only: the tail is the next \
-             episode's pre-declaration, so differing tails are differing answers"
+            "equality over a `Ranking` is STRUCTURAL, not head-only: the recorded answer is \
+             the whole announcement sequence, so differing tails are differing answers"
         );
 
         // ── (c) the SAME ranking twice ⇒ still Uniform ──

--- a/crates/engine/src/types/interaction.rs
+++ b/crates/engine/src/types/interaction.rs
@@ -1061,7 +1061,7 @@ pub enum InteractionResponseSpec {
     /// against the announced-target decision's own published ids and total. A declaration whose
     /// partition IS stated and whose magnitudes are not — a proposal carrying no per-period
     /// signature, or one whose per-slot life charge resolves to a seat the declaration never
-    /// announces (CR 704.5a) — is published with its allocation and an EMPTY entry list: segment
+    /// announces (CR 119.3) — is published with its allocation and an EMPTY entry list: segment
     /// lengths are not magnitudes, and a responder judging accept-or-shorten against half the
     /// proposal is the partial statement this projection rules out. See
     /// `game::interaction::declared_sequence_preview`.
@@ -1193,7 +1193,7 @@ pub struct InteractionShortcutPreview {
     /// never empty — and NOT necessarily positive, since a step starting exactly at the count
     /// takes a zero-length segment.
     ///
-    /// CR 704.5a: `entries` follow this allocation ONLY when the period's life map names
+    /// CR 119.3: `entries` follow this allocation ONLY when the period's life map names
     /// exactly one losing seat that this allocation itself announces and the slot's announced
     /// magnitude is the whole of that seat's per-period loss, which is what makes it positive —
     /// per-seat life magnitudes are then this split multiplied by that rate, and they still

--- a/crates/engine/tests/integration/fantastic_four_bounded_loop.rs
+++ b/crates/engine/tests/integration/fantastic_four_bounded_loop.rs
@@ -4183,7 +4183,7 @@ fn c2_r4b_a_points_empty_offer_is_gated_by_the_owner_firewall_alone() {
 /// `NotALoopDecision` rather than as `UnexposedSlot`.
 ///
 /// The two sets diverge by construction and legitimately so: `victim_slot` is derived from the
-/// period's ANNOUNCED targets, which CR 704.5a charges whoever announces them, while
+/// period's ANNOUNCED targets, which CR 119.3 charges whoever announces them, while
 /// `schema.points` publishes only the proposer's own CR 601.2c choices. A period whose announced
 /// target is nobody's published choice therefore mints a charged slot with no point beside it,
 /// and a fabricated pin naming that slot is what the per-cycle conformance check would size its
@@ -4227,7 +4227,7 @@ fn a_slot_addressing_pin_naming_a_slot_the_offer_never_published_is_refused() {
     );
     assert!(
         magnitude > 0,
-        "REACH-GUARD: the charged slot must carry a strictly positive CR 704.5a magnitude; \
+        "REACH-GUARD: the charged slot must carry a strictly positive CR 119.3 magnitude; \
          got {magnitude} from {:?}",
         per_cycle.victim_slot
     );
@@ -4519,7 +4519,7 @@ fn u2_the_published_victim_domain_gates_the_committed_drive() {
         );
         assert!(
             per_cycle.victim_slot.iter().any(|(_, m)| *m > 0),
-            "REACH-GUARD: a charged slot with a strictly positive CR 704.5a magnitude, else the \
+            "REACH-GUARD: a charged slot with a strictly positive CR 119.3 magnitude, else the \
              lift is the identity whatever the domain. got {:?}",
             per_cycle.victim_slot
         );
@@ -5131,7 +5131,7 @@ fn the_f4_offer_splits_each_published_count_over_its_announced_candidates() {
         assert_eq!(
             life_of(element),
             expected,
-            "CR 704.5a: at count {} the drain is charged to each announced candidate at the \
+            "CR 119.3: at count {} the drain is charged to each announced candidate at the \
              published rate {rate} times its own share",
             element.count
         );
@@ -7100,7 +7100,7 @@ fn the_responder_reads_the_declared_partition_and_its_per_seat_magnitudes() {
     assert_eq!(
         f4_life_entries(element),
         expected,
-        "CR 704.5a: each declared seat's magnitude is the published per-cycle rate times ITS \
+        "CR 119.3: each declared seat's magnitude is the published per-cycle rate times ITS \
          OWN segment — {expected:?} — so a producer that re-attributed the drain uniformly, or \
          keyed it on the seat the period was measured on, fails here"
     );

--- a/crates/engine/tests/integration/interaction_contract.rs
+++ b/crates/engine/tests/integration/interaction_contract.rs
@@ -3860,7 +3860,7 @@ fn declared_amounts(element: &InteractionShortcutPreview) -> Vec<u32> {
         .collect()
 }
 
-/// **CR 704.5a — the attribution guard fires on ONE board and on no other.**
+/// **CR 119.3 — the attribution guard fires on ONE board and on no other.**
 ///
 /// `victim_charge` refuses for FOUR reasons; only one of them is about this
 /// call site's narrower seat domain. The guard therefore re-asks that same rule over the period's
@@ -3926,7 +3926,7 @@ fn the_declared_magnitudes_are_withheld_only_when_the_periods_charge_escapes_the
     );
     assert!(
         element.entries.is_empty(),
-        "CR 704.5a: the period's per-slot charge resolves to a seat this declaration never \
+        "CR 119.3: the period's per-slot charge resolves to a seat this declaration never \
          announces, so NO magnitude is stated rather than one keying the whole drain on the seat \
          the period was measured on. got {:?}",
         element.entries
@@ -3950,7 +3950,7 @@ fn the_declared_magnitudes_are_withheld_only_when_the_periods_charge_escapes_the
     let element = reply
         .declared
         .as_ref()
-        .expect("CR 704.5a: a declaration that announces the charged seat states its magnitudes");
+        .expect("CR 119.3: a declaration that announces the charged seat states its magnitudes");
     assert_eq!(
         declared_amounts(element),
         segments_from(&STARTS, COUNT),
@@ -3976,7 +3976,7 @@ fn the_declared_magnitudes_are_withheld_only_when_the_periods_charge_escapes_the
                 -24
             ),
         ],
-        "CR 704.5a: the drain follows the DECLARATION — 2 cycles on the announced victim and 4 \
+        "CR 119.3: the drain follows the DECLARATION — 2 cycles on the announced victim and 4 \
          on the seat it named second, at the period's own rate — and the two magnitudes differ, \
          so a producer that re-attributed uniformly fails here"
     );
@@ -5867,7 +5867,7 @@ fn the_allocation_is_empty_exactly_when_the_first_targets_point_holds_no_candida
     );
 }
 
-/// CR 704.5a: the published life magnitudes follow the allocation when — and only when — the
+/// CR 119.3: the published life magnitudes follow the allocation when — and only when — the
 /// period's life map names exactly one losing seat that the declaration itself announces and
 /// the announced charge is the whole of that seat's loss, which is what makes the charge
 /// positive.
@@ -5970,7 +5970,7 @@ fn the_preview_spreads_a_charged_life_magnitude_only_over_an_unambiguous_positiv
         assert_eq!(
             life_entries(element),
             expected,
-            "CR 704.5a: each allocated candidate is charged the rate times ITS OWN share of \
+            "CR 119.3: each allocated candidate is charged the rate times ITS OWN share of \
              count {}",
             element.count
         );
@@ -6128,7 +6128,7 @@ fn the_preview_spreads_a_charged_life_magnitude_only_over_an_unambiguous_positiv
                 .map(|(_, amount)| i64::from(*amount))
                 .sum::<i64>(),
             -seat_loss * i64::from(element.count),
-            "CR 704.5a: the published life magnitudes total the period the count runs — a \
+            "CR 119.3: the published life magnitudes total the period the count runs — a \
              split at the announced charge states {undercharge} per cycle where the period \
              takes {seat_loss}"
         );
@@ -8568,7 +8568,7 @@ fn an_authored_split_is_previewed_per_declared_seat() {
             .map(|entry| entry.player)
             .collect()
     };
-    // CR 704.5a governs the LIFE re-attribution and nothing else, so every other family is this
+    // CR 119.3 governs the LIFE re-attribution and nothing else, so every other family is this
     // row's allocation-invariant control.
     let invariant = |element: &InteractionShortcutPreview| -> Vec<InteractionShortcutPreviewEntry> {
         element
@@ -8632,7 +8632,7 @@ fn an_authored_split_is_previewed_per_declared_seat() {
         assert_eq!(
             invariant(element),
             invariant(&canonical),
-            "control: the entries CR 704.5a does not re-attribute are identical across the \
+            "control: the entries CR 119.3 does not re-attribute are identical across the \
              canonical and every authored shape; {name} moved one"
         );
     }

--- a/crates/engine/tests/integration/loop_shortcut.rs
+++ b/crates/engine/tests/integration/loop_shortcut.rs
@@ -9740,7 +9740,7 @@ fn dina_untargeted_drain_4p_offers_at_three_live_opponents() {
         stated.sort_unstable();
         assert_eq!(
             stated, expected,
-            "CR 704.5a: with no announced slot to charge, every life seat keeps the seat \
+            "CR 119.3: with no announced slot to charge, every life seat keeps the seat \
              `payload_seat` gave it at the raw product of its own count {}",
             element.count
         );

--- a/crates/engine/tests/integration/loop_shortcut.rs
+++ b/crates/engine/tests/integration/loop_shortcut.rs
@@ -9777,7 +9777,7 @@ fn dina_untargeted_drain_4p_offers_at_three_live_opponents() {
     for (seat, _, loss) in losses.iter().filter(|(id, _, _)| *id != proposer) {
         assert!(
             published.contains(&(Some(seat.0), (-loss * suggested) as i32)),
-            "CR 704.5a: victim seat {seat:?} loses {loss} per cycle, so its previewed life \
+            "CR 119.3: victim seat {seat:?} loses {loss} per cycle, so its previewed life \
              entry must be the NEGATIVE finished magnitude on that seat's own key — a \
              proposer-keyed subject map publishes it on the wrong HUD; got {published:?}"
         );

--- a/crates/server-core/src/interaction_payload_guard.rs
+++ b/crates/server-core/src/interaction_payload_guard.rs
@@ -105,6 +105,14 @@ mod tests {
         };
 
         assert!(guard_interaction_submission_payload(&msg).is_err());
+
+        let at_limit = InteractionSubmission {
+            interaction_id: InteractionId("x".repeat(MAX_INTERACTION_STRING_LEN)),
+            response: InteractionResponse::Choose {
+                choice_id: choice("a"),
+            },
+        };
+        assert_eq!(guard_interaction_submission_payload(&at_limit), Ok(()));
     }
 
     /// The `OutboundBudget` cumulative path — the only nested branch in the
@@ -131,6 +139,22 @@ mod tests {
         });
 
         assert!(guard_interaction_submission_payload(&msg).is_err());
+
+        // Boundary sibling: the cumulative bound sits at the constant. The
+        // subtrahend is the pin list itself, charged before the per-pin lists.
+        let per_pin = (MAX_INTERACTION_LIST_LEN - 2) / 2;
+        let at_limit: Vec<InteractionShortcutPin> = (0..2)
+            .map(|group| InteractionShortcutPin {
+                group,
+                choice_ids: vec![choice("a"); per_pin],
+                amounts: Vec::new(),
+            })
+            .collect();
+        let at_limit = submission(InteractionResponse::Shortcut {
+            decision: InteractionShortcutDecision::AcceptSuggested,
+            pins: at_limit,
+        });
+        assert_eq!(guard_interaction_submission_payload(&at_limit), Ok(()));
     }
 
     /// The same cumulative branch reached through `amounts` rather than
@@ -165,6 +189,28 @@ mod tests {
         });
 
         assert!(guard_interaction_submission_payload(&msg).is_err());
+
+        // Boundary sibling: the subtrahend is the pin list plus each pin's
+        // single-element `choice_ids` list, both charged before the amounts.
+        let per_pin = (MAX_INTERACTION_LIST_LEN - 4) / 2;
+        let at_limit: Vec<InteractionShortcutPin> = (0..2)
+            .map(|group| InteractionShortcutPin {
+                group,
+                choice_ids: vec![choice("a")],
+                amounts: vec![
+                    AmountAssignment {
+                        choice_id: choice("a"),
+                        amount: 1,
+                    };
+                    per_pin
+                ],
+            })
+            .collect();
+        let at_limit = submission(InteractionResponse::Shortcut {
+            decision: InteractionShortcutDecision::AcceptSuggested,
+            pins: at_limit,
+        });
+        assert_eq!(guard_interaction_submission_payload(&at_limit), Ok(()));
     }
 
     /// Pins the byte-identity claim at this layer so it cannot silently drift

--- a/scripts/check-protocol-version.mjs
+++ b/scripts/check-protocol-version.mjs
@@ -322,10 +322,20 @@ requirePattern(serverCoreSource, new RegExp(`fn protocol_version_is_${P}(?![0-9]
 refusePattern(serverCoreSource, new RegExp(`protocol_version_is_${P - 1}(?![0-9])`),
   "crates/server-core/src/protocol.rs");
 
-requirePattern(p2pProtocolTestSource, new RegExp(`\\bv${W}\\b`),
-  `client/src/network/__tests__/protocol.test.ts v${W}`);
-refusePattern(p2pProtocolTestSource, new RegExp(`\\bv${W - 1}\\b`),
-  "client/src/network/__tests__/protocol.test.ts");
+// Both legs read the file's test TITLES, not its whole source, so coverage that legitimately
+// drives the superseded version in a body is not a bump leftover. Ceiling: double-quoted titles
+// only, so a backtick or single-quoted title falls out of the slice — admit-only, never a false
+// refusal, which is what makes the narrowing safe.
+const p2pProtocolTestTitles = [
+  ...p2pProtocolTestSource.matchAll(/\b(?:describe|it|test)\(\s*"([^"]*)"/g),
+]
+  .map((match) => match[1])
+  .join("\n");
+
+requirePattern(p2pProtocolTestTitles, new RegExp(`\\bv${W}\\b`),
+  `client/src/network/__tests__/protocol.test.ts titles v${W}`);
+refusePattern(p2pProtocolTestTitles, new RegExp(`\\bv${W - 1}\\b`),
+  "client/src/network/__tests__/protocol.test.ts titles");
 
 const P2P_GATE = 'describe("P2P wire-protocol version gate"';
 if (!p2pAdapterTestSource.includes(P2P_GATE)) {

--- a/scripts/check-protocol-version.mjs
+++ b/scripts/check-protocol-version.mjs
@@ -336,14 +336,21 @@ if (!p2pAdapterTestSource.includes(P2P_GATE)) {
   process.exit(1);
 }
 const gateLabel = "client/src/adapter/__tests__/p2p-adapter-multiplayer.test.ts";
-// The legs below deliberately scan the whole file rather than the block just
-// located: a require leg fails on absence, so a wider haystack can only admit and
-// never falsely refuse. The prose leg is require-only for a second reason: this
-// title names the superseded version too, so a refuse leg would red a correct
-// title.
-for (const n of [W - 1, W]) {
-  requirePattern(p2pAdapterTestSource, new RegExp(`setupFrameAt\\(${n}\\)`),
-    `${gateLabel} setupFrameAt(${n})`);
-  requirePattern(p2pAdapterTestSource, new RegExp(`\\bv${n}\\b`),
-    `${gateLabel} v${n}`);
-}
+// Scoped to the gate block: the anchor above to the next top-level `describe(`,
+// or EOF if this is the last one. The slice starts AT the anchor, so it can
+// never widen back to the whole file.
+const gateBlockStart = p2pAdapterTestSource.indexOf(P2P_GATE);
+const gateBlockEnd = p2pAdapterTestSource.indexOf("\ndescribe(", gateBlockStart);
+const gateBlock = p2pAdapterTestSource.slice(
+  gateBlockStart,
+  gateBlockEnd === -1 ? undefined : gateBlockEnd,
+);
+
+// Order binds each numeral to its role: refused named and sent before admitted.
+// Raw-source match: a comment in the block quoting an it(...) title passes the title leg.
+requirePattern(gateBlock,
+  new RegExp(`\\bit\\("[^"]*\\bv${W - 1}\\b[^"]*\\bv${W}\\b[^"]*"`),
+  `${gateLabel} an it(...) title naming refused v${W - 1} before admitted v${W}`);
+requirePattern(gateBlock,
+  new RegExp(`setupFrameAt\\(${W - 1}\\)[\\s\\S]*setupFrameAt\\(${W}\\)`),
+  `${gateLabel} refused setupFrameAt(${W - 1}) before admitted setupFrameAt(${W})`);


### PR DESCRIPTION
## Summary

Review residue from the loop-shortcut interaction preview that merged as `4d5d34bd7`: citation
subjects re-anchored to the rule they actually state, stale doc comments corrected, two wildcard
matches spelled exhaustively so the compiler gates a future variant, boundary siblings for the
payload guard's refusals, a modal panel that fails closed instead of rendering an empty control,
test fixtures typed instead of cast past their brands, and the wire-version guard bound to the role
each numeral names. No runtime behaviour changes outside the modal's fail-closed arm.

## Files changed

- `crates/engine/src/game/interaction.rs` — citation subjects; doc comment; two exhaustive matches
- `crates/engine/src/game/visibility.rs` — citation subjects
- `crates/engine/src/types/game_state.rs` — citation subjects
- `crates/engine/src/types/interaction.rs` — citation subjects
- `crates/engine/tests/integration/loop_shortcut.rs` — citation subjects
- `crates/engine/tests/integration/interaction_contract.rs` — citation subjects
- `crates/engine/tests/integration/fantastic_four_bounded_loop.rs` — citation subjects
- `crates/server-core/src/interaction_payload_guard.rs` — three accept-at-the-ceiling siblings
- `client/src/components/modal/LoopShortcutModal.tsx` — fail closed with nothing to state
- `client/src/components/modal/__tests__/LoopShortcutModal.test.tsx` — brand-typed fixtures
- `client/src/adapter/__tests__/ws-adapter.test.ts` — brand-typed fixtures
- `client/src/adapter/__tests__/server-draft-adapter.test.ts` — brand-typed fixtures
- `client/src/adapter/generated/interaction/index.ts` — regenerated bindings
- `scripts/check-protocol-version.mjs` — bind each version to its role; scope the refusal to titles

## Track

Developer

## LLM

Model: claude-opus-5
Tier: Frontier
Thinking: high

## Implementation method (required)

Method: /engine-implementer

## CR references

`CR 704.5a` (kept where the statement is a seat reaching 0 and being removed), `CR 119.3`
(re-anchored where the statement is the size of a life delta or the seat it is charged to),
`CR 732.2a`, `CR 732.2b`, `CR 704`. Every number was verified by grepping `docs/MagicCompRules.txt`
with the rule's SUBJECT checked against the statement it heads.

## Verification

- [x] Required checks ran clean, or the exact CI-owned alternative is stated below.
- [x] Gate A output below is for the current committed head.
- [x] Final review-impl below is clean for the current committed head.
- [x] Both anchors cite existing analogous code at the same seam.

All commands below ran at the committed head `4e5f5ffffd7deffaa85272c4b5e8621a043c6c88`.

- `cargo fmt --all -- --check` — exit 0
- `cargo clippy --workspace --all-targets -- -D warnings` — exit 0
- `cargo nextest run --workspace` — exit 0; 30485 tests run, 30485 passed, 45 skipped
- `./scripts/check-interaction-bindings.sh --check` — exit 0
- `node scripts/check-protocol-version.mjs` — exit 0
- `./scripts/check-parser-combinators.sh` — exit 0 (Gate A, below)
- `pnpm install --frozen-lockfile` — exit 0
- `pnpm exec tsc -b --noEmit --force` — exit 0
- `pnpm lint` — exit 0
- `pnpm test` — exit 1; 5807 passed, 1 failed, 12 todo. The single failure is
  `client/src/audio/__tests__/AudioManagerDisabled.test.ts`, which this PR does not reach and did
  not introduce:
  - `git diff --stat 755b35edf..4e5f5ffff -- client/src/audio/` is empty; the same command without
    the pathspec is non-empty.
  - The file passes 23/23 when run alone.
  - Two full-suite runs at this head failed *different* members of that file in opposite directions.
  - The identical `pnpm test` at the branch point `755b35edf` — none of these commits present —
    fails the same file (5805 passed, 1 failed).
  - CI's own `Frontend (lint, type-check, test)` job is green on `main` at `726553573`, so this is a
    local-parallelism artifact of the base tree rather than a CI-visible failure.

## Gate A

Gate A PASS head=4e5f5ffffd7deffaa85272c4b5e8621a043c6c88 base=d6d28370c09242182488cac72e16e5a84941885f

## Anchored on

- crates/engine/src/game/interaction.rs:6454 — `loop_shortcut_choices` already matches
  `LoopShortcutCandidateValue` exhaustively, one named arm per variant and no wildcard; the two
  matches this PR converts are spelled to that same shape.
- crates/server-core/src/interaction_payload_guard.rs:122 —
  `rejects_an_oversized_nested_shortcut_pin_budget` is the existing refusal test whose size is
  derived from the bound rather than written as a literal; the accept-at-the-ceiling siblings this
  PR adds sit beside it and derive their sizes the same way.

## Final review-impl

Final review-impl PASS head=4e5f5ffffd7deffaa85272c4b5e8621a043c6c88

## Claimed parse impact

None.

## Scope Expansion

None.

## Validation Failures

None.

## CI Failures

None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented shortcut declarations when no valid choice has been selected.
  - Improved shortcut response rendering so declaration details appear only when applicable.

- **Documentation**
  - Updated rules references and explanatory text related to shortcut previews, victim charges, visibility, and announcements.

- **Tests**
  - Added coverage for valid boundary values in interaction payload validation.
  - Expanded shortcut modal and preview tests for valid and invalid answer scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->