### PR TITLE
feat(helm): server.announceTo, and route /info at the edge

### DIFF
--- a/deploy/helm/phase-server/Chart.yaml
+++ b/deploy/helm/phase-server/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: phase-server
 description: phase.rs multiplayer server (Axum WebSocket) behind Traefik + cert-manager
 type: application
-version: 0.2.0
+version: 0.3.0
 appVersion: "0.59.0"
 home: https://github.com/phase-rs/phase
 sources:

--- a/deploy/helm/phase-server/README.md
+++ b/deploy/helm/phase-server/README.md
@@ -144,6 +144,35 @@ the host in this chart.
 Cloudflare closes idle WebSockets after ~100 s; the client's 5 s application
 ping keeps game connections alive.
 
+## Announcing to a public directory
+
+`server.announceTo` (`PHASE_ANNOUNCE_TO`) makes the server POST a heartbeat to a
+server directory every 60 s so players can find it without a link — for the
+public one, `https://lobby.phase-rs.dev/servers/announce`.
+
+Three things have to hold, and none of them fails the pod:
+
+- **`PUBLIC_URL` must be `https://`.** The directory lists `wss://` addresses
+  only, and it derives them from the advertised URL. An `http://` or unparseable
+  value logs one `error!` at startup — `--announce-to is set but this server
+  cannot announce itself` — and the heartbeat never starts.
+- **`/info` must be reachable from the public internet.** The directory verifies
+  a claim by fetching the announced host's `/info` and comparing mode, server
+  version and both protocol versions against it. The chart routes `/info` on
+  every host it publishes; a proxy or WAF in front of the cluster that hides it
+  makes the announcement unverifiable.
+- **Outbound 443 must be open.** Setting `server.announceTo` opens the same
+  NetworkPolicy egress rule as `networkPolicy.allowBootstrapEgress`.
+
+A directory that is down or refusing logs a `WARN` per tick and nothing else:
+announcing never affects games. `directory refused this announcement` carries
+the status, so a rejection is distinguishable from an unreachable directory.
+
+Under `scaleOut.enabled` each ordinal announces its own
+`phase-<n>.<domain>` — that is the host a join code resolves to. The entry host
+is deliberately not announced: it load-balances across pods, so a player dialling
+it would land on an arbitrary one.
+
 ## Scaling out
 
 `scaleOut.enabled` replaces the single Deployment with a StatefulSet: one pod,

--- a/deploy/helm/phase-server/templates/_helpers.tpl
+++ b/deploy/helm/phase-server/templates/_helpers.tpl
@@ -517,6 +517,10 @@ containers:
             name: {{ . }}
             key: {{ $.Values.server.adminTokenSecretKey }}
       {{- end }}
+      {{- with .Values.server.announceTo }}
+      - name: PHASE_ANNOUNCE_TO
+        value: {{ . | quote }}
+      {{- end }}
       {{- with .Values.server.extraEnv }}
       {{- toYaml . | nindent 6 }}
       {{- end }}

--- a/deploy/helm/phase-server/templates/ingressroute.yaml
+++ b/deploy/helm/phase-server/templates/ingressroute.yaml
@@ -116,8 +116,9 @@ spec:
       {{- end }}
 {{- if .Values.web.enabled }}
 {{- /* The server's non-/ws HTTP surface, walked from build_router and
-     mount_admin_routes rather than recalled: /health, /p2p-draft-backup (and
-     its /{code} form, covered by the same prefix), and /admin/drafts[/{code}]
+     mount_admin_routes rather than recalled: /health, /info,
+     /p2p-draft-backup (and its /{code} form, covered by the same prefix), and
+     /admin/drafts[/{code}]
      when an admin token is mounted. Each match string is the catch-all's plus a
      PathPrefix suffix, so it is unconditionally longer and wins under Traefik's
      default rule-length ordering — the same contract the /ws rule relies on, and
@@ -125,7 +126,7 @@ spec:
      so the first two rules keep the positions
      tests/assert-compression-boundary.sh slices by. */}}
 {{- /* `/admin/*` is deliberately absent here too — see templates/ingress.yaml. */}}
-{{- $serverPaths := list "/health" "/p2p-draft-backup" }}
+{{- $serverPaths := list "/health" "/info" "/p2p-draft-backup" }}
 {{- range $p := $serverPaths }}
     - kind: Rule
       match: Host(`{{ $host }}`) && PathPrefix(`{{ $p }}`)

--- a/deploy/helm/phase-server/templates/networkpolicy.yaml
+++ b/deploy/helm/phase-server/templates/networkpolicy.yaml
@@ -43,8 +43,11 @@ spec:
           protocol: UDP
         - port: 53
           protocol: TCP
-    {{- if .Values.networkPolicy.allowBootstrapEgress }}
-    # Card-data bootstrap (https://data.phase-rs.dev); nothing on the LAN.
+    {{- if or .Values.networkPolicy.allowBootstrapEgress .Values.server.announceTo }}
+    # Card-data bootstrap (https://data.phase-rs.dev) and, when server.announceTo
+    # is set, the directory announce POST; nothing on the LAN. Announcing opens
+    # this rule on its own so turning allowBootstrapEgress off once the PVC is
+    # warm does not silently stop the heartbeat.
     - to:
         - ipBlock:
             cidr: 0.0.0.0/0

--- a/deploy/helm/phase-server/tests/assert-web-routing.sh
+++ b/deploy/helm/phase-server/tests/assert-web-routing.sh
@@ -94,12 +94,43 @@ if [ -f "$workflow" ]; then
 fi
 
 server_src="$repo_root/crates/phase-server/src/main.rs"
-prefixes=$(
+router_src=$(
   { awk '/^fn build_router\(/,/^}/' "$server_src"
-    awk '/^fn mount_admin_routes\(/,/^}/' "$server_src"; } |
-    tr '\n' ' ' |
-    grep -oE '\.route\( *"[^"]+"' |
-    grep -oE '"[^"]+"' | tr -d '"' |
+    awk '/^fn mount_admin_routes\(/,/^}/' "$server_src"; } | tr '\n' ' '
+)
+
+# `.route()` takes a shared path constant as readily as a literal
+# (`.route(INFO_PATH, get(server_info))`), and a literal-only extractor drops
+# those without a word — which is how /info shipped mounted but unrouted, with
+# the SPA catch-all answering it. Each constant is named here with the path it
+# holds, so the next one fails this test instead of vanishing from the surface.
+# The values live in another crate; this list is what keeps them checkable from
+# a script whose only Rust input is the router.
+CONST_ROUTES="INFO_PATH=/info"
+
+const_paths=""
+while IFS= read -r name; do
+  [ -n "$name" ] || continue
+  path=$(grep -oE "^$name=.*" <<<"$CONST_ROUTES" | cut -d= -f2- || true)
+  [ -n "$path" ] ||
+    fail "the router mounts .route($name, ...) but this test does not know which path $name holds — add it to CONST_ROUTES"
+  const_paths+="$path"$'\n'
+done <<<"$(grep -oE '\.route\( *[A-Z][A-Z0-9_]*' <<<"$router_src" | grep -oE '[A-Z][A-Z0-9_]*$' | sort -u || true)"
+
+# Stale entries are as harmful as missing ones: a constant the router dropped
+# would keep this test demanding an edge route for a path nothing serves. This
+# is also the live control for the extractor above — a pattern that stopped
+# matching fails here rather than reporting an empty constant surface.
+while IFS= read -r entry; do
+  [ -n "$entry" ] || continue
+  name=${entry%%=*}
+  grep -qE "\.route\( *$name[^A-Z0-9_]" <<<"$router_src" ||
+    fail "CONST_ROUTES lists $name, but the router no longer mounts it"
+done <<<"$CONST_ROUTES"
+
+prefixes=$(
+  { grep -oE '\.route\( *"[^"]+"' <<<"$router_src" | grep -oE '"[^"]+"' | tr -d '"' || true
+    printf '%s' "$const_paths"; } |
     sed 's|\(/[^/]*\).*|\1|' | sort -u
 )
 # Live instrument: an extractor that silently stopped matching would otherwise

--- a/deploy/helm/phase-server/values.yaml
+++ b/deploy/helm/phase-server/values.yaml
@@ -42,6 +42,15 @@ server:
   # small replicas so one process cannot absorb the whole fleet's traffic.
   maxConnections: ""
   maxGames: ""
+  # Sets PHASE_ANNOUNCE_TO: the public directory endpoint this server announces
+  # itself to every 60s, e.g. https://lobby.phase-rs.dev/servers/announce. Empty
+  # leaves the server unlisted. The directory lists `wss://` addresses derived
+  # from the advertised PUBLIC_URL, so `publicUrl` (or the `ingress.host` it is
+  # derived from) must be https, and it verifies the claim by fetching that
+  # host's `/info` — which the chart routes, but which must also be reachable
+  # from the public internet. Announcing needs outbound 443, so setting this
+  # opens the same egress `networkPolicy.allowBootstrapEgress` does.
+  announceTo: ""
   extraEnv: []
 
 # PHASE_DATA_DIR: card-data.json (~100 MiB, downloaded on first boot),


### PR DESCRIPTION
## Summary

Adds `server.announceTo`, the first-class value for `PHASE_ANNOUNCE_TO` (the directory-announce feature from #8333), and fixes a routing gap it depends on: `/info` was mounted by the server and documented as routed, but the SPA catch-all answered it on the entry host.

## Files changed

- `deploy/helm/phase-server/values.yaml` — `server.announceTo`, documented inline
- `deploy/helm/phase-server/templates/_helpers.tpl` — renders `PHASE_ANNOUNCE_TO`
- `deploy/helm/phase-server/templates/networkpolicy.yaml` — announcing opens the same outbound 443 rule as `networkPolicy.allowBootstrapEgress`
- `deploy/helm/phase-server/templates/ingressroute.yaml` — `/info` added to `$serverPaths`
- `deploy/helm/phase-server/tests/assert-web-routing.sh` — route extractor now resolves path constants
- `deploy/helm/phase-server/README.md` — "Announcing to a public directory"
- `deploy/helm/phase-server/Chart.yaml` — 0.2.0 → 0.3.0

## Track

Developer

## LLM

Model: claude-opus-5[1m]
Tier: Frontier
Thinking: high

## Implementation method (required)

Method: not-applicable — Helm chart and its shell assertion only; no `crates/engine/` game logic is touched.

## CR references

None.

## Verification

- [x] Required checks ran clean, or the exact CI-owned alternative is stated below.
- [x] Gate A output below is for the current committed head.
- [x] Final review-impl below is clean for the current committed head.
- [x] Both anchors cite existing analogous code at the same seam.

Every step of `.github/workflows/helm-chart.yml` was run locally against this head:

- `deploy/helm/phase-server/tests/assert-web-routing.sh` — `server HTTP prefixes: /admin /health /info /p2p-draft-backup /ws` then `assert-web-routing: PASS` (before this change the extractor reported the surface without `/info`)
- `helm lint deploy/helm/phase-server` — `1 chart(s) linted, 0 chart(s) failed`
- `helm template` (default values) — non-empty render
- `helm lint` + `helm template` (scale-out + metrics + autoscaling, with the four `--api-versions`) — renders `StatefulSet`, `HorizontalPodAutoscaler`, `PrometheusRule`, `PodMonitor`, `ServiceMonitor`
- `deploy/helm/phase-server/tests/assert-compression-boundary.sh /tmp/default.yaml /tmp/scaleout-render.yaml` — exit 0
- `helm template` (scale-out, no operator CRDs) — refused, stderr names `monitoring.coreos.com/v1/PrometheusRule`

Behaviour of the new value, both directions:

- `--set server.announceTo=https://lobby.phase-rs.dev/servers/announce --set networkPolicy.allowBootstrapEgress=false` renders `- name: PHASE_ANNOUNCE_TO` with that value **and** one `0.0.0.0/0` egress rule
- the same render with `server.announceTo` unset contains neither (`grep -c` = 0)

The routing assertion is discriminating — three mutants, each caught by a different leg:

- `$serverPaths` back to `list "/health" "/p2p-draft-backup"` → `/info is mounted by the server but no IngressRoute rule routes it under scaleOut`
- `CONST_ROUTES=""` → `the router mounts .route(INFO_PATH, ...) but this test does not know which path INFO_PATH holds`
- a `GONE_PATH=/gone` entry beside the live one → `CONST_ROUTES lists GONE_PATH, but the router no longer mounts it`

The `/info` gap is live-measured, not inferred: on a cluster running this chart at v0.74.0, `curl -i https://<entry-host>/info` returned `200` with `content-type: text/html` and the SPA's `<!doctype html>`, while `curl -i https://<ordinal-host>/info` returned `200 application/json` with the `ServerInfoDocument`.

## Gate A

Gate A PASS head=4152aad86fce628a4540df734d1bb4bfadfc97f9 base=d6d28370c09242182488cac72e16e5a84941885f

The diff touches no Rust, so Gate A's parser range is empty here and its PASS is vacuous — stated rather than presented as coverage.

## Anchored on

- `deploy/helm/phase-server/templates/_helpers.tpl` (`PHASE_MAX_CONNECTIONS` / `PHASE_MAX_GAMES` env block) — the `{{- with .Values.server.<key> }}` shape `announceTo` follows
- `deploy/helm/phase-server/tests/assert-web-routing.sh` (`OPERATOR_ONLY`) — the existing convention of naming an exception in the script so the router walk cannot silently skip a path

## Final review-impl

Final review-impl PASS head=4152aad86fce628a4540df734d1bb4bfadfc97f9

## Claimed parse impact

None.

## Scope Expansion

None.

## Validation Failures

None.

## CI Failures

None.

---

One thing a maintainer has to decide, because contributors cannot touch `.github/workflows/**`:

`assert-web-routing.sh` now reads a path constant whose value is defined in `crates/lobby-broker/src/directory.rs`, which is not in the helm-chart workflow's trigger paths. Changing `INFO_PATH`'s value would not re-run this check. The script's own trigger-path self-assertion only covers files it opens, and it does not open that one — the constant's value is carried in `CONST_ROUTES` instead. Adding `crates/lobby-broker/src/directory.rs` to the workflow's `paths:` would close it.

Separately, and outside this chart: the public directory at `https://lobby.phase-rs.dev/servers/announce` currently rejects every announcement with `422 {"error":"info_unreachable"}`, returned in ~0.1 s. That is `lobby-do.ts`'s `fetchInfoDocument` failing before any network wait. It reproduces against a host that is not behind Cloudflare and serves `200 application/json` at `/info`, and against a target whose origin does not answer at all — same error, same ~0.1 s — so no `/info` subrequest is being made. Filed here only as a pointer; it is a Worker-side issue, not a chart one.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional Helm setting to announce servers to a public directory every 60 seconds.
  * Added `/info` routing to support directory verification.
  * Automatically enables outbound HTTPS access when directory announcements are configured.
  * Added support for announcing individual scaled server instances.

* **Documentation**
  * Documented configuration requirements, verification behavior, and troubleshooting details.

* **Chores**
  * Bumped the Helm chart version to 0.3.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->