### PR TITLE
ci: queue staging deploys instead of cancelling them

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,9 +7,20 @@ on:
     branches: [main]
   workflow_dispatch:
 
+# A deploy runs ~40 minutes; `main` merges more often than that. Cancelling the
+# run in flight therefore starved this workflow completely — every run was
+# superseded before it could publish, so the newest commit never shipped either.
+# On 2026-09-05 that left preview serving five-hour-old content while the
+# Actions tab showed a healthy stream of runs.
+#
+# Queueing instead is bounded, not unbounded: a concurrency group holds at most
+# ONE pending run, because a newly queued run cancels whatever was already
+# pending. Worst case is therefore the run in flight plus one more (~80 min),
+# and the pending slot always carries the newest commit at the moment it starts.
+# We trade "sometimes one deploy behind" for "always makes progress".
 concurrency:
   group: deploy-pages
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 permissions:
   contents: read


### PR DESCRIPTION
A deploy runs ~40 minutes and `main` merges more often than that, so
`cancel-in-progress: true` starved this workflow outright: every run was
superseded before it could publish, which means the newest commit never
shipped either. On 2026-09-05 that left preview serving five-hour-old
content across a merged CORS fix, while the Actions tab showed a healthy
stream of runs - the failure is invisible from the run list, because a
cancelled deploy looks exactly like a superseded one.

Queueing is bounded rather than unbounded. A concurrency group holds at
most ONE pending run, since a newly queued run cancels whatever was
already pending, so the worst case is the run in flight plus one more
(~80 min) and the pending slot always carries the newest commit at the
moment it starts. That trades "sometimes one deploy behind" for "always
makes progress", which is the right side of the trade for a job whose
runtime exceeds its own trigger interval.

The deeper fix is to split the fast Pages content publish from the slow
WASM/server-binary/image builds it currently waits on, so a content-only
change does not cost 40 minutes. Left for its own change.

Claude-Session: https://claude.ai/code/session_01Fj6Taqrff1s2FBoJ6s1enr


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Deployment runs now complete instead of being cancelled when newer changes trigger additional deployments.
  - Pending deployments remain limited to the latest queued run, helping ensure updates are published reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->