### PR TITLE
fix(parser): offer a delayed payload's named "may" to that player (#8439)

### DIFF
--- a/crates/engine/src/game/ability_utils.rs
+++ b/crates/engine/src/game/ability_utils.rs
@@ -18460,6 +18460,7 @@ mod tests {
     ///   * `the_cr_603_5_prompt_census_is_pinned_so_a_sixth_producer_is_a_counted_event`
     ///     counts every code-half occurrence in `game/effects/mod.rs` with no
     ///     test exclusion at all.
+    ///
     /// Neither guard was weakened to place this test.
     ///
     /// CR 603.7d fixes the delayed ability's controller as the caster, which is

--- a/crates/engine/src/game/ability_utils.rs
+++ b/crates/engine/src/game/ability_utils.rs
@@ -18435,4 +18435,102 @@ mod tests {
              clause (not something else) is the discriminator"
         );
     }
+
+    /// CR 608.2d + CR 603.7d: the seat asked to announce a delayed payload's
+    /// "may" is the player the clause NAMES, not the delayed ability's
+    /// controller (issue #8439, Arcane Denial).
+    ///
+    /// Runtime companion to `parser::oracle_effect::tests::
+    /// subject_anchored_delayed_may_binds_the_named_player_not_the_caster`,
+    /// which pins the parsed shape. Driven end-to-end through
+    /// `build_resolved_from_def_with_targets` (this module) and
+    /// `parent_target_controller` (this module) — the two hops the stamp has to
+    /// survive — rather than a hand-built ability, so it fails if either half of
+    /// the fix is reverted: the assembly seam must leave `optional` on the
+    /// payload and stamp `optional_player`, and the recipient authority must
+    /// honour the stamp.
+    ///
+    /// It lives HERE rather than beside either the parser test or the authority
+    /// it calls, because two independent source censuses pin
+    /// `optional_prompt_player` call sites and this is the only home neither
+    /// miscounts:
+    ///   * `f2c_the_cr_603_5_conjunct_set_has_one_production_assembler` scans the
+    ///     whole crate and excludes inline `#[cfg(test)]` module spans (this
+    ///     one) but not a `mod.rs`-declared `tests.rs`;
+    ///   * `the_cr_603_5_prompt_census_is_pinned_so_a_sixth_producer_is_a_counted_event`
+    ///     counts every code-half occurrence in `game/effects/mod.rs` with no
+    ///     test exclusion at all.
+    /// Neither guard was weakened to place this test.
+    ///
+    /// CR 603.7d fixes the delayed ability's controller as the caster, which is
+    /// exactly why the pre-fix routing was wrong rather than coincidentally so.
+    /// The matched negative below differs from the positive in exactly the stamp
+    /// and reproduces that pre-fix seat.
+    #[test]
+    fn subject_anchored_delayed_may_prompts_the_named_player_not_the_controller() {
+        let parsed = crate::parser::parse_oracle_text(
+            "Counter target spell. Its controller may draw up to two cards at the beginning of \
+             the next turn's upkeep.\nYou draw a card at the beginning of the next turn's upkeep.",
+            "Arcane Denial",
+            &[],
+            &["Instant".to_string()],
+            &[],
+        );
+        let counter = parsed.abilities.first().expect("expected a spell ability");
+        let theirs = counter
+            .sub_ability
+            .as_deref()
+            .expect("expected the countered controller's delayed half");
+        let crate::types::ability::Effect::CreateDelayedTrigger {
+            effect: payload, ..
+        } = &*theirs.effect
+        else {
+            panic!("expected a delayed trigger, got {:#?}", theirs.effect);
+        };
+
+        let mut state = GameState::new_two_player(8439);
+        let caster = state.players[0].id;
+        let countered_controller = state.players[1].id;
+        assert_ne!(
+            caster, countered_controller,
+            "reach-guard: the two seats must differ or this test cannot discriminate"
+        );
+        // CR 608.2h: the countered spell sits in its owner's graveyard by the
+        // time the delayed ability resolves — the state the anaphor must still
+        // resolve against.
+        let countered_spell = crate::game::zones::create_object(
+            &mut state,
+            CardId(8439),
+            countered_controller,
+            "Countered Spell".to_string(),
+            Zone::Graveyard,
+        );
+        let mut delayed = build_resolved_from_def_with_targets(
+            payload,
+            ObjectId(0),
+            caster,
+            vec![TargetRef::Object(countered_spell)],
+        );
+        assert!(
+            delayed.optional,
+            "reach-guard: the resolved delayed ability must still carry the may, or the \
+             assertion below is about nothing"
+        );
+
+        assert_eq!(
+            crate::game::effects::optional_prompt_player(&state, &delayed),
+            countered_controller,
+            "CR 608.2d: the countered spell's controller announces the may and draws"
+        );
+
+        // Matched negative on the same instrument, differing in exactly the
+        // stamp — the shape the parser emitted before the fix.
+        delayed.optional_player = None;
+        assert_eq!(
+            crate::game::effects::optional_prompt_player(&state, &delayed),
+            caster,
+            "without the stamp the gate falls back to the ability's controller — the \
+             wrong seat this change exists to correct"
+        );
+    }
 }

--- a/crates/engine/src/parser/oracle_effect/assembly.rs
+++ b/crates/engine/src/parser/oracle_effect/assembly.rs
@@ -1488,6 +1488,39 @@ fn bind_chosen_number_anaphor(def: &mut AbilityDefinition, prior: &[AbilityDefin
     }
 }
 
+/// CR 608.2d + CR 603.7d: Which player announces a delayed-trigger payload's
+/// "may", when the clause names that player instead of leaving the choice with
+/// the ability's controller.
+///
+/// The subject grammar (`oracle_effect::subject`) lowers a subject-anchored
+/// modal — "its controller may …", "its owner may …", "that creature's
+/// controller may …" — to `optional: true` plus a parent-target player anaphor
+/// in the effect's own player slot. That anaphor IS the actor: CR 608.2d has the
+/// announcing player make the choice while the effect is applied, and CR 603.7d
+/// fixes the delayed ability's *controller* as the creating spell's controller,
+/// so the two differ exactly when the clause names someone else.
+///
+/// Returns the anaphor to stamp as `AbilityDefinition::optional_player` (the
+/// engine's single authority for "who receives this may", consumed by
+/// `game::effects::optional_prompt_player`), or `None` for a controller-held
+/// "may" — including a payload that is not optional at all.
+///
+/// Deliberately narrow: only the two parent-target PLAYER anaphors qualify.
+/// `TargetFilter::Player` is an announced target and `Controller` is the
+/// wrapper's own controller; neither shifts the announcing player away from the
+/// existing lift.
+fn delayed_payload_optional_actor(def: &AbilityDefinition) -> Option<TargetFilter> {
+    if !def.optional || def.optional_player.is_some() {
+        return None;
+    }
+    match def.effect.target_filter()? {
+        actor @ (TargetFilter::ParentTargetController | TargetFilter::ParentTargetOwner) => {
+            Some(actor.clone())
+        }
+        _ => None,
+    }
+}
+
 pub(crate) fn assemble_effect_chain(ir: &EffectChainIr) -> AbilityDefinition {
     let kind = ir.kind;
     let continuation_kind = ir.continuation_kind.unwrap_or(AbilityKind::Spell);
@@ -2754,7 +2787,26 @@ pub(crate) fn assemble_effect_chain(ir: &EffectChainIr) -> AbilityDefinition {
                 // #4956) would re-check that creation-time "if you do" signal when
                 // the delayed trigger fires at end step and skip the return.
                 let lifted_condition = std::mem::take(&mut inner.condition);
-                let lifted_optional = std::mem::replace(&mut inner.optional, false);
+                // CR 603.7d + CR 608.2d: The lift above is correct only for a
+                // "may" the DELAYED TRIGGER'S OWN CONTROLLER holds — CR 603.7d
+                // makes that the player who controlled the creating spell, so
+                // hoisting the flag onto the wrapper asks the right player at a
+                // harmlessly earlier moment. It is wrong for a subject-anchored
+                // "may" whose actor the clause NAMES as a parent-target player
+                // anaphor ("Counter target spell. Its controller may draw up to
+                // two cards at the beginning of the next turn's upkeep" — Arcane
+                // Denial; "its owner may …" is the same shape). CR 608.2d puts
+                // that announcement inside the delayed ability's own resolution,
+                // and the announcing player is the named one, not the wrapper's
+                // controller. Keep the flag on the payload and stamp the actor so
+                // `effects::optional_prompt_player` routes the prompt there.
+                let lifted_optional = match delayed_payload_optional_actor(&inner) {
+                    Some(actor) => {
+                        inner.optional_player = Some(actor);
+                        false
+                    }
+                    None => std::mem::replace(&mut inner.optional, false),
+                };
                 let lifted_optional_for = std::mem::take(&mut inner.optional_for);
                 let lifted_repeat_for = std::mem::take(&mut inner.repeat_for);
                 let lifted_player_scope = std::mem::take(&mut inner.player_scope);

--- a/crates/engine/src/parser/oracle_effect/tests.rs
+++ b/crates/engine/src/parser/oracle_effect/tests.rs
@@ -59318,3 +59318,118 @@ fn damage_each_player_scope_accepts_the_partitive_spelling() {
         "the anaphoric partitive must decline rather than guess a referent",
     );
 }
+
+/// CR 603.7d + CR 608.2d: a delayed-trigger payload whose "may" the clause
+/// anchors to a NAMED player keeps that "may" — and records who announces it.
+///
+/// Issue #8439, Arcane Denial (Oracle text verified against MTGJSON
+/// `AtomicCards.json`): "Counter target spell. Its controller may draw up to two
+/// cards at the beginning of the next turn's upkeep. / You draw a card at the
+/// beginning of the next turn's upkeep." CR 603.7d makes the delayed ability's
+/// controller the caster, so hoisting the payload's `optional` onto the
+/// `CreateDelayedTrigger` wrapper handed the countered player's choice to the
+/// caster — the countered opponent was never asked and drew nothing.
+///
+/// The class is the subject-anchored modal ("its controller may …" / "its owner
+/// may …" / "that creature's controller may …") under a temporal suffix, which
+/// `subject::parse_subject_application` already lowers to a parent-target player
+/// anaphor; nothing here keys on this card.
+///
+/// Two assertions here, each independently revert-sensitive: the wrapper no
+/// longer carries the "may" and the payload does, and the payload carries the
+/// named announcer as `optional_player`.
+///
+/// This half pins the PARSED SHAPE only. What that shape buys at runtime — that
+/// the production authority picking the seat the CR 608.2d gate asks returns the
+/// countered spell's controller — is pinned by its companion
+/// `game::ability_utils::tests::
+/// subject_anchored_delayed_may_prompts_the_named_player_not_the_controller`.
+/// That half cannot live in this file, nor beside the authority it calls: two
+/// independent source censuses pin those call sites, and this `tests.rs` is
+/// counted as production by one of them (it excludes inline `#[cfg(test)]`
+/// module spans, but not a `mod.rs`-declared `tests.rs`).
+///
+/// Positive control: the caster's own delayed half ("You draw a card at …")
+/// stays mandatory, controller-bound and unstamped, so the stamp is keyed on the
+/// subject anaphor rather than on "is a delayed payload".
+#[test]
+fn subject_anchored_delayed_may_binds_the_named_player_not_the_caster() {
+    let parsed = parse_oracle_text(
+        "Counter target spell. Its controller may draw up to two cards at the beginning of the \
+         next turn's upkeep.\nYou draw a card at the beginning of the next turn's upkeep.",
+        "Arcane Denial",
+        &[],
+        &["Instant".to_string()],
+        &[],
+    );
+    let counter = parsed.abilities.first().expect("expected a spell ability");
+    assert!(
+        matches!(&*counter.effect, Effect::Counter { .. }),
+        "reach-guard: the head must still counter the spell, got {:#?}",
+        counter.effect
+    );
+
+    let theirs = counter
+        .sub_ability
+        .as_deref()
+        .expect("expected the countered controller's delayed half");
+    let Effect::CreateDelayedTrigger {
+        effect: theirs_payload,
+        ..
+    } = &*theirs.effect
+    else {
+        panic!("expected a delayed trigger, got {:#?}", theirs.effect);
+    };
+    assert!(
+        !theirs.optional,
+        "CR 608.2d: the wrapper's controller does not hold a named player's may"
+    );
+    assert!(
+        theirs_payload.optional,
+        "CR 608.2d: the may is announced while the delayed ability is applied"
+    );
+    assert_eq!(
+        theirs_payload.optional_player,
+        Some(TargetFilter::ParentTargetController),
+        "CR 608.2d: the announcing player is the countered spell's controller"
+    );
+    match &*theirs_payload.effect {
+        Effect::Draw { target, .. } => assert_eq!(
+            *target,
+            TargetFilter::ParentTargetController,
+            "the drawer is the countered spell's controller"
+        ),
+        other => panic!("expected the named half to Draw, got {other:?}"),
+    }
+
+    // Positive control on the caster's own half: same wrapper shape, same
+    // temporal suffix, no named subject — it must stay mandatory and unstamped,
+    // so the stamp is keyed on the subject anaphor rather than on "is delayed".
+    let yours = theirs
+        .sub_ability
+        .as_deref()
+        .expect("expected the caster's delayed half");
+    let Effect::CreateDelayedTrigger {
+        effect: yours_payload,
+        ..
+    } = &*yours.effect
+    else {
+        panic!("expected a delayed trigger, got {:#?}", yours.effect);
+    };
+    assert!(
+        !yours.optional && !yours_payload.optional,
+        "\"You draw a card\" carries no may on either node"
+    );
+    assert_eq!(
+        yours_payload.optional_player, None,
+        "an unnamed subject must not be stamped with an announcer"
+    );
+    match &*yours_payload.effect {
+        Effect::Draw { target, .. } => assert_eq!(
+            *target,
+            TargetFilter::Controller,
+            "the caster's half draws for the caster"
+        ),
+        other => panic!("expected the caster half to Draw, got {other:?}"),
+    }
+}


### PR DESCRIPTION
Fixes #8439 (partly — see the remaining gap below).

Arcane Denial's countered opponent was never prompted, so they drew nothing.

> Counter target spell. **Its controller may draw up to two cards** at the beginning of the next turn's upkeep.
> You draw a card at the beginning of the next turn's upkeep.

## Not a wrong target — a misrouted choice

The draw's player subject was already correct. The parsed AST binds `Draw { count: UpTo(2), target: ParentTargetController }`. What was wrong is **who holds the "may", and when**.

In `oracle_effect/assembly.rs`, the `CreateDelayedTrigger` wrapping seam lifted the payload's `optional` onto the wrapper unconditionally:

```rust
let lifted_optional = std::mem::replace(&mut inner.optional, false);
```

**CR 603.7d** fixes a spell-created delayed ability's controller as the caster: *"The controller of that delayed triggered ability is the player who controlled that spell as it resolved."* So the lift handed the **countered player's** CR 608.2d choice to the **caster**, and asked it at spell resolution rather than at the delayed ability's own resolution. Declining discarded the draw entirely. That is a misroute guaranteed by rule, not a coincidence of this card.

## Fix: lift only a "may" the wrapper's controller actually holds

When the payload names its actor as a parent-target player anaphor — the subject grammar's existing `ParentTargetController` / `ParentTargetOwner` lowering for "its controller may…", "its owner may…" — `optional` stays on the payload and the actor is stamped into the existing typed `AbilityDefinition::optional_player`, already the engine's single authority for "who receives this may" and already consumed by `effects::optional_prompt_player`.

No new field, no new enum variant, no parallel path. Pure AST inspection, no string dispatch.

Only those two anaphors qualify: `TargetFilter::Player` is an announced target and `Controller` is the wrapper's own controller; neither shifts the announcing player.

## Blast radius: 1 card, complement 0

From `client/public/card-data.json`:

| | count |
|---|---|
| `CreateDelayedTrigger` wrapper nodes | 542 |
| (1) of those carrying a lifted `optional` | **1** |
| (2) of (1) naming `ParentTargetController`/`ParentTargetOwner` | **1** (Arcane Denial, `Draw`) |
| (3) complement of (2) inside (1) — must be bit-identical | **0** |

The other 541 short-circuit on `!def.optional` and take the byte-identical path.

Controls both ways on the same keys: `ParentTargetController` matches 458 nodes corpus-wide, `ParentTargetOwner` 48, `optional == true` 755; a bogus filter type and a bogus `optional` value each return 0. `TargetFilter` serializes as an object, so the key is `.target.type` — confirmed by dumping Arcane Denial's own AST first rather than assuming the shape. Population (2) was computed as a **superset** (recursive anaphor scan over the whole payload effect), so the true changed set is a subset of {Arcane Denial}.

## Verification

```
test result: ok. 20580 passed; 0 failed; 6 ignored; 0 measured; 0 filtered out; finished in 91.59s
test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 20584 filtered out; finished in 0.04s
test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 20581 filtered out; finished in 1.77s
```

CR `603.7d`, `608.2d`, `608.2h` grep-verified against `docs/MagicCompRules.txt` with their text read; negative control `608.2zz` -> 0 hits.

```
Gate G PASS (router/grant architecture: strict router vs permissive grant boundary intact)
Gate A PASS head=b2d6d0c59d7886c3fa60d4f17f0a907a0eb5b199 base=b7b993af097f785ae237262da46d6c4feaa44128
```

Checked with `git merge-tree --write-tree` against every other in-flight PR (#8524, #8528, #8530, #8531, #8534): all exit 0, with a known-conflicting pair as the positive control confirming the check discriminates.

## Two source censuses forced the runtime test's home

Worth recording, because targeted tests were **not** sufficient here — the full suite caught it.

`f2c_the_cr_603_5_conjunct_set_has_one_production_assembler` counts `optional_prompt_player(` call sites and excludes `*_tests.rs` and inline `#[cfg(test)] mod` spans — but **not** a `mod.rs`-declared `tests.rs`. Parser-side assertions there read as production sites (1 -> 3) and turned it red. Relocating to `game/effects/mod.rs` then tripped a *second*, differently-scoped census counting every code-half occurrence in that file with no test exclusion (2 -> 4). The final home is `game/ability_utils.rs`'s inline test mod, which both censuses exclude.

**Neither guard's expected counts were edited.** Making a census green by editing its expectation would have removed the only thing that caught this.

## Remaining gap, deliberately out of scope

`Effect::Draw` still resolves `QuantityExpr::UpTo` transparently to its maximum, so the named player is asked **whether** to draw but not **how many** — post-fix Arcane Denial offers 0-or-2, not 0/1/2. The issue's "no prompt to ask how many cards" is therefore only partly addressed; the "drew nothing" harm is fixed. `draw.rs`'s comment claiming the count "has already been resolved via `engine_resolution_choices`" is inaccurate for this path and wants a follow-up.

The four bespoke arms in `optional_prompt_player` (`Sacrifice`/`ChangeZone`/`SearchLibrary`/`CopySpell`) become partly redundant with the general stamp but were left in place; removing them would broaden this change well past the fix.

The census reads **post-lift** serialized data, so it measures the wrapper's `optional`. A card whose lifted `optional` were cleared by some later pass would be invisible to it — no such pass was found, but the instrument cannot exclude one.

https://claude.ai/code/session_01JSZ2G5sVMGvVPFWX7beFCH


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected delayed “may” prompts so Arcane Denial’s optional effect is presented to the player who controlled the countered spell, rather than the player who cast Arcane Denial.
  - Ensured the caster’s separate mandatory draw remains correctly associated with the caster.

- **Tests**
  - Added coverage for parsing and resolving delayed optional effects involving the countered spell’s controller.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->