### PR TITLE
fix(p2p,client): drop the wire decode size cap that hid every full game state

### DIFF
--- a/client/src/network/__tests__/wireEnvelope.test.ts
+++ b/client/src/network/__tests__/wireEnvelope.test.ts
@@ -1,34 +1,25 @@
 import { describe, expect, it } from "vitest";
 
-import {
-  decodeJsonEnvelope,
-  encodeJsonEnvelope,
-  WIRE_MAX_DECODED_BYTES,
-} from "../wireEnvelope";
+import { decodeJsonEnvelope, encodeJsonEnvelope } from "../wireEnvelope";
 
-describe("wire envelope decoded-size limit", () => {
-  it("rejects oversized or malformed raw content", async () => {
-    const envelope = new Uint8Array(WIRE_MAX_DECODED_BYTES + 2);
-    envelope[0] = 0x00;
-
-    await expect(decodeJsonEnvelope(envelope)).rejects.toThrow(
-      "wire message exceeds decoded size limit",
-    );
+describe("wire envelope decoding", () => {
+  it("rejects malformed raw UTF-8", async () => {
     await expect(decodeJsonEnvelope(new Uint8Array([0x00, 0xff]))).rejects.toThrow();
   });
 
-  it("rejects oversized or malformed gzip content", async () => {
-    const json = "x".repeat(WIRE_MAX_DECODED_BYTES + 1);
-    const envelope = await encodeJsonEnvelope(json);
-
-    expect(envelope[0]).toBe(0x01);
-    expect(envelope.byteLength).toBeLessThan(WIRE_MAX_DECODED_BYTES);
-    await expect(decodeJsonEnvelope(envelope)).rejects.toThrow(
-      "wire message exceeds decoded size limit",
-    );
+  it("rejects malformed gzip UTF-8", async () => {
     const stream = new Blob([new Uint8Array([0xff])]).stream()
       .pipeThrough(new CompressionStream("gzip"));
     const compressed = new Uint8Array(await new Response(stream).arrayBuffer());
     await expect(decodeJsonEnvelope(new Uint8Array([0x01, ...compressed]))).rejects.toThrow();
+  });
+
+  it("round-trips a multi-megabyte frame", async () => {
+    // A full viewer game state is several MB of JSON; there is deliberately no
+    // decoded-size ceiling, since one dropped every such frame.
+    const json = JSON.stringify({ type: "state_update", state: "x".repeat(4 * 1024 * 1024) });
+    const envelope = await encodeJsonEnvelope(json);
+    expect(envelope[0]).toBe(0x01);
+    await expect(decodeJsonEnvelope(envelope)).resolves.toBe(json);
   });
 });

--- a/client/src/network/wireEnvelope.ts
+++ b/client/src/network/wireEnvelope.ts
@@ -5,7 +5,6 @@
 
 // Keep this aligned with crates/phase-server/src/wire.rs.
 export const WIRE_COMPRESSION_THRESHOLD = 256;
-export const WIRE_MAX_DECODED_BYTES = 1024 * 1024;
 export type WireFormat = "GzipEnvelopeV1";
 
 const FORMAT_RAW = 0x00;
@@ -38,36 +37,17 @@ export async function decodeJsonEnvelope(bytes: Uint8Array): Promise<string> {
 
   const format = bytes[0];
   const payload = bytes.subarray(1);
+  // No decoded-size ceiling: a full viewer game state (P2P `game_setup` /
+  // `state_update`, server -> client state pushes) is multiple MB of JSON and
+  // grows with seats and board size. A 1 MB cap here silently dropped every
+  // such frame and hung guests on "Waiting for game…".
   if (format === FORMAT_RAW) {
-    if (payload.length > WIRE_MAX_DECODED_BYTES) {
-      throw new Error("wire message exceeds decoded size limit");
-    }
     return new TextDecoder("utf-8", { fatal: true }).decode(payload);
   }
   if (format === FORMAT_GZIP) {
     const stream = new Blob([payload]).stream().pipeThrough(new DecompressionStream("gzip"));
-    const reader = stream.getReader();
-    const decoder = new TextDecoder("utf-8", { fatal: true });
-    let decodedBytes = 0;
-    let decoded = "";
-
-    try {
-      while (true) {
-        const { value, done } = await reader.read();
-        if (done) break;
-        decodedBytes += value.byteLength;
-        if (decodedBytes > WIRE_MAX_DECODED_BYTES) {
-          throw new Error("wire message exceeds decoded size limit");
-        }
-        decoded += decoder.decode(value, { stream: true });
-      }
-      return decoded + decoder.decode();
-    } catch (error) {
-      await reader.cancel(error).catch(() => undefined);
-      throw error;
-    } finally {
-      reader.releaseLock();
-    }
+    const decoded = new Uint8Array(await new Response(stream).arrayBuffer());
+    return new TextDecoder("utf-8", { fatal: true }).decode(decoded);
   }
   throw new Error(`unknown wire format version: 0x${format.toString(16)}`);
 }


### PR DESCRIPTION
## Summary

Multiplayer has been broken since Sept 2 for any game whose viewer state exceeds 1 MB of JSON, which is most Commander games and every game with extra AI/human seats.

PR #8288 routed the P2P DataChannel decode through the shared `wireEnvelope.ts`, which enforced a 1 MB per-frame decoded-size cap. The P2P decoder was previously unbounded. A 2-player Commander `game_setup` is ~1.5 MB raw JSON, so every full-state frame threw `wire message exceeds decoded size limit` and was dropped in `peer.ts`'s warn-and-drop catch.

`game_setup` is the frame that resolves the guest's `initializeGame()` and authenticates the session. Dropped at decode, the guest hangs on "Waiting for game...", every later `state_update` is rejected unauthenticated, and the host loops resending state. The room code is only persisted after `initGame` resolves, so a mid-hang refresh dialed `phase2-undefined` (same root cause).

The same cap governed the client's WebSocket decode (`gzipEnvelopeSocket`), so large server-hosted games were exposed to the identical drop.

## Fix

Remove the decoded-size ceiling and restore the unbounded decode, keeping the strict UTF-8 rejection #8288 also introduced. The server's own inbound cap (client -> server actions, `MAX_WS_MESSAGE_BYTES`) is separate and untouched.

## Verification

- Reproduced locally: P2P Commander host with an AI seat + guest. Guest console: `Failed to decode message from peer: Error: wire message exceeds decoded size limit`, stuck on "Waiting for game...", host looping `state_update`.
- After the change, same flow: guest decodes `game_setup`, sends `state_ack`, exchanges actions, renders the live board through the first-player roll.
- `check-frontend` (type-check + lint) green. Rewritten `wireEnvelope.test.ts` keeps the malformed-UTF-8 rejections and adds a multi-megabyte round-trip.

https://claude.ai/code/session_01DycnSCPfpGUSJJGTF8x16v


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Large compressed messages can now be decoded successfully without being rejected by a 1 MB decoded-size limit.
  * Large JSON payloads are preserved correctly through encoding and decoding.
  * Validation for malformed raw and gzip-encoded UTF-8 data remains in place.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->