### PR TITLE
fix(engine): honor "Activate only if you've completed a dungeon" (Sarevok's Tome)

### DIFF
--- a/crates/engine/src/ai_support/filter.rs
+++ b/crates/engine/src/ai_support/filter.rs
@@ -1084,6 +1084,11 @@ fn condition_reads_only_memo_safe_state(c: &ParsedCondition) -> bool {
         | ParsedCondition::PlayerCountAtLeast { .. }
         | ParsedCondition::HasCityBlessing
         | ParsedCondition::HasEnduringStory
+        // CR 309.7: reads `state.dungeon_progress` for the scoped player (via
+        // `game::dungeon`) — a per-player completion set that only a dungeon
+        // card's removal from the game mutates. apply()-constant and
+        // controller-scoped, exactly like the two designation predicates above.
+        | ParsedCondition::CompletedDungeon { .. }
         // CR 702.179e: reads the controller's `speed` plus a controller-scoped
         // battlefield scan for the CR 101.1 cap-raising static (via
         // `game::speed`) — the same two apply()-constant sources as the

--- a/crates/engine/src/game/restrictions.rs
+++ b/crates/engine/src/game/restrictions.rs
@@ -1670,6 +1670,22 @@ pub(crate) fn evaluate_condition(
         // CR 702.195b: The enduring story is a player designation effects and
         // restrictions may identify.
         ParsedCondition::HasEnduringStory => state.enduring_story.contains(&player),
+        // CR 309.7: "A player completes a dungeon as that dungeon card is removed
+        // from the game." CR 602.5b makes the printed "Activate only if you've
+        // completed a dungeon" (Sarevok's Tome) a restriction on the ability's use.
+        //
+        // Activator-relative like its designation siblings above, not
+        // source-relative like `HasMaxSpeed`: the clause prints "if YOU'VE
+        // completed", addressed to whoever is activating.
+        //
+        // Delegates to the single `game::dungeon` authority that
+        // `AbilityCondition::CompletedDungeon` and
+        // `TriggerCondition::CompletedDungeon` also call, so the restriction
+        // reading of this clause cannot disagree with the resolution and
+        // intervening-if readings about what "completed" means.
+        ParsedCondition::CompletedDungeon { specific } => {
+            crate::game::dungeon::has_completed_dungeon(state, player, specific)
+        }
         // CR 702.178a + the "Max Speed" glossary entry, sense 2: the keyword
         // grants its ability "only if that permanent's controller (or that
         // card's owner, if it isn't on the battlefield) has a speed of 4".
@@ -2507,6 +2523,75 @@ mod tests {
         assert!(!evaluate_condition(&state, player, source_id, &condition));
         state.city_blessing.insert(player);
         assert!(evaluate_condition(&state, player, source_id, &condition));
+    }
+
+    /// CR 309.7 + CR 602.5b: Sarevok's Tome's "Activate only if you've completed
+    /// a dungeon". Peer of the two designation tests around it, and the
+    /// restriction-layer half of the gate: parsing the clause is only half the
+    /// fix — before this variant existed the phrase failed to convert and the
+    /// ability was activatable with no dungeon requirement at all.
+    ///
+    /// Also pins the per-player scoping: an opponent's completion must not
+    /// satisfy your gate, since `dungeon_progress` is keyed by player.
+    #[test]
+    fn completed_dungeon_restriction_checks_player_progress() {
+        let mut state = crate::types::game_state::GameState::new_two_player(42);
+        let player = PlayerId(0);
+        let opponent = PlayerId(1);
+        let source_id = ObjectId(10);
+        let condition = ParsedCondition::CompletedDungeon { specific: None };
+
+        assert!(!evaluate_condition(&state, player, source_id, &condition));
+
+        // An opponent's completed dungeon must not satisfy your gate.
+        state
+            .dungeon_progress
+            .entry(opponent)
+            .or_default()
+            .completed
+            .insert(crate::game::dungeon::DungeonId::TombOfAnnihilation);
+        assert!(!evaluate_condition(&state, player, source_id, &condition));
+
+        state
+            .dungeon_progress
+            .entry(player)
+            .or_default()
+            .completed
+            .insert(crate::game::dungeon::DungeonId::TombOfAnnihilation);
+        assert!(evaluate_condition(&state, player, source_id, &condition));
+    }
+
+    /// CR 309.7: the `specific` axis must discriminate — completing one dungeon
+    /// does not satisfy a gate naming a different one. Guards the field against
+    /// collapsing into the unqualified reading.
+    #[test]
+    fn completed_dungeon_restriction_honors_specific_dungeon() {
+        let mut state = crate::types::game_state::GameState::new_two_player(42);
+        let player = PlayerId(0);
+        let source_id = ObjectId(10);
+        state
+            .dungeon_progress
+            .entry(player)
+            .or_default()
+            .completed
+            .insert(crate::game::dungeon::DungeonId::TombOfAnnihilation);
+
+        assert!(evaluate_condition(
+            &state,
+            player,
+            source_id,
+            &ParsedCondition::CompletedDungeon {
+                specific: Some(crate::game::dungeon::DungeonId::TombOfAnnihilation),
+            }
+        ));
+        assert!(!evaluate_condition(
+            &state,
+            player,
+            source_id,
+            &ParsedCondition::CompletedDungeon {
+                specific: Some(crate::game::dungeon::DungeonId::Undercity),
+            }
+        ));
     }
 
     #[test]

--- a/crates/engine/src/parser/oracle_condition.rs
+++ b/crates/engine/src/parser/oracle_condition.rs
@@ -306,6 +306,19 @@ fn static_condition_to_restriction_condition(
         StaticCondition::HasMaxSpeed => Some(ParsedCondition::HasMaxSpeed),
         // CR 702.195b: The enduring story designation is available to restrictions.
         StaticCondition::HasEnduringStory => Some(ParsedCondition::HasEnduringStory),
+        // CR 309.7 + CR 602.5b: dungeon completion is a player-status leaf of the
+        // same shape as the city's blessing and the enduring story above — read off
+        // the scoped player, carrying no filter or quantity, so it converts EXACTLY
+        // rather than approximately. The `Not` recursion arm yields the negative
+        // sense ("only if you haven't completed a dungeon").
+        //
+        // The shared grammar spells only the unqualified phrase, so `specific` is
+        // `None` here; the field exists to mirror the three sibling layers, whose
+        // named-dungeon form (`specific: Some(d)`) the same restriction evaluator
+        // will read unchanged once a card prints it.
+        StaticCondition::CompletedADungeon => {
+            Some(ParsedCondition::CompletedDungeon { specific: None })
+        }
         StaticCondition::OpponentPoisonAtLeast { count } => {
             Some(ParsedCondition::OpponentPoisonAtLeast { count })
         }
@@ -385,7 +398,6 @@ fn static_condition_to_restriction_condition(
         | StaticCondition::IsMonarch { .. }
         | StaticCondition::IsInitiative
         | StaticCondition::NoMonarch
-        | StaticCondition::CompletedADungeon
         | StaticCondition::WasStartingPlayer { .. }
         | StaticCondition::SpellCastWithVariantThisTurn { .. }
         | StaticCondition::SharesColorWithMostCommonColorAmongPermanents

--- a/crates/engine/src/parser/oracle_tests.rs
+++ b/crates/engine/src/parser/oracle_tests.rs
@@ -22249,6 +22249,56 @@ fn city_blessing_activation_restriction_does_not_emit_condition_warning() {
         )));
 }
 
+/// CR 309.7 + CR 602.5b: Sarevok's Tome — "Activate only if you've completed a
+/// dungeon". The shared grammar already recognized the phrase as
+/// `StaticCondition::CompletedADungeon`, but the restriction converter rejected
+/// it for lack of a `ParsedCondition` peer, so the clause stayed in the ability
+/// text and surfaced as a stranded `Effect::Unimplemented { name: "activate" }`
+/// sub-ability — leaving the ability activatable with NO dungeon requirement,
+/// which is a permissive misreading of the printed card.
+///
+/// Asserts both halves: the gate is present as an activation restriction, AND
+/// no `Unimplemented` remnant is left behind anywhere in the chain (the bug
+/// produced the second without the first).
+#[test]
+fn completed_dungeon_activation_restriction_gates_the_ability() {
+    let oracle = "When this artifact enters, you take the initiative.
+{T}: Add {C}. If you have the initiative, add {C}{C} instead.
+{3}, {T}: Exile cards from the top of your library until you exile a nonland card. You may cast that card without paying its mana cost. Activate only if you've completed a dungeon.";
+    let parsed = parse(oracle, "Sarevok's Tome", &[], &["Artifact"], &["Book"]);
+
+    let gated = parsed
+        .abilities
+        .iter()
+        .find(|ability| matches!(*ability.effect, Effect::ExileFromTopUntil { .. }))
+        .expect("expected the exile-until activated ability");
+
+    assert!(
+        gated
+            .activation_restrictions
+            .iter()
+            .any(|restriction| matches!(
+                restriction,
+                ActivationRestriction::RequiresCondition {
+                    condition: Some(ParsedCondition::CompletedDungeon { specific: None })
+                }
+            )),
+        "dungeon gate missing: {:?}",
+        gated.activation_restrictions
+    );
+
+    // The consumed clause must leave no `Unimplemented` remnant in the chain.
+    let mut node = Some(gated);
+    while let Some(ability) = node {
+        assert!(
+            !matches!(*ability.effect, Effect::Unimplemented { .. }),
+            "stranded Unimplemented remnant: {:?}",
+            ability.effect
+        );
+        node = ability.sub_ability.as_deref();
+    }
+}
+
 /// CR 702.178a: "Max speed — [Ability]" means "As long as your speed is 4, this
 /// object has '[Ability]'." The ability is ABSENT below max speed, so the prefix
 /// lowers to an activation restriction (CR 602.5) — the same treatment CR 702.186b

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -10993,6 +10993,28 @@ pub enum ParsedCondition {
     HasCityBlessing,
     /// CR 702.195b: True when the activating player has the enduring story designation.
     HasEnduringStory,
+    /// CR 309.7 + CR 602.5b: "Activate only if you've completed a dungeon"
+    /// (Sarevok's Tome, Precipitous Drop). True when the activating player has
+    /// completed at least one dungeon (`specific: None`) or the named dungeon
+    /// (`specific: Some(d)`). For the negative sense, wrap with `Not`.
+    ///
+    /// A player-designation leaf in the same sense as `HasCityBlessing` and
+    /// `HasEnduringStory` above: it reads a status off the scoped player and
+    /// carries no filter or quantity to approximate, which is why it converts
+    /// exactly rather than being rejected by
+    /// `static_condition_to_restriction_condition`. It stays a sibling of those
+    /// leaves rather than folding into them because each names its own CR rule
+    /// section (CR 309.7 here, CR 702.131c and CR 702.195b there).
+    ///
+    /// The restriction-layer reading of the same printed clause that
+    /// `StaticCondition::CompletedADungeon`, `TriggerCondition::CompletedDungeon`
+    /// and `AbilityCondition::CompletedDungeon` already read at their own layers.
+    /// All four delegate to the single truth function
+    /// `game::dungeon::has_completed_dungeon`, so the readings cannot drift.
+    CompletedDungeon {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        specific: Option<crate::game::dungeon::DungeonId>,
+    },
     /// CR 702.178a: True when the SOURCE's player has max speed — its
     /// controller on the battlefield, its owner anywhere else, per the "Max
     /// Speed" glossary entry (sense 2). Unlike its designation siblings above,


### PR DESCRIPTION
## The gap

Sarevok's Tome's third ability prints:

> `{3}, {T}: Exile cards from the top of your library until you exile a nonland card. You may cast that card without paying its mana cost. Activate only if you've completed a dungeon.`

The dungeon gate was **silently dropped**. The clause fell out into a stranded `Effect::Unimplemented { name: "activate" }` sub-ability, leaving the ability **activatable with no dungeon requirement at all** — a permissive misreading of the printed card (CR 602.5b).

## Root cause — not in the parser

The shared grammar already recognized the phrase as `StaticCondition::CompletedADungeon`. The failure was one layer down in `static_condition_to_restriction_condition`, a deliberately wildcard-free `StaticCondition` → `ParsedCondition` converter: `CompletedADungeon` sat in the **reject** list, so the parse failed and the text stayed behind as `Unimplemented`.

That reject list is correctly justified for *filter-carrying* conditions with no exact `ParsedCondition` counterpart. Dungeon completion is not one of those — it is a **player-status leaf** carrying no filter and no quantity, structurally identical to `HasCityBlessing` (CR 702.131c) and `HasEnduringStory` (CR 702.195b), which both convert exactly. It was rejected only because no peer variant had ever been added.

## The fix

Added `ParsedCondition::CompletedDungeon { specific }` and wired its three registration points:

| File | Change |
|---|---|
| `types/ability.rs` | New variant, shaped like its 3 sibling layers (`specific: Option<DungeonId>`) |
| `parser/oracle_condition.rs` | Moved out of the reject list into an exact-conversion arm |
| `game/restrictions.rs` | Evaluator delegating to `game::dungeon::has_completed_dungeon` |
| `ai_support/filter.rs` | Classified memo-safe (compiler-forced — the enum has no wildcard) |

Fixed at the **shared converter**, not special-cased for the card. This closes the fourth and last reading of the predicate — the trigger, static, and resolution readings already worked — and all four now delegate to the single authority `game::dungeon::has_completed_dungeon`, so they cannot drift about what "completed" means. The `specific` field mirrors the sibling layers, so a named-dungeon gate evaluates unchanged.

17 cards use the dungeon-completion predicate; the other 16 read it through the layers that already worked.

## CR verification

Both numbers verified against `docs/MagicCompRules.txt`:

- **CR 309.7** — "A player completes a dungeon as that dungeon card is removed from the game."
- **CR 602.5b** — a restriction on an activated ability's use continues to apply to that object.

## Testing

| Check | Result |
|---|---|
| Engine lib suite | 20,325 passed, 0 failed |
| Integration suite | 5,881 passed, 0 failed |
| `clippy --all-targets -- -D warnings` | clean, exit 0 |
| `cargo fmt --all` | clean |

Four new tests, all non-vacuous: before this change `activation_restrictions` was empty **and** the chain carried the `Unimplemented` remnant, so both halves of the parser assertion bind to the real defect. The evaluator tests additionally pin per-player scoping (an opponent's completion must not satisfy your gate) and the `specific` axis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Activation and casting restrictions can now check whether the activating player has completed a dungeon.
  * Conditions can require completion of any dungeon or a specific named dungeon.
  * Dungeon-completion checks are evaluated separately for each player, preventing another player’s progress from satisfying the restriction.

* **Bug Fixes**
  * Cards with dungeon-completion requirements now correctly recognize and enforce those conditions.
  * Negative dungeon-completion requirements are now handled correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->