### PR TITLE
fix(client,engine): draw and place Crystalline Giant's random counter kind (#7796)

### DIFF
--- a/client/src/adapter/__tests__/p2p-adapter-multiplayer.test.ts
+++ b/client/src/adapter/__tests__/p2p-adapter-multiplayer.test.ts
@@ -4171,14 +4171,14 @@ describe("P2P wire-protocol version gate", () => {
   // Both halves stamp LITERALS. A frame built from WIRE_PROTOCOL_VERSION
   // cannot tell a bumped client from an unbumped one, which is why every
   // other handshake fixture in the suite is useless as an instrument for a
-  // bump. Revert 44 → 43 and BOTH halves red: the v43 frame stops being
-  // refused, and the v44 frame stops being admitted. The admitting half is
-  // the reach-guard — without it "refuses v43" is also satisfied by a client
+  // bump. Revert 45 → 44 and BOTH halves red: the v44 frame stops being
+  // refused, and the v45 frame stops being admitted. The admitting half is
+  // the reach-guard — without it "refuses v44" is also satisfied by a client
   // that refuses everything.
-  it("refuses the previous wire protocol (v43) and admits its own (v44)", async () => {
+  it("refuses the previous wire protocol (v44) and admits its own (v45)", async () => {
     const refusing = makeGuest();
     await refusing.adapter.initialize();
-    await refusing.conn.simulateData(setupFrameAt(43));
+    await refusing.conn.simulateData(setupFrameAt(44));
 
     await expect(refusing.adapter.initializeGame()).rejects.toMatchObject({
       code: "P2P_REJECTED",
@@ -4190,7 +4190,7 @@ describe("P2P wire-protocol version gate", () => {
 
     const admitting = makeGuest();
     await admitting.adapter.initialize();
-    await admitting.conn.simulateData(setupFrameAt(44));
+    await admitting.conn.simulateData(setupFrameAt(45));
 
     await expect(admitting.adapter.initializeGame()).resolves.toBeDefined();
     expect(admitting.emitted).not.toHaveBeenCalledWith(

--- a/client/src/adapter/ws-adapter.ts
+++ b/client/src/adapter/ws-adapter.ts
@@ -207,6 +207,14 @@ export class NativeEngineVersionMismatchError extends Error {
  * `crates/server-core/src/protocol.rs`. Bump in lockstep when either side
  * adds, removes, renames, or changes the type of a protocol variant field.
  *
+ * 61 — Effect.ChooseCounterKind gained domain and chooser (CR 608.2d): the
+ *      population a counter-kind choice draws from, and whether the game draws
+ *      one at random instead of prompting. Serde-additive, so an older payload
+ *      reads as the on-target/controller form; the other direction drops the
+ *      printed list and the random draw silently, which is the #7796 defect
+ *      itself. Abilities ride inside GameObject, so every GameState frame
+ *      carries the shape. The full handshake refuses stale peers. Lobby
+ *      messages are unchanged.
  * 60 — DerivedViews.back_face_spell_costs publishes, for each card the viewer
  *      may cast whose player chooses a spell face at cast time (a split card
  *      such as a Room, a spell//spell MDFC — CR 709.3 + CR 712.11b), the live
@@ -428,7 +436,7 @@ export class NativeEngineVersionMismatchError extends Error {
  *      into a MulliganDecisionPhase::BottomCards sub-phase on
  *      WaitingFor::MulliganDecision.
  */
-export const PROTOCOL_VERSION = 60;
+export const PROTOCOL_VERSION = 61;
 
 /**
  * Lowest server protocol version this client will accept in the handshake.

--- a/client/src/network/__tests__/protocol.test.ts
+++ b/client/src/network/__tests__/protocol.test.ts
@@ -70,8 +70,8 @@ const PREVIEW_ANSWER = {
 } as never;
 
 describe("encodeWireMessage / decodeWireMessage", () => {
-  it("pins the P2P wire protocol to v44", () => {
-    expect(WIRE_PROTOCOL_VERSION).toBe(44);
+  it("pins the P2P wire protocol to v45", () => {
+    expect(WIRE_PROTOCOL_VERSION).toBe(45);
   });
 
   it("defaults shortcut actions for a legacy payload created before the additive field", () => {

--- a/client/src/network/protocol.ts
+++ b/client/src/network/protocol.ts
@@ -101,6 +101,13 @@ export function legalActionsFromWire(wire: LegalActionsWire): LegalActionsResult
  * seat or adopts reconnect state.
  *
  * Bumps to date:
+ *  45 — Effect.ChooseCounterKind gained domain and chooser, carried inside
+ *       GameObject.abilities and trigger definitions on every GameState frame
+ *       (CR 608.2d). Additive behind serde defaults; a v44 peer has no field to
+ *       receive the printed list or the random chooser into and silently reads
+ *       both as an on-target prompt, placing no counter. Since game_setup and
+ *       reconnect_ack carry GameState, first contact rejects the version skew.
+ *       Bumped in lockstep with PROTOCOL_VERSION 61.
  *  44 — DerivedViews.back_face_spell_costs publishes, for each card the viewer
  *       may cast whose player chooses a spell face at cast time (a split card
  *       such as a Room, a spell//spell MDFC — CR 709.3 + CR 712.11b), the live
@@ -315,7 +322,7 @@ export type P2PInteractionPreviewAnswer =
   | { type: "preview"; preview: InteractionPreview }
   | { type: "failed"; message: string };
 
-export const WIRE_PROTOCOL_VERSION = 44 as const;
+export const WIRE_PROTOCOL_VERSION = 45 as const;
 
 export type P2PMessage = P2PAuthorityWire & (
   | {

--- a/crates/engine/src/game/ability_rw.rs
+++ b/crates/engine/src/game/ability_rw.rs
@@ -3182,7 +3182,7 @@ fn legacy_effect(x: &Effect) -> bool {
                     } => source_filters.iter().any(|filter| legacy_target_filter(filter)),
                 }
         }
-        Effect::ChooseCounterKind { target } => legacy_target_filter(target),
+        Effect::ChooseCounterKind { target, .. } => legacy_target_filter(target),
         Effect::PutChosenCounter {
             target,
             count,
@@ -4552,7 +4552,7 @@ fn rw_effect(
         // resolution-local, per-iteration binding consumed by a later
         // PutChosenCounter. No board WRITE: placement is the separate
         // PutChosenCounter.
-        Effect::ChooseCounterKind { target } => {
+        Effect::ChooseCounterKind { target, .. } => {
             let mut p = if target.is_context_ref() {
                 reads_board_of(StateKind::ObjectCounters)
             } else {

--- a/crates/engine/src/game/ability_scan.rs
+++ b/crates/engine/src/game/ability_scan.rs
@@ -733,7 +733,7 @@ fn scan_effect(x: &Effect, mode: ScanMode) -> Axes {
             acc = acc.or(scan_target_filter(target, target_ctx, mode));
             acc
         }
-        Effect::ChooseCounterKind { target } => {
+        Effect::ChooseCounterKind { target, .. } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_target_filter(target, target_ctx, mode));
             acc
@@ -8455,7 +8455,14 @@ mod tests {
         census(&settap, false);
         census(&Effect::HeistExile, false);
         census(&Effect::NoOp, false);
-        census(&Effect::ChooseCounterKind { target: f() }, true);
+        census(
+            &Effect::ChooseCounterKind {
+                target: f(),
+                domain: Default::default(),
+                chooser: Default::default(),
+            },
+            true,
+        );
         // CR 701.27a + CR 115.10a: mass Transform is a battlefield census in BOTH oracles
         // (scope:All), and a bounded single-target read (scope:Single) that relaxes. It is
         // a true Census, NOT the SetTapState relax exception (ObjectPt/ability write).

--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -19,16 +19,16 @@ use crate::types::ability::{
     AbilityCondition, AbilityCost, AbilityDefinition, AbilityKind, ActivationRestriction,
     AdditionalCost, AggregateFunction, AttackScope, AttackSubject, CardTypeSetSource, ChoiceType,
     CoinFlipResult, CommanderOwnership, Comparator, ContinuousModification, ControllerRef,
-    CountScope, CounterSourceRider, DelayedTriggerCondition, DieRollModifier, DoublePTMode,
-    Duration, EachDamageRecipient, Effect, EffectOutcomeSignal, EffectScope, FilterProp,
-    ForEachCategoryAction, GameRestriction, LibraryPosition, ManaProduction, ObjectProperty,
-    ObjectScope, ObjectSelectionCardinality, ObjectSelectionEligibility, ParsedCondition,
-    PerpetualModification, PlayerFilter, PlayerRelation, PlayerScope, PtStat, PtValue,
-    PtValueScope, QuantityExpr, QuantityRef, ReplacementCondition, ReplacementDefinition,
-    ReplacementMode, SeatDirection, SharedQuality, SharedQualityRelation, SpeedDelta,
-    SpellCastingOption, SpellCastingOptionKind, SpellStackToGraveyardReplacement, StackAbilityKind,
-    StaticCondition, StaticDefinition, TapStateChange, TargetFilter, TriggerDefinition, TypeFilter,
-    TypedFilter, VoteSubject, ZoneRef,
+    CountScope, CounterKindChooser, CounterKindDomain, CounterSourceRider, DelayedTriggerCondition,
+    DieRollModifier, DoublePTMode, Duration, EachDamageRecipient, Effect, EffectOutcomeSignal,
+    EffectScope, FilterProp, ForEachCategoryAction, GameRestriction, LibraryPosition,
+    ManaProduction, ObjectProperty, ObjectScope, ObjectSelectionCardinality,
+    ObjectSelectionEligibility, ParsedCondition, PerpetualModification, PlayerFilter,
+    PlayerRelation, PlayerScope, PtStat, PtValue, PtValueScope, QuantityExpr, QuantityRef,
+    ReplacementCondition, ReplacementDefinition, ReplacementMode, SeatDirection, SharedQuality,
+    SharedQualityRelation, SpeedDelta, SpellCastingOption, SpellCastingOptionKind,
+    SpellStackToGraveyardReplacement, StackAbilityKind, StaticCondition, StaticDefinition,
+    TapStateChange, TargetFilter, TriggerDefinition, TypeFilter, TypedFilter, VoteSubject, ZoneRef,
 };
 use crate::types::card::CardFace;
 use crate::types::card_type::CoreType;
@@ -3602,8 +3602,50 @@ fn effect_details(effect: &Effect) -> Vec<(String, String)> {
                 ));
             }
         }
-        Effect::ChooseCounterKind { target } => {
+        Effect::ChooseCounterKind {
+            target,
+            domain,
+            chooser,
+        } => {
             d.push(("target".into(), fmt_target(target)));
+            // Both axes belong in the signature: the parse-diff report is what
+            // tells a reviewer which cards a parser change moved, and a domain
+            // or chooser that flipped without the target moving would otherwise
+            // be invisible there.
+            match domain {
+                CounterKindDomain::OnTarget => {
+                    d.push(("kinds".into(), "on target".into()));
+                }
+                CounterKindDomain::Printed {
+                    kinds,
+                    excluding_kinds_on_target,
+                } => {
+                    d.push((
+                        "kinds".into(),
+                        format!(
+                            "printed {}{}",
+                            kinds
+                                .iter()
+                                .map(|kind| kind.as_str().into_owned())
+                                .collect::<Vec<_>>()
+                                .join("/"),
+                            if *excluding_kinds_on_target {
+                                ", excluding kinds on target"
+                            } else {
+                                ""
+                            }
+                        ),
+                    ));
+                }
+            }
+            d.push((
+                "chooser".into(),
+                match chooser {
+                    CounterKindChooser::Controller => "controller",
+                    CounterKindChooser::Random => "at random",
+                }
+                .into(),
+            ));
         }
         Effect::PutChosenCounter {
             target,

--- a/crates/engine/src/game/effects/choose_counter_kind.rs
+++ b/crates/engine/src/game/effects/choose_counter_kind.rs
@@ -14,7 +14,8 @@
 //! read it without leaking a persistent attribute onto the source.
 
 use crate::types::ability::{
-    ChoiceType, Effect, EffectError, EffectKind, ResolvedAbility, TargetFilter,
+    ChoiceType, CounterKindChooser, CounterKindDomain, Effect, EffectError, EffectKind,
+    ResolvedAbility, TargetFilter,
 };
 use crate::types::counter::CounterType;
 use crate::types::events::GameEvent;
@@ -26,8 +27,12 @@ pub fn resolve(
     ability: &ResolvedAbility,
     events: &mut Vec<GameEvent>,
 ) -> Result<(), EffectError> {
-    let target_filter = match &ability.effect {
-        Effect::ChooseCounterKind { target } => target,
+    let (target_filter, kind_source, chooser) = match &ability.effect {
+        Effect::ChooseCounterKind {
+            target,
+            domain,
+            chooser,
+        } => (target, domain, chooser),
         _ => return Err(EffectError::MissingParam("ChooseCounterKind".to_string())),
     };
 
@@ -70,8 +75,31 @@ pub fn resolve(
         } else {
             target_filter
         };
-    let kinds =
-        crate::game::quantity::distinct_counter_kinds_among(state, kind_domain, &filter_ctx);
+    // CR 608.2d: the card text names the population. "choose a counter on it"
+    // reads what the object carries; "from among <list>" prints its own closed
+    // set, and an exclusion clause narrows THAT set before anything is chosen —
+    // never after, or a random draw could pick an already-present kind and then
+    // place nothing.
+    let kinds: Vec<CounterType> = match kind_source {
+        CounterKindDomain::OnTarget => {
+            crate::game::quantity::distinct_counter_kinds_among(state, kind_domain, &filter_ctx)
+        }
+        CounterKindDomain::Printed {
+            kinds,
+            excluding_kinds_on_target,
+        } => {
+            let mut candidates = kinds.clone();
+            if *excluding_kinds_on_target {
+                let present = crate::game::quantity::distinct_counter_kinds_among(
+                    state,
+                    kind_domain,
+                    &filter_ctx,
+                );
+                candidates.retain(|kind| !present.contains(kind));
+            }
+            candidates
+        }
+    };
 
     let resolved = || GameEvent::EffectResolved {
         kind: EffectKind::from(&ability.effect),
@@ -88,6 +116,30 @@ pub fn resolve(
     let choice_type = ChoiceType::CounterKind {
         options: kinds.clone(),
     };
+
+    // The card's "at random" takes the decision off the player, so the game
+    // draws from the seeded RNG and binds the result, exactly as the modal
+    // random axis does. CR 608.2d governs only WHEN the choice is announced;
+    // see `CounterKindChooser::Random` for why no rule number sits on the
+    // randomness itself. No prompt is emitted, so this must come before the
+    // interactive branch.
+    if matches!(chooser, CounterKindChooser::Random) {
+        use rand::seq::IndexedRandom; // rand 0.9: `choose` on `[T]`
+        let drawn = kinds
+            .choose(&mut state.rng)
+            .expect("non-empty: the zero-kind branch returned above")
+            .as_str()
+            .into_owned();
+        crate::game::effects::choose::bind_named_choice(
+            state,
+            &choice_type,
+            &drawn,
+            source.as_mut(),
+            persist_player,
+        );
+        events.push(resolved());
+        return Ok(());
+    }
 
     // CR 608.2d: a single legal option is auto-selected — no interactive prompt.
     if kinds.len() == 1 {
@@ -137,6 +189,8 @@ mod tests {
         let mut ability = ResolvedAbility::new(
             Effect::ChooseCounterKind {
                 target: TargetFilter::ParentTarget,
+                domain: Default::default(),
+                chooser: Default::default(),
             },
             vec![TargetRef::Object(target_obj)],
             source,
@@ -267,6 +321,8 @@ mod tests {
                 target: TargetFilter::Typed(
                     TypedFilter::permanent().controller(ControllerRef::You),
                 ),
+                domain: Default::default(),
+                chooser: Default::default(),
             },
             vec![TargetRef::Object(downstream_target)],
             source,
@@ -354,6 +410,8 @@ mod tests {
                         zone: crate::types::zones::Zone::Exile,
                     }],
                 }),
+                domain: Default::default(),
+                chooser: Default::default(),
             },
             Vec::new(),
             source,

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -11,8 +11,8 @@ use crate::game::speed::has_max_speed;
 use crate::types::ability::{
     AbilityCondition, AbilityCost, AbilityDefinition, AbilityKind, CardPlayMode, CardTypeSetSource,
     CastFromZoneDriver, ChosenAttribute, CommanderOwnership, ControllerRef, CopyRetargetPermission,
-    CostPaidObjectSnapshot, DetachedRemainder, EachDamageRecipient, Effect, EffectError,
-    EffectKind, EffectOutcomeSignal, EffectResolutionResult, EffectScope, FilterProp,
+    CostPaidObjectSnapshot, CounterKindDomain, DetachedRemainder, EachDamageRecipient, Effect,
+    EffectError, EffectKind, EffectOutcomeSignal, EffectResolutionResult, EffectScope, FilterProp,
     ForEachCategoryAction, ForwardedResultContext, ManaProduction, ObjectSelectionCardinality,
     OpponentMayScope, PlayerFilter, PlayerScope, QuantityExpr, QuantityRef,
     ReciprocalZoneChoiceRole, RepeatContinuation, ResolvedAbility, RevealUntilDisposition,
@@ -12598,7 +12598,7 @@ fn resolve_chain_body(
     // here would be wrong (and untested against that resolver's semantics).
     let needs_resolution_object_choice = match &ability.effect {
         Effect::PutCounter { .. } => ability.targets.is_empty(),
-        Effect::ChooseCounterKind { target } => {
+        Effect::ChooseCounterKind { target, .. } => {
             !matches!(target, TargetFilter::SpecificObject { .. })
         }
         _ => false,
@@ -12607,7 +12607,7 @@ fn resolve_chain_body(
         && needs_resolution_object_choice
         && ability.distribution.is_none()
     {
-        if let Effect::PutCounter { target, .. } | Effect::ChooseCounterKind { target } =
+        if let Effect::PutCounter { target, .. } | Effect::ChooseCounterKind { target, .. } =
             &ability.effect
         {
             if !target.contains_source_attachment_host() {
@@ -12620,17 +12620,33 @@ fn resolve_chain_body(
                         filter::matches_target_filter(state, *id, &effective_filter, &filter_ctx)
                     })
                     .filter(|id| {
-                        !matches!(ability.effect, Effect::ChooseCounterKind { .. })
-                            || state.objects.get(id).is_some_and(|object| {
-                                object.counters.values().any(|count| *count > 0)
-                            })
+                        // CR 608.2d: "a player can't choose an impossible
+                        // option" — an object with no counters offers nothing
+                        // to an ON-TARGET choice, so it is not a legal subject.
+                        // A PRINTED list carries its own options and this test
+                        // does not apply to it. No printed-list card reaches
+                        // here today: the only one parses to `SelfRef`, a
+                        // context reference, which `target_choice_timing_for_clause`
+                        // never gives `Resolution` timing. The predicate names
+                        // the domain rather than the effect so that it stays
+                        // true if one ever does.
+                        !matches!(
+                            ability.effect,
+                            Effect::ChooseCounterKind {
+                                domain: CounterKindDomain::OnTarget,
+                                ..
+                            }
+                        ) || state
+                            .objects
+                            .get(id)
+                            .is_some_and(|object| object.counters.values().any(|count| *count > 0))
                     })
                     .collect();
                 match legal.len() {
                     0 => {}
                     1 => {
                         let mut bound = ability.clone();
-                        if let Effect::ChooseCounterKind { target } = &mut bound.effect {
+                        if let Effect::ChooseCounterKind { target, .. } = &mut bound.effect {
                             *target = TargetFilter::SpecificObject { id: legal[0] };
                             if let Some(object) = state.objects.get(&legal[0]) {
                                 bound.set_effect_context_object_recursive(

--- a/crates/engine/src/game/engine_resolution_choices.rs
+++ b/crates/engine/src/game/engine_resolution_choices.rs
@@ -4732,7 +4732,7 @@ pub(super) fn handle_resolution_choice(
             if let Some(frame) = state.active_ability_continuation_frame_mut() {
                 let cont = &mut frame.pending;
                 if let Some(snapshot) = counter_kind_choice {
-                    if let crate::types::ability::Effect::ChooseCounterKind { target } =
+                    if let crate::types::ability::Effect::ChooseCounterKind { target, .. } =
                         &mut cont.chain.effect
                     {
                         *target = crate::types::ability::TargetFilter::SpecificObject {

--- a/crates/engine/src/game/quantity.rs
+++ b/crates/engine/src/game/quantity.rs
@@ -9481,6 +9481,8 @@ mod tests {
             ResolvedAbility::new(
                 Effect::ChooseCounterKind {
                     target: TargetFilter::ParentTargetSlot { index },
+                    domain: Default::default(),
+                    chooser: Default::default(),
                 },
                 vec![TargetRef::Object(second)],
                 source,

--- a/crates/engine/src/parser/oracle_effect/counter.rs
+++ b/crates/engine/src/parser/oracle_effect/counter.rs
@@ -473,9 +473,10 @@ fn try_consume_counter_list_separator(input: &str) -> Option<&str> {
 /// on <recipient> [if it doesn't have a counter of that kind on it]" →
 /// `Effect::PutChosenCounter`. Anaphoric recipients bind to `ParentTarget` (The
 /// Caves of Androzani); declared typed recipients use the shared target parser
-/// (Aven Courier). A source-self recipient remains unsupported because its
-/// producer may be a random counter-kind choice that is not yet bound to
-/// resolution state (Crystalline Giant). The optional suffix becomes an
+/// (Aven Courier). A source-self recipient IS supported: its producer — the
+/// printed-population random choice — now binds a concrete kind into
+/// resolution state before this clause runs (Crystalline Giant), which is the
+/// binding the earlier strict gap was waiting for. The optional suffix becomes an
 /// explicit EQ-zero predicate over each resolved target's count of the chosen
 /// kind. Combinator-based and fully consuming; `input` has already had the
 /// leading "put " stripped.
@@ -498,7 +499,10 @@ pub(super) fn try_parse_put_chosen_counter(input: &str) -> Option<Effect> {
         (TargetFilter::ParentTarget, remainder)
     } else {
         let (target, remainder) = parse_target(recipient_text);
-        if matches!(target, TargetFilter::Any | TargetFilter::SelfRef) {
+        // `Any` is this parser's "no recipient recognized", not a legal
+        // recipient. `SelfRef` is a real one — "on ~" — and its kind is bound
+        // by the preceding choice like every other producer's.
+        if matches!(target, TargetFilter::Any) {
             return None;
         }
         (target, remainder)
@@ -1778,15 +1782,23 @@ mod tests {
         ));
     }
 
-    /// Crystalline Giant's random counter-kind producer is not represented by
-    /// `ChoiceType::CounterKind`, so its source-self consumer must stay outside
-    /// the supported `PutChosenCounter` grammar until that binding exists.
+    /// CR 608.2c: Crystalline Giant's source-self consumer. This was a
+    /// deliberate strict gap for as long as its producer — the printed-list
+    /// random choice — could not bind a kind into resolution state. That
+    /// binding now exists (`CounterKindDomain::Printed` +
+    /// `CounterKindChooser::Random`), so "on ~" is an ordinary recipient and
+    /// the gap is closed rather than merely widened.
     #[test]
-    fn put_chosen_counter_rejects_unbound_source_self_consumer() {
-        assert!(
-            try_parse_put_chosen_counter("a counter of that kind on ~.").is_none(),
-            "an unbound random counter kind must remain a strict parser gap"
-        );
+    fn put_chosen_counter_accepts_source_self_consumer() {
+        let effect = try_parse_put_chosen_counter("a counter of that kind on ~.")
+            .expect("source-self recipient is supported once the producer binds a kind");
+        assert!(matches!(
+            effect,
+            Effect::PutChosenCounter {
+                target: TargetFilter::SelfRef,
+                ..
+            }
+        ));
     }
 
     /// CR 115.1d + CR 608.2c + CR 608.2d: Full-card reach guard for Aven
@@ -1834,6 +1846,7 @@ mod tests {
             choose.effect.as_ref(),
             Effect::ChooseCounterKind {
                 target: TargetFilter::Typed(filter),
+                ..
             } if filter.type_filters == vec![crate::types::ability::TypeFilter::Permanent]
                 && filter.controller == Some(ControllerRef::You)
         ));
@@ -1917,6 +1930,7 @@ mod tests {
             choose.effect.as_ref(),
             Effect::ChooseCounterKind {
                 target: TargetFilter::Typed(filter),
+                ..
             } if filter.type_filters == vec![crate::types::ability::TypeFilter::Creature]
                 && filter.controller == Some(ControllerRef::You)
         ));

--- a/crates/engine/src/parser/oracle_effect/imperative.rs
+++ b/crates/engine/src/parser/oracle_effect/imperative.rs
@@ -40,11 +40,11 @@ use crate::parser::oracle_static::{
 use crate::types::ability::{
     AbilityCondition, AbilityCost, AbilityDefinition, AbilityKind, BounceSelection,
     CardSelectionMode, CategoryChooserScope, ChoiceType, Chooser, ContinuousModification,
-    ControlWindow, ControllerRef, CopyRetargetPermission, CounterAdjustment, DigSource, DoorLockOp,
-    Duration, Effect, EffectScope, FaceDownProfile, FilterProp, ForceBlockAttackerRef,
-    GrantedAbilityScope, LibraryPosition, MultiTargetSpec, ObjectSelectionCardinality,
-    ObjectSelectionEligibility, OutsideGameSourcePool, PerPlayerScope, PlayerScope,
-    PreventionAmount, PreventionScope, PtStat, PtValue, QuantityExpr, QuantityRef,
+    ControlWindow, ControllerRef, CopyRetargetPermission, CounterAdjustment, CounterKindChooser,
+    CounterKindDomain, DigSource, DoorLockOp, Duration, Effect, EffectScope, FaceDownProfile,
+    FilterProp, ForceBlockAttackerRef, GrantedAbilityScope, LibraryPosition, MultiTargetSpec,
+    ObjectSelectionCardinality, ObjectSelectionEligibility, OutsideGameSourcePool, PerPlayerScope,
+    PlayerScope, PreventionAmount, PreventionScope, PtStat, PtValue, QuantityExpr, QuantityRef,
     ReassembleControlMode, SearchSelectionConstraint, StaticDefinition, StickerTicketCostPayment,
     TapStateChange, TargetFilter, TargetSelectionMode, ThisWayCause, TypeFilter, TypedFilter,
     ZoneOwner,
@@ -4298,6 +4298,77 @@ fn try_parse_choose_damage_source(rest: &str) -> Option<ChooseImperativeAst> {
     Some(ChooseImperativeAst::DamageSource { source_filter })
 }
 
+/// CR 608.2d + CR 122.1b: "a kind of counter[ at random][ that <self> doesn't
+/// have on it] from among <list>" — the counter-kind choice whose population is
+/// PRINTED on the card rather than read off the object (Crystalline Giant).
+///
+/// Three independent riders, each optional and each read from the text rather
+/// than assumed:
+///   * " at random" — the GAME picks (`CounterKindChooser::Random`), so no
+///     prompt is ever shown.
+///   * " that <self> doesn't have on it" — narrows the printed set BEFORE the
+///     pick. CR 608.2d: an excluded option can't be chosen; narrowing after
+///     the draw would let a random pick land on a present kind and place
+///     nothing.
+///   * the list itself, read by `classify_and_parse_from_among_counter_list` —
+///     the same item authority Grimdancer's pair pick uses, so a new counter
+///     spelling is learned in exactly one place.
+///
+/// The domain the exclusion is measured against is the ability's own source:
+/// the sentence says "this creature", which the normalizer writes as `~`.
+fn try_parse_choose_counter_kind_from_among(rest_lower: &str) -> Option<ChooseImperativeAst> {
+    let (rest, _) = tag::<_, _, OracleError<'_>>("a kind of counter")
+        .parse(rest_lower.trim())
+        .ok()?;
+    let (rest, random) = opt(tag::<_, _, OracleError<'_>>(" at random"))
+        .parse(rest)
+        .ok()?;
+
+    // Optional exclusion clause. `opt` on the whole sequence, so a card that
+    // prints the list without an exclusion still parses.
+    let exclusion = (
+        tag::<_, _, OracleError<'_>>(" that "),
+        alt((
+            tag("~"),
+            tag("this creature"),
+            tag("this permanent"),
+            tag("it"),
+        )),
+        alt((tag(" doesn't have"), tag(" does not have"))),
+        tag(" on it"),
+    );
+    let (rest, excluded) = match opt(exclusion).parse(rest) {
+        Ok((rest, found)) => (rest, found.is_some()),
+        Err(_) => return None,
+    };
+
+    let (list, _) = tag::<_, _, OracleError<'_>>(" from among ")
+        .parse(rest)
+        .ok()?;
+    let entries = crate::parser::oracle_effect::classify_and_parse_from_among_counter_list(
+        list.trim().trim_end_matches('.'),
+    )?;
+
+    Some(ChooseImperativeAst::CounterKind {
+        // CR 608.2d: the printed set is self-contained; the object the
+        // exclusion reads is the ability's source.
+        target: TargetFilter::SelfRef,
+        domain: CounterKindDomain::Printed {
+            // The list parser also yields a per-entry count. "A kind of
+            // counter" places one of the chosen kind, so the count is not the
+            // choice's business; a printed list that ever spelled a quantity
+            // ("two charge counters") would need it read here.
+            kinds: entries.into_iter().map(|(kind, _count)| kind).collect(),
+            excluding_kinds_on_target: excluded,
+        },
+        chooser: if random.is_some() {
+            CounterKindChooser::Random
+        } else {
+            CounterKindChooser::Controller
+        },
+    })
+}
+
 /// CR 608.2d + CR 122.1: "a [kind of] counter on <domain>" — the counter-kind
 /// choice head. An anaphor (`it` / `that permanent` / `that creature`) binds
 /// to `ParentTarget` (The Caves of Androzani); a typed untargeted domain uses
@@ -4308,6 +4379,13 @@ fn try_parse_choose_damage_source(rest: &str) -> Option<ChooseImperativeAst> {
 /// remains owned by the existing target-designation path rather than being
 /// misclassified as a resolution-time source population.
 fn try_parse_choose_counter_kind(rest_lower: &str) -> Option<ChooseImperativeAst> {
+    // CR 608.2d + CR 122.1b: the printed-population sibling shares this head
+    // ("a kind of counter") and is told apart only by its tail, so it must be
+    // tried first — otherwise "on " never matches and the whole clause falls
+    // through to Unimplemented (Crystalline Giant).
+    if let Some(ast) = try_parse_choose_counter_kind_from_among(rest_lower) {
+        return Some(ast);
+    }
     let (domain, _) = alt((
         tag::<_, _, OracleError<'_>>("a kind of counter on "),
         tag("a counter on "),
@@ -4331,6 +4409,8 @@ fn try_parse_choose_counter_kind(rest_lower: &str) -> Option<ChooseImperativeAst
     {
         return Some(ChooseImperativeAst::CounterKind {
             target: TargetFilter::ParentTarget,
+            domain: CounterKindDomain::default(),
+            chooser: CounterKindChooser::default(),
         });
     }
 
@@ -4342,7 +4422,11 @@ fn try_parse_choose_counter_kind(rest_lower: &str) -> Option<ChooseImperativeAst
     {
         return None;
     }
-    Some(ChooseImperativeAst::CounterKind { target })
+    Some(ChooseImperativeAst::CounterKind {
+        target,
+        domain: CounterKindDomain::default(),
+        chooser: CounterKindChooser::default(),
+    })
 }
 
 /// CR 108.3 + CR 701.38d: Detect "a <type> owned by the voter" and emit
@@ -5645,7 +5729,15 @@ pub(super) fn lower_choose_ast(ast: ChooseImperativeAst) -> Effect {
         ChooseImperativeAst::TwoTargets { target_a, .. } => Effect::TargetOnly { target: target_a },
         // CR 608.2d + CR 122.1: "choose a counter on it" → interactive
         // counter-kind selection on the anaphoric object.
-        ChooseImperativeAst::CounterKind { target } => Effect::ChooseCounterKind { target },
+        ChooseImperativeAst::CounterKind {
+            target,
+            domain,
+            chooser,
+        } => Effect::ChooseCounterKind {
+            target,
+            domain,
+            chooser,
+        },
     }
 }
 
@@ -14941,6 +15033,7 @@ mod tests {
                 .expect("typed untargeted counter domain must parse");
             let ChooseImperativeAst::CounterKind {
                 target: TargetFilter::Typed(filter),
+                ..
             } = ast
             else {
                 panic!("expected typed CounterKind domain, got {ast:?}");
@@ -14998,6 +15091,7 @@ mod tests {
                 try_parse_choose_counter_kind(input),
                 Some(ChooseImperativeAst::CounterKind {
                     target: TargetFilter::ParentTarget,
+                    ..
                 })
             ));
         }

--- a/crates/engine/src/parser/oracle_effect/lower.rs
+++ b/crates/engine/src/parser/oracle_effect/lower.rs
@@ -1799,7 +1799,7 @@ pub(super) fn target_choice_timing_for_clause(clause_ir: &ClauseIr) -> TargetCho
             return TargetChoiceTiming::Resolution;
         }
     }
-    if let Effect::ChooseCounterKind { target } = &clause_ir.parsed.effect {
+    if let Effect::ChooseCounterKind { target, .. } = &clause_ir.parsed.effect {
         let lower = clause_ir
             .source
             .fragment()

--- a/crates/engine/src/parser/oracle_ir/ast.rs
+++ b/crates/engine/src/parser/oracle_ir/ast.rs
@@ -5,12 +5,12 @@ use crate::types::ability::MultiTargetSpec;
 use crate::types::ability::{
     AbilityCondition, AbilityCost, AbilityDefinition, ActivationRestriction, BounceSelection,
     CastingPermission, ChosenCounterCountCondition, ControlWindow, ControllerRef,
-    CopyRetargetPermission, CounterAdjustment, CounterSourceRider, DigRestOrder, DoorLockOp,
-    Duration, Effect, EffectScope, FaceDownProfile, ForceBlockAttackerRef, LibraryPosition,
-    ManaProduction, ManaSpendRestriction, ManaTargetRole, ModalSelectionConstraint,
-    OutsideGameSourcePool, PlayerFilter, PtStat, PtValue, QuantityExpr, SearchDestinationSplit,
-    SearchSelectionConstraint, SpellStackToGraveyardReplacement, StaticCondition, StaticDefinition,
-    SubAbilityLink, TargetFilter, ThisWayCause,
+    CopyRetargetPermission, CounterAdjustment, CounterKindChooser, CounterKindDomain,
+    CounterSourceRider, DigRestOrder, DoorLockOp, Duration, Effect, EffectScope, FaceDownProfile,
+    ForceBlockAttackerRef, LibraryPosition, ManaProduction, ManaSpendRestriction, ManaTargetRole,
+    ModalSelectionConstraint, OutsideGameSourcePool, PlayerFilter, PtStat, PtValue, QuantityExpr,
+    SearchDestinationSplit, SearchSelectionConstraint, SpellStackToGraveyardReplacement,
+    StaticCondition, StaticDefinition, SubAbilityLink, TargetFilter, ThisWayCause,
 };
 use crate::types::card_type::Supertype;
 use crate::types::counter::CounterType;
@@ -1530,8 +1530,16 @@ pub(crate) enum ChooseImperativeAst {
     /// of the distinct counter kinds present on the anaphoric object (The Caves
     /// of Androzani II/III). Lowered to `Effect::ChooseCounterKind`. `target` is
     /// the anaphor (`ParentTarget` for the per-iteration object).
+    ///
+    /// `domain` and `chooser` carry the second surface form of the same
+    /// instruction — "a kind of counter at random ... from among <list>"
+    /// (Crystalline Giant), whose population is printed on the card and whose
+    /// pick is made by the game. Both default to the on-target/controller
+    /// reading, so the anaphoric form above is unchanged.
     CounterKind {
         target: TargetFilter,
+        domain: CounterKindDomain,
+        chooser: CounterKindChooser,
     },
 }
 

--- a/crates/engine/src/parser/oracle_trigger_tests.rs
+++ b/crates/engine/src/parser/oracle_trigger_tests.rs
@@ -98,6 +98,75 @@ fn liberator_mana_spent_intervening_if_survives_the_pipeline() {
     );
 }
 
+/// CR 608.2d + CR 122.1b: Crystalline Giant's combat trigger lowers into a real
+/// choice, not `Unimplemented`. Both halves have to land: the producer (a random
+/// pick from the ten PRINTED kinds, minus the ones already on it) and the
+/// consumer ("put a counter of that kind on ~"), whose source-self recipient was
+/// a deliberate strict gap until exactly this producer existed.
+#[test]
+fn crystalline_giant_random_counter_kind_lowers_to_a_real_choice() {
+    use crate::types::ability::{CounterKindChooser, CounterKindDomain};
+    use crate::types::counter::CounterType;
+
+    let parsed = parse_oracle_text(
+        "At the beginning of combat on your turn, choose a kind of counter at random that this \
+         creature doesn't have on it from among flying, first strike, deathtouch, hexproof, \
+         lifelink, menace, reach, trample, vigilance, and +1/+1. Put a counter of that kind on \
+         this creature.",
+        "Crystalline Giant",
+        &[],
+        &["Artifact".to_string(), "Creature".to_string()],
+        &["Golem".to_string()],
+    );
+
+    let trigger = parsed.triggers.first().expect("begin-combat trigger");
+    let choose = trigger.execute.as_deref().expect("choice effect");
+    let Effect::ChooseCounterKind {
+        target,
+        domain,
+        chooser,
+    } = choose.effect.as_ref()
+    else {
+        panic!("expected ChooseCounterKind, got {:?}", choose.effect);
+    };
+    assert_eq!(*target, TargetFilter::SelfRef);
+    assert_eq!(
+        *chooser,
+        CounterKindChooser::Random,
+        "\"at random\" is the game's draw, not a player decision"
+    );
+    let CounterKindDomain::Printed {
+        kinds,
+        excluding_kinds_on_target,
+    } = domain
+    else {
+        panic!("expected the printed list, got {domain:?}");
+    };
+    assert!(
+        *excluding_kinds_on_target,
+        "\"that this creature doesn't have on it\" must narrow the CHOICE, not the placement"
+    );
+    assert_eq!(kinds.len(), 10, "ten printed kinds, got {kinds:?}");
+    assert!(kinds.contains(&CounterType::Plus1Plus1));
+
+    // The consumer: the counter goes on the Giant itself.
+    let put = choose
+        .sub_ability
+        .as_deref()
+        .expect("put-counter continuation");
+    assert!(
+        matches!(
+            put.effect.as_ref(),
+            Effect::PutChosenCounter {
+                target: TargetFilter::SelfRef,
+                ..
+            }
+        ),
+        "expected PutChosenCounter on ~, got {:?}",
+        put.effect
+    );
+}
+
 /// CR 608.2c + CR 119.3: Palantir's final life loss reduces the exact cards
 /// milled by its preceding clause and applies to the opponent targeted when the
 /// trigger was put on the stack.

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -13662,6 +13662,49 @@ pub struct ChosenCounterCountCondition {
     pub rhs: QuantityExpr,
 }
 
+/// CR 608.2d: Where a `ChooseCounterKind` instruction gets its legal kinds.
+///
+/// Two populations, and the card text says which: "choose a counter ON IT"
+/// reads what the object already carries, while "from among <list>" prints its
+/// own closed set. Modelled as a domain rather than a flag so a new population
+/// is a compile error at every reader instead of a silently-taken default.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type")]
+pub enum CounterKindDomain {
+    /// The distinct kinds already on the resolved target (The Caves of
+    /// Androzani II/III, Aven Courier).
+    #[default]
+    OnTarget,
+    /// A closed list printed on the card. `excluding_kinds_on_target` carries
+    /// the "that this creature doesn't have on it" clause (Crystalline Giant),
+    /// which narrows the CHOICE and not the placement: CR 608.2d forbids
+    /// choosing an option the instruction excludes, and a random draw from the
+    /// unnarrowed list would otherwise land on a kind already present and then
+    /// place nothing.
+    Printed {
+        kinds: Vec<CounterType>,
+        #[serde(default)]
+        excluding_kinds_on_target: bool,
+    },
+}
+
+/// CR 608.2d: Who makes a `ChooseCounterKind` selection.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type")]
+pub enum CounterKindChooser {
+    /// The ability's controller, through the interactive named-choice seam.
+    #[default]
+    Controller,
+    /// The GAME draws uniformly from the seeded `state.rng`; no prompt and no
+    /// player decision. The Comprehensive Rules define no general "at random"
+    /// choice — CR 608.2d says only WHEN the choice is announced and that an
+    /// impossible option can't be taken; the card's own wording is what moves
+    /// the decision off the player, the way CR 701.9b lets an effect require a
+    /// random discard instead of the default player choice. Mirrors the random
+    /// axis `random_select_modal_indices` already provides for modes.
+    Random,
+}
+
 #[allow(clippy::large_enum_variant)]
 #[derive(Clone, PartialEq, Eq, Serialize, Deserialize, strum::IntoStaticStr)]
 #[serde(tag = "type")]
@@ -14863,6 +14906,12 @@ pub enum Effect {
     ChooseCounterKind {
         #[serde(default = "default_target_filter_any")]
         target: TargetFilter,
+        /// CR 608.2d: which kinds are legal to choose from.
+        #[serde(default)]
+        domain: CounterKindDomain,
+        /// CR 608.2d: who picks. `Random` skips the prompt entirely.
+        #[serde(default)]
+        chooser: CounterKindChooser,
     },
     /// CR 122.1 + CR 122.6: "put an additional counter of that kind on that
     /// permanent" — read the resolution-local counter-kind choice and add
@@ -32470,6 +32519,37 @@ mod tests {
                 attacker: None,
                 duration: Duration::UntilEndOfTurn,
             }
+        );
+    }
+
+    /// The protocol bump that ships `domain`/`chooser` calls both fields
+    /// serde-additive; this is what pins that claim. A payload written before
+    /// they existed must read as the on-target/controller form it always meant,
+    /// not as a random draw from an empty printed list.
+    #[test]
+    fn choose_counter_kind_serde_reads_pre_domain_payloads_as_on_target() {
+        let legacy = r#"{"type":"ChooseCounterKind","target":{"type":"ParentTarget"}}"#;
+        assert_eq!(
+            serde_json::from_str::<Effect>(legacy).expect("deserialize legacy counter-kind choice"),
+            Effect::ChooseCounterKind {
+                target: TargetFilter::ParentTarget,
+                domain: CounterKindDomain::OnTarget,
+                chooser: CounterKindChooser::Controller,
+            }
+        );
+
+        let printed = Effect::ChooseCounterKind {
+            target: TargetFilter::SelfRef,
+            domain: CounterKindDomain::Printed {
+                kinds: vec![CounterType::Plus1Plus1],
+                excluding_kinds_on_target: true,
+            },
+            chooser: CounterKindChooser::Random,
+        };
+        let json = serde_json::to_string(&printed).expect("serialize printed counter-kind choice");
+        assert_eq!(
+            serde_json::from_str::<Effect>(&json).expect("round-trip printed counter-kind choice"),
+            printed
         );
     }
 

--- a/crates/engine/tests/integration/crystalline_giant_random_counter_kind.rs
+++ b/crates/engine/tests/integration/crystalline_giant_random_counter_kind.rs
@@ -1,0 +1,156 @@
+//! Runtime regression for issue #7796 (duplicate report #8137) — Crystalline
+//! Giant's beginning-of-combat trigger placed no counter at all: the parser
+//! lowered its "choose ... at random ... from among <list>" clause to
+//! `Effect::Unimplemented`, so the ability resolved as a no-op.
+//!
+//! Oracle text:
+//! > At the beginning of combat on your turn, choose a kind of counter at
+//! > random that this creature doesn't have on it from among flying, first
+//! > strike, deathtouch, hexproof, lifelink, menace, reach, trample,
+//! > vigilance, and +1/+1. Put a counter of that kind on this creature.
+//!
+//! Claim-to-test matrix:
+//! - producer runs at all → a fresh Giant gains exactly one counter, and its
+//!   kind comes from the ten printed ones (reach-guard: without the lowering
+//!   nothing is placed);
+//! - the exclusion narrows the CHOICE, not the placement → with nine of the ten
+//!   already on it the draw has one legal option left and must land there;
+//! - CR 608.2d / the printed ruling → with all ten on it the ability still
+//!   triggers, and places nothing.
+
+use engine::game::scenario::{GameScenario, P0};
+use engine::types::counter::CounterType;
+use engine::types::keywords::KeywordKind;
+use engine::types::phase::Phase;
+use std::collections::HashMap;
+
+const CRYSTALLINE_GIANT: &str =
+    "At the beginning of combat on your turn, choose a kind of counter at random that this \
+     creature doesn't have on it from among flying, first strike, deathtouch, hexproof, \
+     lifelink, menace, reach, trample, vigilance, and +1/+1. Put a counter of that kind on \
+     this creature.";
+
+/// The ten kinds the card prints, in printed order. Written out rather than
+/// read back from the parsed ability: a test that sources its expectation from
+/// the code under test cannot tell a wrong list from a right one.
+fn printed_kinds() -> Vec<CounterType> {
+    vec![
+        CounterType::Keyword(KeywordKind::Flying),
+        CounterType::Keyword(KeywordKind::FirstStrike),
+        CounterType::Keyword(KeywordKind::Deathtouch),
+        CounterType::Keyword(KeywordKind::Hexproof),
+        CounterType::Keyword(KeywordKind::Lifelink),
+        CounterType::Keyword(KeywordKind::Menace),
+        CounterType::Keyword(KeywordKind::Reach),
+        CounterType::Keyword(KeywordKind::Trample),
+        CounterType::Keyword(KeywordKind::Vigilance),
+        CounterType::Plus1Plus1,
+    ]
+}
+
+/// Puts a Giant carrying `preset` on the battlefield, walks the real turn into
+/// beginning of combat, and returns its counters after the trigger resolved.
+/// The stack assertion is the reach-guard: it separates "the trigger placed
+/// nothing" from "no trigger ever fired".
+fn counters_after_begin_combat(preset: &[CounterType]) -> HashMap<CounterType, u32> {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let giant = scenario
+        .add_creature_from_oracle(P0, "Crystalline Giant", 3, 3, CRYSTALLINE_GIANT)
+        .id();
+    for kind in preset {
+        scenario.with_counter(giant, kind.clone(), 1);
+    }
+    let mut runner = scenario.build();
+
+    runner.pass_both_players();
+    assert!(
+        !runner.state().stack.is_empty(),
+        "the beginning-of-combat trigger must reach the stack"
+    );
+    runner.advance_until_stack_empty();
+
+    runner
+        .state()
+        .objects
+        .get(&giant)
+        .expect("Giant stays on the battlefield")
+        .counters
+        .iter()
+        .filter(|(_, count)| **count > 0)
+        .map(|(kind, count)| (kind.clone(), *count))
+        .collect()
+}
+
+/// CR 608.2d + CR 122.1a/CR 122.1b: the trigger draws one of the ten printed
+/// kinds — nine keyword counters and +1/+1 — and puts a single counter of it
+/// on the Giant.
+#[test]
+fn crystalline_giant_puts_one_printed_counter_kind_on_itself() {
+    let counters = counters_after_begin_combat(&[]);
+
+    assert_eq!(
+        counters.len(),
+        1,
+        "exactly one kind must be placed, got {counters:?}"
+    );
+    let (kind, count) = counters.into_iter().next().expect("one entry");
+    assert_eq!(count, 1, "a single counter of that kind, got {count}");
+    assert!(
+        printed_kinds().contains(&kind),
+        "{kind:?} is not one of the ten printed kinds"
+    );
+}
+
+/// CR 608.2d: "that this creature doesn't have on it" narrows the population
+/// BEFORE the draw. With nine of the ten already present the random pick has a
+/// single legal option, so the outcome is exact rather than probabilistic —
+/// drop the exclusion and the draw ranges over all ten again.
+#[test]
+fn crystalline_giant_excludes_kinds_it_already_has_from_the_draw() {
+    let mut preset = printed_kinds();
+    let missing = preset.pop().expect("ten printed kinds");
+    assert_eq!(preset.len(), 9, "nine kinds preset, one left to draw");
+
+    let counters = counters_after_begin_combat(&preset);
+
+    assert_eq!(
+        counters.get(&missing).copied(),
+        Some(1),
+        "the only kind not already on it must be the one drawn, got {counters:?}"
+    );
+    for kind in &preset {
+        assert_eq!(
+            counters.get(kind).copied(),
+            Some(1),
+            "{kind:?} was already there once and must not be doubled"
+        );
+    }
+    assert_eq!(counters.len(), 10, "ten kinds now, got {counters:?}");
+}
+
+/// The first of the card's three 2020-04-17 rulings: "If it has all ten kinds,
+/// the ability will trigger but you won't put any counter on it." An empty
+/// population is a no-op, not a draw from the unnarrowed list.
+///
+/// What this case does NOT pin: an unlowered clause places nothing either, so
+/// this test stays green with the whole `PutChosenCounter` recipient gap back
+/// in place — measured, not assumed. It falls only when the exclusion is
+/// dropped, because the draw then doubles a kind already present. The lowering
+/// is pinned by the other three tests, all of which fall with that gap
+/// restored.
+#[test]
+fn crystalline_giant_with_all_ten_kinds_places_nothing() {
+    let preset = printed_kinds();
+
+    let counters = counters_after_begin_combat(&preset);
+
+    assert_eq!(counters.len(), 10, "no eleventh kind, got {counters:?}");
+    for kind in &preset {
+        assert_eq!(
+            counters.get(kind).copied(),
+            Some(1),
+            "{kind:?} must stay at one — nothing is placed once every kind is present"
+        );
+    }
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -169,6 +169,7 @@ mod crime_tracking;
 mod cross_line_instead_override_branch;
 mod cross_slot_target_binding;
 mod crossway_troublemakers_attacking_keywords;
+mod crystalline_giant_random_counter_kind;
 mod culling_scales_lowest_mana_value_target;
 mod cultivate_split_destination;
 mod culvert_ambusher_turn_face_up_force_block;

--- a/crates/lobby-broker/src/protocol.rs
+++ b/crates/lobby-broker/src/protocol.rs
@@ -38,6 +38,20 @@ pub enum ServerErrorCode {
 /// rather than a parse error, and the handshake is the only place that pairing
 /// can be refused. See 24.
 ///
+/// 61 — `Effect::ChooseCounterKind` gained `domain: CounterKindDomain` and
+///      `chooser: CounterKindChooser` — the population a counter-kind choice
+///      draws its legal kinds from, and whether the GAME draws one at random
+///      instead of prompting the controller (CR 608.2d). Both carry
+///      `#[serde(default)]`, so a v60 payload reads as the on-target/controller
+///      form it always meant. The break is the other direction: a v60 peer has
+///      no field to receive `Printed`/`Random` into and sets no
+///      `deny_unknown_fields` to reject them, so it reads Crystalline Giant's
+///      printed-list random draw as an on-target choice, finds no counters on a
+///      fresh Giant, and places nothing — the exact defect this bump ships the
+///      fix for (#7796). Abilities and trigger definitions ride inside
+///      `GameObject`, so every full-GameState frame carries the shape. Full-game
+///      floors are exact-match on both sides, so the pairing is refused at the
+///      handshake. Lobby messages are unchanged.
 /// 60 — `DerivedViews::back_face_spell_costs` publishes, for each card the
 ///      viewer may cast whose player chooses a spell face at cast time (a split
 ///      card such as a Room, a spell//spell MDFC — CR 709.3 + CR 712.11b), the
@@ -303,7 +317,7 @@ pub enum ServerErrorCode {
 ///      payload; mulligan bottoming folded into a
 ///      `MulliganDecisionPhase::BottomCards` sub-phase on
 ///      `WaitingFor::MulliganDecision`.
-pub const PROTOCOL_VERSION: u32 = 60;
+pub const PROTOCOL_VERSION: u32 = 61;
 
 /// Minimum protocol version accepted by lobby-only brokers at the hello
 /// handshake **from clients that predate [`LOBBY_PROTOCOL_VERSION`]** — the
@@ -1049,12 +1063,12 @@ mod tests {
 
     #[test]
     fn protocol_version_tracks_full_game_wire_additions() {
-        assert_eq!(PROTOCOL_VERSION, 60);
+        assert_eq!(PROTOCOL_VERSION, 61);
         // Lobby keeps its one-version rollout window; full-game servers stay
         // current-only (`server_core::MIN_SUPPORTED_PROTOCOL == PROTOCOL_VERSION`),
         // which is what refuses an older full-game peer whose GameState cannot
         // understand a success acknowledgment the submitting client awaits.
-        assert_eq!(MIN_SUPPORTED_PROTOCOL, 59);
+        assert_eq!(MIN_SUPPORTED_PROTOCOL, 60);
     }
 
     #[test]

--- a/crates/server-core/src/protocol.rs
+++ b/crates/server-core/src/protocol.rs
@@ -3085,8 +3085,8 @@ mod tests {
     }
 
     #[test]
-    fn protocol_version_is_60_for_back_face_spell_costs() {
-        assert_eq!(PROTOCOL_VERSION, 60);
+    fn protocol_version_is_61_for_counter_kind_domain() {
+        assert_eq!(PROTOCOL_VERSION, 61);
     }
 
     /// The bump alone is inert — a version number nobody enforces prevents no
@@ -3097,7 +3097,7 @@ mod tests {
     ///
     /// REVERT-PROBE: relax to `PROTOCOL_VERSION - 1` — the exact regression
     /// this guards — and this test reds while
-    /// `protocol_version_is_60_for_back_face_spell_costs` stays
+    /// `protocol_version_is_61_for_counter_kind_domain` stays
     /// green, which is why the two are separate assertions.
     #[test]
     fn full_game_floor_is_current_only_not_a_rollout_window() {

--- a/scripts/check-protocol-version.mjs
+++ b/scripts/check-protocol-version.mjs
@@ -3,7 +3,7 @@ import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
-const EXPECTED_PROTOCOL_VERSION = 60;
+const EXPECTED_PROTOCOL_VERSION = 61;
 // The LOBBY message-set version, not derived from the full-game number above.
 // The classifier below refuses an expression only on the SOURCE constants; this
 // script never reads itself, so its own EXPECTED_* must stay literals.
@@ -14,7 +14,7 @@ const EXPECTED_LOBBY_PROTOCOL_VERSION = 4;
 // here, so a full-game bump could ship with an unbumped P2P version and CI
 // stayed green — a v(n-1) host and a v(n) guest would then complete a
 // handshake and only fail when the incompatible payload arrived.
-const EXPECTED_WIRE_PROTOCOL_VERSION = 44;
+const EXPECTED_WIRE_PROTOCOL_VERSION = 45;
 
 function extractVersion(source, pattern, label) {
   const match = source.match(pattern);


### PR DESCRIPTION
Closes #7796. Closes #8137 (same card, same cause, reported from a game).

## The defect

Crystalline Giant's beginning-of-combat trigger placed no counter at all. `choose a kind of counter at random that ~ doesn't have on it from among <ten kinds>` lowered to `Effect::Unimplemented`, so the ability resolved as a no-op.

## Fix

**Parser.** The clause lowers to `ChooseCounterKind` carrying the two axes the sentence states: `CounterKindDomain::Printed` (the ten printed kinds plus the "doesn't have on it" exclusion) and `CounterKindChooser::Random`. Both default to the on-target/controller reading, so the anaphoric form (The Caves of Androzani, Aven Courier, Contractual Safeguard) is unchanged. The consumer `put a counter of that kind on ~` was a deliberate strict gap while no producer could bind a kind into resolution state; that producer now exists, so a source-self recipient is ordinary and the gap closes rather than widens.

**Engine.** `Random` draws uniformly from the seeded `state.rng` and binds the result through the same named-choice seam the interactive branch uses — no prompt, because the card's "at random" takes the decision off the player. CR 608.2d governs only when the choice is announced; the Comprehensive Rules define no general "at random" choice, so no rule number sits on the randomness itself. The exclusion narrows the population **before** the draw: from the unnarrowed ten the draw would land on an already-present kind and then place nothing. An empty population keeps the existing no-op branch, which is what the first of the card's three 2020-04-17 rulings requires once all ten kinds are present.

**Coverage.** `effect_details` now emits `domain` and `chooser`. The parse-diff report is how a reviewer sees which cards a parser change moved, and without those fields a domain or chooser flip reads there as no change at all.

**Protocol.** `PROTOCOL_VERSION` 60 → 61, `WIRE_PROTOCOL_VERSION` 44 → 45, in lockstep. Serde-additive in one direction and pinned as such; the other direction drops the printed list and the random draw silently, which is this defect again.

## Measurements

| | |
|---|---|
| Cards carrying `ChooseCounterKind` | 4 |
| …drawing at random from a printed list | 1 (Crystalline Giant) |
| Recipient forms for "counter of that kind on X" | 7 forms, 10 cards |
| …resolving to a source-self recipient | 2 (Crystalline Giant, Bribe Taker) |
| Bribe Taker's path | `PutCounter` + `RebindToIteratedKind`, never this parser |
| Corpus regenerated on this branch vs today's main | 4 entries differ |

Of those four entries only Crystalline Giant differs semantically; Aven Courier, Contractual Safeguard and The Caves of Androzani differ by the two additive default fields alone.

## Tests

- `crystalline_giant_random_counter_kind_lowers_to_a_real_choice` (parser) — the clause reaches `ChooseCounterKind` with all ten kinds, the exclusion flag and the random chooser, and its continuation is `PutChosenCounter` on the source.
- `crystalline_giant_puts_one_printed_counter_kind_on_itself` (runtime, `GameScenario`) — a fresh Giant gains exactly one counter of one of the ten kinds.
- `crystalline_giant_excludes_kinds_it_already_has_from_the_draw` — with nine kinds present the draw has one legal option, so the outcome is exact rather than probabilistic.
- `crystalline_giant_with_all_ten_kinds_places_nothing` — the ruling's edge.
- `choose_counter_kind_serde_reads_pre_domain_payloads_as_on_target` — a payload written before the two fields existed reads as the on-target/controller form.

Counter-probes, each measured: disabling the random branch fails only `puts_one_printed_counter_kind_on_itself` — with nine kinds present the existing single-option auto-select still lands, which is why the exclusion test pins the exclusion and not the draw. Dropping the exclusion fails the other two runtime tests, an already-present kind reaching count 2. Restoring the parser's source-self gap fails three of the four, everything except the all-ten case. That case is green without the fix as well, since an unlowered clause places nothing either, and its test comment says so.

The exclusion probe is seed-dependent by construction: without the narrowing the draw ranges over ten kinds, so it could coincidentally pick the missing one. The all-ten case falls deterministically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V2sfFLrGQyVSkdA5FDwMKP


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for choosing counter kinds from printed lists, including optional exclusion of kinds already present.
  * Added random selection of counter kinds.
  * Improved parsing and resolution for counter-kind effects, including source-self recipients.

* **Bug Fixes**
  * Corrected counter-kind handling for supported card abilities.
  * Preserved compatibility with older serialized effect data.

* **Chores**
  * Updated multiplayer and network protocol versions to support the new counter-kind behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->