### PR TITLE
docs(engine): anchor life-magnitude citations to the life-adjustment rule

### DIFF
--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -3082,7 +3082,7 @@ fn certified_bounded_cycle_offer<'a>(
         v.dedup();
         v
     };
-    // CR 704.5a: what ONE repetition charges to whichever seat a slot's pin names. The
+    // CR 119.3: what ONE repetition charges to whichever seat a slot's pin names. The
     // max-vs-sum reasoning, the gain clamp and the fail-closed direction live on the
     // function; `elimination_bounds` then sums the charged slots per declarable victim.
     // Extracted rather than inlined so the fork has a callable seam. ⚠ THE "`victim_slot` IS
@@ -3482,7 +3482,7 @@ pub(crate) struct EntryPinSlots {
 ///
 /// THE TWO QUESTIONS THIS TYPE KEEPS APART, because conflating them was a measured
 /// fail-OPEN. PUBLICATION answers CR 732.2a — *is this a game choice the player makes?* —
-/// and shapes the schema. CHARGING answers CR 704.5a — *which seat is charged, and how
+/// and shapes the schema. CHARGING answers CR 119.3 — *which seat is charged, and how
 /// much?* — and shapes the bound. A forced announcement is not a choice, so it is withheld
 /// from the schema; its victim still loses the life, so it is still charged. Deriving the
 /// bound from the PUBLISHED point set made the CR 732.2a withhold silently drop the forced
@@ -3546,7 +3546,7 @@ pub(crate) enum TargetAnnouncement {
     ///   routes to `AutoAssigned`), so no prompt is ever raised and a pin would be a
     ///   designation the RNG contradicts at drive time.
     ///
-    /// CHARGED ALL THE SAME: CR 704.5a asks which seat loses how much life, and nobody having
+    /// CHARGED ALL THE SAME: CR 119.3 asks which seat loses how much life, and nobody having
     /// made the choice changes neither who pays nor how much. Only the CR 732.2a publication
     /// reader acts on this value.
     NotProposerChoice,
@@ -3556,7 +3556,7 @@ pub(crate) enum TargetAnnouncement {
 /// BEFORE the CR 732.2a question of how much of it is a published game choice.
 ///
 /// THE SINGLE ACCEPTANCE AUTHORITY. Both [`entry_publishes_pin_slots`] (publication) and
-/// [`bounded_cycle_charged_targets_for_window`] (CR 704.5a charging) are thin readers of
+/// [`bounded_cycle_charged_targets_for_window`] (CR 119.3 charging) are thin readers of
 /// this one function, so the two can never disagree about WHICH entries are in the cycle —
 /// only about which of their announcements is a published choice. Two independent
 /// acceptance chains that could disagree is exactly the shape gate (3)'s single-authority
@@ -3572,7 +3572,7 @@ struct EntryAnnouncement {
 /// A THIN READER of [`entry_announces`], which owns every acceptance conjunct documented
 /// below; this function contributes exactly one thing on top of it — the CR 732.2a
 /// publication decision (a `Forced` announcement is not a game choice, so no point is
-/// published for it). The CR 704.5a charging reader
+/// published for it). The CR 119.3 charging reader
 /// ([`bounded_cycle_charged_targets_for_window`]) reads the SAME announcement, so the two
 /// cannot disagree about which entries are in the cycle.
 ///
@@ -3645,7 +3645,7 @@ pub(crate) fn entry_publishes_pin_slots(
 /// Every acceptance conjunct documented on [`entry_publishes_pin_slots`] lives here. What
 /// does NOT live here is the CR 732.2a publication decision: this function reports whether
 /// the announcement is `Chosen` or `Forced` and lets its two readers apply that fact to the
-/// question each is answering — the schema (publication) or the bound (CR 704.5a charging).
+/// question each is answering — the schema (publication) or the bound (CR 119.3 charging).
 fn entry_announces(
     state: &GameState,
     entry: &StackEntry,
@@ -3803,7 +3803,7 @@ fn entry_announces(
     // inherited from the `may` expression, which is `None` without it. A `may` the three
     // conjunct groups above suppressed leaves shape (B) with NO slot at all, so the whole
     // entry publishes `None` — the fail-closed direction, now applied by the publication
-    // reader rather than restated here. Shape (B) also charges NOTHING under CR 704.5a:
+    // reader rather than restated here. Shape (B) also charges NOTHING under CR 119.3:
     // there is no announced target, so there is no seat a declaration could aim at.
     if slots.is_empty() {
         if !ability.targets.is_empty() {
@@ -3896,7 +3896,7 @@ fn entry_announces(
     // a defect this commit introduced.
     //
     // ⚠ WITHHELD FROM THE SCHEMA IS NOT UNCHARGED, and the two used to be the same act.
-    // CR 704.5a asks which seat loses how much life, and a forced victim loses it exactly as
+    // CR 119.3 asks which seat loses how much life, and a forced victim loses it exactly as
     // a chosen one does — nobody having made the choice changes who pays, not how much.
     // Reporting the shape here rather than dropping the announcement is what lets
     // [`bounded_cycle_charged_targets_for_window`] charge it while
@@ -4070,17 +4070,18 @@ pub(crate) fn bounded_cycle_pin_slots_for_window(
     points
 }
 
-/// CR 704.5a: what ONE CERTIFIED PERIOD CHARGES — the announcement slot of every accepted
+/// CR 119.3: what ONE CERTIFIED PERIOD CHARGES — the announcement slot of every accepted
 /// entry, paired with the seats that announcement may name, whether or not CR 732.2a
 /// publishes it as a decision point.
 ///
 /// DELIBERATELY NOT A FILTER OVER [`bounded_cycle_pin_slots_for_window`]'s OUTPUT, and that
 /// is the entire reason this exists as its own reader. Publication answers CR 732.2a — "a
 /// sequence of game choices, for all players" — so a FORCED announcement publishes nothing.
-/// Charging answers CR 704.5a — "if a player has 0 or less life, that player loses the
-/// game" — and the victim loses that life whether or not anybody chose it. Deriving the
-/// bound from the published set therefore let the CR 732.2a withhold silently drop a forced
-/// victim into `ResourceVector::elimination_bounds`' cheaper `observed_life_loss` arm,
+/// Charging answers CR 119.3 — "if an effect causes a player to gain life or
+/// lose life, that player's life total is adjusted accordingly" — and the victim
+/// loses that life whether or not anybody chose it. Deriving the bound from the
+/// published set therefore let the CR 732.2a withhold silently drop a forced victim
+/// into `ResourceVector::elimination_bounds`' cheaper `observed_life_loss` arm,
 /// RAISING `max_iterations`: the offer would state more legal repetitions than CR 732.2a
 /// permits, on the very operator whose job is to prove the proposed sequence "may be legally
 /// taken based on the current game state".

--- a/crates/engine/tests/integration/fantastic_four_bounded_loop.rs
+++ b/crates/engine/tests/integration/fantastic_four_bounded_loop.rs
@@ -635,7 +635,7 @@ fn r1_the_bounded_offer_fires_on_the_real_f4_dump() {
     // CR 704.5a headroom is `life - 1`: a seat at exactly 0 has LOST, so a legal shortcut must
     // stop one point above it. CR 104.3c: an empty library is only lethal on the next draw, so
     // the library axis divides the whole remaining library.
-    // CR 704.5a: a published re-aimable `Targets` slot may be pointed at ANY of its legal
+    // CR 119.3: a published re-aimable `Targets` slot may be pointed at ANY of its legal
     // player targets in EVERY remaining repetition, so each of them is charged that slot's
     // magnitude ON TOP of its own observed drain. Both terms come off the offer's OWN
     // published data — `certificate.per_cycle.victim_slot` and `schema.points` — never from

--- a/crates/engine/tests/integration/loop_shortcut.rs
+++ b/crates/engine/tests/integration/loop_shortcut.rs
@@ -1574,7 +1574,7 @@ fn setup_2p_vito_optional(mode: LoopDetectionMode) -> (GameRunner, ObjectId) {
     (runner, kickoff)
 }
 
-/// 3p DRAIN_CLERIC/BLOOD_SIPPER loop where BOTH opponents drain equally (CR 704.5a "each
+/// 3p DRAIN_CLERIC/BLOOD_SIPPER loop where BOTH opponents drain equally (CR 119.3 "each
 /// opponent loses 1"). Configurable opponent life for the F2 ≥2-faller hardening tests: the
 /// per-cycle delta is EQUAL for both (so `live_mandatory_loop_winner`'s ≥2-faller floor
 /// passes), while the ABSOLUTE lives differ iff `p1_life != p2_life` (so the offer's own


### PR DESCRIPTION
## Summary

`CR 704.5a` says a player at 0 or less life loses the game. Comments across the bounded-cycle
machinery cited it for a different claim — how much life one repetition charges, and to which
seat — which is `CR 119.3`, the rule that an effect causing a player to lose life adjusts that
player's life total. Twelve citations move; the rest keep the rule they had. Comment-only.

## Files changed

- `crates/engine/src/game/engine.rs` — ten charging citations, including one quotation rewrite
- `crates/engine/tests/integration/loop_shortcut.rs` — a per-cycle drain amount
- `crates/engine/tests/integration/fantastic_four_bounded_loop.rs` — the magnitude a re-aimable
  slot charges each seat it may name

## Track

Developer

## LLM

Model: claude-opus-5
Tier: Frontier
Thinking: high

## Implementation method (required)

Method: /engine-implementer

## CR references

- `CR 704.5a` — a player at 0 or less life loses the game. Kept wherever the statement is about
  a seat reaching zero, a loss threshold, a bound or `life - 1` headroom that exists because
  crossing zero ends the seat, a reserved elimination domain, an SBA check point, or a win.
- `CR 119.3` — an effect causing a player to gain or lose life adjusts that life total. The
  anchor for the twelve statements about magnitude or attribution.

No new rule is cited; both numbers already appear in the tree and were re-verified against
`docs/MagicCompRules.txt` before use.

## Verification

- [x] Required checks ran clean, or the exact CI-owned alternative is stated below.
- [x] Gate A output below is for the current committed head.
- [x] Final review-impl below is clean for the current committed head.
- [x] Both anchors cite existing analogous code at the same seam.

- `cargo fmt --all -- --check` — exit 0, no output
- `./scripts/check-parser-combinators.sh` — Gate A PASS, Gate G PASS
- `./scripts/check-cr-citation-anchors.sh` — exit 0; 3542 files walked, 66639 citing lines, 0
  matched, with the script's own self-check firing in the same run
- `node scripts/check-protocol-version.mjs` — clean

The population and the outcome, both regenerable with
`git grep -c 'CR 704\.5a' <ref> -- crates/ client/` less the two excluded paths:

| | count |
|---|---|
| citations in scope at base | 188 across 32 files (190 occurrences) |
| re-anchored to `CR 119.3` | 12 |
| kept at `CR 704.5a` | 174 |
| left untouched as format specimens | 2 |

Accounting at the head closes on that: 221 tree-wide, less 44 in the out-of-bounds file and 1
in the generated report, plus the 12 removed, is 188. Removed `CR 704.5a` equals added
`CR 119.3` equals 12.

No clippy or test run is included, and the reason is measured rather than assumed: every
changed line is a comment (a filter for non-comment changed lines returns nothing, while the
same filter returns a planted code line), no doc-test fence is touched, and no `doc_markdown`,
`clippy::pedantic` or `[lints]` table exists anywhere in the tree — so doc prose cannot reach
`-D warnings`. Compiled output is byte-unaffected. CI runs both regardless.

## Gate A

Gate A PASS head=5e1ba0ce32c56ad840b016589fb707f60c4c0c4f base=d6d28370c09242182488cac72e16e5a84941885f

## Anchored on

- `crates/engine/src/game/derived_views.rs:2383-2384` — the already-correct rendering of a
  two-subject statement, pairing `CR 119.3` for whose life total is adjusted with `CR 704.5a`
  for why it matters. It is the in-tree precedent this split follows, and it is unchanged here.
- `crates/engine/src/game/interaction.rs` — the same re-anchor applied to the announced-slot
  magnitude when the charging and publication questions were first separated; this change
  applies that settled distinction to the citations that pass did not reach.

## Final review-impl

Final review-impl PASS head=5e1ba0ce32c56ad840b016589fb707f60c4c0c4f (tree-identical to the
reviewed 2d29f9704c11a8c411ff415293d9a1d8d475c872; tree
72d188bbd42a02c902e1d9ca22b993fe750b15f5 — the amend corrected a commit message only)

## Claimed parse impact

None. No parser code is touched.

## Scope Expansion

None.

## Validation Failures

None.

## CI Failures

None.

---

## How the line was drawn

The citation names the concept its token modifies, not the enclosing sentence's subject and not
that concept's downstream consumer. A magnitude that feeds a bound is still a magnitude; a bound
derived from a magnitude is still a bound. That is what separates two adjacent paragraphs in the
same function: the one describing what a repetition charges moves, and the one describing the
bound those charges produce stays.

Two consequences worth stating, because neither shows up in a diff:

- The unit of adjudication is the paragraph, not the grepped line. Engine comments wrap, and one
  of the twelve — the charge magnitude in `fantastic_four_bounded_loop.rs` — carries its subject
  on the paragraph's second line, so a line-oriented sweep does not find it.
- Two lines in `crates/engine/src/bin/rules_audit.rs` list the citation formats the annotation
  auditor accepts. They are specimens of the citation grammar rather than claims about the rule,
  so they are deliberately untouched; editing them would change what that tool matches.

## Follow-up (not made here)

`crates/engine/src/analysis/resource.rs` holds 44 citations of the same rule, including the
direct textual twins of what moved here — the doc of `worst_seat_life_loss`, and the comment on
`victim_slot` describing "the life magnitude one repetition charges". They are excluded because
another change owns that file, so the same value is currently cited to two rules across the
producer/declaration seam. Subject-checking them is the successor to this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Corrected Magic: The Gathering Comprehensive Rules references from 704.5a to 119.3.
  - Expanded related documentation to quote the updated rule text.
  - Updated explanatory comments in integration tests.
  - No functional or test-behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->