### PR TITLE
fix(engine,client,server): surface abilities blocked by unpayable costs

### DIFF
--- a/client/src/adapter/__tests__/p2p-adapter-multiplayer.test.ts
+++ b/client/src/adapter/__tests__/p2p-adapter-multiplayer.test.ts
@@ -4272,14 +4272,14 @@ describe("P2P wire-protocol version gate", () => {
   // Both halves stamp LITERALS. A frame built from WIRE_PROTOCOL_VERSION
   // cannot tell a bumped client from an unbumped one, which is why every
   // other handshake fixture in the suite is useless as an instrument for a
-  // bump. Revert 45 → 44 and BOTH halves red: the v44 frame stops being
-  // refused, and the v45 frame stops being admitted. The admitting half is
-  // the reach-guard — without it "refuses v44" is also satisfied by a client
+  // bump. Revert 46 → 45 and BOTH halves red: the v45 frame stops being
+  // refused, and the v46 frame stops being admitted. The admitting half is
+  // the reach-guard — without it "refuses v45" is also satisfied by a client
   // that refuses everything.
-  it("refuses the previous wire protocol (v44) and admits its own (v45)", async () => {
+  it("refuses the previous wire protocol (v45) and admits its own (v46)", async () => {
     const refusing = makeGuest();
     await refusing.adapter.initialize();
-    await refusing.conn.simulateData(setupFrameAt(44));
+    await refusing.conn.simulateData(setupFrameAt(45));
 
     await expect(refusing.adapter.initializeGame()).rejects.toMatchObject({
       code: "P2P_REJECTED",
@@ -4291,7 +4291,7 @@ describe("P2P wire-protocol version gate", () => {
 
     const admitting = makeGuest();
     await admitting.adapter.initialize();
-    await admitting.conn.simulateData(setupFrameAt(45));
+    await admitting.conn.simulateData(setupFrameAt(46));
 
     await expect(admitting.adapter.initializeGame()).resolves.toBeDefined();
     expect(admitting.emitted).not.toHaveBeenCalledWith(

--- a/client/src/adapter/server-draft-adapter.ts
+++ b/client/src/adapter/server-draft-adapter.ts
@@ -1,4 +1,5 @@
 import type {
+  AbilityBlockEntry,
   EngineAdapter,
   EngineSnapshot,
   GameAction,
@@ -692,6 +693,7 @@ export class ServerDraftAdapter implements EngineAdapter {
           mana_payment_shortcut_actions?: GameAction[];
           spell_costs?: Record<string, ManaCost>;
           legal_actions_by_object?: Record<string, ObjectAction[]>;
+          activation_block_reasons?: Record<string, AbilityBlockEntry[]>;
           viewer_interaction?: LegalActionsResult["viewerInteraction"];
           derived?: GameState["derived"];
         };
@@ -704,6 +706,7 @@ export class ServerDraftAdapter implements EngineAdapter {
             manaPaymentShortcutActions: data.mana_payment_shortcut_actions ?? [],
             spellCosts: data.spell_costs,
             legalActionsByObject: data.legal_actions_by_object,
+            activationBlockReasons: data.activation_block_reasons,
             viewerInteraction: data.viewer_interaction,
           },
         );
@@ -727,6 +730,7 @@ export class ServerDraftAdapter implements EngineAdapter {
           mana_payment_shortcut_actions?: GameAction[];
           spell_costs?: Record<string, ManaCost>;
           legal_actions_by_object?: Record<string, ObjectAction[]>;
+          activation_block_reasons?: Record<string, AbilityBlockEntry[]>;
           viewer_interaction?: LegalActionsResult["viewerInteraction"];
           log_entries?: GameLogEntry[];
           derived?: GameState["derived"];
@@ -740,6 +744,7 @@ export class ServerDraftAdapter implements EngineAdapter {
             manaPaymentShortcutActions: data.mana_payment_shortcut_actions ?? [],
             spellCosts: data.spell_costs,
             legalActionsByObject: data.legal_actions_by_object,
+            activationBlockReasons: data.activation_block_reasons,
             viewerInteraction: data.viewer_interaction,
           },
         );

--- a/client/src/adapter/types.ts
+++ b/client/src/adapter/types.ts
@@ -1295,14 +1295,22 @@ export type PhaseStatus =
   | { status: "PhasedOut"; cause: "Directly" | "Indirectly" };
 
 /**
- * CR 602.5: Why one of an object's activated abilities is blocked from
- * activation. Mirrors the Rust `AbilityBlockKind` (serde `tag = "type"`).
+ * CR 602.5 + CR 118.3: Why one of an object's activated abilities is blocked
+ * from activation. Mirrors the Rust `AbilityBlockKind` (serde `tag = "type"`).
  * Display only.
+ *
+ * **Two channels, one union.** The first three members arrive on
+ * `GameObject.blocked_abilities` (the CR 602.5 prohibition sweep).
+ * `"CostNotPayableNow"` arrives ONLY on the legal-actions payload
+ * (`LegalActionsResult.activationBlockReasons`), is scoped to the acting
+ * player, and never appears on `blocked_abilities`. A consumer of one channel
+ * will never observe the other's members.
  */
 export type AbilityBlockKind =
   | "CantBeActivated"
   | "CantActivateDuring"
-  | "Prohibited";
+  | "Prohibited"
+  | "CostNotPayableNow";
 
 /**
  * CR 602.5: A single blocked-ability read-out entry. `ability_index` indexes the
@@ -4237,6 +4245,13 @@ export interface LegalActionsResult {
    * availability from objects.
    */
   legalActionsByObject?: Record<string, ObjectAction[]>;
+  /**
+   * CR 118.3: per-object read-out of activated abilities the ACTING player is
+   * not being offered solely because they can't pay the cost right now, keyed by
+   * object_id string. Empty for any viewer without action authority. Display
+   * only — these entries are deliberately NOT dispatchable.
+   */
+  activationBlockReasons?: Record<string, AbilityBlockEntry[]>;
   /** Engine progress-wedge diagnostic: present only when the current decision is wedged. */
   stuckDiagnostic?: StuckDecisionDiagnostic;
   /** Engine-authored, viewer-scoped interaction opportunities for this snapshot. */
@@ -4259,6 +4274,8 @@ export interface ViewerSnapshot {
   manaPaymentShortcutActions?: GameAction[];
   spellCosts?: Record<string, ManaCost>;
   legalActionsByObject?: Record<string, ObjectAction[]>;
+  /** CR 118.3: mirrored from `LegalActionsResult` — see the doc there. */
+  activationBlockReasons?: Record<string, AbilityBlockEntry[]>;
   /**
    * Engine progress-wedge diagnostic, mirrored from `LegalActionsResult` for
    * shape parity. Currently inert on this path: the store's `stuckDiagnostic`

--- a/client/src/adapter/ws-adapter.ts
+++ b/client/src/adapter/ws-adapter.ts
@@ -1,4 +1,5 @@
 import type {
+  AbilityBlockEntry,
   EngineAdapter,
   EngineSnapshot,
   GameAction,
@@ -436,7 +437,7 @@ export class NativeEngineVersionMismatchError extends Error {
  *      into a MulliganDecisionPhase::BottomCards sub-phase on
  *      WaitingFor::MulliganDecision.
  */
-export const PROTOCOL_VERSION = 61;
+export const PROTOCOL_VERSION = 62;
 
 /**
  * Lowest server protocol version this client will accept in the handshake.
@@ -1740,7 +1741,7 @@ export class WebSocketAdapter implements EngineAdapter {
       }
 
       case "GameStarted": {
-        const data = msg.data as { state_revision: number; state: GameState; your_player: PlayerId; opponent_name?: string; player_names?: string[]; legal_actions?: GameAction[]; auto_pass_recommended?: boolean; end_continuous_effect_offers?: LegalActionsResult["endContinuousEffectOffers"]; mana_payment_shortcut_actions?: GameAction[]; spell_costs?: Record<string, ManaCost>; legal_actions_by_object?: Record<string, GameAction[]>; viewer_interaction?: LegalActionsResult["viewerInteraction"]; derived?: GameState["derived"]; player_token?: string; full_key?: FullSessionKey; events?: GameEvent[]; rewind_targets?: RewindOption[] };
+        const data = msg.data as { state_revision: number; state: GameState; your_player: PlayerId; opponent_name?: string; player_names?: string[]; legal_actions?: GameAction[]; auto_pass_recommended?: boolean; end_continuous_effect_offers?: LegalActionsResult["endContinuousEffectOffers"]; mana_payment_shortcut_actions?: GameAction[]; spell_costs?: Record<string, ManaCost>; legal_actions_by_object?: Record<string, GameAction[]>; activation_block_reasons?: Record<string, AbilityBlockEntry[]>; viewer_interaction?: LegalActionsResult["viewerInteraction"]; derived?: GameState["derived"]; player_token?: string; full_key?: FullSessionKey; events?: GameEvent[]; rewind_targets?: RewindOption[] };
         const nativeReconnect = this.options.nativePregame?.kind === "reconnect"
           ? this.options.nativePregame
           : null;
@@ -1772,6 +1773,7 @@ export class WebSocketAdapter implements EngineAdapter {
             manaPaymentShortcutActions: data.mana_payment_shortcut_actions ?? [],
             spellCosts: data.spell_costs,
             legalActionsByObject: data.legal_actions_by_object,
+            activationBlockReasons: data.activation_block_reasons,
             viewerInteraction: data.viewer_interaction,
           },
         );
@@ -1853,7 +1855,7 @@ export class WebSocketAdapter implements EngineAdapter {
       }
 
       case "StateUpdate": {
-        const data = msg.data as { state_revision: number; state: GameState; events: GameEvent[]; legal_actions?: GameAction[]; auto_pass_recommended?: boolean; end_continuous_effect_offers?: LegalActionsResult["endContinuousEffectOffers"]; mana_payment_shortcut_actions?: GameAction[]; spell_costs?: Record<string, ManaCost>; legal_actions_by_object?: Record<string, GameAction[]>; viewer_interaction?: LegalActionsResult["viewerInteraction"]; log_entries?: GameLogEntry[]; derived?: GameState["derived"]; rewind_targets?: RewindOption[] };
+        const data = msg.data as { state_revision: number; state: GameState; events: GameEvent[]; legal_actions?: GameAction[]; auto_pass_recommended?: boolean; end_continuous_effect_offers?: LegalActionsResult["endContinuousEffectOffers"]; mana_payment_shortcut_actions?: GameAction[]; spell_costs?: Record<string, ManaCost>; legal_actions_by_object?: Record<string, GameAction[]>; activation_block_reasons?: Record<string, AbilityBlockEntry[]>; viewer_interaction?: LegalActionsResult["viewerInteraction"]; log_entries?: GameLogEntry[]; derived?: GameState["derived"]; rewind_targets?: RewindOption[] };
         // Attach the engine-authored derived views to the state snapshot so
         // components (e.g. CommanderDamage) can read them via gameState.derived
         // without a separate subscription path. See
@@ -1867,6 +1869,7 @@ export class WebSocketAdapter implements EngineAdapter {
             manaPaymentShortcutActions: data.mana_payment_shortcut_actions ?? [],
             spellCosts: data.spell_costs,
             legalActionsByObject: data.legal_actions_by_object,
+            activationBlockReasons: data.activation_block_reasons,
             viewerInteraction: data.viewer_interaction,
           },
         );

--- a/client/src/components/board/PermanentCard.tsx
+++ b/client/src/components/board/PermanentCard.tsx
@@ -3,7 +3,7 @@ import type React from "react";
 import { memo, useCallback, useMemo, useRef } from "react";
 import { useTranslation } from "react-i18next";
 
-import type { AbilityBlockKind, GameObject, Keyword } from "../../adapter/types.ts";
+import type { GameObject, Keyword } from "../../adapter/types.ts";
 import { cardImageLookup, tokenFiltersForObject } from "../../services/cardImageLookup.ts";
 import { useCanActForWaitingState, usePlayerId } from "../../hooks/usePlayerId.ts";
 import { dispatchAction } from "../../game/dispatch.ts";
@@ -19,6 +19,7 @@ import { useGameStore } from "../../stores/gameStore.ts";
 import { renderDescription } from "../../utils/description.ts";
 import { usePreferencesStore } from "../../stores/preferencesStore.ts";
 import { useUiStore } from "../../stores/uiStore.ts";
+import { ABILITY_BLOCK_REASON_KEY } from "../../viewmodel/abilityBlockReason.ts";
 import { buildGrantedKeywordSources, buildPTSources } from "../../viewmodel/attribution.ts";
 import { COUNTER_COLORS, computePTDisplay, counterIconClass, formatCounterType, toRoman } from "../../viewmodel/cardProps.ts";
 import { getCardDisplayColors } from "../card/cardFrame.ts";
@@ -75,17 +76,6 @@ const ATTACHMENT_STACK_STEP_PX = 22;
 const HOVERED_CARD_Z_INDEX = 60;
 const HOVERED_ATTACHMENT_HOST_Z_INDEX = 80;
 const EMPTY_KEYWORD_BADGES: Keyword[] = [];
-
-/**
- * CR 602.5: Maps an engine `AbilityBlockKind` to its i18n reason key. Pure
- * display formatting — no game logic. Exhaustive so a new kind is a compile
- * error until a key is added.
- */
-const ABILITY_BLOCK_REASON_KEY: Record<AbilityBlockKind, string> = {
-  CantBeActivated: "abilityBlock.cantBeActivated",
-  CantActivateDuring: "abilityBlock.cantActivateDuring",
-  Prohibited: "abilityBlock.prohibited",
-};
 
 // CR 602.5: display-only badge summarizing which of this permanent's activated
 // abilities are currently blocked, and why. Reads the engine-provided

--- a/client/src/components/card/CardPreview.tsx
+++ b/client/src/components/card/CardPreview.tsx
@@ -7,7 +7,8 @@ import {
 } from "framer-motion";
 import { useTranslation } from "react-i18next";
 
-import type { AbilityBlockKind, ChosenAttribute, GameObject, Keyword, ManaCost, Zone } from "../../adapter/types.ts";
+import type { ChosenAttribute, GameObject, Keyword, ManaCost, Zone } from "../../adapter/types.ts";
+import { ABILITY_BLOCK_REASON_KEY } from "../../viewmodel/abilityBlockReason.ts";
 import { collectObjectActions } from "../../viewmodel/cardActionChoice.ts";
 import { abilityLabel, loyaltyBadge, spellCostDisplay, stripLoyaltyCostPrefix } from "../../viewmodel/costLabel.ts";
 import { useCardImage } from "../../hooks/useCardImage.ts";
@@ -59,17 +60,6 @@ type CardPreviewArt =
       rungs?: ImageRungs;
       advanceFailedSource?(failedSrc: string): void;
     };
-
-/**
- * CR 602.5: Maps an engine `AbilityBlockKind` to its i18n reason key. Pure
- * display formatting — no game logic. Kept exhaustive so a new kind is a
- * compile error until a key is added.
- */
-const ABILITY_BLOCK_REASON_KEY: Record<AbilityBlockKind, string> = {
-  CantBeActivated: "abilityBlock.cantBeActivated",
-  CantActivateDuring: "abilityBlock.cantActivateDuring",
-  Prohibited: "abilityBlock.prohibited",
-};
 
 let lastPointerPosition: { x: number; y: number } | null = null;
 

--- a/client/src/components/modal/ChoiceModal.tsx
+++ b/client/src/components/modal/ChoiceModal.tsx
@@ -13,6 +13,17 @@ export interface ChoiceOption {
   description?: string;
   /** Optional glyph rendered before the label (e.g. a loyalty badge). */
   icon?: ReactNode;
+  /**
+   * Rendered as a non-selectable row (e.g. an ability whose cost the player
+   * can't pay right now).
+   *
+   * Uses `aria-disabled`, NOT the native `disabled` attribute: `description`
+   * renders as a `<p>` INSIDE the `<button>`, so a native `disabled` would drop
+   * the explanatory reason out of the tab order and out of interactive
+   * screen-reader navigation — exactly for the users who need it. The no-op
+   * `onClick` guard is the real selection guard.
+   */
+  disabled?: boolean;
 }
 
 interface ChoiceModalProps {
@@ -63,8 +74,15 @@ export function ChoiceModal({
           {options.map((opt) => (
             <button
               key={opt.id}
-              onClick={() => onChoose(opt.id)}
-              className="min-h-11 rounded-[16px] border border-white/8 bg-white/5 px-4 py-3 text-left transition hover:bg-white/8 hover:ring-1 hover:ring-cyan-400/40"
+              aria-disabled={opt.disabled || undefined}
+              onClick={() => {
+                if (!opt.disabled) onChoose(opt.id);
+              }}
+              className={
+                opt.disabled
+                  ? "min-h-11 cursor-not-allowed rounded-[16px] border border-white/8 bg-white/[0.02] px-4 py-3 text-left opacity-60"
+                  : "min-h-11 rounded-[16px] border border-white/8 bg-white/5 px-4 py-3 text-left transition hover:bg-white/8 hover:ring-1 hover:ring-cyan-400/40"
+              }
             >
               <span
                 className={`flex items-center gap-2 ${opt.labelTone === "secondary" ? "text-xs font-normal text-slate-400" : "font-semibold text-white"}`}

--- a/client/src/components/modal/__tests__/ChoiceModal.test.tsx
+++ b/client/src/components/modal/__tests__/ChoiceModal.test.tsx
@@ -1,0 +1,102 @@
+import { cleanup, fireEvent, render, screen, within } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { ChoiceModal, type ChoiceOption } from "../ChoiceModal.tsx";
+
+/**
+ * CR 118.3 — matrix rows 15 and 16: the ability picker must render a
+ * NON-SELECTABLE row for an ability the engine is withholding solely because
+ * its cost is unpayable right now, instead of silently omitting it (the
+ * reported defect: Sliver Overlord's two printed `{3}:` abilities simply
+ * vanished from the picker).
+ *
+ * Row 15 — the row renders and cannot be chosen.
+ * Row 16 — the reason reaches assistive tech: `aria-disabled`, NOT the native
+ *          `disabled` attribute, so the row stays in the tab order and its
+ *          explanatory `<p>` (rendered INSIDE the `<button>`, with no
+ *          `aria-describedby`) still feeds the accessible NAME.
+ *
+ * Every negative here is paired with a positive in the SAME render: an
+ * affordable row that IS selectable and carries no `aria-disabled`. A modal
+ * that rendered nothing, or disabled everything, fails.
+ */
+
+const AFFORDABLE = "Regenerate target Sliver";
+const BLOCKED = "Search your library for a Sliver card";
+const REASON = "You can't pay this cost right now";
+
+function options(): ChoiceOption[] {
+  return [
+    { id: "0", label: AFFORDABLE },
+    { id: "blocked:1", label: BLOCKED, description: REASON, disabled: true },
+  ];
+}
+
+function renderModal(onChoose = vi.fn()) {
+  render(
+    <ChoiceModal title="Sliver Overlord" options={options()} onChoose={onChoose} />,
+  );
+  return onChoose;
+}
+
+afterEach(cleanup);
+
+describe("ChoiceModal — non-selectable rows (CR 118.3)", () => {
+  // Row 15.
+  it("renders a non-selectable row per blocked ability and dispatches nothing on click", () => {
+    const onChoose = renderModal();
+
+    const blocked = screen.getByRole("button", { name: /Search your library/ });
+    const affordable = screen.getByRole("button", { name: /Regenerate target Sliver/ });
+
+    expect(blocked).toHaveAttribute("aria-disabled", "true");
+    // PAIRED POSITIVE, mandatory: without it, a modal that disabled every row
+    // would satisfy the assertion above.
+    expect(affordable).not.toHaveAttribute("aria-disabled");
+
+    fireEvent.click(blocked);
+    expect(onChoose).not.toHaveBeenCalled();
+
+    // REACH-GUARD: the same handler in the same render DOES fire for the
+    // affordable row, so the zero above is a refusal, not a dead modal.
+    fireEvent.click(affordable);
+    expect(onChoose).toHaveBeenCalledTimes(1);
+    expect(onChoose).toHaveBeenCalledWith("0");
+  });
+
+  // Row 16.
+  it("keeps the blocked row in the tab order and puts the reason in its accessible name", () => {
+    renderModal();
+
+    const blocked = screen.getByRole("button", { name: /Search your library/ });
+
+    // `aria-disabled`, NOT native `disabled`: a native `disabled` button is
+    // removed from interactive screen-reader navigation, which would hide the
+    // explanation from exactly the users who need it. Asserted directly so the
+    // decision is pinned rather than incidental.
+    expect(blocked).not.toBeDisabled();
+    expect(blocked.hasAttribute("disabled")).toBe(false);
+
+    // The reason renders as a <p> INSIDE the <button> with no
+    // `aria-describedby`, so it feeds the accessible NAME.
+    expect(within(blocked).getByText(REASON)).toBeInTheDocument();
+    expect(blocked).toHaveAccessibleName(expect.stringContaining(REASON) as unknown as string);
+  });
+
+  // Guard: the `disabled` field is optional, so every one of the 26 shipped
+  // `<ChoiceModal>` call sites keeps working untouched.
+  it("leaves rows selectable when `disabled` is omitted entirely", () => {
+    const onChoose = vi.fn();
+    render(
+      <ChoiceModal
+        title="Sliver Overlord"
+        options={[{ id: "0", label: AFFORDABLE }]}
+        onChoose={onChoose}
+      />,
+    );
+    const row = screen.getByRole("button", { name: /Regenerate target Sliver/ });
+    expect(row).not.toHaveAttribute("aria-disabled");
+    fireEvent.click(row);
+    expect(onChoose).toHaveBeenCalledWith("0");
+  });
+});

--- a/client/src/game/sessionCleanup.ts
+++ b/client/src/game/sessionCleanup.ts
@@ -38,6 +38,7 @@ export function clearPromptOverlayState(): void {
     manaPaymentShortcutActions: [],
     spellCosts: {},
     legalActionsByObject: {},
+    activationBlockReasons: {},
     restoredStackAutomation: null,
   });
   useUiStore.getState().setPendingAbilityChoice(null);

--- a/client/src/i18n/locales/de/game.json
+++ b/client/src/i18n/locales/de/game.json
@@ -3,7 +3,8 @@
     "badge": "Blockiert",
     "cantBeActivated": "Diese Fähigkeit kann nicht aktiviert werden",
     "cantActivateDuring": "Kann derzeit nicht aktiviert werden",
-    "prohibited": "Das Aktivieren dieser Fähigkeit ist verboten"
+    "prohibited": "Das Aktivieren dieser Fähigkeit ist verboten",
+    "costNotPayableNow": "Du kannst diese Kosten gerade nicht bezahlen"
   },
   "manaSourceSelection": { "title": "Manaquelle wählen", "description": "Diese Manafähigkeit erfordert das Opfern einer bleibenden Karte.", "sacrifice": "Opfern", "back": "Zurück zur Manabezahlung", "unknownSource": "Manaquelle" },
   "comboShortcut": {

--- a/client/src/i18n/locales/en/game.json
+++ b/client/src/i18n/locales/en/game.json
@@ -3,7 +3,8 @@
     "badge": "Blocked",
     "cantBeActivated": "This ability can't be activated",
     "cantActivateDuring": "Can't be activated right now",
-    "prohibited": "Activating this ability is prohibited"
+    "prohibited": "Activating this ability is prohibited",
+    "costNotPayableNow": "You can't pay this cost right now"
   },
   "manaSourceSelection": {
     "title": "Choose a mana source",

--- a/client/src/i18n/locales/es/game.json
+++ b/client/src/i18n/locales/es/game.json
@@ -3,7 +3,8 @@
     "badge": "Bloqueada",
     "cantBeActivated": "Esta habilidad no puede activarse",
     "cantActivateDuring": "No puede activarse ahora",
-    "prohibited": "Activar esta habilidad está prohibido"
+    "prohibited": "Activar esta habilidad está prohibido",
+    "costNotPayableNow": "No puedes pagar este coste ahora mismo"
   },
   "manaSourceSelection": { "title": "Elige una fuente de maná", "description": "Esta habilidad de maná requiere sacrificar un permanente.", "sacrifice": "Sacrificar", "back": "Volver al pago de maná", "unknownSource": "Fuente de maná" },
   "comboShortcut": {

--- a/client/src/i18n/locales/fr/game.json
+++ b/client/src/i18n/locales/fr/game.json
@@ -3,7 +3,8 @@
     "badge": "Bloquée",
     "cantBeActivated": "Cette capacité ne peut pas être activée",
     "cantActivateDuring": "Ne peut pas être activée pour l'instant",
-    "prohibited": "L'activation de cette capacité est interdite"
+    "prohibited": "L'activation de cette capacité est interdite",
+    "costNotPayableNow": "Vous ne pouvez pas payer ce coût pour le moment"
   },
   "manaSourceSelection": { "title": "Choisir une source de mana", "description": "Cette capacité de mana demande de sacrifier un permanent.", "sacrifice": "Sacrifier", "back": "Retour au paiement de mana", "unknownSource": "Source de mana" },
   "comboShortcut": {

--- a/client/src/i18n/locales/it/game.json
+++ b/client/src/i18n/locales/it/game.json
@@ -3,7 +3,8 @@
     "badge": "Bloccata",
     "cantBeActivated": "Questa abilità non può essere attivata",
     "cantActivateDuring": "Non può essere attivata ora",
-    "prohibited": "L'attivazione di questa abilità è proibita"
+    "prohibited": "L'attivazione di questa abilità è proibita",
+    "costNotPayableNow": "Non puoi pagare questo costo in questo momento"
   },
   "manaSourceSelection": { "title": "Scegli una fonte di mana", "description": "Questa abilità di mana richiede di sacrificare un permanente.", "sacrifice": "Sacrifica", "back": "Torna al pagamento del mana", "unknownSource": "Fonte di mana" },
   "comboShortcut": {

--- a/client/src/i18n/locales/pl/game.json
+++ b/client/src/i18n/locales/pl/game.json
@@ -3,7 +3,8 @@
     "badge": "Zablokowana",
     "cantBeActivated": "Tej zdolności nie można aktywować",
     "cantActivateDuring": "Nie można teraz aktywować",
-    "prohibited": "Aktywacja tej zdolności jest zabroniona"
+    "prohibited": "Aktywacja tej zdolności jest zabroniona",
+    "costNotPayableNow": "Nie możesz teraz zapłacić tego kosztu"
   },
   "manaSourceSelection": { "title": "Wybierz źródło many", "description": "Ta zdolność many wymaga poświęcenia permanenta.", "sacrifice": "Poświęć", "back": "Wróć do płatności many", "unknownSource": "Źródło many" },
   "comboShortcut": {

--- a/client/src/i18n/locales/pt/game.json
+++ b/client/src/i18n/locales/pt/game.json
@@ -3,7 +3,8 @@
     "badge": "Bloqueada",
     "cantBeActivated": "Esta habilidade não pode ser ativada",
     "cantActivateDuring": "Não pode ser ativada agora",
-    "prohibited": "Ativar esta habilidade é proibido"
+    "prohibited": "Ativar esta habilidade é proibido",
+    "costNotPayableNow": "Você não pode pagar este custo agora"
   },
   "manaSourceSelection": { "title": "Escolha uma fonte de mana", "description": "Esta habilidade de mana exige sacrificar uma permanente.", "sacrifice": "Sacrificar", "back": "Voltar ao pagamento de mana", "unknownSource": "Fonte de mana" },
   "comboShortcut": {

--- a/client/src/network/__tests__/protocol.test.ts
+++ b/client/src/network/__tests__/protocol.test.ts
@@ -7,6 +7,7 @@ import {
   decodeWireMessage,
   encodeWireMessage,
   legalActionsFromWire,
+  legalActionsToWire,
   validateMessage,
 } from "../protocol";
 import type { P2PMessage } from "../protocol";
@@ -70,12 +71,44 @@ const PREVIEW_ANSWER = {
 } as never;
 
 describe("encodeWireMessage / decodeWireMessage", () => {
-  it("pins the P2P wire protocol to v45", () => {
-    expect(WIRE_PROTOCOL_VERSION).toBe(45);
+  it("pins the P2P wire protocol to v46", () => {
+    expect(WIRE_PROTOCOL_VERSION).toBe(46);
   });
 
   it("defaults shortcut actions for a legacy payload created before the additive field", () => {
     expect(legalActionsFromWire({ legalActions: [] }).manaPaymentShortcutActions).toEqual([]);
+  });
+
+  // CR 118.3 — matrix row 20: the acting-player "can't pay this cost right now"
+  // read-out must survive the P2P host->guest wire. Omit it from either
+  // projection helper and a P2P guest silently loses the read-out; because the
+  // field is OPTIONAL, `type-check` stays green, so this round-trip is the only
+  // instrument that catches it.
+  it("round-trips the CR 118.3 activation-block read-out host->guest", () => {
+    const activationBlockReasons = {
+      "408": [
+        { ability_index: 0, type: "CostNotPayableNow" as const },
+        { ability_index: 1, type: "CostNotPayableNow" as const },
+      ],
+    };
+
+    const wire = legalActionsToWire({
+      actions: [],
+      autoPassRecommended: false,
+      activationBlockReasons,
+    });
+    // Guard the HOST half separately: a `legalActionsToWire` that dropped the
+    // field would still round-trip to `undefined` below and could be read as an
+    // absent-field pass.
+    expect(wire.activationBlockReasons).toEqual(activationBlockReasons);
+
+    expect(legalActionsFromWire(wire).activationBlockReasons).toEqual(activationBlockReasons);
+  });
+
+  // The absent direction: a v45 peer sends no field at all. It must hydrate to
+  // `undefined` (the store applies its own `?? {}` default) rather than throwing.
+  it("hydrates an absent activation-block read-out without crashing", () => {
+    expect(legalActionsFromWire({ legalActions: [] }).activationBlockReasons).toBeUndefined();
   });
 
   it("preserves the engine-authored pay-to-end offer order and display payload", () => {

--- a/client/src/network/protocol.ts
+++ b/client/src/network/protocol.ts
@@ -1,4 +1,5 @@
 import type {
+  AbilityBlockEntry,
   EndContinuousEffectOffer,
   GameAction,
   GameEvent,
@@ -49,6 +50,8 @@ export interface LegalActionsWire {
   manaPaymentShortcutActions?: GameAction[];
   legalActionsByObject?: Record<string, ObjectAction[]>;
   spellCosts?: Record<string, ManaCost>;
+  /** CR 118.3: acting-player-scoped "can't pay this cost right now" read-out. */
+  activationBlockReasons?: Record<string, AbilityBlockEntry[]>;
   viewerInteraction?: ViewerInteraction;
 }
 
@@ -61,6 +64,7 @@ export function legalActionsToWire(result: LegalActionsResult): LegalActionsWire
     manaPaymentShortcutActions: result.manaPaymentShortcutActions ?? [],
     legalActionsByObject: result.legalActionsByObject,
     spellCosts: result.spellCosts,
+    activationBlockReasons: result.activationBlockReasons,
     viewerInteraction: result.viewerInteraction,
   };
 }
@@ -74,6 +78,7 @@ export function legalActionsFromWire(wire: LegalActionsWire): LegalActionsResult
     manaPaymentShortcutActions: wire.manaPaymentShortcutActions ?? [],
     legalActionsByObject: wire.legalActionsByObject,
     spellCosts: wire.spellCosts,
+    activationBlockReasons: wire.activationBlockReasons,
     viewerInteraction: wire.viewerInteraction,
   };
 }
@@ -322,7 +327,7 @@ export type P2PInteractionPreviewAnswer =
   | { type: "preview"; preview: InteractionPreview }
   | { type: "failed"; message: string };
 
-export const WIRE_PROTOCOL_VERSION = 45 as const;
+export const WIRE_PROTOCOL_VERSION = 46 as const;
 
 export type P2PMessage = P2PAuthorityWire & (
   | {

--- a/client/src/pages/GamePage.tsx
+++ b/client/src/pages/GamePage.tsx
@@ -176,12 +176,16 @@ import { SpectatorChrome } from "../components/spectator/SpectatorChrome.tsx";
 import { useSpectatorMode } from "../hooks/useSpectatorMode.ts";
 import { GameProvider } from "../providers/GameProvider.tsx";
 import { useCanActForWaitingState, usePerspectivePlayerId, usePlayerId } from "../hooks/usePlayerId.ts";
+import { ABILITY_BLOCK_REASON_KEY } from "../viewmodel/abilityBlockReason.ts";
 import {
   abilityChoiceLabel,
+  abilityLabel,
   formatAbilityCost,
   loyaltyBadge,
+  stripCostPrefix,
   stripLoyaltyCostPrefix,
 } from "../viewmodel/costLabel.ts";
+import { renderDescription } from "../utils/description.ts";
 import { LoyaltyBadge } from "../components/ui/LoyaltyBadge.tsx";
 import {
   getCastableZoneViewerTarget,
@@ -3293,6 +3297,16 @@ function AbilityChoiceModal() {
     (s) => s.gameState?.derived?.room_half_identities,
   );
   const viewerInteraction = useGameStore((s) => s.viewerInteraction);
+  // CR 118.3: the engine-authored "can't pay this cost right now" read-out.
+  // Read from the store slice (not from `uiStore.pendingAbilityChoice`) so the
+  // rows stay live against the current state rather than latched to whatever
+  // was true when the choice was queued.
+  // `?? {}` is load-bearing, not defensive noise: a store SNAPSHOT that predates
+  // this slice (a restored session, or any consumer holding an older store
+  // shape) yields `undefined`, and subscripting it would crash the whole game
+  // page for a display-only feature. Mirrors `legalResultState`'s own
+  // `result.activationBlockReasons ?? {}` default.
+  const activationBlockReasons = useGameStore((s) => s.activationBlockReasons) ?? {};
 
   if (!pending || !obj) return null;
 
@@ -3332,7 +3346,8 @@ function AbilityChoiceModal() {
       subtitle={subtitle}
       previewCardName={obj.name}
       previewCardTypes={obj.card_types}
-      options={pending.actions.map((action, i) => {
+      options={[
+        ...pending.actions.map((action, i) => {
         let { label, description } = abilityChoiceLabel(
           action,
           obj,
@@ -3360,16 +3375,62 @@ function AbilityChoiceModal() {
             // badge already expresses its cost, so keeping the effect in the
             // secondary description would visually detach it from that badge.
             label: description ?? stripLoyaltyCostPrefix(label),
-            labelTone: "secondary",
+            // `as const`: a spread element no longer receives `ChoiceOption[]`
+            // as its contextual type, so this would otherwise widen to `string`.
+            labelTone: "secondary" as const,
             icon: (
               <LoyaltyBadge amount={badge.amount} kind="cost" />
             ),
           };
         }
         return { id: String(i), label, description };
-      })}
+        }),
+        // CR 118.3: display-only rows for abilities the engine is withholding
+        // solely because the cost is unpayable right now. Appended AFTER the
+        // action rows so the positional `id = String(i)` <-> `pending.actions[Number(id)]`
+        // contract above is preserved byte-for-byte.
+        //
+        // No de-duplication against the offered rows is needed: the engine's
+        // read-out and its offered set are produced by the SAME
+        // `activation_verdict` core, so an ability is in exactly one of them.
+        ...(activationBlockReasons[String(pending.objectId)] ?? []).map((entry) => {
+          // CR 201.5: `~` is the engine's self-reference token; bind it to the
+          // host object, the idiom both shipped consumers use. A runtime-granted
+          // index has no printed description, so the row falls back to the
+          // reason alone (matching `PermanentCard`'s badge).
+          const ability = entry.ability_index < obj.abilities.length
+            ? obj.abilities[entry.ability_index]
+            : undefined;
+          const reason = t(ABILITY_BLOCK_REASON_KEY[entry.type]);
+          // Same label/description split the OFFERED rows above get from
+          // `abilityChoiceLabel` (`costLabel.ts`: `abilityLabel` for the label,
+          // `stripCostPrefix` for the description). A blocked `{3}` and an
+          // offered `{3}` therefore render identically in the same list and
+          // differ only by the disabled styling — which is the comparison the
+          // reported defect is about, since the card face shows both. Reusing
+          // the shipped helpers rather than re-deriving the split here keeps the
+          // two row kinds from drifting apart. `RichLabel` inside `ChoiceModal`
+          // renders `{3}` as a real mana pip, so no cost plumbing is needed.
+          const effect = ability?.description
+            ? renderDescription(stripCostPrefix(ability.description), obj.name)
+            : undefined;
+          return {
+            id: `blocked:${entry.ability_index}`,
+            label: ability ? renderDescription(abilityLabel(ability), obj.name) : reason,
+            description: effect ? `${effect} — ${reason}` : ability ? reason : undefined,
+            disabled: true,
+          };
+        }),
+      ]}
       onChoose={(id) => {
-        dispatch(pending.actions[Number(id)]);
+        // CR 118.3: blocked rows are display-only and carry a non-numeric id.
+        // Without this guard `Number("blocked:0")` is `NaN`, so
+        // `pending.actions[NaN]` is `undefined` and a malformed dispatch
+        // reaches the engine.
+        if (id.startsWith("blocked:")) return;
+        const action = pending.actions[Number(id)];
+        if (!action) return;
+        dispatch(action);
         setPending(null);
       }}
       onClose={() => setPending(null)}

--- a/client/src/pages/__tests__/GamePage.bracketViolation.test.tsx
+++ b/client/src/pages/__tests__/GamePage.bracketViolation.test.tsx
@@ -59,6 +59,7 @@ const { mockClearPromptOverlayState, mockIsMobile, mockSetGameState, storeOverri
     gameState: null as unknown,
     gameMode: null as unknown,
     waitingFor: null as unknown,
+    activationBlockReasons: {} as Record<string, Array<{ ability_index: number; type: string }>>,
   },
 }));
 
@@ -161,6 +162,10 @@ vi.mock("../../stores/gameStore", async () => ({
         autoPassRecommended: false,
         spellCosts: {},
         legalActionsByObject: {},
+        // CR 118.3: the acting-player "can't pay this cost right now" read-out.
+        // Mutable so a test can seed it; reset in `beforeEach` alongside the
+        // other `storeOverrides` fields.
+        activationBlockReasons: storeOverrides.activationBlockReasons,
         events: [],
         eventHistory: [],
         logHistory: [],
@@ -267,10 +272,33 @@ vi.mock("../../components/modal/CardDataMissingModal", () => ({
 // the rendering boundary lets the test exercise GamePage's module-private
 // AbilityChoiceModal and observe the actual labels it supplies without pulling
 // card-art loading into a label-wiring test.
+// `onChoose` is wired through and called UNCONDITIONALLY — deliberately WITHOUT
+// re-implementing the real `ChoiceModal`'s `opt.disabled` guard. That guard is
+// tested against the real component in
+// `components/modal/__tests__/ChoiceModal.test.tsx`; mirroring it here would
+// make GamePage's OWN `blocked:` / `!action` guard unreachable, and this mock
+// exists precisely so a `blocked:` id can reach it.
 vi.mock("../../components/modal/ChoiceModal", () => ({
-  ChoiceModal: ({ options }: { options: Array<{ id: string; label: string }> }) => (
+  ChoiceModal: ({
+    options,
+    onChoose,
+  }: {
+    options: Array<{ id: string; label: string; description?: string; disabled?: boolean }>;
+    onChoose: (id: string) => void;
+  }) => (
     <div data-testid="ability-choice-options">
-      {options.map((option) => <button key={option.id} type="button">{option.label}</button>)}
+      {options.map((option) => (
+        <button
+          key={option.id}
+          type="button"
+          data-option-id={option.id}
+          data-option-description={option.description}
+          data-option-disabled={option.disabled ? "true" : undefined}
+          onClick={() => onChoose(option.id)}
+        >
+          {option.label}
+        </button>
+      ))}
     </div>
   ),
 }));
@@ -395,6 +423,7 @@ beforeEach(() => {
   storeOverrides.gameState = null;
   storeOverrides.gameMode = null;
   storeOverrides.waitingFor = null;
+  storeOverrides.activationBlockReasons = {};
   useUiStore.setState({ pendingAbilityChoice: null });
   mockIsMobile.mockReturnValue(false);
   usePreferencesStore.setState({
@@ -626,6 +655,141 @@ describe("GamePage — Room unlock labels", () => {
 
     expect(screen.getByRole("button", { name: "Unlock Greenhouse ({2}{G})" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Unlock Rickety Gazebo ({3}{G})" })).toBeInTheDocument();
+  });
+});
+
+describe("GamePage — CR 118.3 unaffordable-ability rows in the ability picker", () => {
+  const ENGINE_ID = 9301 as const;
+  // Index 0 is OFFERED (an action row); index 1 is WITHHELD by the engine
+  // because its cost is unpayable right now, and is the row this feature adds.
+  const OFFERED_DESC = "{1}: Draw a card.";
+  const BLOCKED_DESC = "{7}: Search your library for a Sliver card.";
+  // The localized reason lands in the row's `description`, which this file's
+  // `ChoiceModal` mock deliberately does not render: appending it inside the
+  // <button> would change the accessible names the Room-unlock test above
+  // asserts on. The reason text is covered against the REAL component in
+  // `components/modal/__tests__/ChoiceModal.test.tsx` (rows 15/16).
+
+  /** Seed a board whose picker is open on `ENGINE_ID` with one offered ability. */
+  function seedPicker(activationBlockReasons: Record<string, Array<{ ability_index: number; type: string }>>) {
+    const engine = gameObjectFactory
+      .creature(2, 2)
+      .onBattlefield()
+      .withId(ENGINE_ID)
+      .ownedBy(0)
+      .named("Costly Engine")
+      .build({
+        abilities: [
+          { description: OFFERED_DESC },
+          { description: BLOCKED_DESC },
+        ] as never,
+      });
+    const gameState = gameStateFactory
+      .withPlayers(0, 1)
+      .withObjects(engine)
+      .priority(0)
+      .build();
+    storeOverrides.gameState = gameState;
+    storeOverrides.waitingFor = gameState.waiting_for;
+    storeOverrides.activationBlockReasons = activationBlockReasons;
+    useUiStore.setState({
+      pendingAbilityChoice: {
+        objectId: ENGINE_ID,
+        actions: [
+          { type: "ActivateAbility", data: { source_id: ENGINE_ID, ability_index: 0 } },
+        ],
+      },
+    });
+    renderGamePage();
+  }
+
+  /** Every option button the private `AbilityChoiceModal` supplied, in DOM order. */
+  function optionIds(): string[] {
+    return Array.from(
+      screen.getByTestId("ability-choice-options").querySelectorAll("button"),
+    ).map((b) => b.getAttribute("data-option-id") ?? "");
+  }
+
+  function optionLabels(): string[] {
+    return Array.from(
+      screen.getByTestId("ability-choice-options").querySelectorAll("button"),
+    ).map((b) => b.textContent ?? "");
+  }
+
+  /**
+   * Select by the option's ID, not by its accessible name. `abilityChoiceLabel`
+   * splits an ActivateAbility description at the colon (the offered row renders
+   * as `{1}`, not the whole sentence), and most rows here are not about that
+   * formatting — binding to it would make the test fail for an unrelated
+   * viewmodel change. The one row that IS about it asserts the split explicitly.
+   */
+  function optionButton(id: string): HTMLElement {
+    const el = screen
+      .getByTestId("ability-choice-options")
+      .querySelector(`[data-option-id="${id}"]`);
+    expect(el, `option ${id} must be rendered`).not.toBeNull();
+    return el as HTMLElement;
+  }
+
+  // Row 17 (a) — THE USER-VISIBLE HALF OF THE FIX. The reported defect was that
+  // an ability the engine withholds for cost simply vanished from the picker.
+  // The blocked row must be appended AFTER the action rows, because the offered
+  // rows' ids are positional (`String(i)` <-> `pending.actions[Number(id)]`) and
+  // prepending would silently re-index every dispatch.
+  it("appends a non-selectable row per withheld ability, after the offered rows", () => {
+    seedPicker({ [String(ENGINE_ID)]: [{ ability_index: 1, type: "CostNotPayableNow" }] });
+
+    // The load-bearing claim: the blocked row exists, and it is LAST.
+    expect(optionIds()).toEqual(["0", "blocked:1"]);
+    // The blocked row uses the SAME label/description split as the offered rows
+    // (`abilityLabel` + `stripCostPrefix`), so the bold line is the cost pip on
+    // both and the two are visually comparable in one list — the comparison the
+    // reported defect is about. Asserting the split, not just "some label".
+    expect(optionLabels()[1]).toBe("{7}");
+    expect(optionButton("blocked:1")).toHaveAttribute(
+      "data-option-description",
+      "Search your library for a Sliver card. — You can't pay this cost right now",
+    );
+    // PAIRED POSITIVE for the convention itself: the OFFERED row's label is a
+    // bare cost too, so the assertion above pins a shared shape rather than a
+    // coincidence of this fixture.
+    expect(optionLabels()[0]).toBe("{1}");
+    expect(optionButton("blocked:1")).toHaveAttribute("data-option-disabled", "true");
+    // PAIRED POSITIVE, mandatory: the offered row is NOT disabled, so a modal
+    // that disabled everything cannot satisfy the assertion above.
+    expect(optionButton("0")).not.toHaveAttribute("data-option-disabled");
+  });
+
+  // Row 17 (b) — the empty-read-out control. With no withheld abilities the
+  // picker is byte-for-byte what it was before this feature, so the change is
+  // additive rather than a rewrite of the option list.
+  it("adds no rows when the engine withholds nothing", () => {
+    seedPicker({});
+
+    expect(optionIds()).toEqual(["0"]);
+  });
+
+  // Row 17 (c) — GamePage's OWN dispatch guard, reached through the real
+  // `onChoose`. `setPending(null)` is the observable: a chosen action clears
+  // `pendingAbilityChoice`, so "the picker stays open" is the signal that the
+  // guard refused the id. `useUiStore` is the real store here, not a mock.
+  it("refuses to dispatch a blocked row's id while still dispatching a real one", () => {
+    seedPicker({ [String(ENGINE_ID)]: [{ ability_index: 1, type: "CostNotPayableNow" }] });
+
+    fireEvent.click(optionButton("blocked:1"));
+    expect(
+      useUiStore.getState().pendingAbilityChoice,
+      "clicking a blocked row must not resolve the choice",
+    ).not.toBeNull();
+
+    // PAIRED POSITIVE, mandatory: the SAME handler in the SAME render does
+    // resolve the choice for a real action row, so the refusal above is a
+    // refusal and not a dead modal.
+    fireEvent.click(optionButton("0"));
+    expect(
+      useUiStore.getState().pendingAbilityChoice,
+      "clicking an offered row must resolve the choice",
+    ).toBeNull();
   });
 });
 

--- a/client/src/stores/gameStore.ts
+++ b/client/src/stores/gameStore.ts
@@ -1,6 +1,7 @@
 import { create } from "zustand";
 import { subscribeWithSelector } from "zustand/middleware";
 import type {
+  AbilityBlockEntry,
   EngineAdapter,
   EngineSnapshot,
   FormatConfig,
@@ -29,7 +30,7 @@ import { loadCheckpoints, saveAuthoritativeGame } from "../services/gamePersiste
 import { resetStackThroughput } from "../utils/stackThroughput";
 
 /** Map a LegalActionsResult to the store fields it owns — single source of truth. */
-export function legalResultState(result: LegalActionsResult): Pick<GameStoreState, "legalActions" | "autoPassRecommended" | "endContinuousEffectOffers" | "manaPaymentShortcutActions" | "spellCosts" | "legalActionsByObject" | "stuckDiagnostic" | "viewerInteraction"> {
+export function legalResultState(result: LegalActionsResult): Pick<GameStoreState, "legalActions" | "autoPassRecommended" | "endContinuousEffectOffers" | "manaPaymentShortcutActions" | "spellCosts" | "legalActionsByObject" | "activationBlockReasons" | "stuckDiagnostic" | "viewerInteraction"> {
   return {
     legalActions: result.actions,
     autoPassRecommended: result.autoPassRecommended,
@@ -37,6 +38,7 @@ export function legalResultState(result: LegalActionsResult): Pick<GameStoreStat
     manaPaymentShortcutActions: result.manaPaymentShortcutActions ?? [],
     spellCosts: result.spellCosts ?? {},
     legalActionsByObject: result.legalActionsByObject ?? {},
+    activationBlockReasons: result.activationBlockReasons ?? {},
     stuckDiagnostic: result.stuckDiagnostic ?? null,
     viewerInteraction: result.viewerInteraction ?? null,
   };
@@ -225,6 +227,13 @@ interface GameStoreState {
    */
   legalActionsByObject: Record<string, ObjectAction[]>;
   /**
+   * CR 118.3: acting-player-scoped read-out of activated abilities withheld
+   * solely because their cost is unpayable right now, keyed by object_id
+   * string. Display only — never dispatchable. Default `{}`, matching
+   * `legalActionsByObject`.
+   */
+  activationBlockReasons: Record<string, AbilityBlockEntry[]>;
+  /**
    * Engine-owned non-fatal progress-wedge diagnostic (an engine anomaly, not a
    * rules outcome) — present only when the current decision is wedged (no legal
    * action for any authorized submitter). `null` in normal play. Display-only
@@ -303,6 +312,7 @@ type CommitExtraState = Partial<Omit<GameStoreState,
   | "manaPaymentShortcutActions"
   | "spellCosts"
   | "legalActionsByObject"
+  | "activationBlockReasons"
   | "stuckDiagnostic"
   | "lastCommittedSeq"
   | "engineCommitEpoch"
@@ -465,6 +475,7 @@ const initialState: GameStoreState = {
   manaPaymentShortcutActions: [],
   spellCosts: {},
   legalActionsByObject: {},
+  activationBlockReasons: {},
   stuckDiagnostic: null,
   viewerInteraction: null,
   stateHistory: [],

--- a/client/src/stores/multiplayerDraftStore.ts
+++ b/client/src/stores/multiplayerDraftStore.ts
@@ -1028,6 +1028,7 @@ function disposeMatchAdapter(set: SetFn): void {
         endContinuousEffectOffers: [],
         spellCosts: {},
         legalActionsByObject: {},
+        activationBlockReasons: {},
         stateHistory: [],
         turnCheckpoints: [],
       });

--- a/client/src/stores/replayStore.ts
+++ b/client/src/stores/replayStore.ts
@@ -88,6 +88,7 @@ export const useReplayStore = create<ReplayStore>()((set, get) => ({
         legalActions: [],
         endContinuousEffectOffers: [],
         legalActionsByObject: {},
+        activationBlockReasons: {},
         autoPassRecommended: false,
         spellCosts: {},
         stateHistory: [],

--- a/client/src/viewmodel/abilityBlockReason.ts
+++ b/client/src/viewmodel/abilityBlockReason.ts
@@ -1,0 +1,30 @@
+import type { AbilityBlockKind } from "../adapter/types";
+
+/**
+ * CR 602.5 + CR 118.3: Maps an engine `AbilityBlockKind` to its i18n reason key.
+ *
+ * Pure display formatting — no game logic. Exhaustive over the union, so a new
+ * engine kind is a compile error until a key is added here.
+ *
+ * **Two channels, one map — and every consumer carries keys it can never use.**
+ * The engine publishes these kinds on two independent surfaces:
+ *
+ *   * `CantBeActivated` / `CantActivateDuring` / `Prohibited` ride
+ *     `GameObject.blocked_abilities`, populated by the `derived.rs` CR 602.5
+ *     prohibition sweep and rendered by the board badge and the inspect panel.
+ *   * `CostNotPayableNow` rides the legal-actions payload
+ *     (`LegalActionsResult.activationBlockReasons`), is scoped to the acting
+ *     player, and is rendered by the ability picker.
+ *
+ * The channel is the filter: a consumer of one surface will NEVER receive the
+ * other's kinds, so there is deliberately no `BOARD_BADGE_BLOCK_KINDS`-style
+ * allowlist to keep in sync. The board badge is not broken because it has a
+ * `costNotPayableNow` key it never renders, and the picker is not broken
+ * because it has three prohibition keys it never renders.
+ */
+export const ABILITY_BLOCK_REASON_KEY: Record<AbilityBlockKind, string> = {
+  CantBeActivated: "abilityBlock.cantBeActivated",
+  CantActivateDuring: "abilityBlock.cantActivateDuring",
+  Prohibited: "abilityBlock.prohibited",
+  CostNotPayableNow: "abilityBlock.costNotPayableNow",
+};

--- a/client/src/viewmodel/costLabel.ts
+++ b/client/src/viewmodel/costLabel.ts
@@ -777,7 +777,7 @@ export function additionalCostChoices(
 }
 
 /** Strip the leading cost prefix from Oracle text (e.g. "[+2]: Draw a card." → "Draw a card.") */
-function stripCostPrefix(text: string): string {
+export function stripCostPrefix(text: string): string {
   // Bracket format: [+2]: ..., [−1]: ..., [0]: ...
   const bracketMatch = text.match(/^\[.*?\]:\s*/);
   if (bracketMatch) return text.slice(bracketMatch[0].length);

--- a/client/src/wasm/engine_wasm.d.ts
+++ b/client/src/wasm/engine_wasm.d.ts
@@ -270,8 +270,10 @@ export function get_game_state(): any;
 export function get_legal_actions_for_viewer_js(player_id: number): any;
 
 /**
- * Get the legal actions, auto-pass recommendation, and spell costs for the current game state.
- * Returns `{ actions: GameAction[], autoPassRecommended: boolean, spellCosts: Record<string, ManaCost> }`.
+ * Get the legal actions, auto-pass recommendation, spell costs, and the CR 118.3
+ * "can't pay this cost right now" read-out for the current game state.
+ * Returns `{ actions: GameAction[], autoPassRecommended: boolean, spellCosts: Record<string, ManaCost>,
+ * activationBlockReasons: Record<string, AbilityBlockEntry[]> }`.
  */
 export function get_legal_actions_js(): any;
 

--- a/crates/engine-wasm/src/lib.rs
+++ b/crates/engine-wasm/src/lib.rs
@@ -328,6 +328,10 @@ struct LegalActionsResult {
     /// Frontend uses this for "what can I do with this card?" lookups so it
     /// doesn't have to introspect `GameAction` variants client-side.
     legal_actions_by_object: BTreeMap<String, Vec<engine::game::interaction::ObjectActionPayload>>,
+    /// CR 118.3: per-object read-out of activated abilities the ACTING player is
+    /// not offered solely because they can't pay the cost right now, keyed by
+    /// object_id. Display only — deliberately not dispatchable.
+    activation_block_reasons: BTreeMap<String, Vec<engine::types::ability::AbilityBlockEntry>>,
     /// Engine-level progress-wedge diagnostic: non-fatal signal that an owed
     /// decision has no legal action for any authorized submitter (an engine
     /// anomaly, not a rules outcome). `None` normally.
@@ -2006,8 +2010,10 @@ pub fn get_filtered_game_state(viewer: u8) -> JsValue {
     }
 }
 
-/// Get the legal actions, auto-pass recommendation, and spell costs for the current game state.
-/// Returns `{ actions: GameAction[], autoPassRecommended: boolean, spellCosts: Record<string, ManaCost> }`.
+/// Get the legal actions, auto-pass recommendation, spell costs, and the CR 118.3
+/// "can't pay this cost right now" read-out for the current game state.
+/// Returns `{ actions: GameAction[], autoPassRecommended: boolean, spellCosts: Record<string, ManaCost>,
+/// activationBlockReasons: Record<string, AbilityBlockEntry[]> }`.
 #[wasm_bindgen]
 pub fn get_legal_actions_js() -> JsValue {
     match with_state_mut(|state| {
@@ -2025,6 +2031,13 @@ pub fn get_legal_actions_js() -> JsValue {
             spell_costs: object_id_record(spell_costs),
             legal_actions_by_object: object_id_record(
                 engine::game::interaction::object_action_payloads(&legal_actions_by_object),
+            ),
+            // CR 117.1: the UNSCOPED sibling is correct here and only here —
+            // this entry point takes no viewer and serves a single-player local
+            // surface with exactly one recipient. Every multi-recipient
+            // transport must call `activation_block_reasons_for_viewer`.
+            activation_block_reasons: object_id_record(
+                engine::ai_support::activation_block_reasons(state),
             ),
             stuck_diagnostic: engine::ai_support::stuck_decision_diagnostic(state),
             viewer_interaction: engine::game::interaction::derive_viewer_interaction(
@@ -2113,6 +2126,8 @@ struct ViewerSnapshot<'a> {
     mana_payment_shortcut_actions: Vec<GameAction>,
     spell_costs: BTreeMap<String, ManaCost>,
     legal_actions_by_object: BTreeMap<String, Vec<engine::game::interaction::ObjectActionPayload>>,
+    /// CR 118.3: mirrored from `LegalActionsResult` — see the doc there.
+    activation_block_reasons: BTreeMap<String, Vec<engine::types::ability::AbilityBlockEntry>>,
     /// Engine-level progress-wedge diagnostic: non-fatal signal that an owed
     /// decision has no legal action for any authorized submitter (an engine
     /// anomaly, not a rules outcome). `None` normally.
@@ -2135,6 +2150,11 @@ fn legal_actions_result_for_viewer(state: &GameState, viewer: PlayerId) -> Legal
         spell_costs: object_id_record(spell_costs),
         legal_actions_by_object: object_id_record(
             engine::game::interaction::object_action_payloads(&legal_actions_by_object),
+        ),
+        // CR 117.1: viewer-scoped sibling — empty for a viewer without action
+        // authority, mirroring `legal_actions_for_viewer` above.
+        activation_block_reasons: object_id_record(
+            engine::ai_support::activation_block_reasons_for_viewer(state, viewer),
         ),
         stuck_diagnostic: engine::ai_support::stuck_decision_diagnostic(state),
         viewer_interaction: engine::game::interaction::derive_viewer_interaction(
@@ -2225,6 +2245,7 @@ pub fn get_viewer_snapshot_js(player_id: u32) -> JsValue {
             mana_payment_shortcut_actions: legal.mana_payment_shortcut_actions,
             spell_costs: legal.spell_costs,
             legal_actions_by_object: legal.legal_actions_by_object,
+            activation_block_reasons: legal.activation_block_reasons,
             stuck_diagnostic: legal.stuck_diagnostic,
             viewer_interaction,
         })

--- a/crates/engine/src/ai_support/mod.rs
+++ b/crates/engine/src/ai_support/mod.rs
@@ -21,9 +21,11 @@ use crate::game::layers;
 use crate::game::mana_abilities;
 use crate::game::mana_payment;
 use crate::game::mana_sources;
+use crate::game::restrictions;
 use crate::game::triggers;
 use crate::types::ability::{
-    AbilityKind, CounterCostSelection, TapCreaturesSelectionMode, TargetRef, TriggerDefinition,
+    AbilityBlockEntry, AbilityKind, CounterCostSelection, TapCreaturesSelectionMode, TargetRef,
+    TriggerDefinition,
 };
 use crate::types::actions::GameAction;
 use crate::types::card_type::CoreType;
@@ -2494,6 +2496,295 @@ pub fn legal_actions_for_viewer(state: &GameState, viewer: PlayerId) -> LegalAct
         legal_actions_full(state)
     } else {
         (Vec::new(), HashMap::new(), HashMap::new())
+    }
+}
+
+/// CR 118.3: maximum TOTAL read-out entries summed across every object bucket
+/// in one `activation_block_reasons` result.
+///
+/// **On the total, NOT the key count.** The map is vector-valued
+/// (`ObjectId -> Vec<AbilityBlockEntry>`), so its correct sibling is
+/// `MAX_SNAPSHOT_LEGAL_ACTIONS_BY_OBJECT_TOTAL`, whose guard sums
+/// `map.values().map(Vec::len).sum()` — NOT `MAX_SNAPSHOT_SPELL_COSTS`, which is
+/// a key-count bound and is complete only because `spell_costs` holds one scalar
+/// per key. A key-count bound here would leave every per-object vector
+/// unbounded, which is the exact failure class this read-out's design exists to
+/// avoid.
+///
+/// The bound lives in the ENGINE rather than in `server-core`'s wire guard
+/// because the guard returns `Result` and a broadcast site drops the whole
+/// message on `Err` — so a bound on a DISPLAY map could suppress a FUNCTIONAL
+/// broadcast. `activation_block_reasons` truncates and returns a map instead:
+/// it has no failure mode, so that path is never constructed. CLAUDE.md also
+/// puts logic in the engine and keeps the transport a serialization boundary.
+///
+/// The value is generous by design: the read-out covers ONE seat across five
+/// zones, so a real board produces tens of entries, not thousands.
+pub const MAX_ACTIVATION_BLOCK_TOTAL: usize = 1_000;
+
+/// CR 118.3: collect one object's unaffordable non-mana activated abilities.
+///
+/// Mirrors the per-object filter shape of the five enforcement loops in
+/// `candidates.rs::priority_actions_with_probe` — `AbilityKind::Activated`, the
+/// per-zone `activation_zone` filter, and `!is_mana_ability` — so the read-out's
+/// population is a subset of the population the enforcement gate decides. The
+/// two traversals are parallel by construction (see `activation_block_reasons`);
+/// only the loop structure is duplicated, never the authority.
+fn collect_activation_block_reasons_for_object(
+    state: &GameState,
+    player: PlayerId,
+    gates: &restrictions::ActivationRestrictionStaticGates,
+    obj_id: ObjectId,
+    required_activation_zone: Option<Zone>,
+    examined: &mut usize,
+    out: &mut HashMap<ObjectId, Vec<AbilityBlockEntry>>,
+) {
+    let mut entries: Vec<AbilityBlockEntry> = Vec::new();
+    for (ability_index, ability_def) in casting::activated_ability_definitions(state, obj_id) {
+        if ability_def.kind != AbilityKind::Activated {
+            continue;
+        }
+        if let Some(zone) = required_activation_zone {
+            if ability_def.activation_zone != Some(zone) {
+                continue;
+            }
+        }
+        // CR 605.1a: mana abilities are a different class decided by a different
+        // authority (`mana_abilities::can_activate_mana_ability_now`), which
+        // shares no code with the activation gate. Excluding them is what keeps
+        // the read-out's population a strict subset of the population
+        // `casting::activation_verdict` decides, so the two authorities are
+        // never asked the same question and cannot disagree. Byte-identical to
+        // the `!is_mana_ability` conjunct at all five enforcement sites.
+        if mana_abilities::is_mana_ability(&ability_def) {
+            continue;
+        }
+        *examined += 1;
+        if let Some(reason) =
+            casting::activation_cost_block_reason(state, player, obj_id, ability_index, gates)
+        {
+            entries.push(AbilityBlockEntry {
+                ability_index,
+                reason,
+            });
+        }
+    }
+    if !entries.is_empty() {
+        out.insert(obj_id, entries);
+    }
+}
+
+/// CR 118.3 + CR 602.5: per-object read-out of activated abilities the acting
+/// player is NOT being offered solely because they can't pay the cost right now.
+///
+/// TRANSPORT CALLERS MUST USE [`activation_block_reasons_for_viewer`].
+///
+/// CR 117.1: this function is UNSCOPED. It returns the acting player's read-out
+/// regardless of who is asking. It is `pub` only for the viewer-less
+/// `engine-wasm` entry point (`get_legal_actions_js`), a single-player local
+/// surface with exactly one recipient. Publishing this map from a
+/// multi-recipient transport leaks a controller-relative payability read-out to
+/// opponents — the disclosure defect this design exists to avoid.
+///
+/// Deliberately NOT part of `LegalActionsFull`. Learning the reason requires
+/// running the target-legality tail that `ActivationQuery::Legality`
+/// short-circuits past at the CR 118.3 exit, so this is strictly more work than
+/// enforcement needs. `server-core::session`, the three `phase-ai` policies and
+/// `legal_actions_bench` call `legal_actions_full` and must never pay for it —
+/// a separate entry point is how they don't. Same split as
+/// `flat_priority_actions` deliberately doing less than `legal_actions_full`.
+///
+/// CR 117.1b — "A player may activate an activated ability any time they have
+/// priority" — is why this is gated on `WaitingFor::Priority` rather than
+/// computed on every tick: an activated ability can ONLY be activated at
+/// priority, so an explanation of why you cannot activate one is only
+/// actionable in that window. The gate is the rule, not an optimisation.
+///
+/// Scoped to the acting player across the same five zones and behind the same
+/// `obj.controller == player` / `!is_mana_ability` filters as the enforcement
+/// sites in `candidates.rs`, so an entry can only ever describe an object the
+/// viewer controls.
+///
+/// Bounded by [`MAX_ACTIVATION_BLOCK_TOTAL`]. Returns a map, never a `Result`.
+pub fn activation_block_reasons(state: &GameState) -> HashMap<ObjectId, Vec<AbilityBlockEntry>> {
+    // CR 117.1b: only actionable at priority.
+    let WaitingFor::Priority { player } = &state.waiting_for else {
+        return HashMap::new();
+    };
+    let player = *player;
+
+    // CR 613.1: the read-out must be produced from the SAME state binding the
+    // offered actions come from, or `activated_ability_definitions`'
+    // layer-sensitive ability indices disagree with the indices the offered
+    // `GameAction::ActivateAbility`s carry. Same layers-flush handling
+    // `legal_actions_full` uses, and the same counter, so the once-per-call
+    // whole-state clone is visible to a clone-budget measurement.
+    let flushed_owned;
+    let state: &GameState = if state.layers_dirty.is_dirty() {
+        crate::game::perf_counters::record_priority_cast_probe_state_clone();
+        flushed_owned = {
+            let mut flushed = state.clone();
+            layers::flush_layers(&mut flushed);
+            flushed
+        };
+        &flushed_owned
+    } else {
+        state
+    };
+
+    // Hoisted once, exactly as `candidates.rs::priority_actions_with_probe`
+    // hoists it for the five enforcement loops.
+    let gates = restrictions::ActivationRestrictionStaticGates::compute(state);
+    let mut blocked: HashMap<ObjectId, Vec<AbilityBlockEntry>> = HashMap::new();
+    let mut examined = 0usize;
+
+    // The same five zones, with the same filters, as the five enforcement sites
+    // in `candidates.rs::priority_actions_with_probe`. A comment there names
+    // this traversal; sharing one traversal between them would touch the AI
+    // search hot path and is deliberately out of scope.
+
+    // CR 602.2: "Only an object's controller (or its owner, if it doesn't have a
+    // controller) can activate its activated ability" — battlefield, therefore
+    // controller-scoped, with no `activation_zone` filter
+    // (the gate itself checks `obj.zone != required_zone`).
+    for &obj_id in &state.battlefield {
+        if let Some(obj) = state.objects.get(&obj_id) {
+            if obj.controller == player {
+                collect_activation_block_reasons_for_object(
+                    state,
+                    player,
+                    &gates,
+                    obj_id,
+                    None,
+                    &mut examined,
+                    &mut blocked,
+                );
+            }
+        }
+    }
+
+    // CR 408.3: the command zone holds specially designated cards only in the
+    // casual variants that define them (Commander, Planechase, ...), so this
+    // scan costs formats without one nothing.
+    if state.format_config.command_zone {
+        for &obj_id in &state.command_zone {
+            if let Some(obj) = state.objects.get(&obj_id) {
+                if obj.controller == player {
+                    collect_activation_block_reasons_for_object(
+                        state,
+                        player,
+                        &gates,
+                        obj_id,
+                        None,
+                        &mut examined,
+                        &mut blocked,
+                    );
+                }
+            }
+        }
+    }
+
+    // CR 602.1: hand-activated abilities (Cycling per CR 702.29a, etc.).
+    for &obj_id in &state.players[player.0 as usize].hand {
+        if let Some(obj) = state.objects.get(&obj_id) {
+            if obj.controller == player {
+                collect_activation_block_reasons_for_object(
+                    state,
+                    player,
+                    &gates,
+                    obj_id,
+                    Some(Zone::Hand),
+                    &mut examined,
+                    &mut blocked,
+                );
+            }
+        }
+    }
+
+    // CR 113.6b + CR 602.2: graveyard-activated abilities.
+    for &obj_id in &state.players[player.0 as usize].graveyard {
+        if let Some(obj) = state.objects.get(&obj_id) {
+            if obj.controller == player {
+                collect_activation_block_reasons_for_object(
+                    state,
+                    player,
+                    &gates,
+                    obj_id,
+                    Some(Zone::Graveyard),
+                    &mut examined,
+                    &mut blocked,
+                );
+            }
+        }
+    }
+
+    // CR 702.170b: the plot special action on the top card of this player's own
+    // library. Player-scoped BY CONSTRUCTION (it is the top of that player's
+    // library), not by an `obj.controller` filter — the same shape the fifth
+    // enforcement site has.
+    if let Some((top_id, _src_id)) = casting::top_of_library_plot_source(state, player) {
+        collect_activation_block_reasons_for_object(
+            state,
+            player,
+            &gates,
+            top_id,
+            Some(Zone::Library),
+            &mut examined,
+            &mut blocked,
+        );
+    }
+
+    crate::game::perf_counters::record_activation_block_display_abilities_examined(examined);
+
+    truncate_activation_block_reasons(blocked)
+}
+
+/// CR 118.3: enforce [`MAX_ACTIVATION_BLOCK_TOTAL`] on the TOTAL entry count
+/// across every bucket, deterministically.
+///
+/// Truncation walks objects in `ObjectId` order and abilities in
+/// `ability_index` order, so the same board truncates identically for every
+/// recipient and across repeated calls. Returns a map and cannot fail.
+fn truncate_activation_block_reasons(
+    mut blocked: HashMap<ObjectId, Vec<AbilityBlockEntry>>,
+) -> HashMap<ObjectId, Vec<AbilityBlockEntry>> {
+    let total: usize = blocked.values().map(Vec::len).sum();
+    if total <= MAX_ACTIVATION_BLOCK_TOTAL {
+        return blocked;
+    }
+    let mut ids: Vec<ObjectId> = blocked.keys().copied().collect();
+    ids.sort_unstable();
+    let mut remaining = MAX_ACTIVATION_BLOCK_TOTAL;
+    let mut truncated: HashMap<ObjectId, Vec<AbilityBlockEntry>> = HashMap::new();
+    for id in ids {
+        if remaining == 0 {
+            break;
+        }
+        let Some(mut entries) = blocked.remove(&id) else {
+            continue;
+        };
+        entries.sort_unstable_by_key(|entry| entry.ability_index);
+        entries.truncate(remaining);
+        remaining -= entries.len();
+        if !entries.is_empty() {
+            truncated.insert(id, entries);
+        }
+    }
+    truncated
+}
+
+/// CR 117.1: viewer-scoped sibling of [`activation_block_reasons`], mirroring
+/// `legal_actions_for_viewer` — empty for any viewer without action authority.
+///
+/// This is the entry point every multi-recipient transport must call.
+pub fn activation_block_reasons_for_viewer(
+    state: &GameState,
+    viewer: PlayerId,
+) -> HashMap<ObjectId, Vec<AbilityBlockEntry>> {
+    if crate::game::turn_control::is_authorized_submitter(state, viewer) {
+        activation_block_reasons(state)
+    } else {
+        HashMap::new()
     }
 }
 

--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -19302,7 +19302,7 @@ pub(crate) fn can_pay_ability_cost_now(
     )
 }
 
-/// CR 602.2a: Whether `player` may begin to activate an activated ability on
+/// CR 602.2: Whether `player` may begin to activate an activated ability on
 /// a permanent controlled by `source_controller`.
 fn player_may_begin_activating(
     state: &GameState,
@@ -19321,6 +19321,67 @@ fn player_may_begin_activating(
     }
 }
 
+/// CR 602.5 + CR 118.3: what the activation gate was asked to decide.
+///
+/// The gate has one body and two consumers. `Legality` is enforcement: it
+/// short-circuits at the CR 118.3 affordability exit, which is the cheapest
+/// correct answer for "may this be activated". `BlockReason` is the display
+/// read-out: it records the affordability verdict and CONTINUES into the
+/// target-legality tail, because "you can't pay for this" is only a truthful
+/// explanation once everything else about the activation is known to be legal.
+/// `BlockReason` is therefore strictly MORE work than `Legality`, which is why
+/// it lives behind a separate entry point (`ai_support::activation_block_reasons`)
+/// rather than a widened `legal_actions_full`.
+///
+/// **`Legal` is not authoritative under `BlockReason`.** That mode additionally
+/// declines the display carve-outs (costless / tap-only costs, and refusals that
+/// are structural rather than resource-based) by returning `Illegal` before the
+/// payability probe runs, so an affordable tap-only ability reports `Illegal`
+/// there. Only `CostNotPayableNow` carries meaning in that mode. Every
+/// enforcement caller must use `Legality`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ActivationQuery {
+    /// Enforcement: may this player activate this ability right now?
+    Legality,
+    /// Display: is this ability being withheld SOLELY because the cost is
+    /// unpayable right now?
+    BlockReason,
+}
+
+/// CR 602.5 + CR 118.3: the activation gate's verdict.
+///
+/// `CostNotPayableNow` means every other activation requirement passed — the
+/// CR 602.5 prohibition statics, the activation zone (CR 602.1), the timing
+/// restrictions, CR 302.6 summoning sickness, the modal-mode count and target
+/// legality (CR 601.2c) — and only the CR 118.3 resource gate refused. Anything
+/// else that refuses yields `Illegal`, so a missing target can never be reported
+/// as a payment problem.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ActivationVerdict {
+    /// The ability may be activated right now.
+    Legal,
+    /// The ability may not be activated, for a reason that is not a CR 118.3
+    /// resource shortfall (or for a shortfall under `ActivationQuery::Legality`,
+    /// which does not distinguish).
+    Illegal,
+    /// CR 118.3: legal in every other respect; the player cannot pay the
+    /// post-reduction activation cost right now.
+    CostNotPayableNow,
+}
+
+impl ActivationVerdict {
+    /// CR 118.3: combine the gate's non-cost legality with the affordability
+    /// flag. A `false` legality dominates — an ability that could not be
+    /// activated anyway is `Illegal`, never a payment complaint.
+    fn from_gate(legal_ignoring_cost: bool, cost_not_payable: bool) -> Self {
+        match (legal_ignoring_cost, cost_not_payable) {
+            (false, _) => ActivationVerdict::Illegal,
+            (true, true) => ActivationVerdict::CostNotPayableNow,
+            (true, false) => ActivationVerdict::Legal,
+        }
+    }
+}
+
 pub fn can_activate_ability_now(
     state: &GameState,
     player: PlayerId,
@@ -19331,6 +19392,9 @@ pub fn can_activate_ability_now(
     can_activate_ability_now_with_restriction_gates(state, player, source_id, ability_index, &gates)
 }
 
+/// CR 602.5: enforcement shim over [`activation_verdict`]. The verdict core is
+/// the single activation-legality authority; this preserves the shipped `bool`
+/// signature for its six call sites so display and enforcement can never drift.
 pub fn can_activate_ability_now_with_restriction_gates(
     state: &GameState,
     player: PlayerId,
@@ -19338,12 +19402,38 @@ pub fn can_activate_ability_now_with_restriction_gates(
     ability_index: usize,
     restriction_gates: &restrictions::ActivationRestrictionStaticGates,
 ) -> bool {
+    matches!(
+        activation_verdict(
+            state,
+            player,
+            source_id,
+            ability_index,
+            restriction_gates,
+            ActivationQuery::Legality,
+        ),
+        ActivationVerdict::Legal
+    )
+}
+
+/// CR 602.5 + CR 118.3: the one activation-legality evaluation, shared by
+/// enforcement (`ActivationQuery::Legality`) and the display read-out
+/// (`ActivationQuery::BlockReason`). See [`ActivationQuery`] for what the two
+/// modes do differently and why `Legal` is meaningless under `BlockReason`.
+pub(crate) fn activation_verdict(
+    state: &GameState,
+    player: PlayerId,
+    source_id: ObjectId,
+    ability_index: usize,
+    restriction_gates: &restrictions::ActivationRestrictionStaticGates,
+    query: ActivationQuery,
+) -> ActivationVerdict {
+    crate::game::perf_counters::record_activation_verdict_pass();
     let Some(obj) = state.objects.get(&source_id) else {
-        return false;
+        return ActivationVerdict::Illegal;
     };
     let Some(mut ability_def) = activation_ability_definition(state, source_id, ability_index)
     else {
-        return false;
+        return ActivationVerdict::Illegal;
     };
     if !player_may_begin_activating(
         state,
@@ -19351,12 +19441,12 @@ pub fn can_activate_ability_now_with_restriction_gates(
         obj.controller,
         ability_def.activator_filter.as_ref(),
     ) {
-        return false;
+        return ActivationVerdict::Illegal;
     }
     // CR 702.49: Ninjutsu-family marker abilities are not normal activated
     // abilities — they must route through `GameAction::ActivateNinjutsu`.
     if super::keywords::is_ninjutsu_family_marker_ability(&ability_def) {
-        return false;
+        return ActivationVerdict::Illegal;
     }
 
     // CR 702.61a + CR 702.61b: While a spell with split second is on the stack,
@@ -19364,17 +19454,17 @@ pub fn can_activate_ability_now_with_restriction_gates(
     if super::keywords::stack_has_split_second(state)
         && !super::mana_abilities::is_mana_ability(&ability_def)
     {
-        return false;
+        return ActivationVerdict::Illegal;
     }
 
     // CR 602.1: Check activation zone — default to battlefield.
     let required_zone = ability_def.activation_zone.unwrap_or(Zone::Battlefield);
     if obj.zone != required_zone {
-        return false;
+        return ActivationVerdict::Illegal;
     }
     // CR 701.35a: Detained permanents' activated abilities can't be activated.
     if !obj.detained_by.is_empty() {
-        return false;
+        return ActivationVerdict::Illegal;
     }
     // CR 702.170b + CR 116.2k + CR 602.1c: Plot is a SPECIAL ACTION, not an activated
     // ability, so the activated-ability prohibition gates must not block it. Mirrors
@@ -19391,14 +19481,14 @@ pub fn can_activate_ability_now_with_restriction_gates(
         // CR 605.1a: The ability definition is passed through so the prohibition can apply
         // its mana-ability exemption (Pithing Needle class) via the single classifier authority.
         if is_blocked_by_cant_be_activated(state, player, source_id, &ability_def) {
-            return false;
+            return ActivationVerdict::Illegal;
         }
         // CR 602.5 + CR 117.1b: Time-axis activation prohibition (City of Solitude class).
         if is_blocked_by_cant_activate_during(state, player, &ability_def) {
-            return false;
+            return ActivationVerdict::Illegal;
         }
         if is_blocked_by_cant_activate_abilities(state, player, &ability_def) {
-            return false;
+            return ActivationVerdict::Illegal;
         }
     }
     let is_loyalty_ability = ability_def
@@ -19420,7 +19510,7 @@ pub fn can_activate_ability_now_with_restriction_gates(
             ability_index,
             restriction_gates,
         ) {
-            return false;
+            return ActivationVerdict::Illegal;
         }
     } else if restrictions::check_activation_restrictions_with_static_gates(
         state,
@@ -19432,14 +19522,18 @@ pub fn can_activate_ability_now_with_restriction_gates(
     )
     .is_err()
     {
-        return false;
+        return ActivationVerdict::Illegal;
     }
     // CR 302.6 + CR 602.5a: Universal summoning-sickness gate for {T}/{Q} activated
     // abilities on creatures. Applies to every activated ability regardless of Oracle
     // text, so it lives as a structural helper rather than an ActivationRestriction.
+    //
+    // NOT an affordability failure, even though it reads like one: the source's
+    // summoning sickness is already published on `GameObject::has_summoning_sickness`
+    // and rendered on the card face, so the player is already told. `Illegal`.
     if let Some(ref cost) = ability_def.cost {
         if restrictions::check_summoning_sickness_for_cost(state, obj, cost).is_err() {
-            return false;
+            return ActivationVerdict::Illegal;
         }
     }
     // CR 601.2f: Apply self-referential cost reduction before affordability check.
@@ -19448,61 +19542,111 @@ pub fn can_activate_ability_now_with_restriction_gates(
         .cost
         .clone()
         .map(|cost| activation_cost_for_affordability(cost, ability_def.ability_tag));
-    if affordability_cost.as_ref().is_some_and(|cost| {
+
+    // CR 118.3 read-out declinations, placed BEFORE the payability probe so
+    // these abilities never reach `costs::can_pay`'s dry-run clone.
+    //   (a) `cost_conclusively_payable_by_cheap_gate` — BOTH its arms:
+    //       `None` (no cost at all, so never unaffordable) and a tap/untap-ONLY
+    //       cost, whose payability is decided by the source's rotation state,
+    //       which the card already carries on its face. Do not restate this
+    //       predicate as "tap/untap-only", which omits `None`.
+    //   (b) CR 118.3: a cost whose refusal is STRUCTURAL rather than a resource
+    //       shortfall is not "not payable RIGHT NOW" — this engine's payment
+    //       authority cannot resolve the shape at all, so the refusal holds on
+    //       every board, at any life and mana total. See
+    //       `payability_verdict_is_resource_based`. ~49 shipped cards carry such
+    //       a cost.
+    if query == ActivationQuery::BlockReason
+        && (super::mana_sources::cost_conclusively_payable_by_cheap_gate(&affordability_cost)
+            || affordability_cost
+                .as_ref()
+                .is_some_and(|cost| !cost.payability_verdict_is_resource_based()))
+    {
+        return ActivationVerdict::Illegal;
+    }
+    // CR 118.3: the resource-availability gate — the ONE evaluation.
+    let cost_not_payable = affordability_cost.as_ref().is_some_and(|cost| {
         !can_pay_ability_cost_now(state, player, source_id, cost, Some(ability_index))
-    }) {
-        return false;
+    });
+    if cost_not_payable && query == ActivationQuery::Legality {
+        return ActivationVerdict::Illegal;
     }
 
-    if let Some(ref modal) = ability_def.modal {
-        if affordability_cost.as_ref().is_some_and(requires_untapped) && obj.tapped {
-            return false;
-        }
-        return modal.mode_count > 0;
+    // CR 118.3: a modal ability whose cost needs the source untapped, on a
+    // tapped source. NOT an affordability read-out: it is a modal-activation
+    // restriction that the source's rotation already communicates on the card
+    // face, and it is a strict sub-case of the tap/untap carve-out above.
+    if ability_def.modal.is_some()
+        && affordability_cost.as_ref().is_some_and(requires_untapped)
+        && obj.tapped
+    {
+        return ActivationVerdict::Illegal;
     }
 
-    // CR 608.2 + CR 109.5: Build via the canonical helper so target-slot
-    // collection sees `multi_target`, `target_choice_timing`, `player_scope`,
-    // and the rest of the ability surface that affects legality. Mirrors the
-    // spell-cast path fix from issue #310.
-    let resolved = build_resolved_from_def(&ability_def, source_id, player);
+    let legal_ignoring_cost = if let Some(ref modal) = ability_def.modal {
+        modal.mode_count > 0
+    } else {
+        // CR 608.2 + CR 109.5: Build via the canonical helper so target-slot
+        // collection sees `multi_target`, `target_choice_timing`, `player_scope`,
+        // and the rest of the ability surface that affects legality. Mirrors the
+        // spell-cast path fix from issue #310.
+        let resolved = build_resolved_from_def(&ability_def, source_id, player);
 
-    let mut simulated = state.clone();
-    super::layers::flush_layers(&mut simulated);
+        // CR 613.1: an object's characteristics are determined by starting with
+        // the actual object, so when `layers_dirty` is clean the live state IS
+        // the flushed state and cloning it would produce a byte-identical copy.
+        // Clone only when there are unapplied continuous effects. The clone is
+        // counted, which it was not before — no budget test could previously
+        // see it.
+        let flushed_owned;
+        let simulated: &GameState = if state.layers_dirty.is_dirty() {
+            crate::game::perf_counters::record_activation_verdict_flush_clone();
+            flushed_owned = {
+                let mut flushed = state.clone();
+                super::layers::flush_layers(&mut flushed);
+                flushed
+            };
+            &flushed_owned
+        } else {
+            state
+        };
 
-    if let Some(has_target) = simple_legal_target_assignment_exists_for_ability(
-        &simulated,
-        &resolved,
-        &ability_def.target_constraints,
-    ) {
-        return has_target;
-    }
-
-    match build_target_slots_for_announcement(&simulated, &resolved) {
-        Ok(TargetSlotBuildOutcome::Slots(target_slots)) => {
-            if target_slots.is_empty() {
-                return true;
+        if let Some(has_target) = simple_legal_target_assignment_exists_for_ability(
+            simulated,
+            &resolved,
+            &ability_def.target_constraints,
+        ) {
+            has_target
+        } else {
+            match build_target_slots_for_announcement(simulated, &resolved) {
+                Ok(TargetSlotBuildOutcome::Slots(target_slots)) => {
+                    if target_slots.is_empty() {
+                        true
+                    } else if ability_def.target_constraints.is_empty() && target_slots.len() == 1 {
+                        target_slots[0].optional || !target_slots[0].legal_targets.is_empty()
+                    } else {
+                        has_legal_target_assignment_for_ability(
+                            simulated,
+                            &resolved,
+                            &target_slots,
+                            &ability_def.target_constraints,
+                        )
+                    }
+                }
+                Ok(TargetSlotBuildOutcome::RequiresChosenX) => {
+                    ability_def.cost.as_ref().is_some_and(|cost| {
+                        casting_costs::extract_x_mana_cost(cost).is_some()
+                            || find_non_self_sacrifice_cost(cost)
+                                .is_some_and(|(count, _)| count == u32::MAX)
+                            || casting_costs::activation_cost_needs_x_choice(&resolved, cost)
+                    })
+                }
+                Err(_) => false,
             }
-            if ability_def.target_constraints.is_empty() && target_slots.len() == 1 {
-                return target_slots[0].optional || !target_slots[0].legal_targets.is_empty();
-            }
-            has_legal_target_assignment_for_ability(
-                &simulated,
-                &resolved,
-                &target_slots,
-                &ability_def.target_constraints,
-            )
         }
-        Ok(TargetSlotBuildOutcome::RequiresChosenX) => {
-            ability_def.cost.as_ref().is_some_and(|cost| {
-                casting_costs::extract_x_mana_cost(cost).is_some()
-                    || find_non_self_sacrifice_cost(cost)
-                        .is_some_and(|(count, _)| count == u32::MAX)
-                    || casting_costs::activation_cost_needs_x_choice(&resolved, cost)
-            })
-        }
-        Err(_) => false,
-    }
+    };
+
+    ActivationVerdict::from_gate(legal_ignoring_cost, cost_not_payable)
 }
 
 /// CR 608.2c: Evaluate an activated ability's intervening-if `condition` against
@@ -19780,8 +19924,8 @@ fn try_finalize_activation_mana_payment_from_root(
 }
 
 /// CR 602.2: To activate an ability is to put it onto the stack and pay its costs.
-/// CR 602.2a: Only an object's controller can activate its activated ability unless
-/// the object specifically says otherwise.
+/// Only an object's controller (or its owner, if it doesn't have a controller) can
+/// activate its activated ability unless the object specifically says otherwise.
 pub fn handle_activate_ability(
     state: &mut GameState,
     player: PlayerId,
@@ -19794,7 +19938,7 @@ pub fn handle_activate_ability(
         .get(&source_id)
         .ok_or_else(|| EngineError::InvalidAction("Object not found".to_string()))?;
 
-    // CR 602.2a: Only players permitted by `activator_filter` may begin activation.
+    // CR 602.2: Only players permitted by `activator_filter` may begin activation.
     let Some(mut ability_def) = activation_ability_definition(state, source_id, ability_index)
     else {
         return Err(EngineError::InvalidAction(
@@ -21909,6 +22053,47 @@ pub(super) fn activation_prohibition_reason(
     cant_be_activated_reason(state, player, source_id, ability)
         .or_else(|| cant_activate_during_reason(state, player, ability))
         .or_else(|| cant_activate_abilities_reason(state, player, ability))
+}
+
+/// CR 118.3: display read-out for an activated ability that is legal in every
+/// respect EXCEPT that the acting player can't pay its post-reduction
+/// activation cost right now.
+///
+/// The payability sibling of [`activation_prohibition_reason`], and the same
+/// shape: display-only, no enforcement authority. Both are `.is_some()`-shaped
+/// views over the shared `activation_verdict` core, so the read-out and the
+/// enforcement bool are the SAME evaluation and cannot drift.
+///
+/// `sources` is always empty — CR 118.3 is about the player's own resources,
+/// so no external object prohibits the activation (contrast the CR 602.5 arms,
+/// which name their prohibiting permanents).
+///
+/// Consumed only by `ai_support::activation_block_reasons`. Enforcement keeps
+/// calling `can_activate_ability_now_with_restriction_gates` and is never
+/// routed through this.
+pub(crate) fn activation_cost_block_reason(
+    state: &GameState,
+    player: PlayerId,
+    source_id: ObjectId,
+    ability_index: usize,
+    restriction_gates: &restrictions::ActivationRestrictionStaticGates,
+) -> Option<AbilityBlockReason> {
+    // Exhaustive, no wildcard: a future `ActivationVerdict` arm must be
+    // classified deliberately rather than silently falling into "no read-out".
+    match activation_verdict(
+        state,
+        player,
+        source_id,
+        ability_index,
+        restriction_gates,
+        ActivationQuery::BlockReason,
+    ) {
+        ActivationVerdict::CostNotPayableNow => Some(AbilityBlockReason {
+            sources: Vec::new(),
+            kind: AbilityBlockKind::CostNotPayableNow,
+        }),
+        ActivationVerdict::Legal | ActivationVerdict::Illegal => None,
+    }
 }
 
 /// CR 101.2: Check if any CantBeCast static on the battlefield prevents

--- a/crates/engine/src/game/perf_counters.rs
+++ b/crates/engine/src/game/perf_counters.rs
@@ -23,6 +23,25 @@ pub struct PerfCounterSnapshot {
     pub layers_escalated: u64,
     pub mana_display_sweeps: u64,
     pub mana_display_swept_objects: u64,
+    /// CR 602.5 + CR 118.3: how many times the shared activation-legality core
+    /// (`casting::activation_verdict`) ran, across BOTH the enforcement shim and
+    /// the display read-out. Pins "one core evaluation per examined ability".
+    pub activation_verdict_passes: u64,
+    /// CR 118.3: activated abilities examined by
+    /// `ai_support::activation_block_reasons`. Paired with the counter above so
+    /// a passes-per-ability ratio is attributable rather than coincidental.
+    pub activation_block_display_abilities_examined: u64,
+    /// CR 613.1: whole-state flush clones taken by `casting::activation_verdict`'s
+    /// target-legality tail, which now clones only when `layers_dirty` is dirty
+    /// (it cloned unconditionally before, and incremented no counter at all).
+    ///
+    /// Deliberately its OWN field rather than `state_clone_for_legality`. That
+    /// field is a per-candidate legality-clone budget consumed by shipped memo
+    /// tests in `ai_support::filter`; folding a previously-uncounted clone into
+    /// it would silently double their expected budgets and turn a pure
+    /// instrumentation change into a behavioural-looking regression. Counting it
+    /// separately keeps both numbers attributable.
+    pub activation_verdict_flush_clones: u64,
     pub stack_batch_candidates: u64,
     pub stack_batch_plans: u64,
     pub stack_batch_observer_refusals: u64,
@@ -103,6 +122,9 @@ thread_local! {
         layers_escalated: 0,
         mana_display_sweeps: 0,
         mana_display_swept_objects: 0,
+        activation_verdict_passes: 0,
+        activation_block_display_abilities_examined: 0,
+        activation_verdict_flush_clones: 0,
         stack_batch_candidates: 0,
         stack_batch_plans: 0,
         stack_batch_observer_refusals: 0,
@@ -374,6 +396,18 @@ pub fn record_layers_incremental() {
 
 pub fn record_layers_escalated() {
     with_mut(|s| s.layers_escalated += 1);
+}
+
+pub fn record_activation_verdict_pass() {
+    with_mut(|s| s.activation_verdict_passes += 1);
+}
+
+pub fn record_activation_block_display_abilities_examined(examined: usize) {
+    with_mut(|s| s.activation_block_display_abilities_examined += examined as u64);
+}
+
+pub fn record_activation_verdict_flush_clone() {
+    with_mut(|s| s.activation_verdict_flush_clones += 1);
 }
 
 pub fn record_mana_display_sweep(swept_objects: usize) {

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -3838,9 +3838,16 @@ pub enum ProhibitedActivity {
 
 /// Why a specific activated ability is currently blocked from activation.
 ///
-/// Display read-out only (populated by the derive sweep): carries no enforcement
-/// authority. The three arms mirror the three enforcement predicates in
-/// `game::casting`, in the same order those gates consult them.
+/// Display read-out only: carries no enforcement authority.
+///
+/// **Two channels, one enum.** The first three arms mirror the three CR 602.5
+/// enforcement predicates in `game::casting`, in the order those gates consult
+/// them, and are published on `GameObject::blocked_abilities` by the
+/// `derived.rs` sweep. The fourth arm mirrors the CR 118.3 affordability gate
+/// that follows them in the same function, and is published on the
+/// legal-actions payload for the acting player only — see
+/// `ai_support::activation_block_reasons`. A consumer of one channel will never
+/// observe the other's kinds; the object field is NOT missing the fourth arm.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(tag = "type")]
 pub enum AbilityBlockKind {
@@ -3853,6 +3860,31 @@ pub enum AbilityBlockKind {
     /// CR 602.5: A temporary continuous effect prohibits this activity axis for
     /// the affected players (Kang-class `ProhibitActivity`).
     Prohibited,
+    /// CR 118.3: The player can't pay this ability's activation cost right now —
+    /// they lack the necessary resources ("a player with only 1 life can't pay a
+    /// cost of 2 life"). Every other activation requirement is satisfied: the
+    /// CR 602.5 prohibitions above, the zone, the timing restrictions, CR 302.6
+    /// summoning sickness and target legality all passed.
+    ///
+    /// CR 602.2b + CR 601.2f: the cost weighed is the POST-REDUCTION activation
+    /// cost — CR 602.2b makes an activated ability's activation cost the analog
+    /// of a spell's mana cost "as referenced in rule 601.2f", so the gate applies
+    /// cost reduction before asking whether the player can pay.
+    ///
+    /// `sources` is always empty for this arm: a resource shortfall is a property
+    /// of the player's own board, so no external object prohibits it.
+    ///
+    /// **The name deliberately avoids CR 118.6's "unpayable".** CR 118.6 makes
+    /// that a term of art for a cost that can NEVER be paid (an object with no
+    /// mana cost, or a cost derived from one); this arm is the opposite — a
+    /// shortfall *right now*, which more mana or more life clears. The
+    /// distinction is enforced by `AbilityCost::payability_verdict_is_resource_based`,
+    /// which keeps refusals that are structural rather than resource-based out of
+    /// this arm.
+    ///
+    /// Published only on the legal-actions payload (see the two-channel note on
+    /// this enum), never on `GameObject::blocked_abilities`.
+    CostNotPayableNow,
 }
 
 /// A block reason paired with every prohibiting source object of this kind.
@@ -3860,6 +3892,9 @@ pub enum AbilityBlockKind {
 pub struct AbilityBlockReason {
     /// CR 602.5: sorted, deduped permanents whose static/effect each independently
     /// impose this block kind (two Pithing Needles naming the same card → both).
+    ///
+    /// CR 118.3: empty for `AbilityBlockKind::CostNotPayableNow` — a resource
+    /// shortfall has no prohibiting source object.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub sources: Vec<ObjectId>,
     #[serde(flatten)]
@@ -12193,6 +12228,123 @@ impl AbilityCost {
             | AbilityCost::KeywordCostOfCastSpell { .. }
             | AbilityCost::GetPlayerCounters { .. }
             | AbilityCost::Unimplemented { .. } => false,
+        }
+    }
+
+    /// CR 118.3: `true` when a `false` from `costs::can_pay` for this cost is a
+    /// statement about the player's RESOURCES right now — the thing
+    /// `AbilityBlockKind::CostNotPayableNow` claims. `false` when the refusal is
+    /// structural: the payment authority cannot resolve this cost shape at all,
+    /// so the refusal holds forever, on every board, at any life and mana total.
+    ///
+    /// **The structural arms are NOT CR 118.6 cases and this doc does not claim
+    /// they are.** CR 118.6 is about *objects with no mana cost* — a property of
+    /// the card. `Unimplemented`, an unexpanded `PerCounter`, and an `EffectCost`
+    /// shape outside `supports_effect_cost_payment` are limits of **this engine's
+    /// payment authority**, which CR 118.6 says nothing about. What IS borrowed
+    /// from CR 118.6 is only the *distinction it names* — never-payable versus a
+    /// shortfall right now — and that distinction is why the variant must not be
+    /// called `UnpayableCost`. The distinction is the citation's whole job here.
+    ///
+    /// Exhaustive with no wildcard so a new `AbilityCost` variant forces a
+    /// deliberate decision, mirroring `all_components_cheap_gate_covered` above.
+    ///
+    /// THIRD OBLIGATION on `supports_effect_cost_payment`. `costs.rs` already
+    /// warns that widening that predicate owes a matching arm in the dry-run
+    /// payment path; this is a second such site and the `EffectCost` fallback in
+    /// `costs.rs` a third. Widening it without revisiting all three silently
+    /// changes what this read-out claims.
+    pub fn payability_verdict_is_resource_based(&self) -> bool {
+        match self {
+            // The dry run has a real arm for exactly the shapes
+            // `supports_effect_cost_payment` admits (PutCounter{SelfRef} /
+            // Mana{Fixed}); every other shape hits the payment-path fallback and
+            // is refused on every board. `supports_cumulative_upkeep_payment`
+            // below delegates to the same predicate, but as a MATCH GUARD
+            // (`EffectCost { .. } if self.supports_effect_cost_payment() => true`)
+            // because that function has a `_ => false` fallthrough to absorb the
+            // guard's false case. This predicate is wildcard-free, so a guard arm
+            // here would be non-exhaustive. Same delegation, different arm shape —
+            // do not copy that syntax.
+            AbilityCost::EffectCost { .. } => self.supports_effect_cost_payment(),
+            // CR 702.24a: cumulative upkeep is "put an age counter on this
+            // permanent. Then you may pay [cost] for each age counter on it" —
+            // the per-counter cost multiplication `PerCounter` models.
+            //
+            // ENGINE CONSEQUENCE (not part of the rule): the wrapper must be
+            // expanded against the live counter count before it reaches
+            // `pay_ability_cost`, so an unexpanded wrapper is refused
+            // structurally on every board. The `AbilityCost` TYPE recurses into
+            // `base` in four shipped places (`for_each_quantity_expr`,
+            // `moves_card_to_or_from_library`, `categories`, `consumes_source`);
+            // the PAYMENT AUTHORITY does not, and this arm tracks the payment
+            // authority. It MUST become `base.payability_verdict_is_resource_based()`
+            // the moment `pay_ability_cost` grows a `PerCounter` arm.
+            AbilityCost::PerCounter { .. } => false,
+            // The parser could not classify this cost, so no payment path exists
+            // for it and the refusal is permanent rather than a shortfall.
+            AbilityCost::Unimplemented { .. } => false,
+            // CR 117.1 + CR 118.3: `can_pay` answers a conjunction with `.all()`, so
+            // a refusal is a resource verdict only when every component's is — one
+            // structurally refused component makes the whole refusal structural.
+            AbilityCost::Composite { costs } => costs
+                .iter()
+                .all(AbilityCost::payability_verdict_is_resource_based),
+            // CR 118.12a: `can_pay` answers a disjunction with `.any()` at
+            // Activation scope, so a refusal means EVERY alternative was refused. If
+            // any alternative's refusal is a resource verdict, more resources could
+            // have flipped that alternative and with it the whole cost — so the
+            // disjunction is a resource verdict iff ANY alternative is. This arm
+            // MIRRORS `can_pay`'s operator; the De Morgan dual belongs to the
+            // prohibition predicate (`resolution_cost_includes_impossible_event`),
+            // not here. Writing `.all()` would suppress a legitimate read-out for
+            // `OneOf([<structural>, Mana{3}])` held by a player with an empty pool.
+            AbilityCost::OneOf { costs } => costs
+                .iter()
+                .any(AbilityCost::payability_verdict_is_resource_based),
+            // CR 118.3: every remaining variant's `can_pay` refusal is a
+            // statement about resources the player does or does not have right
+            // now — mana in pool or producible (`Mana`, `ManaDynamic`), loyalty
+            // counters (`Loyalty`), permanents to sacrifice/tap/return/unattach
+            // (`Sacrifice`, `TapCreatures`, `ReturnToHand`, `Unattach`,
+            // `UnattachFrom`), life (`PayLife`), cards in a hidden or public zone
+            // (`Discard`, `Exile`, `ExileMaterials`, `ExileWithAggregate`,
+            // `CollectEvidence`, `Mill`, `Reveal`, `Behold`), counters on an
+            // object or player (`RemoveCounter`, `GetPlayerCounters`), a player
+            // counter pool (`PayEnergy`, `PaySpeed`), an untapped/unexerted or
+            // rotatable source (`Tap`, `Untap`, `Exert`, `Blight`), or a
+            // specific castable/returnable object (`NinjutsuFamily`,
+            // `KeywordCostOfCastSpell`, `Waterbend`). Each of these clears the
+            // moment the board supplies the resource, which is exactly what
+            // `CostNotPayableNow` tells the player.
+            AbilityCost::Tap
+            | AbilityCost::Untap
+            | AbilityCost::Mana { .. }
+            | AbilityCost::ManaDynamic { .. }
+            | AbilityCost::Loyalty { .. }
+            | AbilityCost::Sacrifice(_)
+            | AbilityCost::PayLife { .. }
+            | AbilityCost::Discard { .. }
+            | AbilityCost::Exile { .. }
+            | AbilityCost::ExileMaterials { .. }
+            | AbilityCost::CollectEvidence { .. }
+            | AbilityCost::ExileWithAggregate { .. }
+            | AbilityCost::TapCreatures { .. }
+            | AbilityCost::RemoveCounter { .. }
+            | AbilityCost::PayEnergy { .. }
+            | AbilityCost::PaySpeed { .. }
+            | AbilityCost::ReturnToHand { .. }
+            | AbilityCost::Unattach
+            | AbilityCost::UnattachFrom { .. }
+            | AbilityCost::Mill { .. }
+            | AbilityCost::Exert
+            | AbilityCost::Blight { .. }
+            | AbilityCost::Reveal { .. }
+            | AbilityCost::Behold { .. }
+            | AbilityCost::Waterbend { .. }
+            | AbilityCost::NinjutsuFamily { .. }
+            | AbilityCost::KeywordCostOfCastSpell { .. }
+            | AbilityCost::GetPlayerCounters { .. } => true,
         }
     }
 

--- a/crates/engine/tests/integration/ability_block_display_clone_gate.rs
+++ b/crates/engine/tests/integration/ability_block_display_clone_gate.rs
@@ -1,0 +1,570 @@
+//! CR 118.3 + CR 613.1: clone budget for the ability-affordability read-out.
+//!
+//! Three claims, each with a control that demonstrably fires both ways:
+//!
+//! * **Row 11** — `activation_block_reasons` takes ZERO whole-state flush clones
+//!   on a layers-clean board (CR 613.1: a clean board already IS the flushed
+//!   board), and exactly one on a dirty board. The counter is
+//!   `priority_cast_probe_state_clones`, the same one `legal_actions_full`'s own
+//!   flush increments — a `state_clone_for_legality`-only instrument
+//!   structurally cannot see this clone, which is why both counters are read.
+//! * **Row 12** — the shared `activation_verdict` core runs exactly ONCE per
+//!   examined ability. Paired with a second counter for abilities examined, so
+//!   the number is attributable rather than a coincidence of a traversal that
+//!   never ran; a two-pass mechanism would report ~2x.
+//! * **Row 13** — `legal_actions_full`'s own cost is UNCHANGED: the display tail
+//!   lives behind a separate entry point, so a non-display caller cannot pay for
+//!   it. Paired positive: the `activation_block_reasons` call in the SAME test
+//!   has a non-zero delta, so "unchanged" is never "nothing ran".
+//!
+//! Under `cargo nextest` each test runs in its own process, so the
+//! `thread_local!` perf counters cannot bleed across tests.
+
+use engine::ai_support::{activation_block_reasons, legal_actions_full};
+use engine::game::layers::flush_layers;
+use engine::game::perf_counters;
+use engine::game::scenario::{GameRunner, GameScenario, P0};
+use engine::types::ability::{
+    AbilityCost, AbilityDefinition, AbilityKind, Effect, QuantityExpr, TargetFilter,
+};
+use engine::types::mana::ManaCost;
+use engine::types::phase::Phase;
+
+/// Board size. Every creature carries one unaffordable `Pay 5 life` ability, so
+/// "abilities examined" is exactly `BOARD`.
+const BOARD: usize = 12;
+
+fn draw_for_life(amount: i32) -> AbilityDefinition {
+    AbilityDefinition::new(
+        AbilityKind::Activated,
+        Effect::Draw {
+            count: QuantityExpr::Fixed { value: 1 },
+            target: TargetFilter::Controller,
+        },
+    )
+    .cost(AbilityCost::PayLife {
+        amount: QuantityExpr::Fixed { value: amount },
+    })
+}
+
+/// `BOARD` creatures, each with one unaffordable `Pay 5 life` ability, at 1 life.
+fn unaffordable_board() -> GameRunner {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.with_life(P0, 1);
+    for i in 0..BOARD {
+        scenario
+            .add_creature(P0, &format!("Costly Engine {i}"), 1, 1)
+            .with_ability_definition(draw_for_life(5));
+    }
+    scenario.build()
+}
+
+/// The same board, every ability AFFORDABLE — the positive control for the tail.
+fn affordable_board() -> GameRunner {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.with_life(P0, 20);
+    for i in 0..BOARD {
+        scenario
+            .add_creature(P0, &format!("Costly Engine {i}"), 1, 1)
+            .with_ability_definition(draw_for_life(1));
+    }
+    scenario.build()
+}
+
+/// CR 613.1: genuinely flush the board, which leaves `layers_dirty` `Clean`.
+/// Done through the real `flush_layers` rather than by assigning the enum, so
+/// the "clean" precondition is a fact about the state, not a claim about it.
+fn flushed_clean(runner: &mut GameRunner) {
+    flush_layers(runner.state_mut());
+    assert!(
+        !runner.state().layers_dirty.is_dirty(),
+        "precondition: the board is layers-clean after an explicit flush"
+    );
+}
+
+/// Row 11: zero flush-clones on a layers-clean state; exactly one when dirty.
+/// The counter demonstrably fires both ways, so the `0` is not vacuous.
+#[test]
+fn display_read_out_takes_no_flush_clone_on_a_clean_state() {
+    let mut runner = unaffordable_board();
+
+    // CR 613.1: clean board — no flush clone.
+    flushed_clean(&mut runner);
+    perf_counters::reset();
+    let clean_map = activation_block_reasons(runner.state());
+    let clean = perf_counters::snapshot();
+    assert_eq!(
+        clean.priority_cast_probe_state_clones, 0,
+        "CR 613.1: a layers-clean board is already the flushed board — zero whole-state clones"
+    );
+    assert!(
+        !clean_map.is_empty(),
+        "reach-guard: the traversal genuinely ran and produced entries — a 0 on an \
+         empty board would be vacuous"
+    );
+
+    // Dirty board — exactly one flush clone, so the counter fires both ways.
+    let mut runner = unaffordable_board();
+    runner.state_mut().layers_dirty.mark_full();
+    perf_counters::reset();
+    let dirty_map = activation_block_reasons(runner.state());
+    let dirty = perf_counters::snapshot();
+    assert_eq!(
+        dirty.priority_cast_probe_state_clones, 1,
+        "paired positive: a dirty board costs exactly ONE whole-state flush clone per call"
+    );
+    assert!(
+        !dirty_map.is_empty(),
+        "reach-guard: the dirty-board traversal produced entries too"
+    );
+}
+
+/// Row 12: the shared `activation_verdict` core runs exactly once per examined
+/// ability. The examined counter is the paired instrument that makes the ratio
+/// attributable rather than coincidental.
+#[test]
+fn the_verdict_core_runs_once_per_examined_ability() {
+    let mut runner = unaffordable_board();
+    flushed_clean(&mut runner);
+    perf_counters::reset();
+    let map = activation_block_reasons(runner.state());
+    let snap = perf_counters::snapshot();
+
+    assert_eq!(
+        snap.activation_block_display_abilities_examined, BOARD as u64,
+        "paired positive: the traversal examined every ability on the board"
+    );
+    assert_eq!(
+        snap.activation_verdict_passes, BOARD as u64,
+        "the verdict core ran exactly once per examined ability — a two-pass \
+         mechanism would report ~2x"
+    );
+    assert_eq!(
+        map.values().map(Vec::len).sum::<usize>(),
+        BOARD,
+        "reach-guard: every examined ability produced a read-out entry"
+    );
+}
+
+/// Row 13: `legal_actions_full` does not pay for the display tail — the tail
+/// lives behind a separate entry point, so a non-display caller cannot enter it.
+///
+/// **The structural claim, with both halves non-zero somewhere so neither is
+/// vacuous:** `legal_actions_full` reports ZERO display-traversal abilities
+/// examined while running a non-zero number of verdict-core passes (so the
+/// enforcement gate genuinely ran), and `activation_block_reasons` on the SAME
+/// board reports `BOARD` examined.
+///
+/// ── A CORRECTION TO THE PLAN'S COST MODEL, measured here rather than assumed ──
+///
+/// The plan's §Cost table predicts "unaffordable, resource verdict → one dry-run
+/// clone plus the target-legality tail", and specifies a positive control in
+/// which an ALL-AFFORDABLE board reports a *strictly smaller* tail count. Both
+/// are the wrong way round for `state_clone_for_legality`, and this test pins
+/// the measured truth instead:
+///
+/// `costs::can_pay` consults the cheap `is_payable_for_activation` gate FIRST
+/// and returns `false` from it without cloning; the counted
+/// `record_state_clone_for_legality()` + `state.clone()` dry run sits BELOW that
+/// early return. So a `PayLife 5` shortfall at 1 life costs **zero** clones,
+/// while the same ability at 20 life — where the cheap gate passes and the dry
+/// run must run — costs **one per ability**.
+///
+/// SCOPE OF THAT CLAIM — it is a property of the COST CLASS, not of the counter.
+/// It holds only for costs whose `is_payable_for_activation` arm can answer
+/// `false`. `AbilityCost::Mana` is the counter-case: its arm returns `true`
+/// unconditionally (`cost_payability.rs`, "CR 601.2g: mana affordability is
+/// checked by the mana payment step"), and a bare `Mana` cost matches neither
+/// the `OneOf` nor the bare-`Waterbend` branch, so it reaches the counted clone
+/// on BOTH the affordable and the unaffordable path. `Mana` is the shape in the
+/// reported Sliver Overlord defect (`{3}:`), so it is pinned separately by
+/// `a_mana_cost_reaches_the_dry_run_on_both_paths` below rather than left to
+/// this `PayLife` fixture to imply.
+///
+/// The tail itself is free from this entry point on any board: CR 613.1 means a
+/// clean board needs no clone, and on a dirty board
+/// `activation_block_reasons` flushes ONCE up front (row 11), leaving the state
+/// clean for every per-ability tail evaluation underneath it.
+///
+/// The tail's real discriminating test is row 7 in `ability_cost_block_readout.rs`
+/// (an unaffordable ability with no legal target is not read out), which fails
+/// if the tail is removed. This file pins the clone budget; that file pins the
+/// tail's behaviour.
+#[test]
+fn legal_actions_full_does_not_pay_for_the_display_tail() {
+    let mut runner = unaffordable_board();
+    flushed_clean(&mut runner);
+    perf_counters::reset();
+    let (_actions, _costs, _grouped) = legal_actions_full(runner.state());
+    let enforcement = perf_counters::snapshot();
+
+    let mut runner = unaffordable_board();
+    flushed_clean(&mut runner);
+    perf_counters::reset();
+    let map = activation_block_reasons(runner.state());
+    let display_unaffordable = perf_counters::snapshot();
+
+    let mut runner = affordable_board();
+    flushed_clean(&mut runner);
+    perf_counters::reset();
+    let affordable_map = activation_block_reasons(runner.state());
+    let display_affordable = perf_counters::snapshot();
+
+    // ── the structural claim ────────────────────────────────────────────────
+    assert_eq!(
+        enforcement.activation_block_display_abilities_examined, 0,
+        "row 13: `legal_actions_full` never enters the display traversal"
+    );
+    assert!(
+        enforcement.activation_verdict_passes > 0,
+        "paired positive (mandatory): the enforcement gate genuinely ran on this board, \
+         so the zero above is not vacuous; got {}",
+        enforcement.activation_verdict_passes
+    );
+    assert_eq!(
+        display_unaffordable.activation_block_display_abilities_examined, BOARD as u64,
+        "paired positive (mandatory): the display entry point DOES examine the board"
+    );
+    assert!(
+        !map.is_empty(),
+        "reach-guard: the display call produced entries"
+    );
+    assert!(
+        affordable_map.is_empty(),
+        "reach-guard: the all-affordable control produced NO entries — nothing to explain"
+    );
+
+    // ── the corrected cost model, pinned ────────────────────────────────────
+    assert_eq!(
+        display_unaffordable.state_clone_for_legality, 0,
+        "a cheap-gate refusal (PayLife 5 at 1 life) costs ZERO dry-run clones — \
+         `can_pay` returns before `record_state_clone_for_legality`"
+    );
+    assert_eq!(
+        display_affordable.state_clone_for_legality, BOARD as u64,
+        "and the AFFORDABLE board costs one dry-run clone per ability, because the \
+         cheap gate passes and the dry run must run — for THIS cost class the counter \
+         sees only the dry run's success path, never the tail"
+    );
+    assert!(
+        display_affordable.state_clone_for_legality > display_unaffordable.state_clone_for_legality,
+        "direction pinned explicitly FOR A CHEAP-GATE-REFUSABLE COST (PayLife): the \
+         OPPOSITE of the plan's stated positive control ({} affordable vs {} \
+         unaffordable). This inequality is a property of the fixture's cost class, \
+         not of the counter — an all-`Mana` board makes the two sides EQUAL, which \
+         `a_mana_cost_reaches_the_dry_run_on_both_paths` pins.",
+        display_affordable.state_clone_for_legality,
+        display_unaffordable.state_clone_for_legality,
+    );
+    assert_eq!(
+        display_unaffordable.priority_cast_probe_state_clones, 0,
+        "and no whole-state flush clone on a clean board (row 11's claim, restated \
+         here so the two counters are read together as MAT-3 requires)"
+    );
+    assert_eq!(
+        display_unaffordable.activation_verdict_flush_clones, 0,
+        "CR 613.1: the gate's own target-legality tail takes no flush clone either — \
+         the entry point already flushed, so every per-ability tail evaluation \
+         underneath it sees a clean board"
+    );
+}
+
+/// CR 613.1: the activation gate's tail clone is now CONDITIONAL and COUNTED.
+///
+/// Before this change it cloned the whole `GameState` unconditionally and
+/// incremented no counter, so no budget test could see it. Two claims, with the
+/// counter demonstrably firing both ways:
+///
+///   * on a layers-DIRTY state reached through the enforcement shim, the tail
+///     clones once per examined ability — the pre-existing cost, now visible;
+///   * on a layers-CLEAN state it clones zero times — the cost this change
+///     actually removes.
+///
+/// It is deliberately its own counter rather than `state_clone_for_legality`:
+/// that field is a per-candidate budget consumed by shipped memo tests in
+/// `ai_support::filter`, and folding a newly-counted clone into it would double
+/// their expected budgets for a pure instrumentation change.
+#[test]
+fn the_gate_tail_clone_is_conditional_on_layers_dirty_and_separately_counted() {
+    use engine::game::casting::can_activate_ability_now;
+
+    // AFFORDABLE abilities, deliberately: under `ActivationQuery::Legality` an
+    // UNAFFORDABLE ability early-returns at the CR 118.3 exit and never reaches
+    // the tail at all — which is exactly the property row 13 describes, and
+    // which would make this measurement read 0 for the wrong reason.
+    //
+    // Dirty board: the tail clone fires, once per examined ability.
+    let mut runner = affordable_board();
+    runner.state_mut().layers_dirty.mark_full();
+    perf_counters::reset();
+    for i in 0..BOARD {
+        let id = *runner
+            .state()
+            .battlefield
+            .get(i)
+            .expect("board is populated");
+        let _ = can_activate_ability_now(runner.state(), P0, id, 0);
+    }
+    let dirty = perf_counters::snapshot();
+    assert_eq!(
+        dirty.activation_verdict_flush_clones, BOARD as u64,
+        "paired positive: on a dirty board the tail clones once per examined ability"
+    );
+    // The affordable cost passes `can_pay`'s cheap gate, so its dry run DOES
+    // spend one `state_clone_for_legality` per ability. The discriminating claim
+    // is that the two clones are counted SEPARATELY: had the tail been folded
+    // into this field it would read `2 * BOARD` here, which is exactly the
+    // silent doubling that would have broken the shipped `ai_support::filter`
+    // memo budgets.
+    assert_eq!(
+        dirty.state_clone_for_legality, BOARD as u64,
+        "the dry-run budget counts the dry run ONLY — not the dry run plus the tail"
+    );
+
+    // Clean board: zero. Same call, same abilities — only `layers_dirty` differs.
+    let mut runner = affordable_board();
+    flushed_clean(&mut runner);
+    perf_counters::reset();
+    for i in 0..BOARD {
+        let id = *runner
+            .state()
+            .battlefield
+            .get(i)
+            .expect("board is populated");
+        let _ = can_activate_ability_now(runner.state(), P0, id, 0);
+    }
+    let clean = perf_counters::snapshot();
+    assert_eq!(
+        clean.activation_verdict_flush_clones, 0,
+        "CR 613.1: a clean board is already the flushed board — the clone this \
+         change removes"
+    );
+    assert_eq!(
+        clean.activation_verdict_passes, BOARD as u64,
+        "reach-guard: the gate genuinely ran once per ability, so the 0 above is \
+         not vacuous"
+    );
+}
+
+/// §Cost B3(a) — THE MEASUREMENT, committed as a re-runnable instrument.
+///
+/// `#[ignore]`d so it never costs CI time; run it with
+/// `cargo nextest run -p phase-engine -E 'test(cost_measurement)' --run-ignored all --no-capture`.
+///
+/// Board: 4-player Commander, >=100 permanents across >=2 seats, every ability
+/// unaffordable and TARGETED so the target-legality tail is exercised. Paired:
+/// both entry points, same run, same binary, same board. Both clone counters are
+/// reported (MAT-3: wall time captures both and attributes neither), plus the
+/// board's `layers_dirty`, without which the flush-clone number is unreadable.
+///
+/// Positive control: the same instrument on an ALL-AFFORDABLE board, reported
+/// beside it so the reader can see the counters move rather than taking a single
+/// number on trust.
+///
+/// PROFILE CAVEAT, stated rather than implied: this runs under the `test`
+/// profile (unoptimized + debuginfo). The CLONE COUNTS are profile-independent
+/// and are the attributable half; the WALL TIMES are debug-profile numbers and
+/// must NOT be quoted as release figures.
+#[test]
+#[ignore = "measurement instrument, not an assertion; see the doc comment"]
+fn cost_measurement_display_entry_point_versus_legal_actions_full() {
+    use std::time::Instant;
+
+    /// 4-player Commander, `per_seat` permanents on each of two seats.
+    fn commander_board(per_seat: usize, life: i32, cost: &AbilityCost) -> GameRunner {
+        let mut scenario = GameScenario::new_n_player(4, 7);
+        scenario.at_phase(Phase::PreCombatMain);
+        scenario.with_life(P0, life);
+        for seat in [P0, engine::game::scenario::P1] {
+            for i in 0..per_seat {
+                scenario
+                    .add_creature(seat, &format!("Costly Engine {seat:?} {i}"), 1, 1)
+                    // TARGETED, so the tail has real work to do.
+                    .with_ability_definition(
+                        AbilityDefinition::new(
+                            AbilityKind::Activated,
+                            Effect::Destroy {
+                                target: TargetFilter::Any,
+                                cant_regenerate: false,
+                            },
+                        )
+                        .cost(cost.clone()),
+                    );
+            }
+        }
+        scenario.build()
+    }
+
+    let mut report = String::new();
+    // The cost class is a measured axis, not a constant: `PayLife` is refused by
+    // the cheap gate and clones nothing, while `Mana` — the shape in the reported
+    // Sliver Overlord defect — reaches the dry run on both paths. Measuring only
+    // `PayLife` reports the one class that does NOT behave like the bug.
+    for (label, cost, life) in [
+        (
+            "UNAFFORDABLE PayLife (cheap-gate refusal)",
+            AbilityCost::PayLife {
+                amount: QuantityExpr::Fixed { value: 5 },
+            },
+            1,
+        ),
+        (
+            "ALL-AFFORDABLE PayLife (positive control)",
+            AbilityCost::PayLife {
+                amount: QuantityExpr::Fixed { value: 1 },
+            },
+            40,
+        ),
+        (
+            "UNAFFORDABLE Mana (the reported bug's cost shape)",
+            AbilityCost::Mana {
+                cost: ManaCost::generic(7),
+            },
+            40,
+        ),
+    ] {
+        for dirty in [false, true] {
+            let mut runner = commander_board(55, life, &cost);
+            if dirty {
+                runner.state_mut().layers_dirty.mark_full();
+            } else {
+                flushed_clean(&mut runner);
+            }
+            let permanents = runner.state().battlefield.len();
+
+            perf_counters::reset();
+            let t0 = Instant::now();
+            let blocked = activation_block_reasons(runner.state());
+            let display_ms = t0.elapsed().as_secs_f64() * 1000.0;
+            let d = perf_counters::snapshot();
+
+            let mut runner2 = commander_board(55, life, &cost);
+            if dirty {
+                runner2.state_mut().layers_dirty.mark_full();
+            } else {
+                flushed_clean(&mut runner2);
+            }
+            perf_counters::reset();
+            let t1 = Instant::now();
+            let (actions, _costs, _grouped) = legal_actions_full(runner2.state());
+            let enforce_ms = t1.elapsed().as_secs_f64() * 1000.0;
+            let e = perf_counters::snapshot();
+
+            report.push_str(&format!(
+                "\n=== {label} | layers_dirty={} | permanents={permanents} ===\n\
+                 activation_block_reasons : {display_ms:8.2} ms | entries={:5} \
+                 state_clone_for_legality={:5} priority_cast_probe_state_clones={:3} \
+                 activation_verdict_flush_clones={:5} verdict_passes={:5} examined={:5}\n\
+                 legal_actions_full       : {enforce_ms:8.2} ms | actions={:5} \
+                 state_clone_for_legality={:5} priority_cast_probe_state_clones={:3} \
+                 activation_verdict_flush_clones={:5} verdict_passes={:5} examined={:5}\n",
+                if dirty { "Full " } else { "Clean" },
+                blocked.values().map(Vec::len).sum::<usize>(),
+                d.state_clone_for_legality,
+                d.priority_cast_probe_state_clones,
+                d.activation_verdict_flush_clones,
+                d.activation_verdict_passes,
+                d.activation_block_display_abilities_examined,
+                actions.len(),
+                e.state_clone_for_legality,
+                e.priority_cast_probe_state_clones,
+                e.activation_verdict_flush_clones,
+                e.activation_verdict_passes,
+                e.activation_block_display_abilities_examined,
+            ));
+        }
+    }
+    println!("{report}");
+}
+
+/// `BOARD` creatures, each with one unaffordable `{7}` ability and no mana
+/// sources anywhere. `AbilityCost::Mana` is the cost shape in the reported
+/// Sliver Overlord defect (`{3}:`).
+fn unaffordable_mana_board() -> GameRunner {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    for i in 0..BOARD {
+        scenario
+            .add_creature(P0, &format!("Mana Engine {i}"), 1, 1)
+            .with_ability_definition(
+                AbilityDefinition::new(
+                    AbilityKind::Activated,
+                    Effect::Draw {
+                        count: QuantityExpr::Fixed { value: 1 },
+                        target: TargetFilter::Controller,
+                    },
+                )
+                .cost(AbilityCost::Mana {
+                    cost: ManaCost::generic(7),
+                }),
+            );
+    }
+    scenario.build()
+}
+
+/// The cost-class boundary of `state_clone_for_legality`, measured on both sides
+/// in one test so neither number can be read without the other.
+///
+/// `AbilityCost::Mana`'s `is_payable_for_activation` arm returns `true`
+/// unconditionally, so a mana shortfall is detected only by the dry run — which
+/// clones. A `PayLife` shortfall is caught by the cheap gate and clones nothing.
+/// The two therefore disagree on the SAME entry point and the SAME board size,
+/// which is why `legal_actions_full_does_not_pay_for_the_display_tail`'s
+/// inequality is scoped to its fixture's cost class rather than stated of the
+/// counter.
+///
+/// Consequence worth stating plainly: on a mana-cost board the display traversal
+/// pays one whole-`GameState` clone per examined ability regardless of
+/// affordability. It stays off the AI-search hot path (`legal_actions_full` is
+/// byte-unchanged in what it computes) and is bounded, but it is not free, and
+/// `Mana` is the dominant activated-cost shape.
+#[test]
+fn a_mana_cost_reaches_the_dry_run_on_both_paths() {
+    let mut mana_runner = unaffordable_mana_board();
+    flushed_clean(&mut mana_runner);
+    perf_counters::reset();
+    let mana_map = activation_block_reasons(mana_runner.state());
+    let mana = perf_counters::snapshot();
+
+    let mut life_runner = unaffordable_board();
+    flushed_clean(&mut life_runner);
+    perf_counters::reset();
+    let life_map = activation_block_reasons(life_runner.state());
+    let life = perf_counters::snapshot();
+
+    // Reach-guards first: both boards must actually produce a full read-out, or
+    // the clone counts below are measuring a traversal that never happened.
+    assert_eq!(
+        mana.activation_block_display_abilities_examined, BOARD as u64,
+        "reach-guard: the mana board's abilities were all examined"
+    );
+    assert_eq!(
+        life.activation_block_display_abilities_examined, BOARD as u64,
+        "reach-guard: the life board's abilities were all examined"
+    );
+    assert_eq!(
+        mana_map.values().map(Vec::len).sum::<usize>(),
+        BOARD,
+        "reach-guard: every unaffordable mana ability is read out"
+    );
+    assert_eq!(
+        life_map.values().map(Vec::len).sum::<usize>(),
+        BOARD,
+        "reach-guard: every unaffordable life ability is read out"
+    );
+
+    assert_eq!(
+        mana.state_clone_for_legality, BOARD as u64,
+        "an UNAFFORDABLE mana cost still pays one dry-run clone per ability — \
+         `is_payable_for_activation` returns true unconditionally for `Mana`, so the \
+         shortfall is only detectable below the counted clone"
+    );
+    assert_eq!(
+        life.state_clone_for_legality, 0,
+        "paired contrast (mandatory): the same entry point on the same board size \
+         with a cheap-gate-refusable cost pays ZERO — so the number above is a fact \
+         about the COST CLASS, not about the entry point"
+    );
+}

--- a/crates/engine/tests/integration/ability_cost_block_readout.rs
+++ b/crates/engine/tests/integration/ability_cost_block_readout.rs
@@ -1,0 +1,1030 @@
+//! CR 118.3: the "you can't pay this cost right now" read-out published on the
+//! legal-actions channel by `ai_support::activation_block_reasons`.
+//!
+//! The reported defect: `can_activate_ability_now_with_restriction_gates` drops
+//! an activated ability when its cost is unpayable, so an unaffordable ability
+//! never reaches `legal_actions_by_object` and is silently omitted from the
+//! picker — no greyed-out row, no explanation. Spells do not behave this way
+//! (`spell_costs` exists precisely so an unaffordable spell cost still
+//! displays).
+//!
+//! Every test here drives the production entry point
+//! (`ai_support::activation_block_reasons` / `..._for_viewer` →
+//! `casting::activation_cost_block_reason` → the shared `activation_verdict`
+//! core), never a helper in isolation.
+//!
+//! Sliver Overlord's Oracle text is byte-identical to the constant the shipped
+//! `sliver_overlord_activation_offer.rs` uses. It is NOT verbatim `card-data.json`:
+//! that source ends `…Gain control of target Sliver. (This effect lasts
+//! indefinitely.)`, and the reminder text is dropped here. Immaterial — the parser
+//! strips reminder text — but the two are not the same string.
+
+use std::collections::HashMap;
+
+use engine::ai_support::{
+    activation_block_reasons, activation_block_reasons_for_viewer, legal_actions_full,
+    MAX_ACTIVATION_BLOCK_TOTAL,
+};
+use engine::game::scenario::{GameRunner, GameScenario, P0, P1};
+use engine::types::ability::{
+    AbilityBlockEntry, AbilityBlockKind, AbilityCost, AbilityDefinition, AbilityKind, Effect,
+    EffectScope, GameRestriction, ManaContribution, ManaProduction, ProhibitedActivity,
+    QuantityExpr, RestrictionExpiry, RestrictionPlayerScope, SacrificeCost, TapStateChange,
+    TargetFilter, TypeFilter, TypedFilter,
+};
+use engine::types::actions::GameAction;
+use engine::types::counter::CounterType;
+use engine::types::identifiers::ObjectId;
+use engine::types::mana::{ManaColor, ManaCost};
+use engine::types::phase::Phase;
+use engine::types::statics::ActivationExemption;
+use engine::types::zones::Zone;
+
+const OVERLORD: &str = "{3}: Search your library for a Sliver card, reveal that card, put it into your hand, then shuffle.\n{3}: Gain control of target Sliver.";
+
+// ── helpers ─────────────────────────────────────────────────────────────────
+
+/// The production read-out for `id`, as `(ability_index, sources, kind)` triples
+/// sorted by index so assertions are order-independent.
+fn blocked(runner: &GameRunner, id: ObjectId) -> Vec<(usize, Vec<ObjectId>, AbilityBlockKind)> {
+    entries_of(&activation_block_reasons(runner.state()), id)
+}
+
+fn entries_of(
+    map: &HashMap<ObjectId, Vec<AbilityBlockEntry>>,
+    id: ObjectId,
+) -> Vec<(usize, Vec<ObjectId>, AbilityBlockKind)> {
+    let mut out: Vec<_> = map
+        .get(&id)
+        .map(Vec::as_slice)
+        .unwrap_or(&[])
+        .iter()
+        .map(|e| (e.ability_index, e.reason.sources.clone(), e.reason.kind))
+        .collect();
+    out.sort_by_key(|(i, _, _)| *i);
+    out
+}
+
+/// The ability indices the engine actually OFFERS for `id` — the dispatchable
+/// set, which must stay disjoint from the read-out.
+fn offered_indices(runner: &GameRunner, id: ObjectId) -> Vec<usize> {
+    let (_, _, grouped) = legal_actions_full(runner.state());
+    let mut out: Vec<usize> = grouped
+        .get(&id)
+        .map(Vec::as_slice)
+        .unwrap_or(&[])
+        .iter()
+        .filter_map(|a| match a {
+            GameAction::ActivateAbility {
+                source_id,
+                ability_index,
+            } if *source_id == id => Some(*ability_index),
+            _ => None,
+        })
+        .collect();
+    out.sort_unstable();
+    out
+}
+
+/// `{cost} generic: draw a card` — a plain, resource-verdict mana cost.
+fn draw_for_generic(cost: u32) -> AbilityDefinition {
+    AbilityDefinition::new(
+        AbilityKind::Activated,
+        Effect::Draw {
+            count: QuantityExpr::Fixed { value: 1 },
+            target: TargetFilter::Controller,
+        },
+    )
+    .cost(AbilityCost::Mana {
+        cost: ManaCost::generic(cost),
+    })
+}
+
+/// `Pay N life: draw a card` — the canonical resource-verdict non-mana cost,
+/// used as the paired positive control in every negative test below.
+fn draw_for_life(amount: i32) -> AbilityDefinition {
+    AbilityDefinition::new(
+        AbilityKind::Activated,
+        Effect::Draw {
+            count: QuantityExpr::Fixed { value: 1 },
+            target: TargetFilter::Controller,
+        },
+    )
+    .cost(AbilityCost::PayLife {
+        amount: QuantityExpr::Fixed { value: amount },
+    })
+}
+
+/// CR 113.6b: the same `Pay N life: draw` ability, but activatable from the
+/// graveyard. `AbilityDefinition` has no `activation_zone` builder, so the field
+/// is set directly.
+fn graveyard_draw_for_life(amount: i32) -> AbilityDefinition {
+    let mut def = draw_for_life(amount);
+    def.activation_zone = Some(Zone::Graveyard);
+    def
+}
+
+fn draw_effect() -> Effect {
+    Effect::Draw {
+        count: QuantityExpr::Fixed { value: 1 },
+        target: TargetFilter::Controller,
+    }
+}
+
+// ── Row 1 — the reported defect ─────────────────────────────────────────────
+
+/// Row 1: both of Sliver Overlord's printed `{3}` abilities are read out on a
+/// board that cannot produce three mana.
+///
+/// REVERT: drop the `CostNotPayableNow` arm (or restore the plain
+/// `return false` at the CR 118.3 exit) and the map has no entry for the
+/// Overlord, failing `len() == 2`.
+#[test]
+fn overlord_unaffordable_printed_abilities_are_read_out() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let overlord = scenario
+        .add_creature(P0, "Sliver Overlord", 7, 7)
+        .with_subtypes(vec!["Sliver", "Mutant"])
+        .from_oracle_text(OVERLORD)
+        .id();
+    // A second Sliver so ability 1 ("Gain control of target Sliver") has a
+    // legal target — otherwise row 7's tail would correctly suppress it.
+    scenario
+        .add_creature(P0, "Sliver Drone", 1, 1)
+        .with_subtypes(vec!["Sliver"]);
+    let runner = scenario.build();
+
+    let entries = blocked(&runner, overlord);
+    assert_eq!(
+        entries.len(),
+        2,
+        "both printed {{3}} abilities are read out on a tapped-out board; got {entries:?}"
+    );
+    assert_eq!(
+        entries,
+        vec![
+            (0, vec![], AbilityBlockKind::CostNotPayableNow),
+            (1, vec![], AbilityBlockKind::CostNotPayableNow),
+        ],
+        "each entry names the CR 118.3 arm and carries no prohibiting source"
+    );
+
+    // Reach-guard / sibling: give the controller three lands and the SAME
+    // abilities become offered instead of read out.
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let overlord_b = scenario
+        .add_creature(P0, "Sliver Overlord", 7, 7)
+        .with_subtypes(vec!["Sliver", "Mutant"])
+        .from_oracle_text(OVERLORD)
+        .id();
+    scenario
+        .add_creature(P0, "Sliver Drone", 1, 1)
+        .with_subtypes(vec!["Sliver"]);
+    for _ in 0..3 {
+        scenario.add_basic_land(P0, ManaColor::Green);
+    }
+    let runner_b = scenario.build();
+    assert!(
+        blocked(&runner_b, overlord_b).is_empty(),
+        "with three untapped lands the abilities are affordable, so nothing is read out"
+    );
+    assert!(
+        offered_indices(&runner_b, overlord_b).contains(&0),
+        "paired positive: the affordable board genuinely OFFERS ability 0"
+    );
+}
+
+// ── Row 2b — offered and blocked are disjoint ───────────────────────────────
+
+/// Row 2b: the read-out and the dispatchable set never intersect on
+/// `(ObjectId, ability_index)`. Both sets are non-empty in the same assertion,
+/// so an empty-vs-empty pass is impossible.
+#[test]
+fn offered_and_blocked_ability_indices_are_disjoint() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.with_life(P0, 20);
+    let obj = scenario
+        .add_creature(P0, "Two Ability Engine", 2, 2)
+        // index 0: affordable (1 life at 20 life)
+        .with_ability_definition(draw_for_life(1))
+        // index 1: unaffordable ({7} with no lands)
+        .with_ability_definition(draw_for_generic(7))
+        .id();
+    let runner = scenario.build();
+
+    let offered = offered_indices(&runner, obj);
+    let read_out: Vec<usize> = blocked(&runner, obj)
+        .into_iter()
+        .map(|(i, _, _)| i)
+        .collect();
+
+    assert!(
+        !offered.is_empty(),
+        "paired positive: the affordable ability IS offered; got {offered:?}"
+    );
+    assert!(
+        !read_out.is_empty(),
+        "paired positive: the unaffordable ability IS read out; got {read_out:?}"
+    );
+    assert!(
+        offered.iter().all(|i| !read_out.contains(i)),
+        "offered {offered:?} and read-out {read_out:?} must be disjoint"
+    );
+}
+
+// ── Rows 3 / 3b / 3c — the carve-out, both arms ─────────────────────────────
+
+/// Row 3: a tap-only cost is not read out — the `Some(inner)` arm of
+/// `cost_conclusively_payable_by_cheap_gate`. A tapped source's `{T}` ability is
+/// unpayable, but the card face already shows the tap state.
+///
+/// Row 3c: a COSTLESS ability is not read out either — the predicate's
+/// `None => true` arm, which no shipped test exercised before.
+///
+/// Both negatives share one fixture with a mandatory positive: the same board
+/// carries a `Pay 5 life` ability at 1 life which IS read out, so neither
+/// negative can pass on an empty map.
+#[test]
+fn carve_out_suppresses_costless_and_tap_only_abilities_but_not_resource_costs() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.with_life(P0, 1);
+
+    // `{T}: draw` on a TAPPED source — unpayable, carved out by the tap arm.
+    let tap_only = scenario
+        .add_creature(P0, "Gemhide Sliver", 1, 1)
+        .with_ability_definition(
+            AbilityDefinition::new(AbilityKind::Activated, draw_effect()).cost(AbilityCost::Tap),
+        )
+        .id();
+    // A costless activated ability — the `None` arm.
+    let costless = scenario
+        .add_creature(P0, "Costless Engine", 1, 1)
+        .with_ability_definition(AbilityDefinition::new(
+            AbilityKind::Activated,
+            draw_effect(),
+        ))
+        .id();
+    // The mandatory paired positive: a resource cost the player cannot meet.
+    let life = scenario
+        .add_creature(P0, "Bloodletter", 1, 1)
+        .with_ability_definition(draw_for_life(5))
+        .id();
+    let mut runner = scenario.build();
+    runner
+        .state_mut()
+        .objects
+        .get_mut(&tap_only)
+        .expect("tap-only source exists")
+        .tapped = true;
+
+    assert!(
+        !blocked(&runner, life).is_empty(),
+        "paired positive (mandatory): Pay 5 life at 1 life IS read out — the map is not empty"
+    );
+    assert!(
+        blocked(&runner, tap_only).is_empty(),
+        "row 3: a tap-only cost on a tapped source is carved out"
+    );
+    assert!(
+        blocked(&runner, costless).is_empty(),
+        "row 3c: a costless ability is carved out by the `None` arm"
+    );
+
+    // Sibling for row 3c: give the SAME costless ability a PayLife cost and it
+    // IS read out — proving the exclusion tracks `cost: None`, not the ability.
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.with_life(P0, 1);
+    let now_costed = scenario
+        .add_creature(P0, "Costless Engine", 1, 1)
+        .with_ability_definition(draw_for_life(5))
+        .id();
+    let runner = scenario.build();
+    assert_eq!(
+        blocked(&runner, now_costed)
+            .into_iter()
+            .map(|(i, _, k)| (i, k))
+            .collect::<Vec<_>>(),
+        vec![(0, AbilityBlockKind::CostNotPayableNow)],
+        "sibling: the same ability with a PayLife cost IS read out"
+    );
+
+    // Row 3 sibling: UNTAP the source — still no entry, now because the ability
+    // is affordable rather than carved out. Asserted so the carve-out is never
+    // confused with the affordability gate.
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let untapped = scenario
+        .add_creature(P0, "Gemhide Sliver", 1, 1)
+        .with_ability_definition(
+            AbilityDefinition::new(AbilityKind::Activated, draw_effect()).cost(AbilityCost::Tap),
+        )
+        .id();
+    let runner = scenario.build();
+    assert!(
+        blocked(&runner, untapped).is_empty(),
+        "row 3 sibling: an untapped tap-only ability is affordable, so still no entry"
+    );
+    assert!(
+        offered_indices(&runner, untapped).contains(&0),
+        "reach-guard: and it is genuinely OFFERED, so the empty read-out is not an invisible ability"
+    );
+}
+
+/// Row 3b: the carve-out does not swallow a MIXED cost. `Composite[Tap, PayLife 5]`
+/// on a tapped source at 1 life IS read out, because
+/// `all_components_cheap_gate_covered` returns false for `PayLife`.
+#[test]
+fn carve_out_does_not_swallow_a_mixed_tap_plus_life_cost() {
+    let build = |life: i32| {
+        let mut scenario = GameScenario::new();
+        scenario.at_phase(Phase::PreCombatMain);
+        scenario.with_life(P0, life);
+        let obj = scenario
+            .add_creature(P0, "Mixed Cost Engine", 1, 1)
+            .with_ability_definition(
+                AbilityDefinition::new(AbilityKind::Activated, draw_effect()).cost(
+                    AbilityCost::Composite {
+                        costs: vec![
+                            AbilityCost::Tap,
+                            AbilityCost::PayLife {
+                                amount: QuantityExpr::Fixed { value: 5 },
+                            },
+                        ],
+                    },
+                ),
+            )
+            .id();
+        (scenario.build(), obj)
+    };
+
+    let (runner, obj) = build(1);
+    assert_eq!(
+        blocked(&runner, obj)
+            .into_iter()
+            .map(|(i, _, k)| (i, k))
+            .collect::<Vec<_>>(),
+        vec![(0, AbilityBlockKind::CostNotPayableNow)],
+        "a mixed Tap+PayLife cost is NOT carved out and is read out at 1 life"
+    );
+
+    let (runner, obj) = build(20);
+    assert!(
+        blocked(&runner, obj).is_empty(),
+        "sibling: the same cost at 20 life is affordable, so no entry"
+    );
+}
+
+// ── Rows 4 / 4b — the membership predicate (B1) ─────────────────────────────
+
+/// Row 4: a structurally-refused `EffectCost` is NEVER read out, on any board —
+/// its `can_pay` refusal is a limit of the engine's payment authority, not a
+/// resource shortfall, so a row would be a permanent lie.
+///
+/// Two mandatory controls, because a constant-false predicate would pass the
+/// negative alone:
+///   * a `PayLife` ability on the SAME object at 0 life IS read out;
+///   * Devoted Druid's supported `EffectCost{PutCounter{SelfRef}}` shape IS read
+///     out when its accompanying mana is unaffordable — so the predicate is not
+///     a constant-false on `EffectCost`.
+#[test]
+fn structurally_refused_effect_cost_is_not_read_out() {
+    // Crackleburr's untap-two-red-creatures cost is an `EffectCost{SetTapState}`,
+    // a shape `supports_effect_cost_payment` refuses on every board.
+    let refused_effect_cost = || {
+        AbilityDefinition::new(AbilityKind::Activated, draw_effect()).cost(
+            AbilityCost::EffectCost {
+                effect: Box::new(Effect::SetTapState {
+                    target: TargetFilter::Any,
+                    scope: EffectScope::Single,
+                    state: TapStateChange::Untap,
+                }),
+            },
+        )
+    };
+
+    for (life, label) in [(0, "0 life"), (20, "20 life")] {
+        for tapped in [false, true] {
+            let mut scenario = GameScenario::new();
+            scenario.at_phase(Phase::PreCombatMain);
+            scenario.with_life(P0, life);
+            let obj = scenario
+                .add_creature(P0, "Crackleburr", 2, 2)
+                // index 0: the structurally-refused EffectCost
+                .with_ability_definition(refused_effect_cost())
+                // index 1: the MANDATORY paired positive on the same object
+                .with_ability_definition(draw_for_life(5))
+                .id();
+            let mut runner = scenario.build();
+            runner
+                .state_mut()
+                .objects
+                .get_mut(&obj)
+                .expect("Crackleburr exists")
+                .tapped = tapped;
+
+            let read_out: Vec<usize> = blocked(&runner, obj)
+                .into_iter()
+                .map(|(i, _, _)| i)
+                .collect();
+            assert!(
+                !read_out.contains(&0),
+                "the structurally-refused EffectCost is never read out ({label}, tapped={tapped}); got {read_out:?}"
+            );
+            if life == 0 {
+                assert!(
+                    read_out.contains(&1),
+                    "paired positive (mandatory): PayLife 5 at 0 life on the SAME object IS read out ({label}, tapped={tapped})"
+                );
+            }
+        }
+    }
+
+    // Second control: a SUPPORTED `EffectCost` shape is read out, so the
+    // predicate is not a constant-false on the `EffectCost` variant. Devoted
+    // Druid's "{T}, Put a -1/-1 counter on this: Add {G}" cost shape, paired
+    // with an unaffordable mana component so `can_pay` genuinely refuses.
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let druid = scenario
+        .add_creature(P0, "Devoted Druid", 0, 2)
+        .with_ability_definition(
+            AbilityDefinition::new(AbilityKind::Activated, draw_effect()).cost(
+                AbilityCost::Composite {
+                    costs: vec![
+                        AbilityCost::EffectCost {
+                            effect: Box::new(Effect::PutCounter {
+                                target: TargetFilter::SelfRef,
+                                counter_type: CounterType::Minus1Minus1,
+                                count: QuantityExpr::Fixed { value: 1 },
+                            }),
+                        },
+                        AbilityCost::Mana {
+                            cost: ManaCost::generic(7),
+                        },
+                    ],
+                },
+            ),
+        )
+        .id();
+    let runner = scenario.build();
+    assert_eq!(
+        blocked(&runner, druid)
+            .into_iter()
+            .map(|(i, _, k)| (i, k))
+            .collect::<Vec<_>>(),
+        vec![(0, AbilityBlockKind::CostNotPayableNow)],
+        "second control: a SUPPORTED EffectCost shape IS read out — the predicate is not constant-false"
+    );
+}
+
+/// Row 4b: `PerCounter` and `Unimplemented` are excluded on the same axis. The
+/// bare `PayLife` control from row 4 rides along on the same object.
+#[test]
+fn per_counter_and_unimplemented_costs_are_not_read_out() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.with_life(P0, 0);
+    let obj = scenario
+        .add_creature(P0, "Structural Refusal Engine", 1, 1)
+        // index 0: PerCounter wrapping a resource-verdict base
+        .with_ability_definition(
+            AbilityDefinition::new(AbilityKind::Activated, draw_effect()).cost(
+                AbilityCost::PerCounter {
+                    counter: CounterType::Age,
+                    target: TargetFilter::SelfRef,
+                    base: Box::new(AbilityCost::PayLife {
+                        amount: QuantityExpr::Fixed { value: 1 },
+                    }),
+                },
+            ),
+        )
+        // index 1: Unimplemented
+        .with_ability_definition(
+            AbilityDefinition::new(AbilityKind::Activated, draw_effect()).cost(
+                AbilityCost::Unimplemented {
+                    description: "some cost the parser could not classify".to_string(),
+                },
+            ),
+        )
+        // index 2: the paired positive
+        .with_ability_definition(draw_for_life(5))
+        .id();
+    let runner = scenario.build();
+
+    let read_out: Vec<usize> = blocked(&runner, obj)
+        .into_iter()
+        .map(|(i, _, _)| i)
+        .collect();
+    assert!(
+        read_out.contains(&2),
+        "paired positive: the bare PayLife ability at 0 life IS read out; got {read_out:?}"
+    );
+    assert!(
+        !read_out.contains(&0),
+        "PerCounter is excluded on the structural axis; got {read_out:?}"
+    );
+    assert!(
+        !read_out.contains(&1),
+        "Unimplemented is excluded on the structural axis; got {read_out:?}"
+    );
+}
+
+// ── Row 5 — mana abilities are never read out ───────────────────────────────
+
+/// Row 5: a NON-tap-only mana ability — the exact class the carve-out does not
+/// hide — gets no row, because a different authority
+/// (`mana_abilities::can_activate_mana_ability_now`) decides mana abilities.
+///
+/// Paired positive (mandatory): a NON-mana ability with the same
+/// `Composite[Tap, Sacrifice]` cost on the same board IS read out, so the
+/// negative cannot be satisfied by the carve-out or by an empty map.
+#[test]
+fn mana_abilities_are_never_read_out() {
+    let tap_sac_cost = || AbilityCost::Composite {
+        costs: vec![
+            AbilityCost::Tap,
+            AbilityCost::Sacrifice(SacrificeCost::count(TargetFilter::SelfRef, 1)),
+        ],
+    };
+
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    // A Treasure-shaped mana ability: `{T}, Sacrifice this: Add one mana`.
+    let treasure = scenario
+        .add_creature(P0, "Treasure Token", 0, 0)
+        .with_ability_definition(
+            AbilityDefinition::new(
+                AbilityKind::Activated,
+                Effect::Mana {
+                    produced: ManaProduction::Fixed {
+                        colors: vec![],
+                        contribution: ManaContribution::Base,
+                    },
+                    restrictions: vec![],
+                    grants: vec![],
+                    expiry: None,
+                    target: None,
+                },
+            )
+            .cost(tap_sac_cost()),
+        )
+        .id();
+    // The same cost shape on a NON-mana ability.
+    let non_mana = scenario
+        .add_creature(P0, "Sacrificial Engine", 1, 1)
+        .with_ability_definition(
+            AbilityDefinition::new(AbilityKind::Activated, draw_effect()).cost(tap_sac_cost()),
+        )
+        .id();
+    let mut runner = scenario.build();
+    // Tap both so neither cost is payable.
+    for id in [treasure, non_mana] {
+        runner
+            .state_mut()
+            .objects
+            .get_mut(&id)
+            .expect("source exists")
+            .tapped = true;
+    }
+
+    assert!(
+        !blocked(&runner, non_mana).is_empty(),
+        "paired positive (mandatory): the NON-mana Composite[Tap, Sacrifice] ability IS read out"
+    );
+    assert!(
+        blocked(&runner, treasure).is_empty(),
+        "row 5: the mana ability with the identical cost shape gets NO row"
+    );
+}
+
+// ── Row 6 — prohibition arms keep precedence ────────────────────────────────
+
+/// Row 6: an ability that is BOTH prohibited and unaffordable reports the
+/// CR 602.5 prohibition on the object field, and does not appear in the CR 118.3
+/// read-out — the prohibition gate returns `Illegal` before the payability probe
+/// is ever reached.
+///
+/// Sibling: remove the prohibition and the SAME ability reads
+/// `CostNotPayableNow` with empty `sources`.
+#[test]
+fn prohibitions_take_precedence_over_the_payability_read_out() {
+    let build = |prohibit: bool| {
+        let mut scenario = GameScenario::new();
+        scenario.at_phase(Phase::PreCombatMain);
+        scenario.with_life(P0, 1);
+        let source = scenario.add_creature(P0, "Kang", 0, 0).id();
+        let obj = scenario
+            .add_creature(P0, "Costly Engine", 1, 1)
+            .with_ability_definition(draw_for_life(5))
+            .id();
+        let mut runner = scenario.build();
+        if prohibit {
+            runner
+                .state_mut()
+                .restrictions
+                .push(GameRestriction::ProhibitActivity {
+                    source,
+                    affected_players: RestrictionPlayerScope::AllPlayers,
+                    expiry: RestrictionExpiry::EndOfTurn,
+                    activity: ProhibitedActivity::ActivateAbilities {
+                        exemption: ActivationExemption::None,
+                        only_tag: None,
+                    },
+                });
+        }
+        (runner, obj)
+    };
+
+    let (runner, obj) = build(false);
+    assert_eq!(
+        blocked(&runner, obj),
+        vec![(0, vec![], AbilityBlockKind::CostNotPayableNow)],
+        "sibling: with no prohibition the ability reads CostNotPayableNow with empty sources"
+    );
+
+    let (runner, obj) = build(true);
+    assert!(
+        blocked(&runner, obj).is_empty(),
+        "under a prohibition the payability read-out yields nothing — the CR 602.5 gate wins"
+    );
+}
+
+// ── Row 7 — the target-legality tail ────────────────────────────────────────
+
+/// Row 7: an ability that is unaffordable AND has no legal target is NOT read
+/// out. Reporting "you can't pay this cost" for an ability that could not be
+/// activated anyway names the wrong cause, and this row is what makes
+/// `CostNotPayableNow` mean what its name says.
+///
+/// This row IS the target-legality tail's discriminating test: delete the tail
+/// from `ActivationQuery::BlockReason` and index 1 is read out, failing the
+/// negative below.
+///
+/// Fixture note: the source is deliberately NOT a Sliver. A "target Sliver"
+/// ability on Sliver Overlord itself has a legal target — the Overlord — because
+/// gaining control of a permanent you already control is a legal targeting
+/// choice. The tail can only be exercised by a filter that genuinely matches
+/// nothing on the board.
+#[test]
+fn unaffordable_ability_with_no_legal_target_is_not_read_out() {
+    let sliver_filter = TargetFilter::Typed(TypedFilter {
+        type_filters: vec![TypeFilter::Subtype("Sliver".to_string())],
+        controller: None,
+        properties: vec![],
+    });
+
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.with_life(P0, 1);
+    let obj = scenario
+        .add_creature(P0, "Targeting Engine", 2, 2)
+        // index 0: untargeted and unaffordable → read out.
+        .with_ability_definition(draw_for_life(5))
+        // index 1: unaffordable AND no legal target (no Sliver exists) → NOT read out.
+        .with_ability_definition(
+            AbilityDefinition::new(
+                AbilityKind::Activated,
+                Effect::Destroy {
+                    target: sliver_filter,
+                    cant_regenerate: false,
+                },
+            )
+            .cost(AbilityCost::PayLife {
+                amount: QuantityExpr::Fixed { value: 5 },
+            }),
+        )
+        .id();
+    // A non-Sliver creature, so the board is not empty of creatures either.
+    scenario.add_creature(P1, "Grizzly Bears", 2, 2);
+    let runner = scenario.build();
+
+    let read_out: Vec<usize> = blocked(&runner, obj)
+        .into_iter()
+        .map(|(i, _, _)| i)
+        .collect();
+    assert!(
+        read_out.contains(&0),
+        "paired positive: the untargeted unaffordable ability IS read out — the \
+         instrument fires; got {read_out:?}"
+    );
+    assert!(
+        !read_out.contains(&1),
+        "row 7: the unaffordable ability with NO legal target is NOT read out; got {read_out:?}"
+    );
+
+    // Sibling: add a Sliver and index 1 gains a legal target, so the SAME
+    // ability now IS read out — the exclusion tracks target legality, not the
+    // ability.
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.with_life(P0, 1);
+    let obj = scenario
+        .add_creature(P0, "Targeting Engine", 2, 2)
+        .with_ability_definition(draw_for_life(5))
+        .with_ability_definition(
+            AbilityDefinition::new(
+                AbilityKind::Activated,
+                Effect::Destroy {
+                    target: TargetFilter::Typed(TypedFilter {
+                        type_filters: vec![TypeFilter::Subtype("Sliver".to_string())],
+                        controller: None,
+                        properties: vec![],
+                    }),
+                    cant_regenerate: false,
+                },
+            )
+            .cost(AbilityCost::PayLife {
+                amount: QuantityExpr::Fixed { value: 5 },
+            }),
+        )
+        .id();
+    scenario
+        .add_creature(P1, "Sliver Drone", 1, 1)
+        .with_subtypes(vec!["Sliver"]);
+    let runner = scenario.build();
+    let read_out: Vec<usize> = blocked(&runner, obj)
+        .into_iter()
+        .map(|(i, _, _)| i)
+        .collect();
+    assert!(
+        read_out.contains(&1),
+        "sibling: with a legal Sliver target on the board the same ability IS read out; \
+         got {read_out:?}"
+    );
+}
+
+// ── Row 8 — non-battlefield zones ───────────────────────────────────────────
+
+/// Row 8: the read-out covers the graveyard zone, not just the battlefield
+/// (r3's Deferral 2, free on this channel).
+#[test]
+fn graveyard_activated_abilities_are_read_out() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.with_life(P0, 1);
+    // A battlefield entry in the same map proves the traversal ran at all.
+    let battlefield = scenario
+        .add_creature(P0, "Battlefield Engine", 1, 1)
+        .with_ability_definition(draw_for_life(5))
+        .id();
+    let unaffordable = scenario
+        .add_creature_to_graveyard(P0, "Bloodsoaked Champion", 2, 1)
+        .with_ability_definition(graveyard_draw_for_life(5))
+        .id();
+    let affordable = scenario
+        .add_creature_to_graveyard(P0, "Dread Wanderer", 2, 1)
+        .with_ability_definition(graveyard_draw_for_life(1))
+        .id();
+    let runner = scenario.build();
+
+    assert!(
+        !blocked(&runner, battlefield).is_empty(),
+        "reach-guard: the battlefield loop ran and produced an entry"
+    );
+    assert_eq!(
+        blocked(&runner, unaffordable)
+            .into_iter()
+            .map(|(i, _, k)| (i, k))
+            .collect::<Vec<_>>(),
+        vec![(0, AbilityBlockKind::CostNotPayableNow)],
+        "row 8: an unaffordable graveyard-activated ability IS read out"
+    );
+    assert!(
+        blocked(&runner, affordable).is_empty(),
+        "paired positive: an affordable graveyard ability on the same board is absent"
+    );
+}
+
+// ── Row 9 — two sources sharing an ability index ────────────────────────────
+
+/// Row 9: the entry binds to the MAP KEY (`ObjectId`), not to `ability_index`
+/// alone. Two objects each carry an ability at index 0; only the unaffordable
+/// one appears, and swapping which is affordable inverts the assertion.
+#[test]
+fn two_sources_same_ability_index_are_disambiguated() {
+    let build = |cheap_first: bool| {
+        let mut scenario = GameScenario::new();
+        scenario.at_phase(Phase::PreCombatMain);
+        scenario.with_life(P0, 3);
+        let a = scenario
+            .add_creature(P0, "Sliver A", 1, 1)
+            .with_ability_definition(draw_for_life(if cheap_first { 1 } else { 5 }))
+            .id();
+        let b = scenario
+            .add_creature(P0, "Sliver B", 1, 1)
+            .with_ability_definition(draw_for_life(if cheap_first { 5 } else { 1 }))
+            .id();
+        (scenario.build(), a, b)
+    };
+
+    let (runner, a, b) = build(true);
+    assert!(
+        blocked(&runner, a).is_empty(),
+        "the affordable source is absent from the map"
+    );
+    assert_eq!(
+        blocked(&runner, b)
+            .into_iter()
+            .map(|(i, _, _)| i)
+            .collect::<Vec<_>>(),
+        vec![0],
+        "the unaffordable source carries index 0"
+    );
+
+    // Sibling: swap which is affordable → the assertion inverts.
+    let (runner, a, b) = build(false);
+    assert_eq!(
+        blocked(&runner, a)
+            .into_iter()
+            .map(|(i, _, _)| i)
+            .collect::<Vec<_>>(),
+        vec![0],
+        "swapped: now source A carries the entry"
+    );
+    assert!(
+        blocked(&runner, b).is_empty(),
+        "swapped: source B is now affordable and absent"
+    );
+}
+
+// ── Row 10 — viewer scoping ─────────────────────────────────────────────────
+
+/// Row 10: the viewer-scoped sibling is empty for a viewer without action
+/// authority, and non-empty for the acting seat on the SAME state.
+#[test]
+fn read_out_is_empty_for_a_non_acting_viewer() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.with_life(P0, 1);
+    let obj = scenario
+        .add_creature(P0, "Costly Engine", 1, 1)
+        .with_ability_definition(draw_for_life(5))
+        .id();
+    let runner = scenario.build();
+
+    let acting = activation_block_reasons_for_viewer(runner.state(), P0);
+    let other = activation_block_reasons_for_viewer(runner.state(), P1);
+
+    assert!(
+        !entries_of(&acting, obj).is_empty(),
+        "paired positive (mandatory): the acting seat receives a non-empty read-out"
+    );
+    assert!(
+        other.is_empty(),
+        "row 10: a viewer without action authority receives an empty map; got {other:?}"
+    );
+}
+
+// ── Row 18 — the producer-side bound ────────────────────────────────────────
+
+/// Row 18: the read-out is bounded AT THE PRODUCER on the TOTAL across buckets,
+/// and `activation_block_reasons` returns a map — it has no `Result` and cannot
+/// fail, so no new broadcast-suppressing `Err` path exists.
+///
+/// Hostile fixture (mandatory): ONE object carrying more blocked abilities than
+/// the cap — the case a KEY-COUNT bound would wave through and a TOTAL bound
+/// must catch.
+///
+/// Paired positive (mandatory): a board just UNDER the cap is returned whole
+/// with its true count, so "truncated" is never "always returns the cap".
+#[test]
+fn read_out_is_bounded_on_the_total_across_buckets() {
+    let build = |abilities: usize| {
+        let mut scenario = GameScenario::new();
+        scenario.at_phase(Phase::PreCombatMain);
+        scenario.with_life(P0, 1);
+        let builder = scenario.add_creature(P0, "Hydra of Many Costs", 1, 1);
+        let mut builder = builder;
+        for _ in 0..abilities {
+            builder.with_ability_definition(draw_for_life(5));
+        }
+        let obj = builder.id();
+        (scenario.build(), obj)
+    };
+
+    // Paired positive: just under the cap, returned whole.
+    let under = MAX_ACTIVATION_BLOCK_TOTAL - 1;
+    let (runner, obj) = build(under);
+    let map = activation_block_reasons(runner.state());
+    let total: usize = map.values().map(Vec::len).sum();
+    assert_eq!(
+        total, under,
+        "under the cap the map is returned whole with its true count"
+    );
+    assert_eq!(
+        map.get(&obj).map(Vec::len),
+        Some(under),
+        "and every entry belongs to the single object bucket"
+    );
+
+    // Hostile fixture: ONE object over the cap.
+    let (runner, obj) = build(MAX_ACTIVATION_BLOCK_TOTAL + 25);
+    let map = activation_block_reasons(runner.state());
+    let total: usize = map.values().map(Vec::len).sum();
+    assert!(
+        total <= MAX_ACTIVATION_BLOCK_TOTAL,
+        "the TOTAL across buckets is capped even when ONE object exceeds it; got {total}"
+    );
+    assert_eq!(
+        total, MAX_ACTIVATION_BLOCK_TOTAL,
+        "truncation keeps the cap's worth rather than dropping the bucket"
+    );
+    assert!(
+        map.get(&obj)
+            .is_some_and(|entries| entries.iter().all(|e| e.reason.sources.is_empty())),
+        "every returned CR 118.3 entry carries empty `sources`"
+    );
+
+    // Determinism: the same board truncates identically across calls.
+    let again = activation_block_reasons(runner.state());
+    assert_eq!(
+        entries_of(&map, obj),
+        entries_of(&again, obj),
+        "truncation is deterministic (ObjectId order, then ability_index order)"
+    );
+}
+
+/// CR 118.12a: a DISJUNCTIVE cost is a resource verdict iff ANY alternative is.
+///
+/// `can_pay` answers `OneOf` with `.any()` at Activation scope (`costs.rs`), so a
+/// refusal means every alternative was refused. An alternative refused for lack of
+/// resources could still have been paid on a richer board, so the disjunction's
+/// refusal is a statement about resources — even though a sibling alternative is
+/// refused structurally on every board.
+///
+/// Revert probe: writing the `OneOf` arm of
+/// `AbilityCost::payability_verdict_is_resource_based` as `.all()` (which is
+/// correct for `Composite` and was originally shared with it) makes the mixed
+/// disjunction answer `false` and drops index 0 from the read-out, failing the
+/// first assertion while the all-structural negative control below still passes.
+#[test]
+fn mixed_disjunctive_cost_is_read_out_but_an_all_structural_one_is_not() {
+    // A shape `supports_effect_cost_payment` refuses on every board, so its
+    // refusal is structural rather than a statement about resources.
+    let structural = || AbilityCost::EffectCost {
+        effect: Box::new(Effect::SetTapState {
+            target: TargetFilter::Any,
+            scope: EffectScope::Single,
+            state: TapStateChange::Untap,
+        }),
+    };
+
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.with_life(P0, 0);
+    let obj = scenario
+        .add_creature(P0, "Disjunctive Source", 2, 2)
+        // index 0: MIXED — one structural alternative, one resource alternative
+        // the player cannot currently afford (no mana sources on the board).
+        .with_ability_definition(
+            AbilityDefinition::new(AbilityKind::Activated, draw_effect()).cost(
+                AbilityCost::OneOf {
+                    costs: vec![
+                        structural(),
+                        AbilityCost::Mana {
+                            cost: ManaCost::generic(7),
+                        },
+                    ],
+                },
+            ),
+        )
+        // index 1: NEGATIVE CONTROL — every alternative is structural, so the
+        // whole refusal is structural and no row may be produced.
+        .with_ability_definition(
+            AbilityDefinition::new(AbilityKind::Activated, draw_effect()).cost(
+                AbilityCost::OneOf {
+                    costs: vec![structural(), structural()],
+                },
+            ),
+        )
+        // index 2: PAIRED POSITIVE on the same object, so an empty read-out
+        // cannot pass this test vacuously.
+        .with_ability_definition(draw_for_life(5))
+        .id();
+    let runner = scenario.build();
+
+    let read_out: Vec<usize> = blocked(&runner, obj)
+        .into_iter()
+        .map(|(i, _, _)| i)
+        .collect();
+
+    assert!(
+        read_out.contains(&0),
+        "a disjunction with ONE resource-refused alternative is a resource verdict \
+         (CR 118.12a); got {read_out:?}"
+    );
+    assert!(
+        !read_out.contains(&1),
+        "negative control: an all-structural disjunction is refused on every board \
+         and must NOT be read out; got {read_out:?}"
+    );
+    assert!(
+        read_out.contains(&2),
+        "paired positive (mandatory): PayLife 5 at 0 life on the SAME object is read out"
+    );
+}

--- a/crates/engine/tests/integration/issue_6092_ability_block_reason.rs
+++ b/crates/engine/tests/integration/issue_6092_ability_block_reason.rs
@@ -608,11 +608,21 @@ fn prohibited_entry_survives_departed_source() {
 }
 
 /// Row 15: an ability that is merely unaffordable (no prohibition) is NOT read
-/// out — the read-out reflects only prohibitions, not payability. Reach-guard:
-/// the SAME ability is enumerated by `activated_ability_definitions` and gains an
-/// entry once a prohibition is added.
+/// out ON THE OBJECT FIELD — the read-out reflects only prohibitions, not
+/// payability. Reach-guard: the SAME ability is enumerated by
+/// `activated_ability_definitions` and gains an entry once a prohibition is
+/// added.
+///
+/// **The contract is channel-scoped, and this assertion is deliberately NOT
+/// inverted.** `AbilityBlockKind::CostNotPayableNow` exists, but it is published
+/// on the legal-actions payload by `ai_support::activation_block_reasons`, never
+/// on `GameObject::blocked_abilities` — the `derived.rs` sweep this test drives
+/// consults only `casting::activation_prohibition_reason` (the three CR 602.5
+/// arms). So "an unaffordable ability is not read out here" remains correct as
+/// written; the payability read-out is covered by
+/// `ability_cost_block_readout.rs`.
 #[test]
-fn unaffordable_ability_without_prohibition_is_not_read_out() {
+fn unaffordable_ability_without_prohibition_is_not_read_out_on_the_object_field() {
     use engine::game::casting::activated_ability_definitions;
 
     let mut scenario = GameScenario::new();

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -8,6 +8,8 @@
 mod source_census;
 
 mod abigale_integration;
+mod ability_block_display_clone_gate;
+mod ability_cost_block_readout;
 mod abundance_optional_draw_replacement;
 mod action_rejection;
 mod ad_nauseam_repeat;

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -1075,6 +1075,7 @@ mod skitterfang_reflexive_without_counter;
 mod skullwinder_chosen_opponent;
 mod slaughter_the_strong_total_power_4380;
 mod slitherwisp_flash_spell_cast_trigger;
+mod sliver_overlord_activation_offer;
 mod sliver_static_grants;
 mod smaug_noncombat_damage_treasure;
 mod snow_mana_production;

--- a/crates/engine/tests/integration/sliver_overlord_activation_offer.rs
+++ b/crates/engine/tests/integration/sliver_overlord_activation_offer.rs
@@ -1,0 +1,214 @@
+//! Diagnostic: Sliver Overlord's two printed `{3}` activated abilities must be
+//! offered in `legal_actions_by_object` whenever the controller can produce
+//! three mana — including when the only mana available comes from a mana
+//! ability GRANTED to the Sliver army by another Sliver (Gemhide/Manaweft).
+//!
+//! Reported from play: the ability picker listed only the three abilities
+//! granted by other Slivers (regenerate, pay-2-life bounce, add one mana) and
+//! neither of Sliver Overlord's own `{3}` abilities.
+
+use engine::ai_support::legal_actions_full;
+use engine::game::scenario::{GameRunner, GameScenario, P0};
+use engine::types::actions::GameAction;
+use engine::types::identifiers::ObjectId;
+use engine::types::mana::ManaColor;
+use engine::types::phase::Phase;
+
+const OVERLORD: &str = "{3}: Search your library for a Sliver card, reveal that card, put it into your hand, then shuffle.\n{3}: Gain control of target Sliver.";
+const GEMHIDE: &str = "All Slivers have \"{T}: Add one mana of any color.\"";
+const CRYPT: &str = "All Slivers have \"{T}: Regenerate target Sliver.\"";
+
+fn offered_indices(runner: &GameRunner, id: ObjectId) -> Vec<usize> {
+    let (_, _, grouped) = legal_actions_full(runner.state());
+    grouped
+        .get(&id)
+        .map(Vec::as_slice)
+        .unwrap_or(&[])
+        .iter()
+        .filter_map(|a| match a {
+            GameAction::ActivateAbility {
+                source_id,
+                ability_index,
+            } if *source_id == id => Some(*ability_index),
+            _ => None,
+        })
+        .collect()
+}
+
+#[test]
+fn overlord_abilities_offered_with_lands() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let overlord = scenario
+        .add_creature(P0, "Sliver Overlord", 7, 7)
+        .with_subtypes(vec!["Sliver", "Mutant"])
+        .from_oracle_text(OVERLORD)
+        .id();
+    for _ in 0..3 {
+        scenario.add_basic_land(P0, ManaColor::Green);
+    }
+
+    let runner = scenario.build();
+    let indices = offered_indices(&runner, overlord);
+    assert!(
+        indices.contains(&0) && indices.contains(&1),
+        "expected both printed {{3}} abilities offered with 3 untapped lands; got {indices:?}",
+    );
+}
+
+#[test]
+fn overlord_abilities_offered_with_granted_sliver_mana() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let overlord = scenario
+        .add_creature(P0, "Sliver Overlord", 7, 7)
+        .with_subtypes(vec!["Sliver", "Mutant"])
+        .from_oracle_text(OVERLORD)
+        .id();
+    scenario
+        .add_creature(P0, "Gemhide Sliver", 1, 1)
+        .with_subtypes(vec!["Sliver"])
+        .from_oracle_text(GEMHIDE);
+    scenario
+        .add_creature(P0, "Crypt Sliver", 1, 1)
+        .with_subtypes(vec!["Sliver"])
+        .from_oracle_text(CRYPT);
+    scenario
+        .add_creature(P0, "Metallic Sliver", 1, 1)
+        .with_subtypes(vec!["Sliver"]);
+    scenario
+        .add_creature(P0, "Muscle Sliver", 1, 1)
+        .with_subtypes(vec!["Sliver"]);
+
+    let runner = scenario.build();
+    let indices = offered_indices(&runner, overlord);
+    let (_, _, grouped) = legal_actions_full(runner.state());
+    assert!(
+        indices.contains(&0) && indices.contains(&1),
+        "expected both printed {{3}} abilities offered when 4 Slivers can each tap for mana; got {indices:?}\nall actions: {:?}",
+        grouped.get(&overlord),
+    );
+}
+
+/// Rules out the multiplayer / commander pathway: the report came from a
+/// 4-player Commander game with Sliver Overlord as the commander. The
+/// permanent stays on the battlefield (`with_commander` would move it to the
+/// command zone), carrying only the `is_commander` designation.
+#[test]
+fn overlord_abilities_offered_in_four_player_commander_game() {
+    let mut scenario = GameScenario::new_n_player(4, 7);
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let overlord = scenario
+        .add_creature(P0, "Sliver Overlord", 7, 7)
+        .with_subtypes(vec!["Sliver", "Mutant"])
+        .from_oracle_text(OVERLORD)
+        .commander()
+        .id();
+    for _ in 0..3 {
+        scenario.add_basic_land(P0, ManaColor::Green);
+    }
+
+    let runner = scenario.build();
+    let indices = offered_indices(&runner, overlord);
+    assert!(
+        indices.contains(&0) && indices.contains(&1),
+        "expected both printed {{3}} abilities in a 4-player commander game; got {indices:?}",
+    );
+}
+
+/// Screenshot replica: every other Sliver is tapped, so the ONLY mana the
+/// controller can make is the single mana from the Overlord's own granted
+/// "{T}: Add one mana of any color". `{3}` is then genuinely unpayable, and the
+/// picker shows only the granted abilities — exactly the reported symptom.
+#[test]
+fn overlord_abilities_absent_when_army_is_tapped_out() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let overlord = scenario
+        .add_creature(P0, "Sliver Overlord", 7, 7)
+        .with_subtypes(vec!["Sliver", "Mutant"])
+        .from_oracle_text(OVERLORD)
+        .id();
+    let gemhide = scenario
+        .add_creature(P0, "Gemhide Sliver", 1, 1)
+        .with_subtypes(vec!["Sliver"])
+        .from_oracle_text(GEMHIDE)
+        .id();
+    let crypt = scenario
+        .add_creature(P0, "Crypt Sliver", 1, 1)
+        .with_subtypes(vec!["Sliver"])
+        .from_oracle_text(CRYPT)
+        .id();
+
+    let mut runner = scenario.build();
+    for id in [gemhide, crypt] {
+        runner.state_mut().objects.get_mut(&id).unwrap().tapped = true;
+    }
+
+    let indices = offered_indices(&runner, overlord);
+    assert!(
+        !indices.contains(&0) && !indices.contains(&1),
+        "with only one available mana the {{3}} abilities must be withheld; got {indices:?}",
+    );
+    assert!(
+        !indices.is_empty(),
+        "the granted abilities must still be offered — this is what the player saw",
+    );
+}
+
+/// Isolates the `is_commander` designation from the player count.
+#[test]
+fn overlord_abilities_offered_with_commander_flag_two_players() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let overlord = scenario
+        .add_creature(P0, "Sliver Overlord", 7, 7)
+        .with_subtypes(vec!["Sliver", "Mutant"])
+        .from_oracle_text(OVERLORD)
+        .commander()
+        .id();
+    for _ in 0..3 {
+        scenario.add_basic_land(P0, ManaColor::Green);
+    }
+
+    let runner = scenario.build();
+    let indices = offered_indices(&runner, overlord);
+    assert!(
+        indices.contains(&0) && indices.contains(&1),
+        "commander designation alone must not withhold the {{3}} abilities; got {indices:?}",
+    );
+}
+
+/// Isolates the player count from the `is_commander` designation.
+#[test]
+fn overlord_abilities_offered_in_four_player_game_without_commander_flag() {
+    let mut scenario = GameScenario::new_n_player(4, 7);
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let overlord = scenario
+        .add_creature(P0, "Sliver Overlord", 7, 7)
+        .with_subtypes(vec!["Sliver", "Mutant"])
+        .from_oracle_text(OVERLORD)
+        .id();
+    for _ in 0..3 {
+        scenario.add_basic_land(P0, ManaColor::Green);
+    }
+
+    let runner = scenario.build();
+    let state = runner.state();
+    let indices = offered_indices(&runner, overlord);
+    assert!(
+        indices.contains(&0) && indices.contains(&1),
+        "four seats must not withhold the {{3}} abilities; got {indices:?}\n\
+         active={:?} priority={:?} waiting={:?} battlefield={}",
+        state.active_player,
+        state.priority_player,
+        state.waiting_for,
+        state.battlefield.len(),
+    );
+}

--- a/crates/lobby-broker/src/protocol.rs
+++ b/crates/lobby-broker/src/protocol.rs
@@ -38,6 +38,19 @@ pub enum ServerErrorCode {
 /// rather than a parse error, and the handshake is the only place that pairing
 /// can be refused. See 24.
 ///
+/// 62 — `ServerMessage::{GameStarted, StateUpdate}` gained
+///      `activation_block_reasons: HashMap<ObjectId, Vec<AbilityBlockEntry>>` —
+///      the CR 118.3 "you can't pay this cost right now" read-out, scoped to the
+///      acting player and empty for everyone else. It carries
+///      `#[serde(default, skip_serializing_if = "HashMap::is_empty")]`, so a v61
+///      payload reads as the absent/empty map it always meant. The break is the
+///      other direction, and it is over-determined: `AbilityBlockKind` is
+///      `#[serde(tag = "type")]`, so the new `CostNotPayableNow` arm emits a TAG
+///      VALUE no v61 peer has a case for — a v61 Rust peer fails to deserialize
+///      the entry, and a v61 client indexes its reason-key record with an
+///      unknown member and renders `t(undefined)`. New tag, not merely a new
+///      field, so the bump does not rest on the serde attributes above.
+///
 /// 61 — `Effect::ChooseCounterKind` gained `domain: CounterKindDomain` and
 ///      `chooser: CounterKindChooser` — the population a counter-kind choice
 ///      draws its legal kinds from, and whether the GAME draws one at random
@@ -317,7 +330,7 @@ pub enum ServerErrorCode {
 ///      payload; mulligan bottoming folded into a
 ///      `MulliganDecisionPhase::BottomCards` sub-phase on
 ///      `WaitingFor::MulliganDecision`.
-pub const PROTOCOL_VERSION: u32 = 61;
+pub const PROTOCOL_VERSION: u32 = 62;
 
 /// Minimum protocol version accepted by lobby-only brokers at the hello
 /// handshake **from clients that predate [`LOBBY_PROTOCOL_VERSION`]** — the
@@ -1063,12 +1076,12 @@ mod tests {
 
     #[test]
     fn protocol_version_tracks_full_game_wire_additions() {
-        assert_eq!(PROTOCOL_VERSION, 61);
+        assert_eq!(PROTOCOL_VERSION, 62);
         // Lobby keeps its one-version rollout window; full-game servers stay
         // current-only (`server_core::MIN_SUPPORTED_PROTOCOL == PROTOCOL_VERSION`),
         // which is what refuses an older full-game peer whose GameState cannot
         // understand a success acknowledgment the submitting client awaits.
-        assert_eq!(MIN_SUPPORTED_PROTOCOL, 60);
+        assert_eq!(MIN_SUPPORTED_PROTOCOL, 61);
     }
 
     #[test]

--- a/crates/phase-ai/src/duel_suite/perf.rs
+++ b/crates/phase-ai/src/duel_suite/perf.rs
@@ -194,6 +194,9 @@ impl PerfCounters {
             legend_rule_mode_gate_scans,
             sba_battlefield_snapshot_builds,
             sba_empty_battlefield_short_circuits,
+            activation_verdict_passes,
+            activation_block_display_abilities_examined,
+            activation_verdict_flush_clones,
         } = *snapshot;
 
         let mut map = BTreeMap::new();
@@ -337,6 +340,18 @@ impl PerfCounters {
         map.insert(
             "sba_empty_battlefield_short_circuits".to_string(),
             sba_empty_battlefield_short_circuits,
+        );
+        map.insert(
+            "activation_verdict_passes".to_string(),
+            activation_verdict_passes,
+        );
+        map.insert(
+            "activation_block_display_abilities_examined".to_string(),
+            activation_block_display_abilities_examined,
+        );
+        map.insert(
+            "activation_verdict_flush_clones".to_string(),
+            activation_verdict_flush_clones,
         );
         Self(map)
     }
@@ -1206,6 +1221,9 @@ mod tests {
             legend_rule_mode_gate_scans: 26,
             sba_battlefield_snapshot_builds: 27,
             sba_empty_battlefield_short_circuits: 28,
+            activation_verdict_passes: 43,
+            activation_block_display_abilities_examined: 44,
+            activation_verdict_flush_clones: 45,
         };
         let counters = PerfCounters::from_snapshot(&snapshot);
 

--- a/crates/phase-server/src/main.rs
+++ b/crates/phase-server/src/main.rs
@@ -21,6 +21,7 @@ use axum::routing::{get, post};
 use axum::{Json, Router};
 use clap::Parser;
 use engine::ai_support::{
+    activation_block_reasons_for_viewer as engine_activation_block_reasons_for_viewer,
     auto_pass_recommended_for_viewer as engine_auto_pass_for_viewer,
     end_continuous_effect_offers as engine_end_continuous_effect_offers,
     legal_actions_full as engine_legal_actions_full,
@@ -486,6 +487,16 @@ fn build_game_started_message(
         });
     let derived = derive_transport_views(&session.state, &filtered, Some(player));
     let viewer_interaction = derive_viewer_interaction(&session.state, &filtered, player);
+    // CR 118.3 + CR 117.1: derived per recipient from the same raw pre-filter
+    // state binding its sibling `spell_costs` came from. No `if is_actor`
+    // wrapper: the entry point self-gates on `turn_control::is_authorized_submitter`,
+    // which is the SAME function `server_core::is_acting` delegates to.
+    let activation_block_reasons =
+        engine_activation_block_reasons_for_viewer(&session.state, player);
+    debug_assert!(
+        activation_block_reasons.is_empty() || is_actor,
+        "a non-empty CR 118.3 read-out implies an authorized viewer"
+    );
 
     ServerMessage::GameStarted {
         state_revision: session.state_revision,
@@ -507,6 +518,7 @@ fn build_game_started_message(
         } else {
             HashMap::new()
         },
+        activation_block_reasons,
         derived,
         viewer_interaction,
         player_token,
@@ -584,6 +596,13 @@ fn build_state_update_message(
     } else {
         Vec::new()
     };
+    // CR 118.3 + CR 117.1: same raw state binding the sibling `spell_costs`
+    // came from (both destructured from this `ActionResult`).
+    let activation_block_reasons = engine_activation_block_reasons_for_viewer(raw_state, player);
+    debug_assert!(
+        activation_block_reasons.is_empty() || is_actor,
+        "a non-empty CR 118.3 read-out implies an authorized viewer"
+    );
 
     Ok(ServerMessage::StateUpdate {
         state_revision,
@@ -609,6 +628,7 @@ fn build_state_update_message(
         } else {
             HashMap::new()
         },
+        activation_block_reasons,
         derived,
         viewer_interaction,
         rewind_targets,
@@ -638,6 +658,10 @@ fn build_spectator_game_started_message(session: &GameSession) -> Result<ServerM
         mana_payment_shortcut_actions: Vec::new(),
         spell_costs: HashMap::new(),
         legal_actions_by_object: HashMap::new(),
+        // CR 117.1: a spectator is a non-seat viewer with no action authority,
+        // so the read-out is empty by the same existing design as the two
+        // siblings above.
+        activation_block_reasons: HashMap::new(),
         derived,
         viewer_interaction,
         player_token: None,
@@ -684,6 +708,9 @@ fn build_spectator_state_update_message(
         log_entries: log_entries.to_vec(),
         spell_costs: HashMap::new(),
         legal_actions_by_object: HashMap::new(),
+        // CR 117.1: spectators have no action authority — empty by the same
+        // existing design as the two siblings above.
+        activation_block_reasons: HashMap::new(),
         derived,
         viewer_interaction,
         // Empty for the same reason as the spectator `GameStarted` builder
@@ -2620,9 +2647,123 @@ mod lifecycle_tests {
     use url::Url;
 
     use super::{
-        bootstrap_required, origin_is_allowed, prune_game_connections, select_card_data_source,
-        validate_public_url, CardDataSource, Cli, SharedConnections,
+        bootstrap_required, build_state_update_message, origin_is_allowed, prune_game_connections,
+        select_card_data_source, validate_public_url, CardDataSource, Cli, ServerMessage,
+        SharedConnections,
     };
+
+    /// CR 118.3 + CR 117.1 — matrix row 21 (actor axis), at a REAL
+    /// `ServerMessage` construction site rather than at the engine entry point.
+    ///
+    /// `build_state_update_message` is the sync builder behind `phase-server`'s
+    /// `StateUpdate` fan-out. It derives `activation_block_reasons` from the
+    /// SAME `raw_state` binding its sibling `spell_costs` is destructured from,
+    /// and passes no `if is_actor` wrapper — the engine entry point self-gates
+    /// on `turn_control::is_authorized_submitter`, which is exactly what
+    /// `server_core::is_acting` delegates to.
+    ///
+    /// Both halves asserted in one test so neither is vacuous: the acting seat
+    /// receives a NON-EMPTY read-out, and the non-acting seat receives an empty
+    /// one from the SAME `ActionResult`.
+    ///
+    /// RUNNER: CI. Tilt's test resources are scoped `-p phase-engine -p phase-ai`
+    /// and never compile `phase-server`, so a green `test-engine` is no evidence
+    /// for this test.
+    #[test]
+    fn state_update_publishes_the_cost_block_readout_only_to_the_acting_seat() {
+        // DB-free by construction: `GameState::new_two_player` + `create_object`
+        // only, mirroring `mana_display_self_sacrifice_clone_gate.rs`. `phase-server`
+        // does not enable the engine's `test-support` feature, so `GameScenario`
+        // is not available here.
+        use engine::game::game_object::GameObject;
+        use engine::types::ability::{
+            AbilityCost, AbilityDefinition, AbilityKind, Effect, QuantityExpr, TargetFilter,
+        };
+        use engine::types::game_state::{GameState, WaitingFor};
+        use engine::types::identifiers::CardId;
+        use engine::types::phase::Phase;
+        use engine::types::player::PlayerId;
+        use engine::types::zones::Zone;
+        use std::sync::Arc as StdArc;
+
+        const P0: PlayerId = PlayerId(0);
+        const P1: PlayerId = PlayerId(1);
+
+        let mut raw_state = GameState::new_two_player(42);
+        raw_state.phase = Phase::PreCombatMain;
+        raw_state.waiting_for = WaitingFor::Priority { player: P0 };
+        raw_state.priority_player = P0;
+        raw_state.players[0].life = 1;
+
+        // `game::zones` is `pub(crate)`, so the object is placed directly:
+        // insert into `objects` and push onto the battlefield, which is exactly
+        // what `create_object` does for a pre-existing permanent.
+        let obj = engine::types::identifiers::ObjectId(raw_state.next_object_id);
+        raw_state.next_object_id += 1;
+        raw_state.objects.insert(
+            obj,
+            GameObject::new(
+                obj,
+                CardId(1),
+                P0,
+                "Costly Engine".to_string(),
+                Zone::Battlefield,
+            ),
+        );
+        raw_state.battlefield.push_back(obj);
+        // One unaffordable, resource-verdict ability: `Pay 5 life: draw` at 1 life.
+        {
+            let o = raw_state.objects.get_mut(&obj).expect("object exists");
+            StdArc::make_mut(&mut o.abilities).push(
+                AbilityDefinition::new(
+                    AbilityKind::Activated,
+                    Effect::Draw {
+                        count: QuantityExpr::Fixed { value: 1 },
+                        target: TargetFilter::Controller,
+                    },
+                )
+                .cost(AbilityCost::PayLife {
+                    amount: QuantityExpr::Fixed { value: 5 },
+                }),
+            );
+        }
+
+        let (legal_actions, spell_costs, by_object) =
+            engine::ai_support::legal_actions_full(&raw_state);
+        let result: server_core::session::ActionResult = (
+            raw_state,
+            Vec::new(),
+            legal_actions,
+            Vec::new(),
+            false,
+            spell_costs,
+            by_object,
+        );
+
+        let readout_for = |player| match build_state_update_message(&result, 1, player, Vec::new())
+            .expect("the snapshot guard admits this small board")
+        {
+            ServerMessage::StateUpdate {
+                activation_block_reasons,
+                ..
+            } => activation_block_reasons,
+            other => panic!("expected a StateUpdate, got {other:?}"),
+        };
+
+        let acting = readout_for(P0);
+        let other = readout_for(P1);
+
+        // PAIRED POSITIVE, mandatory: without it, a builder that dropped the
+        // field entirely would satisfy the negative below.
+        assert!(
+            acting.get(&obj).is_some_and(|entries| entries.len() == 1),
+            "the acting seat's StateUpdate carries the CR 118.3 read-out; got {acting:?}"
+        );
+        assert!(
+            other.is_empty(),
+            "a non-acting recipient of the SAME ActionResult gets an empty map; got {other:?}"
+        );
+    }
 
     #[test]
     fn bind_flag_defaults_to_lan_and_accepts_loopback() {
@@ -5332,6 +5473,22 @@ async fn broadcast_ai_results(
                     } else {
                         HashMap::new()
                     };
+                    // CR 118.3: the STALENESS axis is the one part of disclosure
+                    // the engine cannot self-gate — "is this the final transition
+                    // of the fan-out" is a property of the transport's batch, not
+                    // of any `GameState`. An intermediate transition advertises no
+                    // actions, so it must advertise no read-out either. The
+                    // `is_actor` half is redundant with the entry point's own gate
+                    // and is kept only to mirror its `p_spell_costs` sibling above.
+                    let p_activation_block_reasons = if is_last && is_actor {
+                        engine_activation_block_reasons_for_viewer(ai_raw_state, *pid)
+                    } else {
+                        HashMap::new()
+                    };
+                    debug_assert!(
+                        p_activation_block_reasons.is_empty() || is_actor,
+                        "a non-empty CR 118.3 read-out implies an authorized viewer"
+                    );
                     let _ = s.send(ServerMessage::StateUpdate {
                         state_revision: *ai_revision,
                         state: pstate.clone(),
@@ -5348,6 +5505,7 @@ async fn broadcast_ai_results(
                         log_entries: ai_log_entries.clone(),
                         spell_costs: p_spell_costs,
                         legal_actions_by_object: object_action_payloads(&p_by_object),
+                        activation_block_reasons: p_activation_block_reasons,
                         derived: derive_transport_views(ai_raw_state, pstate, Some(*pid)),
                         viewer_interaction: derive_viewer_interaction(ai_raw_state, pstate, *pid),
                         rewind_targets: rewind_targets.to_vec(),
@@ -5447,6 +5605,17 @@ async fn broadcast_takeback_approved(
                 } else {
                     HashMap::new()
                 };
+                // CR 118.3 + CR 117.1: derived from `raw_state` (`snapshot.0`) —
+                // the SAME binding the sibling `spell_costs` (`snapshot.3`) came
+                // from. This path has no `session` in scope, and reading a
+                // different state here is precisely the freshness hazard the
+                // per-site state-binding rule exists to prevent.
+                let p_activation_block_reasons =
+                    engine_activation_block_reasons_for_viewer(&raw_state, *pid);
+                debug_assert!(
+                    p_activation_block_reasons.is_empty() || is_actor,
+                    "a non-empty CR 118.3 read-out implies an authorized viewer"
+                );
                 let _ = s.send(ServerMessage::StateUpdate {
                     state_revision,
                     state: pstate.clone(),
@@ -5459,6 +5628,7 @@ async fn broadcast_takeback_approved(
                     log_entries: vec![],
                     spell_costs: p_spell_costs,
                     legal_actions_by_object: object_action_payloads(&p_by_object),
+                    activation_block_reasons: p_activation_block_reasons,
                     derived: derive_transport_views(&raw_state, pstate, Some(*pid)),
                     viewer_interaction: derive_viewer_interaction(&raw_state, pstate, *pid),
                     // Captured by the caller under the same lock as the
@@ -5988,6 +6158,22 @@ async fn handle_full_game_submission(
                             } else {
                                 HashMap::new()
                             };
+                            // CR 118.3: the STALENESS axis again — a human action
+                            // followed by AI play must not advertise the pre-AI
+                            // action set, so it must not advertise a read-out
+                            // describing a board the player is not being offered
+                            // actions on. `is_actor` mirrors the `p_spell_costs`
+                            // sibling above and is redundant with the entry
+                            // point's own gate.
+                            let p_activation_block_reasons = if ai_results.is_empty() && is_actor {
+                                engine_activation_block_reasons_for_viewer(&raw_state, *pid)
+                            } else {
+                                HashMap::new()
+                            };
+                            debug_assert!(
+                                p_activation_block_reasons.is_empty() || is_actor,
+                                "a non-empty CR 118.3 read-out implies an authorized viewer"
+                            );
                             let _ = s.send(ServerMessage::StateUpdate {
                                 state_revision: human_revision,
                                 state: pstate.clone(),
@@ -6002,6 +6188,7 @@ async fn handle_full_game_submission(
                                 log_entries: log_entries.clone(),
                                 spell_costs: p_spell_costs,
                                 legal_actions_by_object: object_action_payloads(&p_by_object),
+                                activation_block_reasons: p_activation_block_reasons,
                                 derived: derive_transport_views(&raw_state, pstate, Some(*pid)),
                                 viewer_interaction: derive_viewer_interaction(
                                     &raw_state, pstate, *pid,
@@ -8323,6 +8510,11 @@ async fn handle_client_message(
                         log_entries: vec![],
                         spell_costs: HashMap::new(),
                         legal_actions_by_object: HashMap::new(),
+                        // CR 117.1b: the game has not started, so no player has
+                        // priority and no activated ability can be activated —
+                        // the read-out has nothing to describe. Empty by the
+                        // same existing design as its two siblings above.
+                        activation_block_reasons: HashMap::new(),
                         derived,
                         viewer_interaction,
                         // `JoinOutcome::Waiting` — the game has not started, so

--- a/crates/server-core/src/protocol.rs
+++ b/crates/server-core/src/protocol.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 
 use engine::game::interaction::ObjectActionPayload;
+use engine::types::ability::AbilityBlockEntry;
 use engine::types::action_rejection::ActionRejection;
 use engine::types::actions::GameAction;
 use engine::types::events::GameEvent;
@@ -646,6 +647,12 @@ pub enum ServerMessage {
         /// introspecting `GameAction` variants client-side. Empty for non-actors.
         #[serde(default, skip_serializing_if = "HashMap::is_empty")]
         legal_actions_by_object: HashMap<ObjectId, Vec<ObjectActionPayload>>,
+        /// CR 118.3: per-object read-out of activated abilities the acting player
+        /// is not being offered solely because they can't pay the cost right now.
+        /// Acting-player-scoped and empty for non-actors, exactly like
+        /// `legal_actions_by_object` above. Display only — never dispatchable.
+        #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+        activation_block_reasons: HashMap<ObjectId, Vec<AbilityBlockEntry>>,
         /// Engine-authored presentation projections computed alongside
         /// `state`. See `engine::game::derived_views::DerivedViews`.
         /// Required for Commander-format games so the CommanderDamage HUD
@@ -704,6 +711,11 @@ pub enum ServerMessage {
         /// Empty for non-actors.
         #[serde(default, skip_serializing_if = "HashMap::is_empty")]
         legal_actions_by_object: HashMap<ObjectId, Vec<ObjectActionPayload>>,
+        /// CR 118.3: per-object "can't pay this cost right now" read-out.
+        /// Acting-player-scoped and empty for non-actors, exactly like
+        /// `legal_actions_by_object` above. Display only — never dispatchable.
+        #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+        activation_block_reasons: HashMap<ObjectId, Vec<AbilityBlockEntry>>,
         /// Engine-authored presentation projections for this state snapshot.
         /// See `engine::game::derived_views::DerivedViews`. Always populated
         /// by server construction sites — the `#[serde(default)]` exists
@@ -1685,6 +1697,7 @@ mod tests {
                     interaction_action_id: interaction_action_id.clone(),
                 }],
             )]),
+            activation_block_reasons: HashMap::new(),
             derived: Default::default(),
             viewer_interaction: viewer_interaction.clone(),
             player_token: None,
@@ -1736,6 +1749,7 @@ mod tests {
             mana_payment_shortcut_actions: vec![],
             spell_costs: HashMap::new(),
             legal_actions_by_object: HashMap::new(),
+            activation_block_reasons: HashMap::new(),
             derived: Default::default(),
             viewer_interaction: engine::game::interaction::derive_viewer_interaction(
                 &state,
@@ -3085,8 +3099,8 @@ mod tests {
     }
 
     #[test]
-    fn protocol_version_is_61_for_counter_kind_domain() {
-        assert_eq!(PROTOCOL_VERSION, 61);
+    fn protocol_version_is_62_for_activation_block_readout() {
+        assert_eq!(PROTOCOL_VERSION, 62);
     }
 
     /// The bump alone is inert — a version number nobody enforces prevents no
@@ -3097,7 +3111,7 @@ mod tests {
     ///
     /// REVERT-PROBE: relax to `PROTOCOL_VERSION - 1` — the exact regression
     /// this guards — and this test reds while
-    /// `protocol_version_is_61_for_counter_kind_domain` stays
+    /// `protocol_version_is_62_for_activation_block_readout` stays
     /// green, which is why the two are separate assertions.
     #[test]
     fn full_game_floor_is_current_only_not_a_rollout_window() {
@@ -3253,6 +3267,7 @@ mod tests {
             log_entries: vec![],
             spell_costs: HashMap::new(),
             legal_actions_by_object: HashMap::new(),
+            activation_block_reasons: HashMap::new(),
             derived: Default::default(),
             viewer_interaction: viewer_interaction.clone(),
             rewind_targets,

--- a/scripts/check-protocol-version.mjs
+++ b/scripts/check-protocol-version.mjs
@@ -3,7 +3,7 @@ import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
-const EXPECTED_PROTOCOL_VERSION = 61;
+const EXPECTED_PROTOCOL_VERSION = 62;
 // The LOBBY message-set version, not derived from the full-game number above.
 // The classifier below refuses an expression only on the SOURCE constants; this
 // script never reads itself, so its own EXPECTED_* must stay literals.
@@ -14,7 +14,7 @@ const EXPECTED_LOBBY_PROTOCOL_VERSION = 4;
 // here, so a full-game bump could ship with an unbumped P2P version and CI
 // stayed green — a v(n-1) host and a v(n) guest would then complete a
 // handshake and only fail when the incompatible payload arrived.
-const EXPECTED_WIRE_PROTOCOL_VERSION = 45;
+const EXPECTED_WIRE_PROTOCOL_VERSION = 46;
 
 function extractVersion(source, pattern, label) {
   const match = source.match(pattern);


### PR DESCRIPTION
## The report

A player couldn't use their commander's abilities while playing Slivers. In the screenshot, Sliver Overlord's card image shows two `{3}:` abilities, but the ability-choice modal offers only three options.

The modal has no cap, and summoning sickness isn't the cause. The bug is in the engine.

## Root cause

`can_activate_ability_now_with_restriction_gates` returned a bare `false` whenever `can_pay_ability_cost_now` reported the cost unpayable. That makes "you can't afford this right now" indistinguishable from "this ability does not exist" — and since the client renders exactly what the engine offers, those abilities silently vanished. Spells never behaved this way; `spell_costs` exists precisely so an unaffordable spell still displays.

## The fix

`activation_verdict` now returns a typed `ActivationVerdict` rather than a bool, and a new `AbilityBlockKind::CostNotPayableNow` arm records the CR 118.3 case as a **display-only, action-free** read-out keyed by `(ObjectId, ability_index)`. It is rebuilt per call and never latched, so refilling mana or regaining life clears it with no invalidation step.

The read-out is viewer-scoped (CR 117.1b), excludes mana abilities (CR 605.1a is a separate authority), and is bounded by a deterministic total-count truncation. Costs `can_pay` refuses on *every* board — rather than for lack of resources — are screened out first.

The client renders these as disabled rows in the picker, reusing the same `abilityLabel` + `stripCostPrefix` split the offered rows already use, so a blocked `{3}` and an offered `{3}` are directly comparable in one list.

Also makes the CR 613.1 layer flush conditional, removing an unconditional whole-state clone from the shared enforcement tail that `legal_actions_full` was already paying on every call.

## Scope, stated rather than over-claimed

The read-out reaches the picker only when the picker opens, which requires at least one offered non-mana action on the object. A permanent with *no* affordable ability at all still shows nothing; widening the click path and the inspect panel are deferred.

## Verification

- `cargo nextest` — 30041 run, 30040 passed. The single failure is the pre-existing macOS arm64 `game_state_stack_budget::four_player_commander_action_fits_a_bounded_stack` SIGABRT, unrelated to this change.
- `cargo clippy` clean on `phase-engine`, `phase-ai`, `engine-wasm`, `server-core`, `phase-server`, `lobby-broker`.
- Frontend: 468 files / 5850 tests passed, no OOM.
- `type-check` and the protocol gate exit 0, re-run after rebasing onto v0.74.0.
- All 22 CR numbers checked for **direction**, not just existence, against `docs/MagicCompRules.txt`. Two authored cites were corrected (`602.2a`→`602.2`, `903.2`→`408.3`), and three pre-existing wrong `CR 602.2a` cites in `casting.rs` — which describe *who may activate*, i.e. CR 602.2, not the announcement step — were fixed as part of touching that file.

Protocol version bumps to 62 (wire 46); upstream is at 61/45.

https://claude.ai/code/session_01XdoC4fxYSqevQE9bYSWncE


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Ability selection now shows abilities whose costs cannot currently be paid, along with an explanation.
  * Unavailable abilities remain visible but cannot be selected.
  * Legal-action data now includes cost-related activation block reasons for the acting player.
  * Added localized messages for this explanation in supported languages.

* **Bug Fixes**
  * Prevented unaffordable abilities from being incorrectly omitted or activated.
  * Cleared activation-block information when starting, ending, replaying, or disposing of a game session.

* **Tests**
  * Added coverage for multiplayer synchronization, accessibility, selection behavior, and activation-cost handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->