### PR TITLE
fix(parser): anchor "each of its controller's opponents" on the triggering player (#8440)

### DIFF
--- a/crates/engine/src/parser/clause_shell.rs
+++ b/crates/engine/src/parser/clause_shell.rs
@@ -69,8 +69,8 @@
 use crate::parser::oracle_nom::error::OracleError;
 use nom::branch::alt;
 use nom::bytes::complete::{tag, tag_no_case, take_until};
-use nom::combinator::{opt, value};
-use nom::sequence::delimited;
+use nom::combinator::{map, opt, value};
+use nom::sequence::{delimited, terminated};
 use nom::Parser;
 
 use super::oracle_effect::conditions::{
@@ -327,17 +327,19 @@ fn try_peel_opponent_may_prefix(
     }
     nom_on_lower(text, &lower, |input| {
         alt((
-            // CR 102.2 + CR 603.2: "each of that player's opponents may" — the
-            // caster's opponents, fanned out per-player. Must precede the bare
-            // "each opponent may" arm (which scopes to the controller's
-            // opponents). Apostrophe variants: ASCII ' and curly U+2019 '.
-            value(
-                (None, Some(PlayerFilter::OpponentOfTriggeringPlayer)),
-                tag("each of that player's opponents may "),
-            ),
-            value(
-                (None, Some(PlayerFilter::OpponentOfTriggeringPlayer)),
-                tag("each of that player\u{2019}s opponents may "),
+            // CR 102.2 + CR 603.2: "each of ⟨that player | its controller⟩'s
+            // opponents may" — the TRIGGERING player's opponents, fanned out
+            // per-player. Must precede the bare "each opponent may" arm (which
+            // scopes to the ABILITY CONTROLLER's opponents). The subject grammar
+            // itself is the single authority in `oracle_effect::lower`, shared with
+            // the mandatory (no-"may") route so the two cannot drift apart; only
+            // the trailing "may " is this site's own.
+            map(
+                terminated(
+                    super::oracle_effect::lower::parse_each_of_triggering_players_opponents,
+                    tag("may "),
+                ),
+                |scope| (None, Some(scope)),
             ),
             value(
                 (None, Some(PlayerFilter::Opponent)),

--- a/crates/engine/src/parser/oracle_effect/lower.rs
+++ b/crates/engine/src/parser/oracle_effect/lower.rs
@@ -4970,6 +4970,50 @@ fn parse_excluded_player_anchor(i: &str) -> OracleResult<'_, PlayerFilter> {
     .parse(i)
 }
 
+/// CR 102.2 + CR 102.3 + CR 603.2: Parse the possessive subject
+/// `each of ⟨anchor⟩'s opponents ` into
+/// [`PlayerFilter::OpponentOfTriggeringPlayer`] — the opponents of the player the
+/// TRIGGER EVENT names, which in general is NOT the ability's controller.
+///
+/// Two independent axes, one `alt()` each, nested under the shared `each of `
+/// prefix rather than enumerated as whole phrases:
+///
+/// 1. **Possessive anchor.** Every member names the player that one runtime seam,
+///    `targeting::extract_player_from_event`, reads off the trigger event, so they
+///    share a single `PlayerFilter`:
+///    - `that player` — the acting player of the triggering event: the caster for
+///      a `SpellCast` trigger (Heartwood Storyteller, Standstill, Checks and
+///      Balances) and the mana-loser for Mana Max, Afterburner.
+///    - `its controller` — CR 603.10a + CR 109.4: the controller of the triggering
+///      OBJECT, taken from the `ZoneChangeRecord` look-back snapshot made as the
+///      object left the battlefield, so a dies trigger still names the seat that
+///      controlled the creature (Bounty Board, issue #8440).
+/// 2. **Apostrophe form.** Curly U+2019 and ASCII `'`.
+///
+/// NOT `PlayerFilter::Opponent`: that is the opponents of the ABILITY's controller.
+/// A bounty creature can die under any seat, so in a multiplayer game the two sets
+/// differ — and the Bounty Board controller is themselves a recipient whenever an
+/// opponent's bounty creature dies.
+///
+/// NOT `PlayerFilter::ParentObjectTargetController` either, which is what
+/// `parse_excluded_player_anchor` above maps a bare `its controller` to: that anchor
+/// reads the resolving ability's first OBJECT TARGET (Fractured Identity's exiled
+/// permanent). A dies trigger declares no targets, so it would resolve to no player.
+pub(crate) fn parse_each_of_triggering_players_opponents(
+    i: &str,
+) -> OracleResult<'_, PlayerFilter> {
+    value(
+        PlayerFilter::OpponentOfTriggeringPlayer,
+        (
+            tag("each of "),
+            alt((tag("that player"), tag("its controller"))),
+            alt((tag("\u{2019}s "), tag("'s "))),
+            tag("opponents "),
+        ),
+    )
+    .parse(i)
+}
+
 pub(super) fn strip_each_player_subject(text: &str) -> (Option<PlayerFilter>, String) {
     // CR 701.9a + CR 608.2c: Reserve only the exact Kroxa/Strongarm
     // mandatory-FILTERED decline-tail grammar for its dedicated dispatcher.
@@ -4988,17 +5032,11 @@ pub(super) fn strip_each_player_subject(text: &str) -> (Option<PlayerFilter>, St
                 tag("each player with the highest speed among players "),
             ),
             value(PlayerFilter::Opponent, tag("each other player ")),
-            // CR 102.2 + CR 603.2: "each of that player's opponents" — the
-            // caster's opponents (mandatory variant), fanned out per-player.
-            // Apostrophe variants: ASCII ' and curly U+2019 '.
-            value(
-                PlayerFilter::OpponentOfTriggeringPlayer,
-                tag("each of that player's opponents "),
-            ),
-            value(
-                PlayerFilter::OpponentOfTriggeringPlayer,
-                tag("each of that player\u{2019}s opponents "),
-            ),
+            // CR 102.2 + CR 603.2: "each of ⟨that player | its controller⟩'s
+            // opponents" — the TRIGGERING player's opponents (mandatory variant),
+            // fanned out per-player. Must precede the bare "each opponent " arm,
+            // which scopes to the ABILITY CONTROLLER's opponents instead.
+            parse_each_of_triggering_players_opponents,
             value(PlayerFilter::Opponent, tag("each opponent ")),
             // CR 608.2c + CR 109.4 + CR 608.2h: "each player other than <ref>" —
             // all players except the anchor's player (resolved with last-known

--- a/crates/engine/src/parser/oracle_effect/tests.rs
+++ b/crates/engine/src/parser/oracle_effect/tests.rs
@@ -29708,6 +29708,180 @@ fn strip_each_player_subject_still_strips_imperatives() {
     assert_eq!(result, "lose 2 life");
 }
 
+/// CR 102.2 + CR 102.3 + CR 603.2 (issue #8440): the possessive
+/// "each of ⟨anchor⟩'s opponents" subject grammar, pinned across BOTH axes the
+/// combinator composes — the anchor and the apostrophe form — rather than on one
+/// card's sentence.
+///
+/// The anchor axis decides WHOSE opponents. `that player` and `its controller`
+/// both name the player the trigger event carries, so both must reach
+/// `OpponentOfTriggeringPlayer`; only the bare, unpossessed `each opponent`
+/// means the ability CONTROLLER's opponents. That contrast is the whole point of
+/// the variant, so it is asserted here as the negative control — and it is not a
+/// vacuous negative: the same call returns `Some(..)` with a stripped predicate,
+/// proving the input reached and was consumed by this parser rather than being
+/// rejected upstream.
+#[test]
+fn each_of_possessive_opponents_subject_grammar() {
+    // Anchor axis. Both anchors, same filter, predicate deconjugated identically.
+    for anchor in ["that player", "its controller"] {
+        let (scope, result) =
+            strip_each_player_subject(&format!("each of {anchor}'s opponents draws a card"));
+        assert_eq!(
+            scope,
+            Some(PlayerFilter::OpponentOfTriggeringPlayer),
+            "\"each of {anchor}'s opponents\" must scope to the TRIGGERING player's opponents"
+        );
+        assert_eq!(result, "draw a card", "predicate for anchor {anchor}");
+    }
+
+    // Apostrophe axis, crossed with the anchor axis: the curly U+2019 form Oracle
+    // text actually ships must behave identically to the ASCII form.
+    for anchor in ["that player", "its controller"] {
+        let (scope, result) =
+            strip_each_player_subject(&format!("each of {anchor}\u{2019}s opponents gains 2 life"));
+        assert_eq!(
+            scope,
+            Some(PlayerFilter::OpponentOfTriggeringPlayer),
+            "curly apostrophe must parse identically for anchor {anchor}"
+        );
+        assert_eq!(result, "gain 2 life", "predicate for anchor {anchor}");
+    }
+
+    // NEGATIVE CONTROL with a positive reach-guard: the unpossessed subject is a
+    // DIFFERENT player set (the ability controller's opponents). `Some(Opponent)`
+    // plus the stripped predicate proves the text reached this parser, so the
+    // "not OpponentOfTriggeringPlayer" half is a real discrimination.
+    let (scope, result) = strip_each_player_subject("each opponent draws a card");
+    assert_eq!(scope, Some(PlayerFilter::Opponent));
+    assert_ne!(
+        scope,
+        Some(PlayerFilter::OpponentOfTriggeringPlayer),
+        "a bare \"each opponent\" has no possessive anchor and must NOT reroute to \
+         the triggering player's opponents"
+    );
+    assert_eq!(result, "draw a card");
+
+    // The possessive must not match a foreign anchor. Positive reach-guard: the
+    // fallthrough still strips a scope, so the text was parsed, not rejected.
+    let (scope, _) = strip_each_player_subject("each player draws a card");
+    assert_eq!(scope, Some(PlayerFilter::All));
+}
+
+/// CR 603.10a + CR 102.2 (issue #8440): Bounty Board — "Whenever a creature with
+/// a bounty counter on it dies, each of its controller's opponents draws a card
+/// and gains 2 life."
+///
+/// Oracle text verbatim from MTGJSON `AtomicCards.json` (`data["Bounty Board"]`).
+///
+/// BUG: the possessive subject had no arm in `strip_each_player_subject`, so the
+/// recipient fell through to `parse_target` and became a TARGETED player — the UI
+/// prompted for one player and only that player drew and gained life. The
+/// revert-failing assertions are the two `player_scope`s and the `Draw` recipient:
+/// before the fix `player_scope` was `None` and the recipient was a targetable
+/// `TargetFilter::Typed`.
+///
+/// Mathas, Fiend Seeker is the shape control below — the same "draws a card and
+/// gains 2 life" dies-trigger body with the UNPOSSESSED subject, which must keep
+/// its ability-controller-relative `PlayerFilter::Opponent`.
+#[test]
+fn bounty_board_each_of_its_controllers_opponents_is_not_targeted() {
+    let def = crate::parser::oracle_trigger::parse_trigger_line(
+        "Whenever a creature with a bounty counter on it dies, each of its controller's \
+         opponents draws a card and gains 2 life.",
+        "Bounty Board",
+    );
+
+    let execute = def.execute.as_deref().expect("execute body");
+    assert_eq!(
+        execute.player_scope,
+        Some(PlayerFilter::OpponentOfTriggeringPlayer),
+        "the draw must fan out to the DYING creature's controller's opponents"
+    );
+    let Effect::Draw { count, target } = execute.effect.as_ref() else {
+        panic!("expected Draw, got {:?}", execute.effect);
+    };
+    assert_eq!(*count, QuantityExpr::Fixed { value: 1 });
+    assert_eq!(
+        *target,
+        TargetFilter::Controller,
+        "the draw recipient must be the per-iteration Controller, never a targeted player"
+    );
+
+    // The second conjunct rides the same per-player iteration (Mathas's shape).
+    let sub = execute
+        .sub_ability
+        .as_deref()
+        .expect("gains 2 life conjunct");
+    assert_eq!(
+        sub.player_scope,
+        Some(PlayerFilter::OpponentOfTriggeringPlayer),
+        "the life gain must fan out to the same opponents as the draw"
+    );
+    assert!(
+        matches!(
+            sub.effect.as_ref(),
+            Effect::GainLife {
+                amount: QuantityExpr::Fixed { value: 2 },
+                ..
+            }
+        ),
+        "expected GainLife 2, got {:?}",
+        sub.effect
+    );
+}
+
+/// CR 102.2 (issue #8440) — invariance control. Mathas, Fiend Seeker's granted
+/// trigger is the SAME dies-trigger body with the unpossessed subject: "When this
+/// creature dies, each opponent draws a card and gains 2 life." It must keep
+/// `PlayerFilter::Opponent` (the ability controller's opponents), confirming the
+/// new possessive arm is selective rather than a blanket reroute of every
+/// each-opponent dies trigger.
+#[test]
+fn mathas_unpossessed_each_opponent_dies_trigger_stays_controller_relative() {
+    let def = crate::parser::oracle_trigger::parse_trigger_line(
+        "When this creature dies, each opponent draws a card and gains 2 life.",
+        "Mathas, Fiend Seeker",
+    );
+
+    let execute = def.execute.as_deref().expect("execute body");
+    assert_eq!(execute.player_scope, Some(PlayerFilter::Opponent));
+    let sub = execute
+        .sub_ability
+        .as_deref()
+        .expect("gains 2 life conjunct");
+    assert_eq!(sub.player_scope, Some(PlayerFilter::Opponent));
+}
+
+/// CR 102.2 + CR 608.2d (issue #8440): the optional ("may") route peels the same
+/// possessive subject through `clause_shell`, which now shares the single
+/// combinator authority with the mandatory route above. Without that sharing the
+/// two sites drift: "that player" would be optional-capable and "its controller"
+/// would not, for no reason in the rules. The "may" axis is orthogonal to the
+/// anchor axis, so both anchors must reach the same scope with `optional: true`.
+#[test]
+fn each_of_possessive_opponents_may_route_shares_the_anchor_grammar() {
+    for anchor in ["that player", "its controller"] {
+        let def = crate::parser::oracle_trigger::parse_trigger_line(
+            &format!(
+                "Whenever a creature with a bounty counter on it dies, \
+                 each of {anchor}'s opponents may draw a card."
+            ),
+            "Test Card",
+        );
+        let execute = def.execute.as_deref().expect("execute body");
+        assert_eq!(
+            execute.player_scope,
+            Some(PlayerFilter::OpponentOfTriggeringPlayer),
+            "\"may\" route must reach the same scope for anchor {anchor}"
+        );
+        assert!(
+            execute.optional,
+            "the per-recipient \"may\" must survive the peel for anchor {anchor}"
+        );
+    }
+}
+
 /// CR 508.6 + CR 104.3e: An "[source] attacked this turn" relative clause
 /// narrows the player set to `OpponentAttacked { Source, ThisTurn }` (Angel of Destiny,
 /// issue #1599). General over the predicate verb and over the self-ref

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -9205,16 +9205,28 @@ pub enum PlayerFilter {
     /// event clause. Falls back to plain `Opponent` semantics when no trigger
     /// event is in scope (i.e. only excludes the controller).
     OpponentOtherThanTriggering,
-    /// CR 102.2 + CR 603.2 + CR 608.2d: Each opponent of the *triggering* player
-    /// (the caster of the spell that fired the trigger), resolved live from
-    /// `state.current_trigger_event` via `extract_player_from_event`. Models
-    /// "each of that player's opponents [may] <effect>" (Heartwood Storyteller) —
-    /// "that player" is the triggering/casting player, NOT the source's controller.
+    /// CR 102.2 + CR 102.3 + CR 603.2 + CR 608.2d: Each opponent of the
+    /// *triggering* player, resolved live from `state.current_trigger_event` via
+    /// `extract_player_from_event`. Never the SOURCE's controller — which is what
+    /// makes this distinct from plain `Opponent`.
+    ///
+    /// Which seat "the triggering player" is comes from the event, so the same
+    /// filter serves every phrasing whose possessive anchors on it:
+    /// - CR 603.2 `SpellCast` — the caster: "each of that player's opponents [may]
+    ///   <effect>" (Heartwood Storyteller, Standstill, Checks and Balances).
+    /// - CR 603.10a `ZoneChanged` — the controller the moving object had in the
+    ///   look-back snapshot: "each of its controller's opponents <effect>" on a
+    ///   dies trigger (Bounty Board). The Bounty Board controller is themselves a
+    ///   recipient when an opponent's bounty creature dies, which `Opponent` — the
+    ///   ability controller's opponents — can never express.
+    ///
     /// The recipient SET is fanned out per-player by the standard `player_scope`
-    /// loop; the body recipient stays `Controller`, rebound per opponent. CR 102.2
-    /// two-player opponent (`p.id != caster`); CR 102.3 teams intentionally not
-    /// modeled (mirrors `Opponent`). Fails closed (no recipient, count 0) when no
-    /// trigger event is in scope — the caster anchor is undefined without it.
+    /// loop; the body recipient stays `Controller`, rebound per opponent.
+    /// Opponent-ness is CR 102.3-aware (2HG teammates are not opponents): every
+    /// consumer — `matches_player_scope`, `deal_damage`, `quantity`,
+    /// `speed_effects` — routes through `players::is_opponent`. Fails closed (no
+    /// recipient, count 0) when no trigger event is in scope, since the anchor is
+    /// undefined without one.
     OpponentOfTriggeringPlayer,
     /// CR 506.2 + CR 508.6 + CR 603.4: Each opponent of the *triggering/attacking*
     /// player (resolved from the active AttackersDeclared trigger event) who is NOT


### PR DESCRIPTION
Fixes #8440.

Bounty Board's dies trigger made its draw/lifegain **targeted** instead of scoping it to each opponent of the dying creature's controller.

Card text verbatim from MTGJSON `data["Bounty Board"]`, not the issue's paraphrase:

> Whenever a creature with a bounty counter on it dies, each of its controller's opponents draws a card and gains 2 life.

## Root cause

`strip_each_player_subject` recognized `each of ⟨anchor⟩'s opponents` for the anchor `that player` only. `its controller` had no arm, so the recipient fell out of the player-scope cascade into `parse_target` and became a targetable player filter.

Confirmed in the shipped artifact rather than in a parse trace — `client/public/card-data.json` gives Bounty Board's `Draw` a `target: "Typed"` with **no** `player_scope` key, while Standstill's structurally identical construction has `target: "Controller"` + `player_scope: OpponentOfTriggeringPlayer`.

The fix is the anchor axis of the existing `PlayerFilter::OpponentOfTriggeringPlayer`. `extract_player_from_event` already answers "caster" for `SpellCast` and, per **CR 603.10a** (look-back-in-time zone-change triggers), the moving object's snapshot controller for `ZoneChanged` — which for a dies trigger *is* "its controller".

## Combinator shape

Two enumerated full-phrase tags per route collapse into one nested combinator, one `alt()` per axis:

```rust
value(PlayerFilter::OpponentOfTriggeringPlayer, (
    tag("each of "),
    alt((tag("that player"), tag("its controller"))),   // anchor axis
    alt((tag("\u{2019}s "), tag("'s "))),               // apostrophe axis
    tag("opponents "),
))
```

**Single authority, shown structurally rather than asserted:** exactly 1 definition and 2 call sites — the mandatory route (`lower.rs`) and the "may" route (`clause_shell.rs`). No `tag("each of …")` literal survives at either, so an edit to one route cannot silently diverge from the other.

## Blast radius: exactly one card

Corpus predicate over every printing in `AtomicCards.json`:

```
1  each of its controller's opponents   <- the NEW anchor  (Bounty Board)
4  each of that player's opponents      <- pre-existing    (Checks and Balances,
                                            Heartwood Storyteller, Mana Max
                                            Afterburner, Standstill)
```

The 4 pre-existing hits are the positive control: the predicate shape can match, so the 1 is a measurement rather than a broken query. The serialized-shape check on `card-data.json` was likewise controlled — the four control cards each print a real `OpponentOfTriggeringPlayer`, so Bounty Board's `ABSENT + Typed` is a discrimination, not the only answer the query could produce.

## Verification

```
test result: ok. 13 passed; 0 failed; 0 ignored; 0 measured; 20552 filtered out; finished in 0.12s
```

4 new tests plus the 9 pre-existing `strip_each_player_subject` / Heartwood regression tests. The pre-existing Heartwood "may"-route test is the invariance control for touching `clause_shell.rs`.

Discrimination without a revert build: the pre-fix `card-data.json` **is** the counterfactual. The tests assert `player_scope == Some(OpponentOfTriggeringPlayer)` and `Draw.target == Controller`; both are false against that artifact, so both flip on revert.

CR numbers — `102.2, 102.3, 109.4, 603.2, 603.10a, 608.2d` — each grep-verified against `docs/MagicCompRules.txt`, negative control `603.10zz` -> 0 hits.

```
Gate G PASS (router/grant architecture: strict router vs permissive grant boundary intact)
Gate A PASS head=0ab9d7eb3810524caa7ac6dc455b2c9f4e950c92 base=b7b993af097f785ae237262da46d6c4feaa44128
```

## Judgement calls

- **No new enum variant.** The anchor is a parse-time axis, not a runtime one; a sibling variant would have been the proliferation smell CLAUDE.md warns about.
- **Deliberately not `ParentObjectTargetController`**, which is what the adjacent `parse_excluded_player_anchor` maps a bare "its controller" to. That anchor reads the resolving ability's first *object target*; a dies trigger declares none, so it would have resolved to no player — a silent no-op. This is called out in the combinator doc so a later reader does not "fix" it that way.
- **Touched the "may" route too**, though Bounty Board is mandatory. Adding the anchor to one route only would leave "that player" optional-capable and "its controller" not, for no reason in the rules.
- **Corrected a stale doc sentence** on `PlayerFilter` claiming CR 102.3 teams were "intentionally not modeled", after reading all four consumers — every one routes through `players::is_opponent`, which is team-aware. Doc-comment only: 0 non-`///` added lines in `types/ability.rs`.

## Known gaps

- **No new integration test.** The runtime fan-out for this filter is covered by `crates/engine/tests/integration/heartwood_storyteller_opponents_draw.rs`, but no Bounty Board runtime test was added — the integration binary could not be built within the machine's memory budget while other lanes compiled. That is a gap, not a claim of coverage.
- Only the targeted lib filter was run locally; clippy, full `test-engine` and `card-data` are left to CI.
- Regenerating `card-data.json` will change exactly one card — Bounty Board's `Draw` gains `player_scope: OpponentOfTriggeringPlayer` + `target: Controller`, and the `GainLife` conjunct gains the same scope, matching Mathas, Fiend Seeker's structure.

https://claude.ai/code/session_01JSZ2G5sVMGvVPFWX7beFCH
