### PR TITLE
fix(parser): bind "reveals their hand" to the declared target subject (#8428)

### DIFF
--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -23973,6 +23973,34 @@ fn inject_subject_target(effect: &mut Effect, subject: &SubjectPhraseAst) {
         Effect::CopyTokenOf { ref mut owner, .. } if *owner == TargetFilter::Controller => {
             *owner = subject_filter;
         }
+        // CR 701.20a + CR 115.1 (issue #8428): "target opponent reveals THEIR
+        // hand". `parse_hand_possessive_target` resolves the bare possessive
+        // pronoun "their hand" to `TriggeringPlayer`, which is the right answer
+        // only when the clause has no subject of its own to bind to ("Look at
+        // their hand." — the antecedent then comes from the triggering event).
+        // When the clause DOES name a declared target as its subject, that
+        // subject is the antecedent, and it outranks the pronoun default: a
+        // "target opponent" is chosen as the ability goes on the stack (CR
+        // 601.2c, reached via CR 603.3d for a triggered ability), so the reveal
+        // must show THAT player's hand.
+        //
+        // The pronoun default is not `Any`, so the injection group below could
+        // not correct it, and the fabricated antecedent erased the declared
+        // target — Brain Maggot's ETB built no player target slot at all and
+        // `reveal_hand` fell back to the triggering event's player, revealing
+        // its own controller's hand.
+        //
+        // `subject.target` (not `subject.affected`) is the discriminator, the
+        // same one the `Sacrifice` arm below uses: it is `Some` only for a
+        // DECLARED target ("target opponent" / "target player"), so an
+        // anaphoric subject ("that player reveals their hand" — Biting-Palm
+        // Ninja) keeps the triggering-player binding it already resolves to.
+        Effect::RevealHand { target, .. }
+            if *target == TargetFilter::TriggeringPlayer
+                && subject.target.as_ref().is_some_and(TargetFilter::is_player_scope) =>
+        {
+            *target = subject_filter;
+        }
         // CR 701.14a: "enchanted creature fights target creature" — the subject
         // of the fight is the enchanted/equipped creature, not the Aura/Equipment.
         Effect::Fight {

--- a/crates/engine/src/parser/oracle_trigger_tests.rs
+++ b/crates/engine/src/parser/oracle_trigger_tests.rs
@@ -31942,3 +31942,148 @@ fn ogre_marauder_attack_trigger_carries_defending_player_unless_sacrifice() {
         "the body must not fall through to a parser gap"
     );
 }
+
+/// CR 701.20a + CR 115.1: "target opponent reveals **their** hand" — when the
+/// clause names a DECLARED target as its subject, that subject is the
+/// possessive pronoun's antecedent, not the player who triggered the ability.
+/// The target is chosen as the triggered ability goes on the stack (CR 603.3d →
+/// CR 601.2c), so the reveal must show that chosen player's hand.
+///
+/// Issue #8428 (Brain Maggot). `parse_hand_possessive_target` resolves a bare
+/// "their hand" to `TriggeringPlayer`, which is correct only for a clause with
+/// no subject to bind to (`parse_look_at_possessive_hands_targets_player_axes`
+/// pins "Look at their hand." to exactly that, and it stays pinned). Because
+/// that default is not `Any`, `inject_subject_target`'s `Any`-guarded group
+/// could not correct it, so the pronoun default outranked a real declared
+/// subject and erased the target.
+///
+/// The two wordings below are the control pair: Brain Maggot and Kitesail
+/// Freebooter print the SAME clause and differ only in whether the choose
+/// clause is fused with "and" or split into its own sentence. Only the fused
+/// wording reaches the possessive parser — the split wording falls through it
+/// and was already binding its subject correctly. Asserting the two agree tests
+/// the building block (a possessive pronoun resolves to its clause subject)
+/// rather than one card's constant.
+#[test]
+fn possessive_their_hand_binds_to_the_clause_subject_not_the_trigger() {
+    fn reveal_target(line: &str) -> TargetFilter {
+        fn find(a: &AbilityDefinition) -> Option<TargetFilter> {
+            if let Effect::RevealHand { target, .. } = &*a.effect {
+                return Some(target.clone());
+            }
+            a.sub_ability.as_deref().and_then(find)
+        }
+        let def = parse_trigger_line(line, "Probe");
+        find(
+            def.execute
+                .as_ref()
+                .expect("trigger must have an execute body"),
+        )
+        .expect("trigger body must contain a RevealHand")
+    }
+
+    let opponent = TargetFilter::Typed(TypedFilter::default().controller(ControllerRef::Opponent));
+
+    // Fused ("… and you choose …") — the wording that regressed.
+    let fused = reveal_target(
+        "When this creature enters, target opponent reveals their hand and you choose a nonland card from it. Exile that card until this creature leaves the battlefield.",
+    );
+    assert_eq!(
+        fused, opponent,
+        "\"target opponent reveals their hand\" must reveal the DECLARED target's hand"
+    );
+
+    // Split ("… their hand. You choose …") — the same clause, already correct.
+    let split = reveal_target(
+        "When this creature enters, target opponent reveals their hand. You choose a noncreature, nonland card from it. Exile that card until this creature leaves the battlefield.",
+    );
+    assert_eq!(
+        fused, split,
+        "fusing the choose clause with \"and\" must not change whose hand is revealed"
+    );
+
+    // CR 608.2c: the same pronoun under a "that player" subject still resolves
+    // to the triggering player — the fix defers to the subject, it does not
+    // rewrite every reveal to an opponent (Biting-Palm Ninja).
+    assert_eq!(
+        reveal_target(
+            "When you do, that player reveals their hand and you choose a nonland card from it. Exile that card.",
+        ),
+        TargetFilter::TriggeringPlayer,
+        "\"that player reveals their hand\" must still bind to the triggering player"
+    );
+}
+
+/// Runtime half of the issue #8428 fix: the corrected AST must actually put the
+/// TARGET OPPONENT's cards in front of the controller. Drives Brain Maggot's
+/// verbatim Oracle text through the real cast pipeline (CR 601.2 cast → ETB
+/// trigger per CR 603.2 → CR 603.3d target choice → CR 701.20a reveal) and
+/// asserts on the hand the engine offers for the choose clause.
+///
+/// A parse-only assertion cannot see this: the reveal resolver reads its player
+/// from `ability.targets` first, and a `TriggeringPlayer` effect target builds
+/// NO player slot at all, so the wrong-hand behavior only becomes visible once
+/// the trigger reaches the stack.
+#[test]
+fn brain_maggot_reveals_the_target_opponents_hand_at_runtime() {
+    use crate::types::phase::Phase;
+
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.with_mana_pool(
+        P0,
+        vec![
+            crate::types::mana::ManaUnit::new(
+                crate::types::mana::ManaType::Black,
+                crate::types::identifiers::ObjectId(98_420),
+                false,
+                Vec::new(),
+            ),
+            crate::types::mana::ManaUnit::new(
+                crate::types::mana::ManaType::Black,
+                crate::types::identifiers::ObjectId(98_421),
+                false,
+                Vec::new(),
+            ),
+        ],
+    );
+
+    let maggot = scenario
+        .add_creature_to_hand_from_oracle(
+            P0,
+            "Brain Maggot",
+            1,
+            1,
+            "When this creature enters, target opponent reveals their hand and you choose a nonland card from it. Exile that card until this creature leaves the battlefield.",
+        )
+        .id();
+
+    // Distinct hands so the revealed set identifies its owner unambiguously.
+    let mine = scenario.add_card_to_hand(P0, "Duress");
+    let theirs_a = scenario.add_card_to_hand(P1, "Llanowar Elves");
+    let theirs_b = scenario.add_card_to_hand(P1, "Giant Growth");
+
+    let mut runner = scenario.build();
+    let outcome = runner.cast(maggot).target_player(P1).resolve();
+
+    let WaitingFor::RevealChoice { player, cards, .. } = outcome.final_waiting_for() else {
+        panic!(
+            "expected the reveal's choose prompt, got {:?}",
+            outcome.final_waiting_for()
+        );
+    };
+    assert_eq!(
+        *player, P0,
+        "CR 701.20a: the controller makes the choice from the revealed hand"
+    );
+
+    let revealed: std::collections::HashSet<_> = cards.iter().copied().collect();
+    assert!(
+        revealed.contains(&theirs_a) && revealed.contains(&theirs_b),
+        "the TARGET OPPONENT's hand must be revealed, got {revealed:?}"
+    );
+    assert!(
+        !revealed.contains(&mine),
+        "the controller's own hand must NOT be revealed (issue #8428), got {revealed:?}"
+    );
+}

--- a/crates/engine/src/parser/oracle_trigger_tests.rs
+++ b/crates/engine/src/parser/oracle_trigger_tests.rs
@@ -32002,7 +32002,7 @@ fn possessive_their_hand_binds_to_the_clause_subject_not_the_trigger() {
         "fusing the choose clause with \"and\" must not change whose hand is revealed"
     );
 
-    // CR 608.2c: the same pronoun under a "that player" subject still resolves
+    // The same pronoun under a "that player" subject still resolves
     // to the triggering player — the fix defers to the subject, it does not
     // rewrite every reveal to an opponent (Biting-Palm Ninja).
     assert_eq!(
@@ -32074,7 +32074,7 @@ fn brain_maggot_reveals_the_target_opponents_hand_at_runtime() {
     };
     assert_eq!(
         *player, P0,
-        "CR 701.20a: the controller makes the choice from the revealed hand"
+        "CR 109.5: \"you choose\" is the ability's controller, not the revealing player"
     );
 
     let revealed: std::collections::HashSet<_> = cards.iter().copied().collect();


### PR DESCRIPTION
Fixes #8428.

Brain Maggot — "When this creature enters, target opponent reveals their hand and you choose a nonland card from it." — revealed its **own controller's** hand.

## Cause

`parse_hand_possessive_target` resolves a bare possessive "their hand" to `TargetFilter::TriggeringPlayer`. That is the correct antecedent only for a clause with no subject of its own ("Look at their hand." — the antecedent then comes from the triggering event). When the clause *does* name a declared target as its subject, that subject is the antecedent and outranks the pronoun default: a "target opponent" is chosen as the ability goes on the stack (CR 115.1 + CR 601.2c, reached via CR 603.3d for a triggered ability), so the reveal must show that chosen player's hand (CR 701.20a).

Because the pronoun default is not `Any`, `inject_subject_target`'s `Any`-guarded injection group could not correct it, and the fabricated antecedent erased the declared target. Brain Maggot's ETB built no player target slot at all, so `reveal_hand` fell back to the triggering event's player.

## Fix

`inject_subject_target` gains an arm letting a declared player subject win. `subject.target` (not `subject.affected`) is the discriminator — the same one the neighbouring `Sacrifice` arm uses — so it is `Some` only for a real declared target, and an anaphoric subject ("that player reveals their hand" — Biting-Palm Ninja) keeps the triggering-player binding it already resolves to.

## Why the split wording was already correct

"target opponent reveals their hand. You choose ..." (Kitesail Freebooter) never reaches the possessive parser, falls through to `Any`, and was already binding its subject correctly. Only the fused "... and you choose a nonland card from it" wording and the "reveals all [type] cards in their hand" wording reached the pronoun — which is why the class is larger than the one reported card but smaller than every reveal effect.

## Blast radius

Measured over all 34,665 cards in `AtomicCards.json` — six cards change binding, nothing else moves:

| card | before | after |
|---|---|---|
| brain maggot | TriggeringPlayer | Typed(Opponent) |
| mesmeric fiend | TriggeringPlayer | Typed(Opponent) |
| tidehollow sculler | TriggeringPlayer | Typed(Opponent) |
| boareskyr tollkeeper | TriggeringPlayer | Typed(Opponent) |
| thought partition | TriggeringPlayer | Typed(Opponent) |
| juggernaut peddler | TriggeringPlayer | Player |

## Tests

A shape test pinning the fused and split wordings to the same binding, with Biting-Palm Ninja as the negative control, and a runtime test that casts Brain Maggot's verbatim Oracle text through the cast pipeline and asserts the reveal prompt offers the target opponent's cards. The runtime half is load-bearing: a `TriggeringPlayer` effect target builds no player target slot, so the wrong hand only becomes observable once the trigger resolves.

https://claude.ai/code/session_01JSZ2G5sVMGvVPFWX7beFCH


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected “their hand” resolution in reveal effects so the declared target’s hand is revealed instead of the triggering player’s hand.
  - Preserved existing behavior for wording such as “that player reveals their hand.”
  - Reveal choices now consistently present the intended player’s hand in affected scenarios.

- **Tests**
  - Added coverage for fused and split clause wording.
  - Added a full game-scenario test confirming the correct hand is presented for reveal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->