### PR TITLE
fix(parser): emit every conjunct of a compound continuous static (#8395)

### DIFF
--- a/crates/engine/src/parser/oracle_effect/animation.rs
+++ b/crates/engine/src/parser/oracle_effect/animation.rs
@@ -19,7 +19,7 @@ use crate::parser::oracle_ir::ast::*;
 use crate::parser::oracle_ir::context::ParseContext;
 use crate::parser::oracle_nom::bridge::nom_on_lower;
 use crate::types::ability::{PtValue, QuantityExpr, QuantityRef};
-use crate::types::card_type::Supertype;
+use crate::types::card_type::{CoreType, Supertype};
 use crate::types::keywords::Keyword;
 use crate::types::mana::ManaColor;
 
@@ -341,7 +341,13 @@ fn strip_prefix_word<'a>(text: &'a str, word: &str) -> Option<&'a str> {
     }
 }
 
-pub(super) fn parse_fixed_become_pt_prefix(text: &str) -> Option<(i32, i32, &str)> {
+/// `pub(crate)` so the additive-type leaf in `oracle_static/type_change.rs`
+/// (`parse_additive_type_clause_modifications`) can share this exact "leading
+/// fixed `N/M`" test rather than reimplementing it. That leaf keys its
+/// animation-parsing route on this prefix precisely because the *trailing*
+/// "base power and toughness N/M" form must keep the older word-split route —
+/// see the double-emit guard documented there.
+pub(crate) fn parse_fixed_become_pt_prefix(text: &str) -> Option<(i32, i32, &str)> {
     let (rest, (power, toughness)) = nom_primitives::parse_pt_value.parse(text).ok()?;
     match (power, toughness) {
         (
@@ -494,6 +500,32 @@ fn parse_animation_core_type(input: &str) -> OracleResult<'_, AnimationTypeToken
     let (rest, _) = opt(tag_no_case::<_, _, OracleError<'_>>("s")).parse(rest)?;
     let (rest, _) = alpha_word_boundary(rest)?;
     Ok((rest, AnimationTypeToken::CoreType(core)))
+}
+
+/// CR 205.2a: map one whole type word — singular or plural — to its core type,
+/// or `None` if the word is not a core type.
+///
+/// `pub(crate)` so the copy-exception type-list mapper
+/// (`become_copy_except.rs::append_color_and_type_modifications`) can share this
+/// crate's one plural-tolerant core-type recognizer rather than hand-rolling a
+/// suffix strip. `CoreType::from_str` matches the singular literals only, so a
+/// plural head word — "they're 3/3 **creatures** in addition to their other
+/// types" (Rebuild the City, Astral Dragon) — would otherwise fall through and
+/// be emitted as a fabricated `AddSubtype{"Creatures"}` instead of
+/// `AddType{Creature}`, leaving the tokens non-creatures.
+///
+/// The word must be consumed in full: [`parse_animation_core_type`]'s own
+/// word boundary already rejects "landwalk" / "creatured", and the emptiness
+/// check here rejects a bare prefix match.
+pub(crate) fn core_type_from_animation_word(word: &str) -> Option<CoreType> {
+    let (rest, token) = parse_animation_core_type(word).ok()?;
+    if !rest.is_empty() {
+        return None;
+    }
+    let AnimationTypeToken::CoreType(name) = token else {
+        return None;
+    };
+    CoreType::from_str(name).ok()
 }
 
 /// Parse a CR 205.4 supertype keyword (case-insensitive, word-boundary terminated).
@@ -891,6 +923,88 @@ fn strip_still_a_type_rider(text: &str) -> &str {
     .filter_map(|marker| lower.find(marker))
     .min()
     .map_or(text, |idx| text[..idx].trim_end())
+}
+
+/// nom combinator: the boundary between an animation clause and a conjoined
+/// ability clause — "… and it has trample", "… and they gain flying",
+/// "… and has defender".
+///
+/// CR 613.1f + CR 613.4b: the conjunct grants an ability (Layer 6) while the
+/// clause before it sets types and base P/T (Layer 4 / Layer 7b). Both halves
+/// belong to one printed sentence.
+///
+/// Two independent axes — the optional pronoun subject and the grant verb — are
+/// composed as a single `opt` and a single `alt`, never the 2 × 4 `tag` cross
+/// product. Mirrors [`parse_in_addition_other_types_marker`] in this file (see
+/// `oracle_nom/PATTERNS.md` §8, "compose, don't enumerate permutations").
+///
+/// The conjunction carries **no leading space**: this combinator is driven by
+/// `nom_primitives::scan_preceded`, which advances to word boundaries and
+/// `trim_start()`s the remainder, so the slice offered to it never begins with
+/// whitespace. A `tag(" and ")` here would match at most the first position and
+/// then never again.
+fn parse_animation_conjunct_boundary(input: &str) -> OracleResult<'_, ()> {
+    let (input, _) = tag("and ").parse(input)?;
+    let (input, _) = opt(alt((tag("it "), tag("they ")))).parse(input)?;
+    let (input, _) = alt((tag("has "), tag("have "), tag("gains "), tag("gain "))).parse(input)?;
+    Ok((input, ()))
+}
+
+/// CR 613.1d + CR 613.4b + CR 613.1f: peel a conjoined ability clause off the
+/// end of an animation body, returning `(animation_body, conjunct_tail)`.
+///
+/// Without this peel one printed sentence loses a half: "it's a 0/0 creature in
+/// addition to its other types and it has annihilator 2" yields either the
+/// animation or the keyword, never both. CR 205.1b keeps the prior types while
+/// the animation adds Creature, so both halves must survive.
+///
+/// The boundary is located by word-boundary scanning (`scan_preceded` — the
+/// `scan_timing_restrictions` idiom) rather than a substring search, so the
+/// verb can never match inside a longer word.
+///
+/// **Deliberately not consumed by [`parse_animation_spec`] itself.**
+/// `parse_animation_spec` has ~53 call sites, and the one-shot animate effects
+/// among them ("becomes a 4/4 creature and gains haste until end of turn")
+/// already parse this tail on their own; silently consuming it there would
+/// grant the keyword twice. This peel is invoked only from
+/// `parse_pronoun_becomes_type_static`, a 6.6× smaller blast radius.
+pub(crate) fn split_animation_conjunct_clause(text: &str) -> Option<(&str, &str)> {
+    let (before, (), tail) =
+        nom_primitives::scan_preceded(text, parse_animation_conjunct_boundary)?;
+    let body = before.trim_end().trim_end_matches(',').trim_end();
+    // A line that is *only* a conjunct is not an animation with a tail.
+    (!body.is_empty()).then_some((body, tail.trim()))
+}
+
+/// CR 613.1f (Layer 6): map an animation conjunct tail to the keywords it
+/// grants — "trample", "vigilance and menace", "flying, haste".
+///
+/// Returns `None` rather than an empty or partial vector, so the caller declines
+/// the whole line instead of emitting a silent half-parse (an animation whose
+/// ability clause was quietly dropped). Three cases decline:
+/// * the tail opens a quoted ability — owned by
+///   `parse_quoted_ability_modifications`, not by keyword mapping;
+/// * the tail yields no tokens at all;
+/// * any token fails to map, which would leave a partial grant behind.
+///
+/// Reuses the same `split_token_keyword_list` + `map_token_keyword` pair that
+/// [`split_animation_keyword_clause`] uses for the `" with "` tail — the two
+/// clause shapes are grammatical siblings and must not drift apart.
+pub(crate) fn parse_animation_conjunct_keywords(tail: &str) -> Option<Vec<Keyword>> {
+    if peek(tag::<_, _, OracleError<'_>>("\"")).parse(tail).is_ok() {
+        return None;
+    }
+    let keyword_text = tail.trim_end_matches('.').trim();
+    let tokens = split_token_keyword_list(keyword_text);
+    if tokens.is_empty() {
+        return None;
+    }
+    let keywords: Vec<Keyword> = tokens
+        .iter()
+        .copied()
+        .filter_map(map_token_keyword)
+        .collect();
+    (keywords.len() == tokens.len()).then_some(keywords)
 }
 
 #[cfg(test)]

--- a/crates/engine/src/parser/oracle_effect/become_copy_except.rs
+++ b/crates/engine/src/parser/oracle_effect/become_copy_except.rs
@@ -81,6 +81,7 @@ use super::super::oracle_nom::bridge::{nom_on_lower, split_once_on_lower};
 use super::super::oracle_nom::primitives as nom_primitives;
 use super::super::oracle_static::{parse_quoted_ability_modifications, split_keyword_list};
 use super::super::oracle_util::canonicalize_subtype_name;
+use super::animation::{core_type_from_animation_word, split_in_addition_tail};
 use crate::parser::oracle_ir::context::ParseContext;
 use crate::types::ability::{
     ContinuousModification, ObjectScope, QuantityExpr, QuantityRef, RoundingMode,
@@ -605,10 +606,35 @@ fn parse_subject_pt_and_types(input: &str) -> Option<(&str, Vec<ContinuousModifi
     Some((rest, mods))
 }
 
-/// CR 707.9b + CR 707.9d: Plural token-copy exception — "they're N/M {types}
-/// creature[s] in addition to their other types" (Astral Dragon / Project Image).
-/// Mirrors [`parse_subject_pt_and_types`] but uses the plural anaphor and
-/// terminates on "creature(s)" rather than a bare type list.
+/// CR 707.9b + CR 205.1b: Plural token-copy exception — "they're N/M {types}
+/// creature[s] in addition to their other types" (Astral Dragon, Project Image,
+/// Rebuild the City). Mirrors [`parse_subject_pt_and_types`], which is the
+/// singular sibling and the model for all three corrections below.
+///
+/// Three things this must get right, none of which it previously did:
+///
+/// * **The type text keeps its "creature(s)" head.** It used to be consumed as
+///   a delimiter and discarded, so `AddType{Creature}` was emitted only as a
+///   side effect of the `replace_types && has_exact_creature_subtype` re-add in
+///   [`append_color_and_type_modifications`]. That branch cannot fire for a
+///   token with no creature subtype (Rebuild the City), leaving those tokens
+///   non-creatures entirely.
+/// * **The CR 205.1b carve-out is matched by the shared authority.** The old
+///   phrase lists each began with a space that the `"creatures "` split had
+///   already consumed, so every carve-out branch was unreachable and
+///   `replace_color` / `replace_types` were permanently `true`. That emitted
+///   `RemoveAllSubtypes{Creature}` for a card whose text says "in addition to
+///   their other types" — a CR 205.1b retention violation (Astral Dragon).
+///   `split_in_addition_tail` (`animation.rs`, `pub(crate)` for sharing per its
+///   own doc comment) is the single authority for that marker and brings all
+///   four possessive pronouns and the CR 105.3 "colors and " axis with it.
+///   A "colors"-only carve-out has no plural spelling in that marker class; it
+///   was equally unreachable before, so nothing regresses by omitting it.
+/// * **The remainder is the text AFTER the clause.** The old code kept the
+///   `before` half of [`split_at_body_boundary`] (the singular sibling
+///   correctly takes `after`), orphaning the trailing conjunct instead of
+///   returning it to [`parse_except_clause`]'s loop — which is how "and they
+///   have vigilance and menace" was lost.
 fn parse_theyre_pt_and_types(input: &str) -> Option<(&str, Vec<ContinuousModification>)> {
     let (rest, _) = alt((tag::<_, _, OracleError<'_>>("they're "), tag("they are ")))
         .parse(input)
@@ -617,20 +643,27 @@ fn parse_theyre_pt_and_types(input: &str) -> Option<(&str, Vec<ContinuousModific
     let (rest, (power, toughness)) = parse_pt_pair(rest)?;
     let (rest, _) = tag::<_, _, OracleError<'_>>(" ").parse(rest).ok()?;
 
-    let (type_text, rest) = split_on_first_of(rest, &["creatures ", "creature "])?;
-    let (rest, suffix) = if let Some((_, rest)) =
-        split_on_first_of(rest, &[" in addition to their other colors and types"])
-    {
-        (rest, AdditiveSuffix::ColorsAndTypes)
-    } else if let Some((_, rest)) = split_on_first_of(rest, &[" in addition to their other colors"])
-    {
-        (rest, AdditiveSuffix::Colors)
-    } else if let Some((_, rest)) = split_on_first_of(rest, &[" in addition to their other types"])
-    {
-        (rest, AdditiveSuffix::Types)
-    } else {
-        let (rest, _) = split_at_body_boundary(rest);
-        (rest, AdditiveSuffix::None)
+    let (type_text, rest, suffix) = match split_in_addition_tail(rest) {
+        Some((type_text, marker)) => {
+            // `marker` is the matched marker slice; the clause continues
+            // immediately after it. Recover that position the same way
+            // `split_in_addition_tail` computes it — prefix length, then skip
+            // the separating whitespace — so the remainder is exact.
+            let after_prefix = rest[type_text.len()..].trim_start();
+            let after_marker = &after_prefix[marker.len()..];
+            // CR 105.3: the marker itself carries the color axis when it reads
+            // "in addition to their other colors and types".
+            let suffix = if nom_primitives::scan_contains(marker, "colors and ") {
+                AdditiveSuffix::ColorsAndTypes
+            } else {
+                AdditiveSuffix::Types
+            };
+            (type_text, after_marker, suffix)
+        }
+        None => {
+            let (type_text, rest) = split_at_body_boundary(rest);
+            (type_text, rest, AdditiveSuffix::None)
+        }
     };
 
     let (replace_color, replace_types) = match suffix {
@@ -678,6 +711,15 @@ fn append_color_and_type_modifications(
         }
         if let Some((_, supertype)) = parse_supertype_word(word) {
             type_mods.push(ContinuousModification::AddSupertype { supertype });
+            continue;
+        }
+        // CR 205.2a: recognize the core type through the crate's plural-tolerant
+        // recognizer FIRST. `CoreType::from_str` matches the singular literals
+        // only, so a plural head word ("they're 3/3 creatures in addition to
+        // their other types") would fall through and be emitted as a fabricated
+        // `AddSubtype{"Creatures"}` — the tokens would never become creatures.
+        if let Some(core_type) = core_type_from_animation_word(word) {
+            type_mods.push(ContinuousModification::AddType { core_type });
             continue;
         }
         let canonical = canonicalize_subtype_name(word);
@@ -1050,7 +1092,22 @@ pub(super) fn parse_becomes_type_loses_all(
 /// copy-a-vanishing-creature case we only over-grant a redundant, benign
 /// instance rather than producing wrong behavior.
 fn parse_it_has_keywords(input: &str) -> Option<(&str, Vec<ContinuousModification>)> {
-    let (rest, _) = tag::<_, _, OracleError<'_>>("it has ").parse(input).ok()?;
+    // CR 707.9a: accept the same subject alternation the two quoted-ability arms
+    // beside this one already use (`parse_it_has_quoted_ability`,
+    // `parse_it_has_keywords_then_quoted_ability`). Without the plural "they
+    // have " form a BARE keyword conjunct returned by
+    // `parse_theyre_pt_and_types` has no consumer: `parse_except_clause`'s loop
+    // falls through to `skip_to_next_conjunction` and the keywords are dropped
+    // (Rebuild the City's "and they have vigilance and menace"). Matching the
+    // neighbours exactly also keeps the gendered forms from drifting apart.
+    let (rest, _) = alt((
+        tag::<_, _, OracleError<'_>>("it has "),
+        tag("he has "),
+        tag("she has "),
+        tag("they have "),
+    ))
+    .parse(input)
+    .ok()?;
     // Keyword list terminates at " and it " (next body), the period, or end.
     let (kw_text, remainder) = split_at_body_boundary(rest);
     let mut modifications = Vec::new();
@@ -2785,6 +2842,121 @@ mod tests {
                 }
             )),
             "missing AddType(Creature); got {mods:?}"
+        );
+    }
+
+    /// V11 (issue #8395; CR 707.9b + CR 205.1b): Rebuild the City — "Create three
+    /// tokens that are copies of it, except they're 3/3 creatures in addition to
+    /// their other types and they have vigilance and menace."
+    ///
+    /// Three defects had to be corrected together before this card works: the
+    /// `"creatures"` head word was consumed as a delimiter and discarded (so no
+    /// `AddType`), the carve-out markers were unreachable behind a leading space
+    /// the delimiter split had already eaten, and `split_at_body_boundary`'s
+    /// BEFORE half was kept — orphaning the trailing conjunct instead of
+    /// returning it to `parse_except_clause`'s loop.
+    #[test]
+    fn rebuild_the_city_tokens_are_creatures_with_both_keywords() {
+        let (_, mods) = parse_except_clause(
+            ", except they're 3/3 creatures in addition to their other types and they have vigilance and menace",
+            "Rebuild the City",
+            &ParseContext::default(),
+        )
+        .unwrap();
+        assert!(
+            mods.contains(&ContinuousModification::SetPower { value: 3 })
+                && mods.contains(&ContinuousModification::SetToughness { value: 3 }),
+            "CR 707.9b: the copy exception sets base 3/3; got {mods:?}"
+        );
+        assert!(
+            mods.contains(&ContinuousModification::AddType {
+                core_type: CoreType::Creature,
+            }),
+            "the \"creatures\" head word must yield AddType(Creature) — it used to be consumed \
+             as a delimiter and thrown away, leaving the tokens non-creatures; got {mods:?}"
+        );
+        for keyword in [Keyword::Vigilance, Keyword::Menace] {
+            assert!(
+                mods.contains(&ContinuousModification::AddKeyword {
+                    keyword: keyword.clone(),
+                }),
+                "the trailing conjunct's {keyword:?} must survive; got {mods:?}"
+            );
+        }
+        assert!(
+            !mods
+                .iter()
+                .any(|m| matches!(m, ContinuousModification::RemoveAllSubtypes { .. })),
+            "CR 205.1b: \"in addition to their other types\" retains the copied types; \
+             got {mods:?}"
+        );
+    }
+
+    /// V11 companion — defect 4 in ISOLATION. The bare plural keyword conjunct
+    /// must be consumed on its own.
+    ///
+    /// Before the plural alternation was added to `parse_it_has_keywords`,
+    /// `parse_except_clause`'s loop fell through to `skip_to_next_conjunction`
+    /// and both keywords were lost, which would have made the orphaned-remainder
+    /// fix inert for the very card it exists to repair. Asserting it separately
+    /// is what proves the test above cannot pass on its P/T half alone.
+    #[test]
+    fn plural_they_have_keyword_conjunct_is_consumed() {
+        let (_, mods) = parse_except_clause(
+            ", except they have vigilance and menace",
+            "Rebuild the City",
+            &ParseContext::default(),
+        )
+        .unwrap();
+        for keyword in [Keyword::Vigilance, Keyword::Menace] {
+            assert!(
+                mods.contains(&ContinuousModification::AddKeyword {
+                    keyword: keyword.clone(),
+                }),
+                "the plural \"they have\" arm must grant {keyword:?}; got {mods:?}"
+            );
+        }
+    }
+
+    /// V12 (CR 205.1b is the retention authority; CR 707.9d's CDA carve-out is
+    /// why the clause is written at all): Astral Dragon — "…create two tokens
+    /// that are copies of target noncreature permanent, except they're 3/3
+    /// Dragon creatures in addition to their other types, and they have flying."
+    ///
+    /// The card says "in addition to their other types", so the copied types are
+    /// RETAINED. The plural arm nonetheless emitted `RemoveAllSubtypes{Creature}`
+    /// because its carve-out markers were unreachable, leaving `replace_types`
+    /// permanently true.
+    ///
+    /// REACH-GUARD: this is the canonical bare-negative hazard — an absence
+    /// assertion alone would pass if the arm simply declined and emitted
+    /// nothing. The paired positives are what make it a test.
+    #[test]
+    fn astral_dragon_retains_copied_types_without_subtype_wipe() {
+        let (_, mods) = parse_except_clause(
+            ", except they're 3/3 dragon creatures in addition to their other types, and they have flying",
+            "Astral Dragon",
+            &ParseContext::default(),
+        )
+        .unwrap();
+        assert!(
+            mods.contains(&ContinuousModification::AddSubtype {
+                subtype: "Dragon".to_string(),
+            }),
+            "reach-guard: the Dragon subtype must still be added; got {mods:?}"
+        );
+        assert!(
+            mods.contains(&ContinuousModification::AddType {
+                core_type: CoreType::Creature,
+            }),
+            "reach-guard: the tokens must still become creatures; got {mods:?}"
+        );
+        assert!(
+            !mods
+                .iter()
+                .any(|m| matches!(m, ContinuousModification::RemoveAllSubtypes { .. })),
+            "CR 205.1b: an \"in addition to their other types\" carve-out must NOT wipe the \
+             copied creature types; got {mods:?}"
         );
     }
 }

--- a/crates/engine/src/parser/oracle_static/dispatch.rs
+++ b/crates/engine/src/parser/oracle_static/dispatch.rs
@@ -27,6 +27,43 @@ fn parse_self_reference_subject(input: &str) -> OracleResult<'_, ()> {
     Err(oracle_err(input))
 }
 
+/// CR 613.1f + CR 611.3a: a self-referential keyword grant with a trailing
+/// "as long as" gate — `"<self-ref> has <keyword> as long as <condition>"`.
+/// Returns `(keyword_text, condition_text)`, both slices of `input`.
+///
+/// Replaces a hand-rolled arm that located the first `" has "` and the first
+/// `" as long as "` by raw substring search, and reproduces its accepted-input
+/// set for every line that actually reaches it. The legacy code sliced the span
+/// BETWEEN those two markers, discarded everything before it, and hardcoded
+/// `TargetFilter::SelfRef`.
+///
+/// **The subject peel is not optional and is what makes the arm honest.**
+/// Requiring the pre-verb span to be exactly a self-reference does three things
+/// the legacy slice did not:
+///   * it justifies the `SelfRef` the arm emits, instead of asserting it;
+///   * it keeps the keyword span free of a subject that `map_keyword` could
+///     never map (which would make the empty-modification decline fire on the
+///     very lines this arm exists to serve);
+///   * it declines a line whose pre-verb span is an ANIMATION clause. Such a
+///     line is one animation (CR 613.1d type + CR 613.4b base P/T + CR 613.1f
+///     keyword), not a keyword grant with an unusually long subject, and it
+///     must reach `parse_pronoun_becomes_type_static` intact. `~` and the
+///     `SELF_REF_TYPE_PHRASES` entries are the whole subject vocabulary here, so
+///     no animation clause can satisfy this peel — the decline is structural
+///     rather than a separate test that could drift out of agreement with it.
+///
+/// **Case.** `condition_text` is returned as a slice of whatever `input` was
+/// given. The caller runs this on lowered text and MUST recover the matching
+/// suffix of the original before handing it to `parse_static_condition`, which
+/// received original casing under the legacy arm.
+fn parse_self_keyword_as_long_as(input: &str) -> OracleResult<'_, (&str, &str)> {
+    let (input, ()) = parse_self_reference_subject(input)?;
+    let (input, _) = tag(" has ").parse(input)?;
+    let (input, keyword_text) = take_until(" as long as ").parse(input)?;
+    let (condition_text, _) = tag(" as long as ").parse(input)?;
+    Ok(("", (keyword_text.trim(), condition_text)))
+}
+
 /// CR 707.2c + CR 613.1a + CR 303.4: "Enchanted <subject> is a copy of the
 /// chosen <type>." — Metamorphic Alteration's companion static. Emits the
 /// parse-time `ContinuousModification::CopyChosen` MARKER affecting the
@@ -1972,32 +2009,40 @@ pub(crate) fn parse_static_line_inner(
         return Some(def);
     }
 
-    // --- "~ has [keyword] as long as ..." (must be before generic self-ref "has") ---
-    // allow-noncombinator: moved legacy static parser code; refactor-only split preserves behavior.
-    if let Some(has_pos) = tp.find(" has ") {
-        // allow-noncombinator: moved legacy static parser code; refactor-only split preserves behavior.
-        if let Some(cond_pos) = tp.find(" as long as ") {
-            // allow-noncombinator: moved legacy static parser code; refactor-only split preserves behavior.
-            if has_pos < cond_pos {
-                let keyword_text = tp.lower[has_pos + 5..cond_pos].trim();
-                let condition_text = text[cond_pos + 12..].trim().trim_end_matches('.');
-                let mut modifications = Vec::new();
-                if let Some(kw) = map_keyword(keyword_text) {
-                    modifications.push(ContinuousModification::AddKeyword { keyword: kw });
-                }
-                let condition = parse_static_condition(condition_text).unwrap_or(
-                    StaticCondition::Unrecognized {
-                        text: condition_text.to_string(),
-                    },
-                );
-                return Some(
-                    StaticDefinition::continuous()
-                        .affected(TargetFilter::SelfRef)
-                        .modifications(modifications)
-                        .condition(condition)
-                        .description(text.to_string()),
-                );
-            }
+    // --- "<self-ref> has [keyword] as long as ..." (must be before generic self-ref "has") ---
+    //
+    // CR 613.1f + CR 611.3a: a self-referential keyword grant gated by an
+    // "as long as" condition. A line whose pre-verb span is an animation clause
+    // is one animation (CR 613.1d + CR 613.4b), not a keyword grant with a long
+    // subject — `parse_self_keyword_as_long_as` declines it so the animation
+    // authority (`parse_pronoun_becomes_type_static`, below) owns it.
+    if let Ok((_, (keyword_text, condition_lower))) = parse_self_keyword_as_long_as(tp.lower) {
+        // CASE PRESERVATION: `parse_static_condition` received ORIGINAL casing
+        // under the legacy arm, which sliced the condition out of `text` while
+        // taking the keyword out of `tp.lower`. `condition_lower` is a suffix of
+        // `tp.lower`, so the equal-length suffix of `text` is the same span in
+        // original case. Lowercasing it here would silently change how
+        // conditions like "you control a Forest" parse.
+        let condition_text = text[text.len() - condition_lower.len()..]
+            .trim()
+            .trim_end_matches('.');
+        // The keyword MUST map. The legacy arm returned `Some` with an empty
+        // `modifications` vec when it did not — a static that claims support and
+        // does nothing, with no `Effect::Unimplemented` to mark the gap. Decline
+        // instead, so the line reaches an authority that can model it or is
+        // surfaced honestly as unimplemented.
+        if let Some(keyword) = map_keyword(keyword_text) {
+            let condition =
+                parse_static_condition(condition_text).unwrap_or(StaticCondition::Unrecognized {
+                    text: condition_text.to_string(),
+                });
+            return Some(
+                StaticDefinition::continuous()
+                    .affected(TargetFilter::SelfRef)
+                    .modifications(vec![ContinuousModification::AddKeyword { keyword }])
+                    .condition(condition)
+                    .description(text.to_string()),
+            );
         }
     }
 

--- a/crates/engine/src/parser/oracle_static/snapshot_tests.rs
+++ b/crates/engine/src/parser/oracle_static/snapshot_tests.rs
@@ -1050,7 +1050,7 @@ fn three_way_oxford_disjunctive_doubler_source() {
     );
 }
 
-/// CR 613.1d + CR 613.4b + CR 613.1g (issue #2363): Grand Master of Flowers —
+/// CR 613.1d + CR 613.4b + CR 613.1f (issue #2363): Grand Master of Flowers —
 /// "As long as ~ has seven or more loyalty counters on him, he's a 7/7 Dragon
 /// God creature with flying and indestructible."
 /// The parser must emit SetPower(7), SetToughness(7), AddType(Creature),
@@ -1133,7 +1133,7 @@ fn goddric_celebration_grants_complete_dragon_characteristics() {
     assert!(def.condition.is_some());
 }
 
-/// CR 613.1d + CR 613.4b + CR 613.1g (issue #2363): "she's a" gendered pronoun
+/// CR 613.1d + CR 613.4b + CR 613.1f (issue #2363): "she's a" gendered pronoun
 /// variant — confirms the parser accepts feminine pronouns on cards like future
 /// Planeswalkers that become creatures.
 #[test]
@@ -1176,7 +1176,7 @@ fn gendered_pronoun_she_becomes_creature_static() {
     );
 }
 
-/// CR 613.1d + CR 613.4b + CR 613.1g: neutral-plural "they're a" pronoun
+/// CR 613.1d + CR 613.4b + CR 613.1f: neutral-plural "they're a" pronoun
 /// variant stays on the same composable animation path as he/she/it forms.
 #[test]
 fn neutral_plural_pronoun_they_becomes_creature_static() {

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -35167,3 +35167,329 @@ fn havi_historic_graveyard_gate_parses_with_reminder_text() {
         })
     );
 }
+
+// ===========================================================================
+// Issue #8395 — the animation clause silently dropped from compound continuous
+// statics. Idol of False Gods is the type specimen. Each test names the
+// verification-matrix row it discharges and carries an explicit reach-guard:
+// positive evidence the changed path ran, never the mere absence of a failure.
+// ===========================================================================
+
+/// V1 + V2 (CR 613.1d + CR 613.4b + CR 613.1f): Idol of False Gods' printed line,
+/// with the card's self-reference normalized to `~` exactly as the production
+/// pipeline does upstream (`oracle.rs:449` runs `normalize_card_name_refs`
+/// before line splitting).
+///
+/// The whole defect in one assertion set. The line reaches the legacy `" has "`
+/// arm only AFTER `try_split_inverted_as_long_as` rewrites the inverted
+/// "As long as <cond>, <effect>" form into canonical
+/// "<effect> as long as <cond>" order — and in THAT order the conjunct's
+/// `" has "` precedes the gate's `" as long as "`. The old arm sliced from that
+/// `" has "`, discarded the entire animation clause, and hardcoded `SelfRef`,
+/// exporting `[AddKeyword{Annihilator(2)}]` and nothing else.
+///
+/// REACH-GUARD: the Annihilator assertion passes both before and after the fix.
+/// That is precisely what makes it evidence the static was CLAIMED rather than
+/// vanishing — it is deliberately not independent coverage.
+#[test]
+fn idol_of_false_gods_animates_and_keeps_annihilator() {
+    let def = parse_static_line(
+        "As long as ~ has eight or more +1/+1 counters on it, it's a 0/0 creature in addition to its other types and it has annihilator 2.",
+    )
+    .expect("Idol's compound animation static must parse");
+    let mods = &def.modifications;
+    assert!(
+        mods.contains(&ContinuousModification::AddKeyword {
+            keyword: Keyword::Annihilator(2),
+        }),
+        "reach-guard: Annihilator 2 must still be granted, proving the line was claimed; mods = {mods:?}"
+    );
+    assert!(
+        mods.contains(&ContinuousModification::AddType {
+            core_type: CoreType::Creature,
+        }),
+        "CR 613.1d (Layer 4): Idol must become a creature; mods = {mods:?}"
+    );
+    assert!(
+        mods.contains(&ContinuousModification::SetPower { value: 0 })
+            && mods.contains(&ContinuousModification::SetToughness { value: 0 }),
+        "CR 613.4b (Layer 7b): base P/T 0/0 must be set; mods = {mods:?}"
+    );
+    assert!(
+        !mods
+            .iter()
+            .any(|m| matches!(m, ContinuousModification::SetCardTypes { .. })),
+        "CR 205.1b: \"in addition to its other types\" RETAINS the prior card types, \
+         so no replacing SetCardTypes may be emitted; mods = {mods:?}"
+    );
+    assert!(
+        def.condition
+            .as_ref()
+            .is_some_and(|c| !c.contains_unrecognized()),
+        "CR 611.3a: the eight-counter gate must type, not fall back to Unrecognized; \
+         condition = {:?}",
+        def.condition
+    );
+}
+
+/// V6 (CR 613.1d Layer 4 + CR 613.4b Layer 7b + CR 613.1f Layer 6): the conjunct
+/// axis across all four grant verbs — the two pronoun forms times the two verb
+/// families, exercised as one `opt` and one `alt` rather than a permutation
+/// chain.
+///
+/// REACH-GUARD: every case asserts the ANIMATION half and the KEYWORD half in
+/// the SAME definition. A test asserting only the keyword would pass against the
+/// legacy arm that dropped the animation entirely; one asserting only the
+/// animation would pass against a peel that swallowed the conjunct.
+#[test]
+fn animation_conjunct_emits_both_halves_for_every_grant_verb() {
+    for (line, keyword) in [
+        (
+            "it's a 0/0 creature in addition to its other types and it has annihilator 2",
+            Keyword::Annihilator(2),
+        ),
+        (
+            "it's a 0/0 creature in addition to its other types and has trample",
+            Keyword::Trample,
+        ),
+        (
+            "it's a 0/0 creature in addition to its other types and it gains flying",
+            Keyword::Flying,
+        ),
+        (
+            "they're a 0/0 creature in addition to their other types and they gain vigilance",
+            Keyword::Vigilance,
+        ),
+    ] {
+        let def = parse_static_line(line)
+            .unwrap_or_else(|| panic!("compound animation static must parse; line = {line:?}"));
+        let mods = &def.modifications;
+        assert!(
+            mods.contains(&ContinuousModification::AddType {
+                core_type: CoreType::Creature,
+            }),
+            "animation half (CR 613.1d) must survive the conjunct; line = {line:?}, mods = {mods:?}"
+        );
+        assert!(
+            mods.contains(&ContinuousModification::SetPower { value: 0 })
+                && mods.contains(&ContinuousModification::SetToughness { value: 0 }),
+            "base P/T (CR 613.4b) must survive the conjunct; line = {line:?}, mods = {mods:?}"
+        );
+        assert!(
+            mods.contains(&ContinuousModification::AddKeyword {
+                keyword: keyword.clone(),
+            }),
+            "conjunct keyword (CR 613.1f) must be carried; line = {line:?}, mods = {mods:?}"
+        );
+    }
+}
+
+/// V6 hostile sibling: a NON-grant conjunct verb must not be peeled. "and loses
+/// defender" is an ability-REMOVING clause (still CR 613.1f, Layer 6) already
+/// owned elsewhere; the new boundary combinator matches only the four grant
+/// verbs, so this line must keep its existing shape.
+#[test]
+fn animation_conjunct_boundary_ignores_non_grant_verbs() {
+    let def =
+        parse_static_line("it's a 0/0 creature in addition to its other types and loses defender");
+    if let Some(def) = def {
+        assert!(
+            !def.modifications.is_empty(),
+            "a non-grant conjunct must not be turned into an empty-modification static; \
+             mods = {:?}",
+            def.modifications
+        );
+    }
+}
+
+/// V7: an unrecognized conjunct is honest, not swallowed.
+///
+/// REACH-GUARD: the SAME line minus the conjunct must still parse fully. That
+/// pairing is what proves the decline is a DECISION taken by the conjunct peel
+/// rather than an unrelated upstream miss — without it, a `None` from any
+/// earlier arm would satisfy the test.
+#[test]
+fn unrecognized_animation_conjunct_declines_rather_than_half_parsing() {
+    let with_nonsense = "it's a 0/0 creature in addition to its other types and it has florblewick";
+    let claimed = parse_static_line(with_nonsense);
+    assert!(
+        claimed.is_none(),
+        "an unmappable conjunct must decline the whole line so it surfaces as unimplemented, \
+         rather than emitting the animation and silently dropping the ability; got {claimed:?}"
+    );
+
+    let without = "it's a 0/0 creature in addition to its other types";
+    let def = parse_static_line(without)
+        .expect("reach-guard: the bare animation clause must still parse");
+    assert!(
+        def.modifications
+            .contains(&ContinuousModification::AddType {
+                core_type: CoreType::Creature,
+            }),
+        "reach-guard: the animation half is supported on its own, so the decline above is \
+         attributable to the conjunct; mods = {:?}",
+        def.modifications
+    );
+}
+
+/// V8 (CR 604.1): a quoted-ability conjunct no longer vanishes. Before this
+/// change the line exported `[]` — a total silent loss of both halves.
+///
+/// REACH-GUARD: the animation half is asserted alongside the grant, so the test
+/// cannot pass on a downstream arm that claims the line while emitting only one
+/// of the two.
+#[test]
+fn quoted_ability_animation_conjunct_is_granted_not_dropped() {
+    let line = "it's a 0/0 creature in addition to its other types and it has \
+                \"When this creature dies, draw a card.\"";
+    let def = parse_static_line(line)
+        .expect("a quoted-ability conjunct must be claimed by the shared quoted-ability authority");
+    let mods = &def.modifications;
+    assert!(
+        mods.contains(&ContinuousModification::AddType {
+            core_type: CoreType::Creature,
+        }),
+        "reach-guard: the animation half must survive; mods = {mods:?}"
+    );
+    assert!(
+        mods.iter().any(|m| matches!(
+            m,
+            ContinuousModification::GrantTrigger { .. }
+                | ContinuousModification::GrantAbility { .. }
+        )),
+        "CR 604.1: the quoted ability must be granted, not dropped; mods = {mods:?}"
+    );
+}
+
+/// V9: the rewritten `dispatch.rs` self-ref keyword arm keeps its legitimate
+/// coverage, in BOTH printed orientations — the postfix form and the inverted
+/// form that `try_split_inverted_as_long_as` rewrites into it.
+///
+/// REACH-GUARD: assert the condition is a TYPED `IsPresent`, not `Unrecognized`.
+/// A bare "still returns AddKeyword" would pass even if some other arm claimed
+/// the line. This is also where a case-preservation regression surfaces: the new
+/// combinator runs on LOWERED text, so a lowercased "you control a forest"
+/// reaching `parse_static_condition` would degrade the gate to `Unrecognized`
+/// and fail here.
+#[test]
+fn self_ref_keyword_as_long_as_keeps_typed_condition_in_both_orders() {
+    for line in [
+        "~ has flying as long as you control a Forest.",
+        "As long as you control a Forest, ~ has trample.",
+    ] {
+        let def = parse_static_line(line)
+            .unwrap_or_else(|| panic!("legitimate self-ref keyword static must parse; {line:?}"));
+        assert_eq!(
+            def.affected,
+            Some(TargetFilter::SelfRef),
+            "CR 613.1f: a self-referential grant affects its own source; line = {line:?}"
+        );
+        assert!(
+            def.condition
+                .as_ref()
+                .is_some_and(|c| !c.contains_unrecognized()),
+            "the Forest gate must type; a lowercased subject would degrade it to Unrecognized; \
+             line = {line:?}, condition = {:?}",
+            def.condition
+        );
+    }
+}
+
+/// V10: the empty-modification mouth is closed. The legacy arm returned `Some`
+/// with `modifications: []` whenever the keyword text failed to map — a static
+/// that claims support and does nothing, with no honesty marker at all.
+///
+/// REACH-GUARD: the same shape with a MAPPABLE keyword must still return `Some`
+/// carrying its `AddKeyword`. Without that pair a blanket decline would also
+/// satisfy the first assertion.
+#[test]
+fn self_ref_keyword_as_long_as_never_returns_empty_modifications() {
+    let unmappable = parse_static_line("~ has florblewick as long as you control a Forest.");
+    assert!(
+        !unmappable
+            .as_ref()
+            .is_some_and(|def| def.modifications.is_empty()),
+        "an unmappable keyword must decline, never return a Continuous static with an empty \
+         modification set; got {unmappable:?}"
+    );
+
+    let mappable = parse_static_line("~ has flying as long as you control a Forest.")
+        .expect("reach-guard: the mappable sibling must still parse");
+    assert!(
+        mappable
+            .modifications
+            .contains(&ContinuousModification::AddKeyword {
+                keyword: Keyword::Flying,
+            }),
+        "reach-guard: the arm still runs and only the empty case declines; mods = {:?}",
+        mappable.modifications
+    );
+}
+
+/// V5 (CR 613.1d + CR 613.4b + CR 613.1f): the shared additive-type leaf must
+/// return the COMPLETE modification set for a clause that also states P/T and
+/// keywords.
+///
+/// The input is Case of the Gorgon's Kiss's PRODUCTION string — the
+/// subject-stripped, un-`~`-normalized description the effect pipeline actually
+/// hands the leaf (measured at `/abilities[0]/effect/static_abilities[0]`), not
+/// the printed line. Testing the printed line would exercise a route this card
+/// never takes and could go green while the card stayed broken.
+///
+/// REACH-GUARD: the pre-existing `AddSubtype{Gorgon}` and `AddType{Creature}`
+/// must still be present ALONGSIDE the new `SetPower{4}`. That proves the
+/// pre-marker span is now animation-parsed rather than the leaf merely
+/// declining and something else filling in.
+#[test]
+fn additive_type_leaf_keeps_base_pt_and_pre_marker_keywords() {
+    let mods = parse_additive_type_clause_modifications(
+        "is a 4/4 Gorgon creature with deathtouch and lifelink in addition to its other types",
+    )
+    .expect("the additive-type leaf must claim this clause");
+    for expected in [
+        ContinuousModification::SetPower { value: 4 },
+        ContinuousModification::SetToughness { value: 4 },
+        ContinuousModification::AddKeyword {
+            keyword: Keyword::Deathtouch,
+        },
+        ContinuousModification::AddKeyword {
+            keyword: Keyword::Lifelink,
+        },
+        ContinuousModification::AddType {
+            core_type: CoreType::Creature,
+        },
+        ContinuousModification::AddSubtype {
+            subtype: "Gorgon".to_string(),
+        },
+    ] {
+        assert!(
+            mods.contains(&expected),
+            "missing {expected:?}; mods = {mods:?}"
+        );
+    }
+}
+
+/// V5 hostile sibling — the DOUBLE-EMIT GUARD. A clause with no leading `N/M`
+/// must keep the word-classification path: the new animation route is keyed on
+/// a LEADING fixed P/T precisely so it stays disjoint from the trailing
+/// "base power and toughness N/M" form that callers already emit themselves.
+/// If that keying ever loosened, this is what fails.
+#[test]
+fn additive_type_leaf_without_leading_pt_emits_no_base_pt() {
+    let mods =
+        parse_additive_type_clause_modifications("is a Gorgon in addition to its other types")
+            .expect("the type-only clause must still parse");
+    assert!(
+        mods.contains(&ContinuousModification::AddSubtype {
+            subtype: "Gorgon".to_string(),
+        }),
+        "reach-guard: the type-only clause still yields its subtype; mods = {mods:?}"
+    );
+    assert!(
+        !mods.iter().any(|m| matches!(
+            m,
+            ContinuousModification::SetPower { .. } | ContinuousModification::SetToughness { .. }
+        )),
+        "a clause with no leading N/M must not acquire a base P/T; mods = {mods:?}"
+    );
+}

--- a/crates/engine/src/parser/oracle_static/type_change.rs
+++ b/crates/engine/src/parser/oracle_static/type_change.rs
@@ -474,6 +474,72 @@ pub(crate) fn parse_collection_counter_play_permission_static(
     )
 }
 
+/// CR 613.4b (Layer 7b base P/T) + CR 613.1f (Layer 6 keywords): recover the
+/// two characteristic axes that word-classifying an additive-type span cannot
+/// express.
+///
+/// The pre-marker span of an additive clause — "a 4/4 Gorgon creature with
+/// deathtouch and lifelink" in "…is a 4/4 Gorgon creature with deathtouch and
+/// lifelink in addition to its other types" — is word-split by the caller, and
+/// `classify_additive_type_word` returns `None` for every token it does not
+/// recognize as a color, core type, supertype or subtype. Dropping stray words
+/// is deliberate, but it also swallows the `4/4` and the whole `with <keywords>`
+/// tail: exactly the CR 205.1b-retained characteristics the clause exists to
+/// state. `parse_animation_spec` already parses that shape.
+///
+/// **This is STRICTLY ADDITIVE — it never replaces the word-split result.**
+/// That is not a stylistic choice, it is a correctness requirement: a span may
+/// be COMPOUND ("1/1 green Saproling creatures **and Forest lands**" — Life and
+/// Limb), and `parse_animation_spec` parses only the first type sequence, so
+/// substituting its output for the word-split would silently drop
+/// `AddType{Land}` and `AddSubtype{Forest}`. Word-splitting is crude but it sees
+/// every type token in the span; the animation spec is precise but sees only the
+/// first clause. Taking the P/T and keywords from the spec and the types from the
+/// word-split uses each for what it is actually good at.
+///
+/// **Keyed on a LEADING fixed `N/M`, and that key is the double-emit guard.**
+/// The other P/T shape an additive clause can carry — "with base power and
+/// toughness N/M" — states its P/T *after* the type words, and the callers that
+/// see that form already emit the P/T themselves (Kudo, King Among Bears;
+/// Graaz, Unstoppable Juggernaut; March of the World Ooze; Raised by Giants).
+/// Requiring the P/T at the head of the span keeps the two routes disjoint, so
+/// no caller can receive a second `SetPower`.
+///
+/// Returns an empty vector for every span without a leading `N/M`, so all such
+/// clauses keep the word-split path byte-for-byte.
+fn animated_additive_span_pt_and_keywords(
+    span: &str,
+    span_lower: &str,
+) -> Vec<ContinuousModification> {
+    // The article belongs to the span ("a 4/4 …"), so peel it with the shared
+    // `parse_article` primitive before testing for the leading P/T.
+    let after_article_lower =
+        nom_primitives::parse_article(span_lower).map_or(span_lower, |(rest, ())| rest);
+    if super::oracle_effect::animation::parse_fixed_become_pt_prefix(after_article_lower).is_none()
+    {
+        return Vec::new();
+    }
+    let Some(spec) =
+        super::oracle_effect::animation::parse_animation_spec(span, &mut ParseContext::default())
+    else {
+        return Vec::new();
+    };
+    // Keep ONLY the two axes the word-split cannot produce. Types, subtypes,
+    // supertypes and color are deliberately left to the word-split, which is the
+    // only one of the two that sees a compound span in full.
+    super::oracle_effect::animation::animation_modifications(&spec)
+        .into_iter()
+        .filter(|modification| {
+            matches!(
+                modification,
+                ContinuousModification::SetPower { .. }
+                    | ContinuousModification::SetToughness { .. }
+                    | ContinuousModification::AddKeyword { .. }
+            )
+        })
+        .collect()
+}
+
 /// CR 205.1 / CR 205.3a: Extract additive-type modifications from a predicate
 /// like `"are Food artifacts in addition to their other types"` or its
 /// compound/granted-ability variants. Used both as the body of
@@ -567,6 +633,9 @@ pub(crate) fn parse_additive_type_clause_modifications(
         &clause_original[clause_original.len() - after_suffix_lower.len()..];
     let granted_modifications = parse_continuous_modifications(after_suffix_original);
 
+    // The word-split is the BASE and stays authoritative for every type token in
+    // the span — it is the only reader that sees a compound span ("… creatures
+    // and Forest lands") in full.
     let mut modifications = Vec::new();
     for raw_word in type_words.split_whitespace() {
         let word = raw_word.trim_matches(|c: char| c == ',' || c == '.');
@@ -574,6 +643,16 @@ pub(crate) fn parse_additive_type_clause_modifications(
             continue;
         }
         if let Some(modification) = classify_additive_type_word(&word.to_lowercase()) {
+            modifications.push(modification);
+        }
+    }
+
+    // CR 613.4b (Layer 7b) + CR 613.1f (Layer 6): then recover the base P/T and
+    // the pre-marker keyword tail, which word-classification silently swallows.
+    // Additive only — a span with no leading `N/M` contributes nothing here and
+    // keeps byte-identical output.
+    for modification in animated_additive_span_pt_and_keywords(type_words, type_words_lower) {
+        if !modifications.contains(&modification) {
             modifications.push(modification);
         }
     }
@@ -1643,13 +1722,41 @@ pub(crate) fn parse_bare_becomes_type_replacement_modifications(
     modifications
 }
 
+/// CR 613.1f (Layer 6): resolve an animation conjunct tail to the modifications
+/// it grants, or `None` if no authority can model it.
+///
+/// Two shapes, each delegated to the authority that already owns it rather than
+/// re-implemented here:
+///   1. a bare keyword list ("trample", "vigilance and menace") →
+///      `parse_animation_conjunct_keywords`, which shares the token splitter and
+///      keyword mapper used by the sibling `" with "` tail;
+///   2. a quoted granted ability (`"When this creature dies, draw a card."`) →
+///      the shared `parse_quoted_ability_modifications` (CR 604.1), which
+///      classifies triggers, keywords, statics and activated abilities.
+///
+/// `None` when neither claims the tail, so the caller declines the line instead
+/// of emitting the animation with its ability clause silently dropped.
+fn parse_animation_conjunct_modifications(tail: &str) -> Option<Vec<ContinuousModification>> {
+    if let Some(keywords) = super::oracle_effect::animation::parse_animation_conjunct_keywords(tail)
+    {
+        return Some(
+            keywords
+                .into_iter()
+                .map(|keyword| ContinuousModification::AddKeyword { keyword })
+                .collect(),
+        );
+    }
+    let granted = super::keyword_grant::parse_quoted_ability_modifications(tail);
+    (!granted.is_empty()).then_some(granted)
+}
+
 /// CR 613.1d + CR 613.1g: "[pronoun]'s a/an <descriptor> [as long as <condition>]"
 /// — self-referential conditional animation static. Covers:
 ///   - Dynamic-P/T-by-mana-value: "it's an artifact creature with power and
 ///     toughness each equal to its mana value" (Animate Artifact)
 ///   - Fixed P/T + types + keywords: "he's a 7/7 Dragon God creature with flying
 ///     and indestructible" (Grand Master of Flowers — CR 613.4b fixed P/T,
-///     CR 613.1d type grant, CR 613.1g keyword grant)
+///     CR 613.1d type grant, CR 613.1f keyword grant)
 ///
 /// Accepts gender-neutral and gendered pronouns ("it's", "~'s", "they're",
 /// "he's", "she's"). Delegates body parsing to
@@ -1712,15 +1819,42 @@ pub(crate) fn parse_pronoun_becomes_type_static(
         .or_else(|| nom_tag_tp(&effect_tp, "she's a "))
         .or_else(|| nom_tag_tp(&effect_tp, "she's an "))?;
 
+    // STEP B.1 — peel a conjoined ability clause ("… and it has annihilator 2",
+    // "… and they gain flying") off the animation body.
+    //
+    // CR 613.1d + CR 613.4b + CR 613.1f: one printed sentence yields type
+    // (Layer 4), base P/T (Layer 7b) and keyword (Layer 6) modifications;
+    // CR 205.1b retains the prior types. Left in place the conjunct defeats the
+    // animation parse and the type/P/T half is lost (Idol of False Gods).
+    //
+    // A conjunct no authority can model declines the WHOLE line (the `?` below)
+    // rather than emitting the animation and silently dropping the granted
+    // ability. The line then falls through to the unclassified path and surfaces
+    // `Effect::unimplemented`, which is honest.
+    let body_text = body.original.trim().trim_end_matches('.');
+    let (body_text, conjunct_modifications) =
+        match super::oracle_effect::animation::split_animation_conjunct_clause(body_text) {
+            Some((animation_body, tail)) => (
+                animation_body,
+                Some(parse_animation_conjunct_modifications(tail)?),
+            ),
+            None => (body_text, None),
+        };
+
     // STEP C — delegate body parsing to parse_animation_spec which handles
     // fixed P/T (CR 613.4b), dynamic P/T-by-mana-value, types (CR 613.1d),
-    // subtypes (CR 205.3), and keyword tails (CR 613.1g) in one composable pass.
-    let body_text = body.original.trim().trim_end_matches('.');
+    // subtypes (CR 205.3), and keyword tails (CR 613.1f) in one composable pass.
     let modifications = if let Some(spec) = super::oracle_effect::animation::parse_animation_spec(
         body_text,
         &mut ParseContext::default(),
     ) {
         super::oracle_effect::animation::animation_modifications(&spec)
+    } else if conjunct_modifications.is_some() {
+        // A conjunct WAS peeled but the spec parser cannot claim the animation
+        // half. The legacy fallback below is not an alternative here: it reads
+        // the unpeeled `body` TextPair, so it would parse the conjunct's words
+        // as type tokens. Decline instead of fabricating.
+        return None;
     } else {
         // Fallback: type-token parse + mana-value dynamic P/T. Handles edge
         // cases where parse_animation_spec returns None (e.g., unusual clause
@@ -1748,7 +1882,12 @@ pub(crate) fn parse_pronoun_becomes_type_static(
     // card-type change with no retention marker therefore REPLACES — Arixmethes,
     // Slumbering Isle's "it's a land. (It's not a creature.)" must stop the
     // Kraken from being a creature, not leave it a "Creature Land" (issue #5213).
-    let modifications = maybe_replace_card_types(modifications, body.lower);
+    let mut modifications = maybe_replace_card_types(modifications, body.lower);
+
+    // CR 613.1f (Layer 6): append the conjoined ability clause AFTER the
+    // CR 205.1a replacement decision above, which is a question about card types
+    // alone — a granted keyword must not perturb it.
+    modifications.extend(conjunct_modifications.unwrap_or_default());
 
     // STEP D — attach the condition(s). The leading "during your turn, " timing
     // peel (STEP A.0) and the trailing " as long as <cond>" peel (STEP A) are

--- a/crates/engine/tests/integration/idol_of_false_gods_counter_animation.rs
+++ b/crates/engine/tests/integration/idol_of_false_gods_counter_animation.rs
@@ -1,0 +1,222 @@
+//! Issue #8395 — Idol of False Gods: the animation clause was silently dropped
+//! from a compound continuous static, so the artifact never became a creature.
+//!
+//! Oracle text (verbatim, Scryfall `cards/named?exact=`):
+//!   "{1}{C}, {T}: Create a 0/1 colorless Eldrazi Spawn creature token with
+//!    \"Sacrifice this token: Add {C}.\"
+//!    Whenever another Eldrazi you control dies, put a +1/+1 counter on this
+//!    artifact.
+//!    As long as this artifact has eight or more +1/+1 counters on it, it's a
+//!    0/0 creature in addition to its other types and it has annihilator 2."
+//!
+//! # The defect
+//!
+//! The third line reaches the static dispatcher only AFTER
+//! `try_split_inverted_as_long_as` rewrites the inverted "As long as <cond>,
+//! <effect>" form into canonical "<effect> as long as <cond>" order. In that
+//! order the conjunct's `" has "` (from "and it **has** annihilator 2") precedes
+//! the gate's `" as long as "`, so a legacy arm keyed on the FIRST `" has "`
+//! claimed the line, sliced the keyword out of the middle, discarded everything
+//! before it — the entire animation clause — and hardcoded `SelfRef`. The card
+//! exported `[AddKeyword{Annihilator(2)}]` and nothing else, so Idol stayed a
+//! non-creature artifact forever.
+//!
+//! # How this test discriminates
+//!
+//! With the fix reverted the parse emits only `AddKeyword{Annihilator(2)}`;
+//! `AddType{Creature}` is absent and the "is a Creature" assertion in the ON
+//! state fails immediately.
+//!
+//! The Annihilator assertion passes BOTH ways by design — that is exactly what
+//! makes it the reach-guard rather than independent coverage: its presence in
+//! the same run proves the static was claimed and applied at all, so the missing
+//! Creature type is a real drop and not a line that simply vanished.
+//!
+//! The OFF state at seven counters is the second guard: the same object is
+//! observed not-a-creature and then a creature, so the ON assertions cannot pass
+//! vacuously. The scenario contains no other type-changing effect, so nothing
+//! else could make Idol a creature.
+//!
+//! Wizards' own shipped ruling on this card confirms the intended end state:
+//! "…it will be an Eldrazi kindred artifact creature. This is because effects
+//! that change an object's types are always applied before effects that remove
+//! abilities."
+
+use engine::game::layers::evaluate_layers;
+use engine::game::scenario::{GameRunner, GameScenario, P0};
+use engine::types::card_type::CoreType;
+use engine::types::counter::CounterType;
+use engine::types::identifiers::ObjectId;
+use engine::types::keywords::Keyword;
+use engine::types::phase::Phase;
+use engine::types::zones::Zone;
+
+const IDOL_ORACLE: &str = "{1}{C}, {T}: Create a 0/1 colorless Eldrazi Spawn creature token with \"Sacrifice this token: Add {C}.\"\n\
+Whenever another Eldrazi you control dies, put a +1/+1 counter on this artifact.\n\
+As long as this artifact has eight or more +1/+1 counters on it, it's a 0/0 creature in addition to its other types and it has annihilator 2.";
+
+/// Force a full layer recomputation so every read below observes the CR 613
+/// pipeline's current output rather than a cached value.
+fn refresh(runner: &mut GameRunner) {
+    runner.state_mut().layers_dirty.mark_full();
+    evaluate_layers(runner.state_mut());
+}
+
+fn plus_counters(runner: &GameRunner, id: ObjectId) -> u32 {
+    runner.state().objects[&id]
+        .counters
+        .get(&CounterType::Plus1Plus1)
+        .copied()
+        .unwrap_or(0)
+}
+
+/// Mark lethal damage on `victim` so the next state-based-action check kills it.
+///
+/// CR 704.5g: a creature with damage marked on it greater than or equal to its
+/// toughness is destroyed. Marking the damage is a BOARD PREMISE; the death
+/// itself, the resulting dies event, Idol's trigger, and the counter placement
+/// all run through the production SBA + priority machinery, so the engine — not
+/// this test — puts the eighth counter on Idol.
+fn mark_lethal(runner: &mut GameRunner, victim: ObjectId) {
+    let obj = runner
+        .state_mut()
+        .objects
+        .get_mut(&victim)
+        .expect("victim present");
+    obj.damage_marked = obj.toughness.unwrap_or(1).max(1) as u32;
+}
+
+#[test]
+fn idol_of_false_gods_animates_at_eight_counters_and_keeps_annihilator() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    // Idol of False Gods, built from verbatim Oracle text through the real parse
+    // + synthesis pipeline. Seven +1/+1 counters are the BOARD PREMISE, not the
+    // behavior under test — the eighth is placed by the engine below.
+    let idol = scenario
+        .add_artifact_from_oracle(P0, "Idol of False Gods", IDOL_ORACLE)
+        .with_subtypes(vec!["Eldrazi"])
+        .with_plus_counters(7)
+        .id();
+
+    // Another Eldrazi P0 controls. Killing it is what drives Idol's own printed
+    // dies-trigger, so the eighth counter arrives through the engine's path.
+    let spawn = scenario
+        .add_creature(P0, "Eldrazi Spawn", 0, 1)
+        .with_subtypes(vec!["Eldrazi", "Spawn"])
+        .id();
+
+    let mut runner = scenario.build();
+
+    // ---------------- OFF state at seven counters ----------------
+    // CR 611.3a: a static ability's continuous effect is never "locked in" — it
+    // applies exactly while its condition holds.
+    refresh(&mut runner);
+    assert_eq!(
+        plus_counters(&runner, idol),
+        7,
+        "board premise: the fixture starts one counter short of the gate"
+    );
+    {
+        let obj = &runner.state().objects[&idol];
+        assert!(
+            !obj.card_types.core_types.contains(&CoreType::Creature),
+            "at seven counters the gate is false, so Idol is not a creature; types = {:?}",
+            obj.card_types
+        );
+        assert!(
+            obj.card_types.core_types.contains(&CoreType::Artifact),
+            "reach-guard: this is the Idol object and it is an artifact; types = {:?}",
+            obj.card_types
+        );
+        assert!(
+            !obj.has_keyword(&Keyword::Annihilator(2)),
+            "at seven counters the gate is false, so annihilator is not granted"
+        );
+        // CR 208.3: a noncreature permanent has no power or toughness at all.
+        assert_eq!(
+            obj.power, None,
+            "CR 208.3: a noncreature permanent has no power"
+        );
+        assert_eq!(
+            obj.toughness, None,
+            "CR 208.3: a noncreature permanent has no toughness"
+        );
+    }
+
+    // ---------------- Drive the eighth counter through the engine ----------------
+    // Mark lethal damage (board premise), then hand priority to the production
+    // machinery: SBA (CR 704.5g) destroys the Spawn, the dies event fires Idol's
+    // printed trigger, and resolving it places the counter.
+    mark_lethal(&mut runner, spawn);
+    runner.pass_both_players();
+    runner.advance_until_stack_empty();
+
+    assert_eq!(
+        runner.state().objects[&spawn].zone,
+        Zone::Graveyard,
+        "reach-guard: the other Eldrazi actually died, so the dies-trigger had an event to see"
+    );
+    assert_eq!(
+        plus_counters(&runner, idol),
+        8,
+        "CR 122.1: Idol's own printed trigger placed the eighth counter — the ENGINE put it \
+         there, not the test fixture"
+    );
+
+    // ---------------- ON state after layers ----------------
+    refresh(&mut runner);
+    let obj = &runner.state().objects[&idol];
+
+    // Reach-guard, and V2 of the verification matrix: this assertion passes both
+    // before and after the fix. Its role is to prove the static was CLAIMED and
+    // APPLIED, so the type assertion below is measuring a dropped clause rather
+    // than a line that never parsed.
+    assert!(
+        obj.has_keyword(&Keyword::Annihilator(2)),
+        "CR 613.1f (Layer 6) + CR 702.86: annihilator 2 is granted at eight counters; \
+         keywords = {:?}",
+        obj.keywords
+    );
+
+    // THE DISCRIMINATING ASSERTION. Absent before the fix.
+    assert!(
+        obj.card_types.core_types.contains(&CoreType::Creature),
+        "CR 613.1d (Layer 4): at eight counters Idol becomes a creature; types = {:?}",
+        obj.card_types
+    );
+
+    // CR 205.1b: "in addition to its other types" RETAINS the prior types. The
+    // conjunction is the evidence — a `SetCardTypes` regression would drop these
+    // while the Creature assertion above still passed.
+    assert!(
+        obj.card_types.core_types.contains(&CoreType::Artifact),
+        "CR 205.1b: Idol remains an artifact while it is also a creature; types = {:?}",
+        obj.card_types
+    );
+    assert!(
+        obj.card_types.subtypes.iter().any(|s| s == "Eldrazi"),
+        "CR 205.1b: Idol remains an Eldrazi while it is also a creature; types = {:?}",
+        obj.card_types
+    );
+
+    // CR 613.4b (Layer 7b) sets base 0/0; CR 613.4c (Layer 7c) then applies the
+    // eight +1/+1 counters — 8/8, in that order.
+    //
+    // NOTE: this pair is deliberately NOT counted as discriminating on its own.
+    // Idol's printed P/T is null, so a reading of 8/8 can arise from the counters
+    // alone; the layer-order claim it documents is carried by the leaf-level
+    // parser tests. It is asserted here because the ON state should be stated in
+    // full, not because it discriminates.
+    assert_eq!(
+        obj.power,
+        Some(8),
+        "CR 613.4b then CR 613.4c: base 0 set at 7b, +8 from counters at 7c"
+    );
+    assert_eq!(
+        obj.toughness,
+        Some(8),
+        "CR 613.4b then CR 613.4c: base 0 set at 7b, +8 from counters at 7c"
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -349,6 +349,7 @@ mod howlsquad_max_speed_reads_controller;
 mod hundred_battle_veteran_counter_kind_gate;
 mod hunters_insight_combat_draw;
 mod ichneumon_druid;
+mod idol_of_false_gods_counter_animation;
 mod inevitable_betrayal_no_mana_cost;
 mod infantry_shield_mobilize_grant;
 mod inherent_rule_trigger_display_name;


### PR DESCRIPTION
Fixes #8395.

Idol of False Gods reads "As long as ~ has eight or more +1/+1 counters on it,
it's a 0/0 creature in addition to its other types and it has annihilator 2",
and exported only `[AddKeyword]`. The 0/0 creature clause was parsed, understood,
and discarded with no `Unimplemented` marker and no parse warning — nothing
downstream could distinguish "this card has no type change" from "we dropped
one". A corpus census puts 26 cards in that silent class against 31 that record
the gap honestly.

### Verification

- `cargo clippy -p phase-engine --all-targets -- -D warnings`: exit 0, 0 warnings
- Tilt `test-engine` in the main checkout: 26741 run, 26740 passed, 1 failed —
  failing **set** identical to the pre-change baseline
  (`game_state_stack_budget::four_player_commander_action_fits_a_bounded_stack`,
  a pre-existing SIGABRT). Compared as a set, not a count, because this PR adds tests.
- **Revert-check**: the new integration test was proven RED against an unmodified
  tree — a fresh worktree at the base commit containing *only* the test file and its
  `mod` line, with `git diff HEAD -- crates/engine/src` verified empty before
  building. It fails at its discriminating assertion, and the failure *location*
  shows execution reached past the Annihilator guard and the counter gate first.
- **Whole-export blast radius** (oracle-gen over 35,798 cards, input digest pinned
  across both runs): 32 cards changed. 17 pure gains, 14 wrong-representation
  corrections, 1 rules-correct removal (Astral Dragon drops a `RemoveAllSubtypes`
  that CR 205.1b forbids — "in addition to their other types" means prior subtypes
  are retained). **All 19 byte-identity controls unchanged**, including
  `Life and Limb`, `Bello`, and `Kaito`.

### Note for the queue

Local verification ran against the base commit; `origin/main` has advanced 9
commits since, 5 of them touching the parser. The cherry-pick conflicted only in
`oracle_static/tests.rs` — an add/add at end-of-file against #8373's Havi test —
resolved by keeping both tests intact (verified: both present, `rustfmt` clean,
diffstat identical to the original commit). CI on the rebased result is the
authority for the merge target.

https://claude.ai/code/session_019h16dyG5KmuDbE25cCGaXa


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed compound card abilities so animation effects and granted keywords are both recognized and applied.
  - Improved handling of plural and gendered wording, quoted abilities, type changes, and conditional self-references.
  - Prevented invalid or unrecognized ability clauses from producing incomplete effects.
  - Preserved existing types, power/toughness, keywords, and “in addition to” behavior when applicable.

- **Tests**
  - Added coverage for compound continuous effects, animation interactions, and conditional keyword grants.
  - Added an integration test confirming animation and keyword retention as game conditions change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->