### PR TITLE
fix(engine): republish the zone-change ledger after an EffectZoneChoice (#8455)

### DIFF
--- a/crates/engine/src/game/engine_resolution_choices.rs
+++ b/crates/engine/src/game/engine_resolution_choices.rs
@@ -6521,6 +6521,34 @@ pub(super) fn handle_resolution_choice(
             // set of dies-events whose triggers issue #423 must not lose.
             let events_after_move = events.len();
 
+            // CR 608.2c + CR 400.7: republish the resolution-local "moved this
+            // way" ledger from the moves THIS selection performed, mirroring
+            // the synchronous publish `resolve_ability_chain` runs after an
+            // effect that completes without pausing. A parent effect that
+            // paused for this prompt already stamped `last_zone_changed_ids`
+            // from its own event slice, which was still EMPTY — so a
+            // `ZoneChangedThisWay` rider (Town Greeter's "If you put a Town
+            // card into your hand this way, you gain 2 life", issue #8455)
+            // deferred onto the continuation would be re-evaluated by the
+            // drain below against that empty set and silently dropped, while
+            // its negated twin ("If you didn't put a card onto the battlefield
+            // this way", Rulik Mons) would fire unconditionally. The sibling
+            // interactive paths already republish here — `DiscardChoice` in
+            // `finalize_discard_choice_completion`, surveil in
+            // `BatchCompletion::SurveilKeepOnTop`, dig in `RevealRestPile`.
+            //
+            // Unconditional, exactly like that synchronous publish: `Sacrifice`
+            // never reaches here (every arm of its completion match diverges),
+            // and a kind that moved nothing republishes the empty set the
+            // synchronous path would have written anyway.
+            state.last_zone_changed_ids = events[events_before_effect..events_after_move]
+                .iter()
+                .filter_map(|event| match event {
+                    GameEvent::ZoneChanged { object_id, .. } => Some(*object_id),
+                    _ => None,
+                })
+                .collect();
+
             // Step B: resolve the reflexive `WhenYouDo` continuation (Grist's
             // `[-2]`). `waiting_for` is still `Priority` here, so
             // `resume_with_error_propagation`'s guard passes and

--- a/crates/engine/tests/integration/issue_8455_town_greeter.rs
+++ b/crates/engine/tests/integration/issue_8455_town_greeter.rs
@@ -1,0 +1,351 @@
+//! Issue #8455 — Town Greeter: "When this creature enters, mill four cards.
+//! You may put a land card from among them into your hand. If you put a Town
+//! card into your hand this way, you gain 2 life."
+//!
+//! The parse was already correct: the `GainLife` sub carries
+//! `AbilityCondition::ZoneChangedThisWay { Subtype("Town"), Hand }`. The defect
+//! was at runtime. "You may put a land card from among them" pauses at
+//! `WaitingFor::EffectZoneChoice`, and a paused parent effect still stamps
+//! `state.last_zone_changed_ids` from its own event slice — empty, because
+//! nothing has moved yet. The rider is correctly deferred onto the ability
+//! continuation, but the choice's completion handler never republished the
+//! ledger, so the drain re-evaluated `ZoneChangedThisWay` against an empty set:
+//! false for every card, so the life gain was silently dropped.
+//!
+//! CR 608.2c ("this way" scopes to the objects the resolving instruction moved)
+//! + CR 400.7 (the moved object is the referent).
+//!
+//! CLASS, NOT CARD: every `ZoneChangedThisWay` rider whose parent zone change is
+//! a player selection routes through the same completion handler — Nashi,
+//! Spelunking, Oviya, Rulik Mons, The Vast Scrier. `spelunking_class_*` below is
+//! that shape with NO preceding zone-change instruction, so it pins the fix at
+//! the interactive-selection layer rather than at Town Greeter's mill. The
+//! negated twin ("If you didn't put a card … this way") is the same defect at
+//! the opposite polarity: an empty ledger makes `Not { ZoneChangedThisWay }`
+//! fire unconditionally.
+//!
+//! DISCRIMINATION: revert the `last_zone_changed_ids` republish in
+//! `engine_resolution_choices.rs` and the two positive legs read the empty
+//! ledger and gain 0 life, while their non-matching partners keep passing —
+//! which is why each asserts a matching AND a non-matching selection against
+//! the same body. `patient_naturalist_*` pins the opposite sign, where the
+//! empty ledger produces an EXTRA effect rather than a missing one.
+
+use engine::game::ability_utils::build_resolved_from_def;
+use engine::game::effects::resolve_ability_chain;
+use engine::game::scenario::{GameRunner, GameScenario};
+use engine::parser::oracle_effect::parse_effect_chain;
+use engine::types::ability::{AbilityCondition, AbilityKind, TargetFilter};
+use engine::types::actions::GameAction;
+use engine::types::card_type::CoreType;
+use engine::types::identifiers::ObjectId;
+use engine::types::player::PlayerId;
+use engine::types::zones::Zone;
+
+const P0: PlayerId = PlayerId(0);
+
+const TOWN_GREETER: &str = "mill four cards. you may put a land card from among them into your \
+hand. if you put a town card into your hand this way, you gain 2 life.";
+
+/// Spelunking's shape without the preceding draw: the selected zone change is
+/// the FIRST instruction, so its rider has no earlier ledger to accidentally
+/// read. Pre-fix the ledger is empty here too (cleared at chain depth 0).
+const SPELUNKING: &str = "you may put a land card from your hand onto the battlefield. if you put \
+a cave onto the battlefield this way, you gain 4 life.";
+
+/// Give a seeded generic card the land type line the body filters on.
+fn make_land(runner: &mut GameRunner, id: ObjectId, subtypes: &[&str]) {
+    let obj = runner.state_mut().objects.get_mut(&id).unwrap();
+    obj.card_types.core_types = vec![CoreType::Land];
+    obj.card_types.subtypes = subtypes.iter().map(|s| (*s).to_string()).collect();
+    obj.base_card_types = obj.card_types.clone();
+}
+
+/// Whether a rider's condition gates on `ZoneChangedThisWay` — directly, or
+/// under the `Not` wrapper the negated riders carry (Patient Naturalist's "if
+/// you can't").
+///
+/// WIDENED DELIBERATELY, AND CONTROLLED. The original form accepted only the
+/// bare variant. That is the same conflation of *negation* with *composition*
+/// that mislabelled the card census, encoded a second time in the harness. A
+/// widened assertion that quietly stops rejecting would void the precondition
+/// for every leg below without turning anything red, so
+/// `the_gate_predicate_still_rejects_an_unrelated_condition` pins both signs.
+fn gates_on_zone_changed_this_way(condition: &AbilityCondition) -> bool {
+    match condition {
+        AbilityCondition::ZoneChangedThisWay { .. } => true,
+        AbilityCondition::Not { condition } => gates_on_zone_changed_this_way(condition),
+        _ => false,
+    }
+}
+
+#[test]
+fn the_gate_predicate_still_rejects_an_unrelated_condition() {
+    let zctw = || AbilityCondition::ZoneChangedThisWay {
+        filter: TargetFilter::Any,
+        destination: None,
+    };
+    // Reach guards: the two shapes the harness must accept really are accepted.
+    assert!(gates_on_zone_changed_this_way(&zctw()));
+    assert!(gates_on_zone_changed_this_way(&AbilityCondition::Not {
+        condition: Box::new(zctw()),
+    }));
+    // The control: widening must not have turned the gate into a tautology.
+    assert!(
+        !gates_on_zone_changed_this_way(&AbilityCondition::IsYourTurn),
+        "an unrelated condition must still be refused"
+    );
+    // The one a loose `Not` arm fails: it must inspect its inner condition, not
+    // report true merely because a `Not` is present.
+    assert!(
+        !gates_on_zone_changed_this_way(&AbilityCondition::Not {
+            condition: Box::new(AbilityCondition::IsYourTurn),
+        }),
+        "Not-wrapping an unrelated condition must not launder it through the gate"
+    );
+}
+
+/// Resolve `body` as a top-level chain and assert it really is the gated shape
+/// under test — a body that stopped parsing the rider would make every
+/// assertion below vacuous.
+fn resolve_body(runner: &mut GameRunner, body: &str, source: ObjectId) {
+    let def = parse_effect_chain(body, AbilityKind::Spell);
+    let gate = def
+        .sub_ability
+        .as_ref()
+        .and_then(|sub| sub.sub_ability.as_ref())
+        .or(def.sub_ability.as_ref())
+        .and_then(|sub| sub.condition.as_ref());
+    assert!(
+        gate.is_some_and(gates_on_zone_changed_this_way),
+        "{body:?} must lower its rider to ZoneChangedThisWay — got {gate:?}"
+    );
+    let ability = build_resolved_from_def(&def, source, P0);
+    let mut events = Vec::new();
+    resolve_ability_chain(runner.state_mut(), &ability, &mut events, 0).expect("chain resolves");
+}
+
+/// Accept the "you may …" yes/no that precedes the card pick. Town Greeter's
+/// "you may put a land card from among them" lowers the optional onto the
+/// `ChangeZone` itself (`up_to`), so it goes straight to the selection; a body
+/// whose optional is its own decision (Spelunking's "you may put a land card
+/// from your hand") pauses here first.
+fn accept_optional(runner: &mut GameRunner) {
+    assert_eq!(
+        runner.waiting_for_kind(),
+        "OptionalEffectChoice",
+        "this body's optional is expected to be its own decision"
+    );
+    runner
+        .act(GameAction::DecideOptionalEffect { accept: true })
+        .expect("accepting the optional is legal");
+}
+
+/// Assert the chain is parked on the card pick — the interactive path the fix
+/// lives on. Without this a body that resolved straight through would make
+/// every assertion below vacuous.
+fn expect_selection(runner: &GameRunner) {
+    assert_eq!(
+        runner.waiting_for_kind(),
+        "EffectZoneChoice",
+        "the put must pause for a card selection"
+    );
+}
+
+/// Answer the pending `EffectZoneChoice` and report the controller's life delta.
+fn select(runner: &mut GameRunner, cards: Vec<ObjectId>) -> i32 {
+    let before = runner.state().players[0].life;
+    runner
+        .act(GameAction::SelectCards { cards })
+        .expect("selection is legal");
+    runner.state().players[0].life - before
+}
+
+/// Town Greeter with four cards milled and both a Town and a non-Town land
+/// among them, so the same board answers both polarities.
+fn town_greeter_board() -> (GameRunner, ObjectId, ObjectId, ObjectId) {
+    let mut scenario = GameScenario::new();
+    let source = scenario.add_creature(P0, "Town Greeter", 1, 1).id();
+    let town = scenario.add_card_to_library_top(P0, "Adventurer's Inn");
+    let plains = scenario.add_card_to_library_top(P0, "Plains");
+    scenario.add_card_to_library_top(P0, "Filler A");
+    scenario.add_card_to_library_top(P0, "Filler B");
+    let mut runner = scenario.build();
+    make_land(&mut runner, town, &["Town"]);
+    make_land(&mut runner, plains, &["Plains"]);
+    (runner, source, town, plains)
+}
+
+#[test]
+fn town_greeter_gains_two_life_when_a_town_is_put_into_hand_this_way() {
+    let (mut runner, source, town, _) = town_greeter_board();
+    resolve_body(&mut runner, TOWN_GREETER, source);
+    expect_selection(&runner);
+    assert_eq!(
+        select(&mut runner, vec![town]),
+        2,
+        "Town put into hand → +2"
+    );
+    assert_eq!(
+        runner.state().objects[&town].zone,
+        Zone::Hand,
+        "the Town really was put into hand — the life gain is what was missing"
+    );
+}
+
+#[test]
+fn town_greeter_gains_no_life_when_the_land_put_into_hand_is_not_a_town() {
+    let (mut runner, source, _, plains) = town_greeter_board();
+    resolve_body(&mut runner, TOWN_GREETER, source);
+    expect_selection(&runner);
+    assert_eq!(
+        select(&mut runner, vec![plains]),
+        0,
+        "a non-Town land put this way gains nothing"
+    );
+    assert_eq!(runner.state().objects[&plains].zone, Zone::Hand);
+}
+
+#[test]
+fn town_greeter_gains_no_life_when_the_optional_put_is_declined() {
+    let (mut runner, source, town, _) = town_greeter_board();
+    resolve_body(&mut runner, TOWN_GREETER, source);
+    expect_selection(&runner);
+    assert_eq!(
+        select(&mut runner, vec![]),
+        0,
+        "declining the put gains nothing even with a Town among the milled cards"
+    );
+    assert_eq!(
+        runner.state().objects[&town].zone,
+        Zone::Graveyard,
+        "the declined Town stayed in the graveyard the mill put it in"
+    );
+}
+
+/// The same rider on a selected zone change with NO preceding zone-change
+/// instruction: the ledger the rider reads can only have been published by the
+/// selection itself.
+fn spelunking_board() -> (GameRunner, ObjectId, ObjectId, ObjectId) {
+    let mut scenario = GameScenario::new();
+    let source = scenario.add_creature(P0, "Spelunking", 1, 1).id();
+    let cave = scenario
+        .add_land_to_hand(P0, "Sunken Citadel")
+        .with_subtypes(vec!["Cave"])
+        .id();
+    let plains = scenario
+        .add_land_to_hand(P0, "Plains")
+        .with_subtypes(vec!["Plains"])
+        .id();
+    (scenario.build(), source, cave, plains)
+}
+
+#[test]
+fn spelunking_class_gains_life_when_the_land_put_onto_the_battlefield_is_a_cave() {
+    let (mut runner, source, cave, _) = spelunking_board();
+    resolve_body(&mut runner, SPELUNKING, source);
+    accept_optional(&mut runner);
+    expect_selection(&runner);
+    assert_eq!(select(&mut runner, vec![cave]), 4, "Cave put this way → +4");
+    assert_eq!(runner.state().objects[&cave].zone, Zone::Battlefield);
+}
+
+#[test]
+fn spelunking_class_gains_no_life_when_the_land_put_onto_the_battlefield_is_not_a_cave() {
+    let (mut runner, source, _, plains) = spelunking_board();
+    resolve_body(&mut runner, SPELUNKING, source);
+    accept_optional(&mut runner);
+    expect_selection(&runner);
+    assert_eq!(
+        select(&mut runner, vec![plains]),
+        0,
+        "a non-Cave land put this way gains nothing"
+    );
+    assert_eq!(runner.state().objects[&plains].zone, Zone::Battlefield);
+}
+
+// ---------------------------------------------------------------------------
+// Patient Naturalist — the NEGATED twin of the same ledger omission.
+// ---------------------------------------------------------------------------
+//
+// "When this creature enters, mill three cards. Put a land card from among the
+// milled cards into your hand. If you can't, create a Treasure token."
+//
+//   Mill{3} → ChangeZone{Hand, TrackedSetFiltered(Land), up_to}
+//           → Token{Treasure} gated on Not { ZoneChangedThisWay { Any } }
+//
+// This is the opposite sign of the Town Greeter bug and the one that hides. An
+// always-empty ledger makes `Not { ZoneChangedThisWay }` true unconditionally,
+// so pre-fix Patient Naturalist mints a Treasure EVEN WHEN a land was put into
+// hand — an extra permanent, rather than a missing life gain.
+//
+// PRE-FIX REDNESS IS DEDUCED, NOT RE-RUN. The probe on unmodified origin/main
+// measured `last_zone_changed_ids = []` after the selection completed, with the
+// chosen card confirmed in hand. `Not { ZoneChangedThisWay { Any } }` over an
+// empty ledger is true by construction, so the Treasure is minted. No revert
+// build was run for this leg.
+const PATIENT_NATURALIST: &str = "mill three cards. put a land card from among the milled cards \
+into your hand. if you can't, create a treasure token.";
+
+fn treasures(runner: &GameRunner) -> usize {
+    runner
+        .battlefield_names()
+        .iter()
+        .filter(|name| name.as_str() == "Treasure")
+        .count()
+}
+
+#[test]
+fn patient_naturalist_creates_no_treasure_when_a_land_is_put_into_hand() {
+    let mut scenario = GameScenario::new();
+    let source = scenario.add_creature(P0, "Patient Naturalist", 1, 1).id();
+    let forest = scenario.add_card_to_library_top(P0, "Forest");
+    scenario.add_card_to_library_top(P0, "Filler A");
+    scenario.add_card_to_library_top(P0, "Filler B");
+    let mut runner = scenario.build();
+    make_land(&mut runner, forest, &["Forest"]);
+
+    resolve_body(&mut runner, PATIENT_NATURALIST, source);
+    expect_selection(&runner);
+    select(&mut runner, vec![forest]);
+
+    assert_eq!(
+        runner.state().objects[&forest].zone,
+        Zone::Hand,
+        "the land really was put into hand — that is what makes the gate false"
+    );
+    assert_eq!(
+        treasures(&runner),
+        0,
+        "a land WAS put this way, so `if you can't` must NOT fire"
+    );
+}
+
+/// Non-vacuity partner for the leg above: it proves the Treasure branch can fire
+/// at all, so the zero there is not an artifact of an inert `Token` effect.
+///
+/// SCOPE: this leg does NOT exercise the republish under test. With no land
+/// among the milled cards the eligible set is empty, so the `ChangeZone` raises
+/// no `EffectZoneChoice` and the rider is evaluated on the inline path. The
+/// `assert_ne!` below is what keeps that claim checkable rather than asserted.
+#[test]
+fn patient_naturalist_creates_a_treasure_when_no_land_was_milled() {
+    let mut scenario = GameScenario::new();
+    let source = scenario.add_creature(P0, "Patient Naturalist", 1, 1).id();
+    scenario.add_card_to_library_top(P0, "Filler A");
+    scenario.add_card_to_library_top(P0, "Filler B");
+    scenario.add_card_to_library_top(P0, "Filler C");
+    let mut runner = scenario.build();
+
+    resolve_body(&mut runner, PATIENT_NATURALIST, source);
+    assert_ne!(
+        runner.waiting_for_kind(),
+        "EffectZoneChoice",
+        "an empty eligible set must raise no selection — this leg is the inline path"
+    );
+    assert_eq!(
+        treasures(&runner),
+        1,
+        "no land was milled, so `if you can't` fires"
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -821,6 +821,7 @@ mod issue_822_erode_path_to_exile_search_controller;
 mod issue_828_full_throttle;
 mod issue_8302_liberator_mana_spent_power;
 mod issue_841_selvala_explorer_returned;
+mod issue_8455_town_greeter;
 mod issue_847_braids_cabal_minion;
 mod issue_852_torrential_gearhulk;
 mod issue_859_weathered_wayfarer;


### PR DESCRIPTION
Fixes #8455.

Town Greeter never gained the 2 life. The AST is **correct** — this is entirely a runtime defect.

> When this creature enters, mill four cards. You may put a land card from among them into your hand. **If you put a Town card into your hand this way, you gain 2 life.**

## The AST was never the problem

```
Mill{4} → ChangeZone{dest: Hand, target: TrackedSetFiltered(Land), up_to: true}
        → GainLife{2}   condition: ZoneChangedThisWay{ Subtype("Town"), Hand }
```

Byte-identical to `client/public/card-data.json`, and `Town` canonicalises correctly (`infer_core_type_for_subtype("Town") → Land`; 26 cards carry the subtype). No clause drop, no mis-binding.

Measured on **unmodified `origin/main`**, driving the real pause/resume:

```
last_zone_changed_ids (paused)  = []          <- ledger zeroed at the pause
act(SelectCards[town])          = ok
last_zone_changed_ids (after)   = []          <- never republished
town zone                       = Some(Hand)  <- the card DID arrive
life delta                      = 0           <- rider silently dropped
```

## Mechanism

`resolve_ability_chain` stamps `last_zone_changed_ids` from an effect's own event slice **even when that effect paused before moving anything**, so the ledger is zeroed at the `EffectZoneChoice` prompt. The engine then correctly defers the rider onto the continuation — it knows the condition is not yet answerable. But the `EffectZoneChoice` completion arm republished the tracked set and stamped `last_effect_count` and **never touched the ledger**, so the drain re-evaluated against `[]`.

That this is an omission rather than a design choice has three witnesses: `finalize_discard_choice_completion` (whose comment states outright that the ledger "is empty while the parent's discard pauses"), `BatchCompletion::SurveilKeepOnTop`, and the dig `RevealRestPile` all republish. Only `ChangeZone` was never wired.

The fix mirrors the synchronous publish. **One pure-insertion hunk, zero deleted lines**, inside the `WaitingFor::EffectZoneChoice` arm; the three sibling paths are structurally outside it (two elsewhere in the file, one in `effects/mod.rs`), so they are bit-identical.

## Two opposite-signed manifestations

This is the part that reframes the change. An always-empty ledger does not only *drop* riders:

- **Bare `ZoneChangedThisWay`** (Town Greeter) evaluates false → the rider is silently **dropped**. A missing life gain is visible to a player.
- **`Not{ZoneChangedThisWay}`** (Patient Naturalist) is unconditionally **true** → the rider **fires when it should not**. *"Mill three cards. Put a land card from among the milled cards into your hand. If you can't, create a Treasure token."* Pre-fix it mints a Treasure **even when you did put a land into your hand.** An extra permanent nobody questions — the direction that hides.

Polarity across all 173 gated effects: **143 bare, 26 `Not`, 2 `And`, 1 `Or`, 1 `ConditionInstead`**.

## Class size

| | |
|---|---|
| effects with a `ZoneChangedThisWay` condition | **173** across 155 cards |
| of those, under a `ChangeZone` parent | **41** / 39 cards |
| **provably player-selected** (`up_to` or `optional`) | **11** / 10 cards |

The other 30 are mandatory picks that pause only when the candidate set actually requires a choice, which cannot be settled statically — both figures are given rather than one presented as certain.

**Controls, both directions.** Positive: the predicate matches **132 rows not expected to change** (non-`ChangeZone` parents, including `renegade reaper` under `Mill`, which has a passing runtime test), so the population is a discrimination rather than a query that only ever matches its own case. Negative: a bogus condition type matches **0**. The key path was read off Town Greeter's real serialized bytes — `TargetFilter` is an object here, so the query keys on `effect.type` / `effect.up_to` / node `optional`, not on an assumed field.

## Verification

```
Run A  full integration suite, canary skipped (mirrors CI)
       test result: ok. 6239 passed; 0 failed; 3 ignored; 0 measured; 1 filtered out; finished in 1524.88s

Final  targeted, 8 tests incl. both negated legs + the gate control
       test result: ok. 8 passed; 0 failed; 0 ignored; 0 measured; 6238 filtered out; finished in 0.17s
       CARGO_EXIT=0
```

The one skipped test is `game_state_stack_budget::four_player_commander_action_fits_a_bounded_stack`, `#![cfg(all(target_arch = "aarch64", target_os = "macos"))]` and red on `main` since 2026-09-02, which Linux CI never compiles. Isolated under nextest it aborts in 0.164s with 6242 skipped — deterministic, not contention. Skipping it locally **reproduces** CI rather than hiding anything.

**Pre-fix redness of the negated leg is deduced, not re-run**, and says so in the test file: the probe measured an empty ledger on unmodified `origin/main`, and `Not{ZoneChangedThisWay{Any}}` over an empty ledger is true by construction. No revert build was performed.

Checked with `git merge-tree --write-tree` against all nine other in-flight PRs — all exit 0, with a known-conflicting pair as the positive control.

## Two corrections made mid-flight

1. **The `Sacrifice` guard was dead, not load-bearing.** It was initially excluded on the belief that its completion already publishes an announced-scoped ledger. All three arms of that match diverge before the tail, so the guard could never fire; the belief was inherited from a neighbouring `matches!` that lists `Sacrifice` and is itself apparently dead breadth. The guard is removed and the publish is unconditional.
2. **A polarity mislabel.** The first census counted "not a bare top-level `ZoneChangedThisWay`" as "negated", conflating negation with composition. Cache Grab is `Or{ControllerControlsMatching(Squirrel), ZoneChangedThisWay(Squirrel)}` — a false *negative* (the `Or` loses a disjunct), not a false positive. Patient Naturalist is the true `Not`, and the only one with `up_to == true`.

## Deliberately out of scope

- The `chosen.is_empty()` decline branch — already correct by construction, pinned by `town_greeter_gains_no_life_when_the_optional_put_is_declined`.
- The 30 mandatory-pick `ChangeZone` rows: the same fix applies where they pause, but which ones do was not enumerated.
- The pre-existing dead `Sacrifice` arm in the tail's tracked-set `matches!`.
- The `Or`-composite shape (Cache Grab) benefits from the fix but is untested here.
- Leg 2 of the Patient Naturalist pair does **not** exercise the change — with an empty eligible set no `EffectZoneChoice` is raised, so it takes the inline path. It is the non-vacuity partner, proving the Treasure branch can fire at all, and that claim is made checkable by an `assert_ne!` on the waiting state rather than left as a comment.

The census ran against the main checkout's `card-data.json`, generated from local `main`; the only parser delta vs `origin/main` is #8380, which does not touch this shape, and the probe confirmed Town Greeter's AST is byte-identical when parsed on `origin/main`.

https://claude.ai/code/session_01JSZ2G5sVMGvVPFWX7beFCH
