### PR TITLE
docs(engine): repoint 50 stale CR citations at the rules they describe (#8523)

### DIFF
--- a/crates/engine/src/ai_support/candidates.rs
+++ b/crates/engine/src/ai_support/candidates.rs
@@ -2739,7 +2739,7 @@ pub fn candidate_actions_broad_with_probe(
             TacticalClass::Selection,
             Some(*player),
         )],
-        // CR 310.11 + CR 704.5w + CR 704.5x: controller chooses a new protector.
+        // CR 310.11 + CR 704.5x: controller chooses a new protector.
         WaitingFor::BattleProtectorChoice {
             player, candidates, ..
         } => candidates

--- a/crates/engine/src/analysis/resource.rs
+++ b/crates/engine/src/analysis/resource.rs
@@ -14407,7 +14407,7 @@ mod tests {
                 true,
             ),
             (
-                "BattleProtectorChoice (CR 310.11 + CR 704.5w / CR 704.5x)",
+                "BattleProtectorChoice (CR 310.11 + CR 704.5x)",
                 WaitingFor::BattleProtectorChoice {
                     player: PlayerId(0),
                     battle_id: ObjectId(5),

--- a/crates/engine/src/game/combat.rs
+++ b/crates/engine/src/game/combat.rs
@@ -7276,7 +7276,7 @@ mod tests {
         assert_eq!(
             defending_player_cr508_5(&state, source, Some(&ctx)),
             Some(PlayerId(2)),
-            "CR 310.8d: a battle's PROTECTOR is the defending player, not its controller"
+            "CR 310.9d: a battle's PROTECTOR is the defending player, not its controller"
         );
     }
 

--- a/crates/engine/src/game/combat.rs
+++ b/crates/engine/src/game/combat.rs
@@ -1300,9 +1300,9 @@ fn per_permanent_defender_caps(state: &GameState) -> Vec<(ObjectId, u32)> {
         .collect()
 }
 
-/// CR 508.5 + CR 310.8d: Resolve the defending player for an `AttackTarget` —
+/// CR 508.5 + CR 310.9d: Resolve the defending player for an `AttackTarget` —
 /// the player for a direct attack, the CONTROLLER of the planeswalker being
-/// attacked, or the PROTECTOR of the battle being attacked. CR 310.8d is
+/// attacked, or the PROTECTOR of the battle being attacked. CR 310.9d is
 /// explicit that when a battle's protector differs from its controller, every
 /// rule and effect referring to the "defending player" relative to that battle
 /// means the protector.
@@ -1316,10 +1316,12 @@ fn per_permanent_defender_caps(state: &GameState) -> Vec<(ObjectId, u32)> {
 /// `match` with a caller-supplied fallback. One `AttackTarget` → player rule,
 /// one home, next to `AttackTarget` itself.
 ///
-/// (This corrects a pre-existing citation on this function and at
-/// `apply_attack_declarations`, both of which pointed at a `310.9d` subrule
-/// that does not exist: CR 310.9 is the battle-attachment state-based action
-/// and has no lettered subrules. Verified absent from `docs/MagicCompRules.txt`.)
+/// (An earlier edit rewrote this function and `apply_attack_declarations`
+/// from `310.9d` to `310.8d`, believing CR 310.9 to be the battle-attachment
+/// state-based action. That was backwards. WotC inserted the non-Siege
+/// defense-0 SBA at CR 310.8, which moved the protector block down to
+/// CR 310.9 — so `310.9d` is correct and `310.8d` does not exist, and
+/// attachment is now CR 310.10. Do not re-invert this.)
 pub(crate) fn defending_player_for_target_or(
     state: &GameState,
     target: AttackTarget,
@@ -1340,7 +1342,7 @@ pub(crate) fn defending_player_for_target_or(
     }
 }
 
-/// CR 508.5 + CR 310.8d: [`defending_player_for_target_or`] with the historical
+/// CR 508.5 + CR 310.9d: [`defending_player_for_target_or`] with the historical
 /// `PlayerId(0)` fallback used by attack-declaration bookkeeping.
 fn defending_player_for_target(state: &GameState, target: AttackTarget) -> PlayerId {
     defending_player_for_target_or(state, target, PlayerId(0))
@@ -4042,7 +4044,7 @@ fn attacker_can_attack_target(
     gates: &CombatStaticGates,
     active_team: &[PlayerId],
 ) -> bool {
-    // CR 508.1b + CR 310.5/310.8b: target validity + active-team exclusion.
+    // CR 508.1b + CR 310.5/310.9b: target validity + active-team exclusion.
     match target {
         AttackTarget::Player(pid) => {
             if !state.players.iter().any(|p| p.id == pid)
@@ -5173,7 +5175,7 @@ pub(super) fn commit_attack_declaration(
     let mut attackers: Vec<AttackerInfo> = attacks
         .iter()
         .map(|(object_id, target)| {
-            // CR 508.5 + CR 310.8d: Defending player for a battle = its protector,
+            // CR 508.5 + CR 310.9d: Defending player for a battle = its protector,
             // not its controller. For planeswalkers, defending player = controller.
             let defending_player = defending_player_for_target(state, *target);
             AttackerInfo::new(*object_id, *target, defending_player)
@@ -6551,7 +6553,7 @@ fn attack_entries(event: &GameEvent) -> Option<(&[(ObjectId, AttackTarget)], Pla
 /// asker" — so it skipped past the asker's own entry and fell through to the
 /// coarse global field. Resolving the matched entry through
 /// [`defending_player_for_target_or`] answers with the planeswalker's
-/// controller or the battle's protector (CR 310.8d) instead.
+/// controller or the battle's protector (CR 310.9d) instead.
 fn entry_defender(
     state: &GameState,
     entries: &[(ObjectId, AttackTarget)],
@@ -6632,7 +6634,7 @@ fn sole_attacker_defender(
 ///    clause — "an ability of an attacking creature refers to a defending
 ///    player". Resolved through [`defending_player_for_target_or`], so a
 ///    planeswalker target answers with its controller and a battle target with
-///    its protector (CR 310.8d) instead of being skipped.
+///    its protector (CR 310.9d) instead of being skipped.
 /// 2. The bound event's SOLE attacker, when the event names exactly one.
 ///
 ///    **THIS STEP EXISTS TO OUTRANK THE LATCH (step 3), NOT TO RESOLVE THE
@@ -6818,11 +6820,11 @@ pub fn get_valid_attack_targets(state: &GameState) -> Vec<AttackTarget> {
         }
     }
 
-    // CR 310.8b + CR 506.2: A battle can be attacked by any attacking player for whom
+    // CR 310.9b + CR 506.2: A battle can be attacked by any attacking player for whom
     // its protector is a defending player. Notably a Siege can be attacked by its own
-    // controller if the protector is a different player (CR 310.8b "Notably, a Siege
+    // controller if the protector is a different player (CR 310.9b "Notably, a Siege
     // battle can be attacked by its own controller"). The only player who cannot
-    // attack is the battle's protector (CR 310.8b: "A battle's protector can never
+    // attack is the battle's protector (CR 310.9b: "A battle's protector can never
     // attack it").
     for &id in &state.battlefield {
         if let Some(obj) = state.objects.get(&id) {
@@ -7212,7 +7214,7 @@ mod tests {
         );
     }
 
-    /// CR 508.5 + CR 310.8d hardening: the asker's own entry resolves a
+    /// CR 508.5 + CR 310.9d hardening: the asker's own entry resolves a
     /// PLANESWALKER target to its controller and a BATTLE target to its
     /// PROTECTOR, instead of being skipped.
     ///
@@ -7256,7 +7258,7 @@ mod tests {
             "Battle".to_string(),
             Zone::Battlefield,
         );
-        // CR 310.8d: the protector is the durable `ChosenAttribute::Player`
+        // CR 310.9d: the protector is the durable `ChosenAttribute::Player`
         // persisted by the Siege's "as ~ enters" replacement, and it is
         // deliberately DIFFERENT from the battle's controller (P0) here.
         {

--- a/crates/engine/src/game/effects/free_cast_from_zones.rs
+++ b/crates/engine/src/game/effects/free_cast_from_zones.rs
@@ -160,7 +160,7 @@ pub(crate) fn eligible_candidates(
             let zone_ids = match zone {
                 Zone::Graveyard => &player.graveyard,
                 Zone::Hand => &player.hand,
-                // CR 400.10a + CR 608.2g: Exile is a shared zone — the whole pile
+                // CR 400.1 + CR 608.2g: Exile is a shared zone — the whole pile
                 // is scanned and the `filter` (e.g. `ExiledBySource` +
                 // `Not(InTrackedSet)`) narrows it to this resolution's linked set
                 // regardless of who owns the exiled cards (Plargg and Nassari

--- a/crates/engine/src/game/effects/gain_activated_abilities.rs
+++ b/crates/engine/src/game/effects/gain_activated_abilities.rs
@@ -869,7 +869,7 @@ mod tests {
                 .abilities
                 .iter()
                 .any(|a| *a == draw_ability()),
-            "CR 112.6a: the grant must still land on the ORIGINAL ability \
+            "CR 109.5 + CR 113.8: the grant must still land on the ORIGINAL ability \
              controller's (P0) Horror even though the source has left play \
              and `state.objects` no longer has an entry for it"
         );

--- a/crates/engine/src/game/effects/gain_activated_abilities.rs
+++ b/crates/engine/src/game/effects/gain_activated_abilities.rs
@@ -133,7 +133,7 @@ pub fn resolve(
             // or overwrite each other (CR 611.2c fixes each affected set
             // independently).
             //
-            // CR 112.6a: "you control" must resolve against the resolving
+            // CR 109.5 + CR 113.8: "you control" must resolve against the resolving
             // ability's controller, not whatever player currently controls the
             // live source object. `FilterContext::from_ability` binds
             // `source_controller` to `ability.controller` (captured when the
@@ -799,7 +799,7 @@ mod tests {
     }
 
     // ── Regression: group recipients must resolve against the resolving
-    // ability's controller (CR 112.6a), not the live source object's current
+    // ability's controller (CR 109.5 + CR 113.8), not the live source object's current
     // controller. Simulates the source (Grell) leaving the battlefield before
     // its triggered ability resolves — `state.objects` no longer holds it, so
     // `FilterContext::from_source` would read `source_controller: None` and

--- a/crates/engine/src/game/engine_resolution_choices.rs
+++ b/crates/engine/src/game/engine_resolution_choices.rs
@@ -7216,7 +7216,7 @@ pub(super) fn handle_resolution_choice(
                 })
             }
         }
-        // CR 310.11 + CR 704.5w + CR 704.5x: controller assigns the battle's new
+        // CR 310.11 + CR 704.5x: controller assigns the battle's new
         // protector. Re-running the SBA fixpoint (via the Priority resumption) will
         // find any remaining battles still needing reassignment.
         (

--- a/crates/engine/src/game/engine_tests.rs
+++ b/crates/engine/src/game/engine_tests.rs
@@ -5465,7 +5465,7 @@ fn new_game_creates_two_player_state() {
 }
 
 /// CR 117.1c + CR 503.2: After Untap (no priority), the active player
-/// receives priority during their Upkeep step. CR 103.7a skips the
+/// receives priority during their Upkeep step. CR 103.8a skips the
 /// first-turn Draw step entirely, so passing both priorities through
 /// Upkeep lands at PreCombatMain.
 #[test]
@@ -5483,7 +5483,7 @@ fn start_game_pauses_at_first_turn_upkeep_priority() {
         }
     ));
 
-    // Both players pass through Upkeep → CR 103.7a skips Draw → PreCombatMain.
+    // Both players pass through Upkeep → CR 103.8a skips Draw → PreCombatMain.
     apply_as_current(&mut state, GameAction::PassPriority).unwrap();
     let result = apply_as_current(&mut state, GameAction::PassPriority).unwrap();
     assert_eq!(state.phase, Phase::PreCombatMain);
@@ -5591,7 +5591,7 @@ fn integration_full_turn_cycle() {
     let mut state = new_game(42);
 
     // Start game (turn 1, player 0) — engine pauses at Upkeep priority per
-    // CR 117.1c. CR 103.7a skips the first-turn Draw step entirely.
+    // CR 117.1c. CR 103.8a skips the first-turn Draw step entirely.
     // (Libraries are empty, which is fine because the first-turn player
     // never draws and we stop the test before turn 2's draw step.)
     let _result = start_game_with_starting_player(&mut state, PlayerId(0));
@@ -5701,7 +5701,7 @@ fn integration_play_land_then_pass() {
 
     // CR 305.3 + CR 117.1c: lands are sorcery-speed, so pass Upkeep
     // priority (both players) to reach PreCombatMain before playing.
-    // CR 103.7a skips first-turn Draw so two passes is enough.
+    // CR 103.8a skips first-turn Draw so two passes is enough.
     apply_as_current(&mut state, GameAction::PassPriority).unwrap();
     apply_as_current(&mut state, GameAction::PassPriority).unwrap();
     assert_eq!(state.phase, Phase::PreCombatMain);
@@ -7525,7 +7525,7 @@ fn full_turn_integration_with_mulligan() {
     ));
     assert_eq!(state.phase, Phase::Upkeep);
 
-    // Drain Upkeep priority (turn 1 skips Draw per CR 103.7a) to reach Main.
+    // Drain Upkeep priority (turn 1 skips Draw per CR 103.8a) to reach Main.
     apply_as_current(&mut state, GameAction::PassPriority).unwrap();
     apply_as_current(&mut state, GameAction::PassPriority).unwrap();
     assert_eq!(state.phase, Phase::PreCombatMain);

--- a/crates/engine/src/game/sba.rs
+++ b/crates/engine/src/game/sba.rs
@@ -260,7 +260,7 @@ pub fn check_state_based_actions(state: &mut GameState, events: &mut Vec<GameEve
                 &battlefield_snapshot,
             );
 
-            // CR 704.5w + CR 704.5x + CR 310.11: Battle with no (or illegal) protector —
+            // CR 704.5x + CR 310.11: Battle with no (or illegal) protector —
             // controller chooses an appropriate protector; graveyard if none can be chosen.
             check_battle_protector(state, events, &mut any_performed, &battlefield_snapshot);
             if mid_resolution_entry_pauses_sba(state) {
@@ -1947,7 +1947,7 @@ fn check_illegal_attachment_unattach(
     }
 }
 
-/// CR 704.5w + CR 704.5x + CR 310.11 + CR 310.12a: If a battle that isn't being
+/// CR 704.5x + CR 310.11 + CR 310.12a: If a battle that isn't being
 /// attacked has no protector, an illegal protector, or (for Sieges) a protector
 /// that equals its controller, its controller chooses a legal protector. If no
 /// legal player exists, the battle is put into its owner's graveyard.
@@ -2015,7 +2015,7 @@ fn check_battle_protector(
 
         // Compute legal choices.
         // CR 310.12a: a Siege's controller "must choose its protector from among their
-        // opponents", and CR 704.5w's SBA phrasing — "no player IN THE GAME designated as
+        // opponents", and CR 704.5x's SBA phrasing — "no player IN THE GAME designated as
         // its protector ... chooses an appropriate player" — seats CR 102.1 directly on
         // this seam. A CHOICE, not a target (CR 115.10a), so the candidate list is the
         // CHOOSABLE opponents. The pre-existing `eliminated_players` filter is LEFT IN
@@ -2038,7 +2038,7 @@ fn check_battle_protector(
                 if live_battlefield_object(state, &battle_id).is_none() {
                     continue;
                 }
-                // CR 310.11 / CR 704.5w + CR 614.6: No legal protector exists —
+                // CR 310.11 / CR 704.5x + CR 614.6: No legal protector exists —
                 // the battle is put into the graveyard, a "leaves the
                 // battlefield" event that must consult Moved redirects. Bail on a
                 // CR 616.1 pause (the SBA fixpoint re-runs and finds the rest).
@@ -2067,7 +2067,7 @@ fn check_battle_protector(
                 if live_battlefield_object(state, &battle_id).is_none() {
                     continue;
                 }
-                // CR 310.11 + CR 704.5w + CR 704.5x: multiple legal protectors —
+                // CR 310.11 + CR 704.5x: multiple legal protectors —
                 // the controller must choose. Pause the SBA fixpoint and yield
                 // a WaitingFor (mirrors `check_legend_rule`). The SBA re-runs
                 // on the next apply and finds any remaining battles.

--- a/crates/engine/src/game/trigger_matchers.rs
+++ b/crates/engine/src/game/trigger_matchers.rs
@@ -4335,7 +4335,7 @@ pub(super) fn matching_you_attack_events_by_attacked_player(
     let mut groups: Vec<(PlayerId, Vec<(ObjectId, crate::game::combat::AttackTarget)>)> =
         Vec::new();
     for (attacker, target) in matching_you_attack_pairs(event, trigger, source_context, state) {
-        // CR 508.5a + CR 310.8d: resolve the attacked object to the one player
+        // CR 508.5a + CR 310.9d: resolve the attacked object to the one player
         // it answers for (planeswalker → controller, battle → protector) so a
         // mixed declaration still groups by player identity.
         let attacked =

--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -2883,7 +2883,7 @@ fn trigger_source_ids_for_zone(state: &GameState, zone: Zone) -> Vec<ObjectId> {
             .iter()
             .filter_map(|entry| match &entry.kind {
                 StackEntryKind::Spell { .. } => Some(entry.id),
-                // CR 111.1b + CR 113.3b: Activated/triggered ability stack entries
+                // CR 113.3b + CR 113.3c: Activated/triggered ability stack entries
                 // (including KeywordAction) are abilities, not objects.
                 StackEntryKind::ActivatedAbility { .. }
                 | StackEntryKind::TriggeredAbility { .. }

--- a/crates/engine/src/game/turns.rs
+++ b/crates/engine/src/game/turns.rs
@@ -3221,7 +3221,7 @@ fn auto_advance_once(state: &mut GameState, events: &mut Vec<GameEvent>) -> Auto
             if let (_, Some(prompt)) = process_phase_triggers(state, &event_snapshot, events) {
                 return AutoAdvanceStep::waiting(prompt);
             }
-            // CR 504.3 + CR 117.1c: The active player ALWAYS receives priority
+            // CR 504.2 + CR 117.1c: The active player ALWAYS receives priority
             // during the draw step (after the turn-based draw and any triggers).
             // See the Upkeep arm above for the rationale — same pattern.
             return AutoAdvanceStep::waiting(WaitingFor::Priority {

--- a/crates/engine/src/parser/oracle_tests.rs
+++ b/crates/engine/src/parser/oracle_tests.rs
@@ -20676,7 +20676,7 @@ fn untargeted_become_monarch_keeps_the_controller_default_cr_109_5() {
 
 /// CR 508.5: the rebind is gated on the trigger clause naming an attacked
 /// PLAYER. `Planeswalker` / `Battle` attack scopes name no player antecedent
-/// (a battle's anaphor would be its protector, CR 310.8d — a different
+/// (a battle's anaphor would be its protector, CR 310.9d — a different
 /// reference), so a `ScopedPlayer` anchor must survive unchanged there.
 ///
 /// There are two distinct noun sources, and each is asserted in the shape the

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -5064,7 +5064,7 @@ pub(crate) fn attack_intervening_if_anaphor_is_defending_player(def: &TriggerDef
 ///   supplies no antecedent.
 ///
 /// `Planeswalker` and `Battle` name no player noun at all — the correct anaphor
-/// for a battle would be "its protector" (CR 310.8d), a different reference.
+/// for a battle would be "its protector" (CR 310.9d), a different reference.
 /// `Owner`, `OwnerOrPlaneswalker` and `PlayerOrPermanents` are attack-RESTRICTION
 /// scopes with no arm in `attack_target_type_matches`, so a trigger carrying one
 /// never fires at all. Exhaustive — a future attack scope must decide here.

--- a/crates/engine/src/types/actions.rs
+++ b/crates/engine/src/types/actions.rs
@@ -710,7 +710,7 @@ pub enum GameAction {
     ChooseLegend {
         keep: ObjectId,
     },
-    /// CR 310.11 + CR 704.5w + CR 704.5x: Choose which player becomes the
+    /// CR 310.11 + CR 704.5x: Choose which player becomes the
     /// battle's new protector when the SBA pauses with a `BattleProtectorChoice`.
     ChooseBattleProtector {
         protector: PlayerId,

--- a/crates/engine/src/types/actions.rs
+++ b/crates/engine/src/types/actions.rs
@@ -94,7 +94,7 @@ pub enum AlternativeCastDecision {
     Normal,
     /// Pay the keyword-granted alternative cost. Resolution applies the
     /// keyword's post-payment effects (Overload's target→each text change per
-    /// CR 702.96b-c, Evoke's ETB-sacrifice trigger per CR 702.74b, Bestow's
+    /// CR 702.96b-c, Evoke's ETB-sacrifice trigger per CR 702.74a, Bestow's
     /// Aura transformation per CR 702.103b, Warp's exile-at-end-step rider).
     Alternative,
 }

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -8799,7 +8799,7 @@ pub enum AlternativeCastKeyword {
     /// Custom Warp keyword — exile-at-end-step rider; no CR section.
     Warp,
     /// CR 702.74a: ETB + sacrifice trigger fires when the resolving permanent
-    /// was cast for its evoke cost (CR 702.74b).
+    /// was cast for its evoke cost.
     Evoke,
     /// CR 702.119a-c: Emerge alternative cost requires sacrificing the specified
     /// permanent quality while casting and reduces the emerge cost by that
@@ -13125,7 +13125,7 @@ pub enum WaitingFor {
     ///   may be recast from exile later (no CR section; rider lives on the
     ///   keyword).
     /// - `Evoke` (CR 702.74a) — creature ETBs and sacrifices itself when cast
-    ///   for the evoke cost (CR 702.74b).
+    ///   for the evoke cost.
     /// - `Overload` (CR 702.96a) — substitutes the overload cost and rewrites
     ///   every "target" in the spell's text to "each" (CR 702.96b-c).
     /// - `Bestow` (CR 702.103a) — substitutes the bestow cost and turns the

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -13945,7 +13945,7 @@ pub enum WaitingFor {
         /// The zone the commander is currently in (Graveyard, Exile, Hand, or Library).
         current_zone: Zone,
     },
-    /// CR 310.11 + CR 310.12a + CR 704.5w + CR 704.5x: A battle that isn't being attacked has no
+    /// CR 310.11 + CR 310.12a + CR 704.5x: A battle that isn't being attacked has no
     /// protector, an illegal protector, or (for Sieges) a protector equal to its
     /// controller. The battle's controller (`player`) chooses a legal protector from
     /// `candidates`. Emitted only when `candidates.len() > 1`; the SBA auto-applies
@@ -15133,7 +15133,7 @@ impl WaitingFor {
     ///   fixpoint before priority is granted.
     /// * [`WaitingFor::BattleProtectorChoice`] — CR 310.11 ("its controller chooses an
     ///   appropriate player to be its protector ... This is a state-based action")
-    ///   + CR 704.5w / CR 704.5x, likewise answered inside the CR 704.3 fixpoint.
+    ///   + CR 704.5x, likewise answered inside the CR 704.3 fixpoint.
     ///
     /// Those SBA members (the commander-zone, legend and battle-protector choices) are
     /// the COMPLETE set of player-choice pauses `game::sba` opens inside the SBA
@@ -26378,7 +26378,7 @@ mod forced_cascade_window_tests {
                 },
             ),
             (
-                "BattleProtectorChoice (CR 310.11 + CR 704.5w / CR 704.5x — likewise an SBA)",
+                "BattleProtectorChoice (CR 310.11 + CR 704.5x — likewise an SBA)",
                 WaitingFor::BattleProtectorChoice {
                     player: PlayerId(0),
                     battle_id: ObjectId(5),

--- a/crates/engine/tests/integration/dark_depths_thespian_stage.rs
+++ b/crates/engine/tests/integration/dark_depths_thespian_stage.rs
@@ -24,7 +24,7 @@
 //! end-to-end.
 //!
 //! CR references (verified against `docs/MagicCompRules.txt`):
-//!   - CR 121.1c: a permanent enters with no counters except as the result of
+//!   - CR 614.1c: a permanent enters with no counters except as the result of
 //!     a replacement / sub-effect specifying otherwise.
 //!   - CR 122.1: counter handling.
 //!   - CR 603.8: state triggers re-evaluate after each SBA cycle.

--- a/crates/engine/tests/integration/issue_4955_greenbelt_rampager.rs
+++ b/crates/engine/tests/integration/issue_4955_greenbelt_rampager.rs
@@ -247,7 +247,7 @@ fn scenario_with_stolen_rampager(
     // `GameScenario::at_phase` hands the active player/priority to P0 (the
     // scenario default). The reanimation spell is cast by P1, so hand P1 both
     // active-player status and priority — otherwise the sorcery-speed cast is
-    // rejected as "not a castable zone" (CR 601.3g: sorcery-speed casting
+    // rejected as "not a castable zone" (CR 307.1: sorcery-speed casting
     // requires the caster to be the active player with an empty stack).
     runner.state_mut().active_player = P1;
     runner.state_mut().priority_player = P1;

--- a/crates/engine/tests/integration/issue_6504_jeweled_amulet_noted_mana.rs
+++ b/crates/engine/tests/integration/issue_6504_jeweled_amulet_noted_mana.rs
@@ -270,7 +270,7 @@ fn jeweled_amulet_bounced_mid_stack_does_not_note_on_new_incarnation() {
         "reach-guard: the zone change must have bumped the object's incarnation"
     );
 
-    // (3) CR 112.7a: the ability is independent of its departed source and
+    // (3) CR 113.7a: the ability is independent of its departed source and
     // still resolves.
     runner.resolve_top();
     assert!(

--- a/crates/engine/tests/integration/mbaku_attacked_monarch_intervening_if.rs
+++ b/crates/engine/tests/integration/mbaku_attacked_monarch_intervening_if.rs
@@ -36,7 +36,7 @@
 //!   - CR 508.5 / CR 508.5a: an ability referring to both an attacking creature
 //!     and a defending player means the player THAT creature is attacking, and
 //!     in multiplayer that player is determined individually per attacker.
-//!   - CR 310.8d: a battle's protector, and a planeswalker's controller, are the
+//!   - CR 310.9d: a battle's protector, and a planeswalker's controller, are the
 //!     defending player for an attack against them (Test 5's planeswalker).
 //!   - CR 603.2 / CR 603.2c: the trigger fires once per matching attacker.
 //!   - CR 603.4: the intervening-if is checked at fire time AND again as the

--- a/crates/engine/tests/integration/namor_attacking_that_player.rs
+++ b/crates/engine/tests/integration/namor_attacking_that_player.rs
@@ -505,7 +505,7 @@ fn ordruun_mentor_offers_exactly_the_attackers_of_the_attacked_player_cr_603_3d(
 ///
 /// It also answers the reachability question the per-attacked-player split
 /// raises: that split maps a planeswalker to its controller (CR 508.5a /
-/// CR 310.8d) when grouping, which in isolation looks like it could admit a
+/// CR 310.9d) when grouping, which in isolation looks like it could admit a
 /// planeswalker attack as a player attack. It cannot — the
 /// `attack_target_filter` type gate runs UPSTREAM, inside
 /// `matching_you_attack_pairs`, so a planeswalker-only declaration produces

--- a/crates/engine/tests/integration/rules/battle.rs
+++ b/crates/engine/tests/integration/rules/battle.rs
@@ -447,7 +447,7 @@ fn battle_protector_narrowing_to_one_auto_applies_silently() {
     assert_eq!(
         runner.state().objects[&battle].protector(),
         Some(PlayerId(3)),
-        "the auto-applied seat is the ONLY surviving legal opponent (CR 310.11a)"
+        "the auto-applied seat is the ONLY surviving legal opponent (CR 310.12a)"
     );
     assert!(runner.state().battlefield.contains(&battle));
 }

--- a/crates/engine/tests/integration/rules/battle.rs
+++ b/crates/engine/tests/integration/rules/battle.rs
@@ -3,9 +3,9 @@
 //! Covers:
 //! - Defense-counter ETB (CR 310.4b)
 //! - Zero-defense SBA (CR 704.5v + CR 310.7)
-//! - Protector choice/getter (CR 310.11a + CR 310.8a)
-//! - Attack target routing — defending player = protector (CR 508.5 + CR 310.8d)
-//! - Protector cannot attack own battle (CR 310.8b)
+//! - Protector choice/getter (CR 310.9a + CR 310.12a)
+//! - Attack target routing — defending player = protector (CR 508.5 + CR 310.9d)
+//! - Protector cannot attack own battle (CR 310.9b)
 
 #![allow(unused_imports)]
 use super::*;
@@ -63,7 +63,7 @@ fn battle_has_defense_equal_to_counters() {
     assert_eq!(obj.counters.get(&CounterType::Defense).copied(), Some(4));
 }
 
-/// CR 310.11b + CR 712.14a: Accepting a Siege victory cast during trigger
+/// CR 310.12b + CR 712.14a: Accepting a Siege victory cast during trigger
 /// resolution must preserve `cast_transformed`, so the permanent resolves onto
 /// the battlefield back face up.
 #[test]
@@ -168,7 +168,7 @@ fn zero_defense_battle_goes_to_graveyard_via_sba() {
     );
 }
 
-/// CR 310.8 + CR 310.8a: The `protector()` getter returns the chosen opponent.
+/// CR 310.9 + CR 310.9a: The `protector()` getter returns the chosen opponent.
 #[test]
 fn protector_getter_returns_chosen_player() {
     let (runner, battle) = prime_siege(P0, P1, "Protected Siege", 3);
@@ -185,10 +185,10 @@ fn non_battle_has_no_protector() {
     assert_eq!(runner.state().objects[&creature].protector(), None);
 }
 
-/// CR 508.1b + CR 508.5 + CR 310.8d: When a creature attacks a battle, the
+/// CR 508.1b + CR 508.5 + CR 310.9d: When a creature attacks a battle, the
 /// defending player for combat purposes is the battle's protector, not the
 /// battle's controller. Controller (P0) can attack their own Siege when the
-/// protector (P1) is different — CR 310.8b.
+/// protector (P1) is different — CR 310.9b.
 #[test]
 fn battle_attack_defending_player_is_protector() {
     let mut scenario = GameScenario::new();
@@ -244,7 +244,7 @@ fn battle_attack_defending_player_is_protector() {
 #[test]
 fn battle_protector_auto_applies_with_single_candidate_2p() {
     let (mut runner, battle) = prime_siege(P0, P0, "Self-Protected Siege", 3);
-    // Baseline: protector == controller (illegal per CR 310.11a).
+    // Baseline: protector == controller (illegal per CR 310.12a).
     assert_eq!(runner.state().objects[&battle].protector(), Some(P0));
 
     let mut events = Vec::new();
@@ -330,7 +330,7 @@ fn battle_protector_choice_rejects_invalid_candidate() {
         WaitingFor::BattleProtectorChoice { .. }
     ));
 
-    // P0 is the controller — not a legal Siege protector (CR 310.11a).
+    // P0 is the controller — not a legal Siege protector (CR 310.12a).
     let err = runner
         .act(GameAction::ChooseBattleProtector { protector: P0 })
         .expect_err("choosing a non-candidate player must be rejected");
@@ -367,7 +367,7 @@ fn battle_with_no_legal_protector_goes_to_graveyard() {
     ));
 }
 
-/// R4l — CR 310.11a (*"must choose its protector from among their opponents"*) +
+/// R4l — CR 310.12a (*"must choose its protector from among their opponents"*) +
 /// CR 704.5w (*"no player **in the game** designated as its protector"*): the protector
 /// pick is a CHOICE (CR 115.10a), so a phased-out seat is not among the choosable
 /// opponents (the CR 702.26b MIRROR), and a departed one is not either (CR 800.4 +
@@ -415,7 +415,7 @@ fn battle_protector_choice_excludes_a_phased_out_opponent_and_still_offers_the_r
 /// boundary, and at `1` the engine writes the protector ITSELF and publishes nothing: no
 /// `WaitingFor`, no events. That is invisible to every `candidates` assertion the R4-family
 /// shape prescribes, so it needs its own arm. The auto-applied seat is not wrong — it is
-/// the sole surviving legal opponent, which CR 310.10 + CR 310.11a make the only
+/// the sole surviving legal opponent, which CR 310.11 + CR 310.12a make the only
 /// appropriate player. What this arm guards is the SILENT DISAPPEARANCE of the prompt.
 ///
 /// BOTH halves are required: (a) alone would pass on a board where the SBA never ran at
@@ -544,7 +544,7 @@ fn battle_protector_choice_emits_ai_candidates_per_opponent() {
     assert_eq!(picks.len(), 2);
 }
 
-/// CR 310.8b: A battle's protector cannot attack it — the declaration is illegal.
+/// CR 310.9b: A battle's protector cannot attack it — the declaration is illegal.
 #[test]
 fn battle_protector_cannot_attack_own_battle() {
     let mut scenario = GameScenario::new();

--- a/crates/engine/tests/integration/rules/battle.rs
+++ b/crates/engine/tests/integration/rules/battle.rs
@@ -234,7 +234,7 @@ fn battle_attack_defending_player_is_protector() {
 }
 
 // ---------------------------------------------------------------------------
-// CR 310.10 + CR 704.5w + CR 704.5x: SBA protector reassignment.
+// CR 310.11 + CR 704.5x: SBA protector reassignment.
 // Multi-candidate (3+ player) branch must pause with
 // `WaitingFor::BattleProtectorChoice`; singleton (2-player) must auto-apply.
 // ---------------------------------------------------------------------------
@@ -262,7 +262,7 @@ fn battle_protector_auto_applies_with_single_candidate_2p() {
     assert!(runner.state().battlefield.contains(&battle));
 }
 
-/// CR 310.10 + CR 704.5w + CR 704.5x: In a 3-player game the controller has two
+/// CR 310.11 + CR 704.5x: In a 3-player game the controller has two
 /// legal opponents, so the SBA must pause with `BattleProtectorChoice`. Submitting
 /// `ChooseBattleProtector` assigns the chosen player via `ChosenAttribute::Player`
 /// and resumes the game.
@@ -312,7 +312,7 @@ fn battle_protector_pauses_for_choice_with_multiple_candidates_3p() {
     ));
 }
 
-/// CR 310.10: Submitting a protector that isn't in the candidate list is rejected.
+/// CR 310.11: Submitting a protector that isn't in the candidate list is rejected.
 #[test]
 fn battle_protector_choice_rejects_invalid_candidate() {
     const P2: PlayerId = PlayerId(2);
@@ -347,12 +347,12 @@ fn battle_protector_choice_rejects_invalid_candidate() {
     assert_eq!(runner.state().objects[&battle].protector(), Some(P2));
 }
 
-/// CR 310.10 / CR 704.5w: When no legal candidate exists, the battle is put
+/// CR 310.11 / CR 704.5x: When no legal candidate exists, the battle is put
 /// into its owner's graveyard. This preserves the existing 0-candidate fallback.
 #[test]
 fn battle_with_no_legal_protector_goes_to_graveyard() {
     // 2-player Siege whose only opponent (P1) has been eliminated — no legal
-    // protector exists, so CR 310.10 sends the battle to the graveyard.
+    // protector exists, so CR 310.11 sends the battle to the graveyard.
     let (mut runner, battle) = prime_siege(P0, P0, "Abandoned Siege", 3);
     runner.state_mut().eliminated_players.push(P1);
 
@@ -368,7 +368,7 @@ fn battle_with_no_legal_protector_goes_to_graveyard() {
 }
 
 /// R4l — CR 310.12a (*"must choose its protector from among their opponents"*) +
-/// CR 704.5w (*"no player **in the game** designated as its protector"*): the protector
+/// CR 704.5x (*"no player **in the game** designated as its protector"*): the protector
 /// pick is a CHOICE (CR 115.10a), so a phased-out seat is not among the choosable
 /// opponents (the CR 702.26b MIRROR), and a departed one is not either (CR 800.4 +
 /// CR 102.1).
@@ -453,7 +453,7 @@ fn battle_protector_narrowing_to_one_auto_applies_silently() {
 }
 
 /// R4l arm 3 — the `→ 0` crossing: with every opponent phased out there is no appropriate
-/// player, and CR 310.10 / CR 704.5w put the battle into its owner's graveyard.
+/// player, and CR 310.11 / CR 704.5x put the battle into its owner's graveyard.
 ///
 /// Reached by PHASING rather than by elimination on purpose: eliminating every opponent
 /// also ends the game (`waiting_for = GameOver`), which would confound the assertions with
@@ -475,7 +475,7 @@ fn battle_protector_narrowing_to_zero_sends_the_battle_to_the_graveyard() {
     assert!(
         !matches!(runner.state().waiting_for, WaitingFor::GameOver { .. }),
         "the table must still be LIVE — reaching 0 by phasing rather than by elimination \
-         is what keeps this arm about CR 310.10 instead of about the game ending"
+         is what keeps this arm about CR 310.11 instead of about the game ending"
     );
 }
 
@@ -511,7 +511,7 @@ fn phased_protector_board(phase_out: &[PlayerId]) -> (GameRunner, ObjectId) {
     (runner, battle)
 }
 
-/// CR 310.10 + CR 704.5w: AI routing — when the 3-player SBA pauses with a
+/// CR 310.11 + CR 704.5x: AI routing — when the 3-player SBA pauses with a
 /// protector choice, `legal_actions` emits one `ChooseBattleProtector` candidate
 /// per legal opponent, so the AI has a deterministic decision surface.
 #[test]

--- a/crates/engine/tests/integration/statecraft_damage_prevention.rs
+++ b/crates/engine/tests/integration/statecraft_damage_prevention.rs
@@ -769,10 +769,16 @@ fn fog_bank_both_directions_correct_after_unifying_self_ref() {
     }
 }
 
-/// CR 614.1a + CR 302.6c: Gaseous Form, cast and attached through the REAL
-/// production pipeline (`GameRunner::cast(..).target_object(..).resolve()`,
-/// not a manually-set `attached_to`), then driven through real
+/// CR 614.1a: Gaseous Form, cast and attached through the REAL production
+/// pipeline (`GameRunner::cast(..).target_object(..).resolve()`, not a
+/// manually-set `attached_to`), then driven through real
 /// `DeclareAttackers`/`DeclareBlockers`/combat-damage resolution.
+///
+/// Only CR 614.1a is cited here, deliberately. What this test adds over its
+/// siblings is a fixture-construction route, and the CR has no opinion on how
+/// a test reaches a board state. The rules content it does touch is cited at
+/// the point of use below (CR 303.4a for the Aura target slot, CR 704.5m for
+/// the orphan-Aura sweep). Do not attach a second rule number here.
 ///
 /// The other tests in this file that exercise `AttachedTo`-scoped cards use
 /// `attach_aura` (manual field-setting) + a direct `replace_event` probe


### PR DESCRIPTION
Fixes #8523 (47 of 51 sites; see deferrals below).

50 CR citations across `crates/` referenced rule ids absent from `docs/MagicCompRules.txt`. CLAUDE.md: *"A wrong CR number is worse than no CR number: it creates false confidence that code was verified against the wrong rule."*

## These were mostly not hallucinations

The largest cluster is **stale, not invented**. The battle-protector rules moved from `310.8x` to `310.9x` when WotC inserted the non-Siege defense-0 state-based action at `310.8`. The tell is that the quoted text still matches — at the neighbouring number:

> `combat.rs` cited `CR 310.8b` and quoted *"Notably, a Siege battle can be attacked by its own controller"* — which is verbatim **`310.9b`**.

A hallucinated citation has no such anchor. So the commit says *stale*, not *bogus*, and records the renumbering history rather than just swapping digits.

| Cited (absent) | Repointed to | Basis |
|---|---|---|
| `310.8a` / `310.11a` | `310.9a` or `310.12a` | **per-site**, see below |
| `310.8b` | `310.9b` | protector can never attack it |
| `310.8d` | `310.9d` | defending player relative to an attacked battle |
| `310.11b` | `310.12b` | Sieges' last-defense-counter ability |
| `103.7a` (5 sites) | `103.8a` | `103.7` is Planechase; `103.8a` is the two-player first-turn draw skip |

`310.11a` was adjudicated **per site**, not batch-replaced. Every changed instance turned out to be Siege legality (`310.12a`) rather than general protector-on-ETB — `battle.rs:370` quotes *"must choose its protector from among their opponents"*, verbatim `310.12a`. Only the module-header bullet covers both, and now reads `CR 310.9a + CR 310.12a`.

## A prior fix here had been applied backwards

`combat.rs` carried a note recording that it had "corrected" `310.9d` → `310.8d`, reasoning that "CR 310.9 is the battle-attachment SBA." That reasoned about what the rule *should* say instead of locating the quoted text. The note is replaced with the renumbering history so the same inversion is not made a third time.

## A site the audit instrument structurally could not see

`combat.rs:3986` reads `CR 508.1b + CR 310.5/310.8b` — the second id has no `CR ` prefix, so a regex anchored on that prefix reads straight past it. Found by asking what counterexample the instrument cannot return, and fixed here (the 51st site).

## Deletions, not substitutions

Where no rule governs the code, the annotation is **removed** with the absence marked deliberate — the resolution taken in #8522, and what CLAUDE.md requires. `CR 302.6c` described a fixture-construction route the CR has no opinion about; a redundant trailing `(CR 702.74b)` was dropped at two sites already led by `702.74a`.

## Now also covered: the three assert-message literals

Three of the ids lived inside **assert-message string literals** rather than comments (`gain_activated_abilities.rs`, `battle.rs`, `combat.rs`): `112.6a` -> `109.5 + 113.8`, `310.11a` -> `310.12a`, `310.8d` -> `310.9d`.

The comment-only property does not apply to these, so they are their own commit with their own proof: no changed line contains an assertion or predicate construct (0, against a live positive control of 1), all three added lines open a string literal, and **reverting just the three CR tokens restores a byte-identical tree** — only the failure message moved, never what is asserted.

## Now also covered: citations that EXIST but describe different code

The audit checks that an id exists, not that it governs the code, so it is structurally blind to this class — and a real-but-wrong id passes the existence check and therefore *reads as verified*. An existence gate and a governance gate are different instruments.

**`CR 310.10` -> `310.11`: 10 found, 8 changed, 2 left alone.**

- `sba.rs:1829` is **left, because it is correct** — `CR 704.5p (+ CR 310.10 for the battle half)` sits above a block quoting 704.5p about "may not be attached", and `310.10` genuinely *is* the battle half of that. This is the one site that looks like the cluster and is not; a batch replace would have broken it.
- `battle.rs:418` is left because the earlier commit in this PR already corrects it to `CR 310.11 + CR 310.12a`.

**`CR 704.5w` -> `704.5x`: 18 found, 18 changed — as two different edits.** Twelve are **deletions**: they already read `CR 704.5w + CR 704.5x`, so the correct id was alongside all along and substituting would have produced `CR 704.5x + CR 704.5x` twelve times. Only 6 were substitutions where `704.5w` stood alone, two of which quote `704.5x`'s text verbatim while citing `704.5w`. None of the 18 was a legitimate defense-0 citation.

Three of that commit's 21 lines are string literals rather than comments — one assert message and two `label` fields of `(label, WaitingFor, expected)` test tables. Both consumers were checked first: the label is only interpolated into an assert message, the discriminators are `is_forced_cascade_window()` and the table's own flag, and the accompanying `fold` ignores the label with `(_, _, e)`.

## Still deferred (1 site), deliberately

`cost_payability.rs:701` is a **likely engine bug rather than a citation bug**, filed as #8529. It cites nonexistent `701.13b` for "the cost is always payable" over `AbilityCost::Mill { .. } => true`, but the real mill rule `701.17b` says the opposite: *"the player can't pay a cost that includes milling a number of cards greater than the number of cards in their library."* The comment applied that rule's **effect** clause ("if instructed, mill as many as possible") to a **cost**. Repointing the number alone would leave a citation whose text refutes its own code — worse than the current state, since a wrong number at least fails a grep.

## Verification

```
audit RESULT: 1 cited id(s) NOT found in the rules text, 1 site(s)   (was 50)
  the 1 remaining is cost_payability.rs:701, deferred to #8529
  positive controls: 104 / 310.9e / 109.5 / 704.5a / 702.2c   present
  negative controls: 999.9z / 310.8e / 888                    absent
  scanned 89991 citations across 2121 distinct ids

residual stale ids across the whole branch:
  CR 310.8[abd] -> 0     CR 310.11[ab] -> 0
  CR 704.5w     -> 0     CR 103.7a     -> 0
positive control, correct replacements present:
  CR 310.9d -> 16        CR 704.5x -> 21        CR 103.8a -> 15

comment-only proof (first commit, *.rs vs origin/main):
  non-comment lines added = 0, removed = 0
  positive control: total added lines = 78  (filter is not vacuously zero)

rustfmt --edition 2021 --check: clean on all 22 touched files
```

No behavior change. No cargo build/clippy/test run locally, by design — CI is the gate.

**Rebase note:** #8321 landed under this change and inserted `per_permanent_defender_caps` in `combat.rs` directly above an edited line, producing one conflict. Resolved by keeping **all** of #8321's new function and taking only the corrected citation line; verified afterwards that `per_permanent_defender_caps` survives and no markers remain. A second, adjacent-line conflict between the two later commits in `battle.rs` was resolved to the union — `310.12a` for the Siege-protector half, `704.5x` for the no-protector-in-game half — both of which were independently checked against the rules text.

https://claude.ai/code/session_01JSZ2G5sVMGvVPFWX7beFCH
