### PR TITLE
fix(lobby): stop rejecting every server announcement

### DIFF
--- a/lobby-worker/package-lock.json
+++ b/lobby-worker/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "devDependencies": {
         "@cloudflare/workers-types": "^5.20260721.1",
+        "miniflare": "4.20260721.0",
         "tsx": "^4.19.4",
         "typescript": "^5.6.0",
         "wrangler": "^4.113.0"

--- a/lobby-worker/package.json
+++ b/lobby-worker/package.json
@@ -13,6 +13,7 @@
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^5.20260721.1",
+    "miniflare": "4.20260721.0",
     "tsx": "^4.19.4",
     "typescript": "^5.6.0",
     "wrangler": "^4.113.0"

--- a/lobby-worker/src/lobby-do.ts
+++ b/lobby-worker/src/lobby-do.ts
@@ -707,14 +707,22 @@ export class LobbyDO {
    *  reader rather than hanging past the timeout. Nothing throws out of here —
    *  the announcer gets a 4xx, never a 5xx.
    *
-   *  `redirect: "error"` is load-bearing twice over. The question this fetch
-   *  asks is whether THIS host serves an info document matching THIS
+   *  Not following redirects is load-bearing twice over. The question this
+   *  fetch asks is whether THIS host serves an info document matching THIS
    *  announcement, and a redirect answers a different question — some other
    *  host does — so following one would verify the wrong server even with no
    *  attacker present. It also closes the pivot: announcing is open by design
    *  (see the charter), so a follower would let any caller aim the verifier at
    *  a public hostname that redirects wherever it likes. Failing closed on a
    *  redirect keeps the destination equal to the announced one.
+   *
+   *  `redirect: "manual"` is how that is spelled on Workers: the runtime
+   *  refuses `redirect: "error"` at the call, throwing
+   *  `TypeError: Invalid redirect value, must be one of "follow" or "manual"`,
+   *  which this method's catch would report as an unreachable host for every
+   *  announcement including the good ones. Under `"manual"` a 3xx arrives as
+   *  an ordinary non-ok response with the redirect NOT taken, so the `ok`
+   *  test below is what refuses it.
    *
    *  What this deliberately does NOT do is resolve the hostname and reject
    *  private, loopback or link-local addresses. Workers exposes no DNS
@@ -727,9 +735,10 @@ export class LobbyDO {
       const response = await fetch(infoUrl, {
         signal: AbortSignal.timeout(INFO_FETCH_TIMEOUT_MS),
         headers: { accept: "application/json" },
-        redirect: "error",
+        redirect: "manual",
       });
-      // A 404 and a refused connection are one fact here: no usable document.
+      // A 3xx, a 404 and a refused connection are one fact here: no usable
+      // document.
       // `body === null` is handled explicitly rather than optional-chained,
       // which would silently read `undefined`.
       if (!response.ok || response.body === null) return { kind: "unreachable" };

--- a/lobby-worker/test/directory.test.mjs
+++ b/lobby-worker/test/directory.test.mjs
@@ -1,7 +1,5 @@
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
 import { test } from "node:test";
-import { fileURLToPath } from "node:url";
 
 import {
   ANNOUNCE_TIMEOUT_MS,
@@ -848,30 +846,4 @@ test("serverProbeEvents projects through the shared column layout", () => {
   const [missing] = serverProbeEvents([{ url: KNOWN_URL, outcome: "connect_fail" }]);
   assert.deepEqual(missing.blobs, [KNOWN_URL, "connect_fail", ""]);
   assert.deepEqual(missing.doubles, [0]);
-});
-
-// `fetchInfoDocument` lives in `lobby-do.ts`, which imports `DurableObject` and
-// so cannot be loaded outside workerd — there is no harness here that can drive
-// a real redirect at it. This asserts the option is present in the source
-// instead. That is a weaker claim than a behavioural test and is written down
-// as one: it proves the flag has not been dropped, not that the runtime honours
-// it. It exists because the alternative is no gate at all on a verification
-// fetch that any caller can aim, announcing being open by design.
-test("the info-document verification fetch refuses redirects", () => {
-  const source = readFileSync(
-    fileURLToPath(new URL("../src/lobby-do.ts", import.meta.url)),
-    "utf8",
-  );
-  const call = source.slice(source.indexOf("await fetch(infoUrl, {"));
-  assert.ok(
-    call.startsWith("await fetch(infoUrl, {"),
-    "the verification fetch call was not found — this guard is keyed on it",
-  );
-  const options = call.slice(0, call.indexOf("});") + 3);
-  assert.match(
-    options,
-    /redirect:\s*"error"/,
-    'the verification fetch must pass redirect: "error" so a redirecting host '
-      + "fails closed instead of pointing the verifier at another origin",
-  );
 });

--- a/lobby-worker/test/info-fetch.test.mjs
+++ b/lobby-worker/test/info-fetch.test.mjs
@@ -1,0 +1,145 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import http from "node:http";
+import { dirname, resolve } from "node:path";
+import { after, before, test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+import { Miniflare } from "miniflare";
+
+// `fetchInfoDocument` (lobby-do.ts) is the announce handler's verifier: it
+// fetches the announced host's own `/info` and every non-`ok` outcome becomes
+// a 422 `info_unreachable`. Its contract is entirely about how the WORKERS
+// runtime answers a `fetch` — a redirect option Node accepts and workerd
+// rejects reads as "every server on earth is unreachable" — so this runs the
+// real method body inside workerd rather than under Node's fetch.
+//
+// The body is read as SOURCE TEXT and re-hosted in a Miniflare worker for the
+// same reason `conn-attachment.test.mjs` parses its declarations: `lobby-do.ts`
+// imports `../broker-wasm-pkg/broker_bg.wasm` and calls `initSync` at module
+// scope, and that package is a gitignored build artifact absent from the plain
+// checkout CI tests (`npm ci && pnpm test`, never a wasm build).
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(HERE, "../..");
+const SOURCE = readFileSync(resolve(REPO_ROOT, "lobby-worker/src/lobby-do.ts"), "utf8");
+
+// Deliberately unlike production's 3 s / 4096: a body that reached for a
+// literal instead of these would hang the timeout row for three seconds and
+// stop discriminating the over-cap row.
+const TIMEOUT_MS = 250;
+const MAX_BYTES = 512;
+
+/** The body between `header`'s opening `{` and its brace-depth-matched close. */
+function methodBody(header) {
+  const start = SOURCE.indexOf(header);
+  assert.notEqual(start, -1, `expected to find \`${header}\``);
+  const bodyStart = SOURCE.indexOf("{", start);
+  let depth = 0;
+  for (let index = bodyStart; index < SOURCE.length; index += 1) {
+    if (SOURCE[index] === "{") depth += 1;
+    if (SOURCE[index] === "}") {
+      depth -= 1;
+      if (depth === 0) return SOURCE.slice(bodyStart + 1, index);
+    }
+  }
+  throw new Error(`expected \`${header}\` to be closed by a matching brace`);
+}
+
+const WORKER = `
+const INFO_FETCH_TIMEOUT_MS = ${TIMEOUT_MS};
+const MAX_INFO_BYTES = ${MAX_BYTES};
+
+// Stand-in for directory.ts's reader, whose own bound behaviour is pinned by
+// directory.test.mjs. Same contract: the text, or null once the cap is passed.
+async function readBoundedText(body, max) {
+  const text = await new Response(body).text();
+  return text.length > max ? null : text;
+}
+
+async function fetchInfoDocument(infoUrl) {${methodBody("private async fetchInfoDocument(infoUrl: string): Promise<InfoFetch> {")}}
+
+export default {
+  async fetch(request) {
+    const target = new URL(request.url).searchParams.get("u");
+    return Response.json(await fetchInfoDocument(target));
+  },
+};
+`;
+
+const INFO_BODY = JSON.stringify({ mode: "Full", server_version: "0.74.0" });
+
+let mf;
+let origin;
+let base;
+/** Paths the origin actually served, so "unreachable" can be told apart from
+ *  "never asked". */
+const hits = [];
+
+before(async () => {
+  origin = http.createServer((request, response) => {
+    const path = request.url;
+    hits.push(path);
+    if (path === "/info") {
+      response.writeHead(200, { "content-type": "application/json" });
+      response.end(INFO_BODY);
+    } else if (path === "/moved") {
+      response.writeHead(302, { location: "/info" });
+      response.end();
+    } else if (path === "/huge") {
+      response.writeHead(200, { "content-type": "application/json" });
+      response.end("x".repeat(MAX_BYTES + 1));
+    } else if (path === "/slow") {
+      // Held open with no bytes and no close: only the fetch's own timeout
+      // ends this one.
+    } else {
+      response.writeHead(404);
+      response.end("no such document");
+    }
+  });
+  await new Promise((ready) => origin.listen(0, "127.0.0.1", ready));
+  base = `http://127.0.0.1:${origin.address().port}`;
+  mf = new Miniflare({ compatibilityDate: "2026-05-01", modules: true, script: WORKER });
+  await mf.ready;
+});
+
+after(async () => {
+  await mf?.dispose();
+  origin?.closeAllConnections();
+  await new Promise((done) => origin.close(done));
+});
+
+const probe = async (path) => {
+  const response = await mf.dispatchFetch(`http://verifier/?u=${encodeURIComponent(base + path)}`);
+  return response.json();
+};
+
+test("a 200 info document is read back verbatim", async () => {
+  assert.deepEqual(await probe("/info"), { kind: "ok", text: INFO_BODY });
+});
+
+test("a redirect is unreachable and is not followed", async () => {
+  const before = hits.length;
+  assert.deepEqual(await probe("/moved"), { kind: "unreachable" });
+  // The redirect target is the same origin, so a follower would have returned
+  // `ok` above; this pins that the second request never happened either.
+  assert.deepEqual(hits.slice(before), ["/moved"]);
+});
+
+test("a 404 is unreachable", async () => {
+  assert.deepEqual(await probe("/gone"), { kind: "unreachable" });
+});
+
+test("a host that never answers is unreachable, not a hang", async () => {
+  const before = hits.length;
+  const started = Date.now();
+  assert.deepEqual(await probe("/slow"), { kind: "unreachable" });
+  // Reached the origin and was ended by the fetch's own timeout — otherwise
+  // this row would pass for a host that simply refused the connection.
+  assert.deepEqual(hits.slice(before), ["/slow"]);
+  assert.ok(Date.now() - started >= TIMEOUT_MS, "returned before the timeout could fire");
+});
+
+test("an over-cap body is too_large, not unreachable", async () => {
+  assert.deepEqual(await probe("/huge"), { kind: "too_large" });
+});


### PR DESCRIPTION
## Summary

The lobby directory's verification fetch passed `redirect: "error"`, an option the Workers runtime refuses at the call itself, so every server announcement was answered `422 info_unreachable` and `GET /servers` listed nobody. This switches it to `redirect: "manual"`, which keeps the redirect unfollowed, and replaces the source-text guard that let the bad value ship with a test that drives the real method body inside workerd.

## Files changed

- `lobby-worker/src/lobby-do.ts` — `fetchInfoDocument` uses `redirect: "manual"`; the surrounding comment now describes what the runtime actually does.
- `lobby-worker/test/info-fetch.test.mjs` — new: runs the method body in workerd via Miniflare against a local origin.
- `lobby-worker/test/directory.test.mjs` — drops the superseded source-text guard (and its two now-unused imports).
- `lobby-worker/package.json`, `lobby-worker/package-lock.json` — `miniflare` promoted from a transitive dependency of `wrangler` to an explicit devDependency, pinned to the version already in the lockfile.

## Track

Developer

## LLM

Model: claude-opus-5[1m]
Tier: Frontier
Thinking: high

## Implementation method (required)

Method: not-applicable — Cloudflare Worker shell fix, no `crates/engine/` game logic.

## CR references

None.

## Verification

- [x] Required checks ran clean, or the exact CI-owned alternative is stated below.
- [x] Gate A output below is for the current committed head.
- [x] Final review-impl below is clean for the current committed head.
- [x] Both anchors cite existing analogous code at the same seam.

- `cd lobby-worker && npm ci && pnpm test` (the CI "Lobby worker" job's exact commands) — `# tests 94 # pass 94 # fail 0`.
- The measured cause, from a Miniflare run on the pinned runtime (workerd 1.20260721.1, `compatibility_date = "2026-05-01"`): `fetch(url, { redirect: "error" })` throws `TypeError: Invalid redirect value, must be one of "follow" or "manual" ("error" won't be implemented since it does not make sense at the edge; use "manual" and check the response status code).` The same fetch with `redirect: "manual"`, in the same run, returned `200` for a JSON document and `302` (not followed) for a redirect. `fetchInfoDocument` maps any throw to `unreachable`, and `announceResponse` maps that to `422 info_unreachable` — which is what the live alpha server has been getting on every 60 s announce.
- How the new test discriminates: run against the pre-fix source it fails 4 of 5 rows, including the plain 200 document, because the fetch throws before a request leaves the isolate; against the fixed source all 5 pass. The redirect row asserts both that the answer is `unreachable` and that the origin logged exactly one request — the redirect target is on the same origin, so following it would have produced `ok`, and throwing before the fetch would have produced no request at all. The timeout row likewise asserts the origin was reached and that at least the timeout elapsed, so it cannot pass for a host that merely refused the connection. Its fixture timeout (250 ms) and body cap (512 B) differ from production's (3 s, 4096 B) so a body reaching for a literal instead of the constants it is given would not stay green.
- `npm run typecheck` reports three errors on this branch (`../broker-wasm-pkg/broker.js` missing, two `unknown[]` arguments). The identical three are present on the base commit — that script is not part of the CI job, and the wasm package it wants is a gitignored build artifact.

## Gate A

Gate A PASS head=4a611e43aee0f6b1cfd42441b3a390d502990c11 base=d6d28370c09242182488cac72e16e5a84941885f

Gate A is the Rust parser-combinator gate; this diff changes no Rust, so it passes over an empty set of relevant files rather than by inspecting this change.

## Anchored on

- `lobby-worker/test/conn-attachment.test.mjs:23` — the existing precedent for reading `lobby-do.ts` as source text, because it calls `initSync` on a gitignored wasm artifact at module scope and cannot be imported.
- `lobby-worker/test/directory.test.mjs:41` — the existing convention of giving a harness constants deliberately unlike production's, so code that reaches for a literal fails instead of coinciding.

## Final review-impl

Final review-impl PASS head=4a611e43aee0f6b1cfd42441b3a390d502990c11

## Claimed parse impact

None.

## Scope Expansion

None.

## Validation Failures

None.

## CI Failures

None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of announced host information documents when the host returns a redirect.
  - Redirect responses are no longer followed and are treated as unavailable, preventing them from being incorrectly reported as unreachable.
  - Improved handling of unavailable documents, including not-found responses, connection failures, timeouts, and oversized responses.

- **Tests**
  - Added coverage for successful retrievals, redirects, unavailable hosts, timeouts, and response-size limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->