### PR TITLE
chore(hooks): run the CR citation anchor check before commit

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -9,4 +9,7 @@ echo "  [rust] parser combinator gate"
 echo "  [rust] PreLowered ratchet"
 ./scripts/check-prelowered-ratchet.sh
 
+echo "  [rust] CR citation anchors"
+./scripts/check-cr-citation-anchors.sh
+
 echo "All pre-commit checks passed."

--- a/scripts/check-cr-citation-anchors.sh
+++ b/scripts/check-cr-citation-anchors.sh
@@ -59,6 +59,15 @@
 
 set -euo pipefail
 
+# A hook runs this with git's environment exported, and GIT_INDEX_FILE is an
+# absolute path in a linked worktree and under `git commit -a` / `-p`. The
+# self-check below builds a throwaway repo and stages into it; with that
+# variable inherited, its `git add` writes to the OUTER commit's index instead,
+# leaving the caller's staged work destroyed rather than merely unstaged. The
+# walk wants this repository read plainly, so drop git's ambient environment
+# before anything runs a git command.
+unset GIT_INDEX_FILE GIT_DIR GIT_WORK_TREE GIT_PREFIX
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 


### PR DESCRIPTION
## Summary

The check that keeps rules-document line coordinates out of CR citations landed in the sweep
that removed them, but nothing invoked it, so a coordinate could come back with nothing to
notice until someone swept again. This runs it from the pre-commit hook, after making it safe
to run from one: the check stages into a throwaway repository to prove its own verdict path,
and under a hook that staging was silently retargeting the caller's index.

## Files changed

- `scripts/check-cr-citation-anchors.sh` — drop git's ambient environment before the walk
- `.githooks/pre-commit` — two lines invoking that check

## Track

Developer

## LLM

Model: claude-opus-5
Tier: Frontier
Thinking: high

## Implementation method (required)

Method: /engine-implementer — implementation and final-review stages. This is the wiring half
held back from the pull request that added the script; it adds no engine logic.

## CR references

None. No CR annotation is added or changed.

## Verification

- [x] Required checks ran clean, or the exact CI-owned alternative is stated below.
- [x] Gate A output below is for the current committed head.
- [x] Final review-impl below is clean for the current committed head.
- [x] Both anchors cite existing analogous code at the same seam.

The hook was run end-to-end in both directions, which is the test that this wiring works
rather than merely exists:

| tree | hook exit | what the check reported |
|---|---|---|
| clean | 0 | walked 3536 source files, 66471 citing lines, matched 0 |
| one rules-document coordinate planted beside a real CR citation | 1 | matched 1 |

The planted file was byte-restored afterwards and the tree left carrying only this change.

Running it from a hook is a different environment from running it by hand, and the difference
mattered. Git exports `GIT_INDEX_FILE`, and in a linked worktree, under `git commit -a`, and
under a pathspec or interactive commit it is an absolute path — so the throwaway repository the
check stages into was writing to the caller's index instead. Measured in a scratch linked
worktree with the unfixed script installed as a real hook: a commit with one file staged left
the index holding two entries belonging to the self-check, every real tracked file staged as
deleted, and the staged file gone. Git's abort does not roll that back, because in a linked
worktree the file is the live index rather than a lock.

With the first commit applied, the same three cases:

| commit form (linked worktree) | index before | index after | self-check entries left behind |
|---|---|---|---|
| plain | 4 | 5 | 0 |
| `git commit -a` | 4 | 5 | 0 |
| `git commit -- <pathspec>` | 4 | 5 | 0 |

A staged rules-document coordinate still blocks the commit and leaves the index intact, so the
fix removed the damage without removing the check.

- `./.githooks/pre-commit` — exit 0 on a clean tree, exit 1 on a planted coordinate
- `./scripts/check-parser-combinators.sh` — Gate A PASS, Gate G PASS

No cargo build, clippy or test run is included: this change touches no compiled code, and the
check it wires in needs no build, no network, and about fifteen seconds.

## Gate A

Gate A PASS head=dfaa7d278068d47c536beddabb2ec612a67c106d base=d6d28370c09242182488cac72e16e5a84941885f

## Anchored on

- `.githooks/pre-commit:9-10` — `check-prelowered-ratchet.sh`, the ratchet-family gate this
  sits beside; same hook, same one-line-echo-then-invoke shape, same exit-code contract
- `scripts/check-prelowered-ratchet.sh` — the script this check was modelled on when it was
  written, deriving its repo root the same way so it behaves identically under a hook's
  working directory

## Final review-impl

Final review-impl PASS head=dfaa7d278068d47c536beddabb2ec612a67c106d

## Claimed parse impact

None. No parser code is touched.

## Scope Expansion

The wiring was the intended change; making the check safe to run under a hook was not, and is
the first commit here. Turning it on without that would have destroyed staged work.

## Known limitation, not addressed here

The check lists paths from the index but reads their contents from the working tree, so under a
hook it can disagree with what is being committed in both directions. `check-parser-combinators.sh`
solves this by switching to `--cached` when `GIT_INDEX_FILE` is set. Adopting that here changes
what the check reads in every context including CI, not only under a hook, so it belongs in its
own change rather than in this one.

It is narrow in practice: a false positive needs an unstaged edit that carries a rules-document
coordinate attached to a CR citation, and the tree holds 66,472 citing lines with none of those,
so the case is close to "someone is writing the defect right now", where blocking is the point.
The natural place to unify is the CI leg proposed below, which reads the commit's tree by
construction — that would leave the hook as the only divergent reader.

## Validation Failures

None.

## CI Failures

None.

---

## Proposed CI wiring (still not made here)

`.github/workflows/**` remains out of scope, so this covers local commits only — it does not
stop a coordinate reaching main through a path that skips hooks. The CI half is one block,
needing no arguments, no build and no network:

```yaml
      - name: CR citation anchors
        run: ./scripts/check-cr-citation-anchors.sh
```

The check self-tests before it walks and exits 2 rather than passing if the self-test does not
reproduce, so a green run in CI is distinguishable from a run that did nothing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented citation-anchor checks from interfering with files staged for a commit, including commits in linked worktrees or partial staging workflows.

- **Chores**
  - Added citation-anchor validation to the pre-commit checks, helping identify invalid or missing references before changes are committed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->