### PR TITLE
fix(engine): apply the zero-defense trigger deferral to Sieges only (#8533)

### DIFF
--- a/crates/engine/src/game/sba.rs
+++ b/crates/engine/src/game/sba.rs
@@ -44,6 +44,18 @@ fn live_battlefield_object_mut<'a>(
     })
 }
 
+/// CR 205.3q + CR 310.3: does this permanent have the Siege battle type?
+/// ("Battles have a unique subtype, called a battle type.")
+///
+/// Single authority for the Siege test inside this state-based-action sweep, so
+/// the CR 704.5v zero-defense deferral and the CR 310.12a protector-legality
+/// rule can never disagree about what a Siege is. Reads the layer-derived
+/// `card_types` rather than `base_card_types`, so a type-changing effect that
+/// grants or removes the Siege battle type is honored.
+fn has_siege_type(obj: &crate::game::game_object::GameObject) -> bool {
+    obj.card_types.subtypes.iter().any(|s| s == "Siege")
+}
+
 /// CR 704.4: state-based actions pay no attention to what happens during the
 /// resolution of a spell or ability. An entry that is mid-resolution — parked on
 /// a CR 616.1 replacement-ordering choice, or on a CR 303.4f Aura-host choice —
@@ -240,9 +252,10 @@ pub fn check_state_based_actions(state: &mut GameState, events: &mut Vec<GameEve
                 return;
             }
 
-            // CR 704.5v + CR 310.7: If a battle has defense 0 and isn't the source of an
-            // ability that has triggered but not yet left the stack, it's put into its
-            // owner's graveyard.
+            // CR 704.5v + CR 310.7: a Siege with defense 0 that isn't the source of an
+            // ability that has triggered but not yet left the stack is put into its
+            // owner's graveyard. CR 704.5w + CR 310.8: a non-Siege battle with defense 0
+            // is put into its owner's graveyard with no such deferral.
             check_zero_defense(state, events, &mut any_performed, &battlefield_snapshot);
             if mid_resolution_entry_pauses_sba(state) {
                 return;
@@ -1771,9 +1784,24 @@ fn check_zero_loyalty(
     zones::mark_simultaneous_departures(events, &zones::departed_subset(state, &performed_ids));
 }
 
-/// CR 704.5v + CR 310.7: A battle with defense 0 is put into its owner's graveyard,
-/// unless it's the source of an ability that has triggered but not yet left the
-/// stack (e.g., the Siege's victory trigger).
+/// CR 704.5v + CR 704.5w: a battle with defense 0 is put into its owner's
+/// graveyard. The rule is split across two sub-rules by battle type, and only
+/// the Siege half carries a trigger-on-stack deferral:
+///
+/// > 704.5v If a Siege battle has defense 0 and it isn't the source of an
+/// > ability that has triggered but not yet left the stack, it's put into its
+/// > owner's graveyard.
+///
+/// > 704.5w If a non-Siege battle has defense 0, it's put into its owner's
+/// > graveyard.
+///
+/// CR 310.12b is why the carve-out is Siege-shaped: a Siege's intrinsic "when
+/// the last defense counter is removed from this permanent, exile it, then you
+/// may cast it transformed without paying its mana cost" has to find its source
+/// still on the battlefield when it resolves. A battle with any other battle
+/// type has no such intrinsic, so CR 704.5w grants it no deferral — it is put
+/// into its owner's graveyard immediately, even with one of its own triggered
+/// abilities still on the stack.
 fn check_zero_defense(
     state: &mut GameState,
     events: &mut Vec<GameEvent>,
@@ -1796,8 +1824,14 @@ fn check_zero_defense(
             if obj.defense.unwrap_or(0) != 0 {
                 return false;
             }
-            // CR 310.7: Don't SBA-destroy while one of this battle's triggered
-            // abilities is still on the stack (mirrors CR 714.4 Saga deferral).
+            // CR 704.5w: a non-Siege battle has no trigger-on-stack deferral —
+            // it dies now.
+            if !has_siege_type(obj) {
+                return true;
+            }
+            // CR 704.5v: a Siege is spared while one of its own abilities has
+            // triggered but not yet left the stack (mirrors the CR 714.4 Saga
+            // deferral), so its CR 310.12b victory trigger can resolve.
             let ability_on_stack = state.stack.iter().any(|entry| {
                 matches!(
                     &entry.kind,
@@ -1993,7 +2027,7 @@ fn check_battle_protector(
             continue;
         };
         let controller = battle.controller;
-        let is_siege = battle.card_types.subtypes.iter().any(|s| s == "Siege");
+        let is_siege = has_siege_type(battle);
         let protector = battle.protector();
 
         // Legal protectors for a Siege are opponents of the controller (CR 310.12a).

--- a/crates/engine/tests/integration/rules/battle.rs
+++ b/crates/engine/tests/integration/rules/battle.rs
@@ -12,9 +12,11 @@ use super::*;
 
 use engine::game::sba;
 use engine::game::scenario::{GameRunner, GameScenario, P0, P1};
-use engine::types::ability::ChosenAttribute;
+use engine::game::stack;
+use engine::types::ability::{ChosenAttribute, Effect, ResolvedAbility};
 use engine::types::card_type::CoreType;
 use engine::types::counter::CounterType;
+use engine::types::game_state::{StackEntry, StackEntryKind};
 
 /// Convert an existing battlefield creature into a Siege with the given defense.
 fn make_into_siege(
@@ -165,6 +167,86 @@ fn zero_defense_battle_goes_to_graveyard_via_sba() {
         runner.state().objects[&battle].zone,
         Zone::Graveyard,
         "0-defense battle should be sent to graveyard by SBA"
+    );
+}
+
+/// Put a triggered ability whose source is `source` onto the stack, so the
+/// zero-defense SBA sees the battle as "the source of an ability that has
+/// triggered but not yet left the stack" (CR 704.5v).
+fn push_own_trigger(runner: &mut GameRunner, source: ObjectId, controller: PlayerId) {
+    let entry = {
+        let state = runner.state_mut();
+        let id = ObjectId(state.next_object_id);
+        state.next_object_id += 1;
+        StackEntry {
+            id,
+            source_id: source,
+            controller,
+            kind: StackEntryKind::TriggeredAbility {
+                source_id: source,
+                ability: Box::new(ResolvedAbility::new(
+                    Effect::unimplemented("battle trigger", "this battle's own trigger"),
+                    vec![],
+                    source,
+                    controller,
+                )),
+                condition: None,
+                trigger_event: None,
+                description: None,
+                source_name: String::new(),
+                subject_match_count: None,
+                die_result: None,
+                provenance: None,
+            },
+        }
+    };
+    stack::push_to_stack(runner.state_mut(), entry, &mut Vec::new());
+}
+
+/// CR 704.5v + CR 310.7: a Siege at defense 0 is NOT put into its owner's
+/// graveyard while it is the source of an ability that has triggered but not
+/// yet left the stack — CR 310.12b's victory trigger has to find the Siege on
+/// the battlefield when it resolves.
+#[test]
+fn zero_defense_siege_survives_its_own_trigger_on_stack() {
+    let (mut runner, battle) = prime_siege(P0, P1, "Deferred Siege", 0);
+    push_own_trigger(&mut runner, battle, P0);
+
+    let mut events = Vec::new();
+    sba::check_state_based_actions(runner.state_mut(), &mut events);
+
+    assert_eq!(
+        runner.state().objects[&battle].zone,
+        Zone::Battlefield,
+        "CR 704.5v: a 0-defense Siege must survive while its own triggered ability is on the stack"
+    );
+}
+
+/// CR 704.5w + CR 310.8: a non-Siege battle at defense 0 is put into its owner's
+/// graveyard even while it is the source of an ability that has triggered but
+/// not yet left the stack. CR 704.5w states the rule with no deferral clause at
+/// all — the clause in CR 704.5v is Siege-only.
+#[test]
+fn zero_defense_non_siege_battle_dies_with_its_own_trigger_on_stack() {
+    // CR 310.9a: a battle with no battle type may only have its controller as
+    // its protector, so P0 is both here. The non-Siege battles that ship in the
+    // card data (Occupation of Kulrath / Occupation of Llanowar, "Battle —
+    // Control Point") reach CR 704.5w by the same door: not being a Siege.
+    let (mut runner, battle) = prime_siege(P0, P0, "Occupied Battle", 0);
+    {
+        let obj = runner.state_mut().objects.get_mut(&battle).unwrap();
+        obj.card_types.subtypes.clear();
+        obj.base_card_types.subtypes.clear();
+    }
+    push_own_trigger(&mut runner, battle, P0);
+
+    let mut events = Vec::new();
+    sba::check_state_based_actions(runner.state_mut(), &mut events);
+
+    assert_eq!(
+        runner.state().objects[&battle].zone,
+        Zone::Graveyard,
+        "CR 704.5w: a 0-defense non-Siege battle has no trigger-on-stack deferral"
     );
 }
 


### PR DESCRIPTION
Fixes #8533.

**Stacked on #8528** — base is `ship/repoint-stale-cr-citations`, not `main`, because the two conflict in `crates/engine/tests/integration/rules/battle.rs`. GitHub retargets the base to `main` automatically when #8528 merges; auto-merge gets armed at that point, not before.

## The rule is split by battle type and only one half defers

`check_zero_defense` applied the "isn't the source of an ability that has triggered but not yet left the stack" exemption to **every** battle. That exemption is Siege-only:

> **CR 704.5v** If a Siege battle has defense 0 and it isn't the source of an ability that has triggered but not yet left the stack, it's put into its owner's graveyard.
>
> **CR 704.5w** If a non-Siege battle has defense 0, it's put into its owner's graveyard.

704.5w has no deferral clause at all. CR 310.7 / CR 310.8 restate the same split from the battle side. So a non-Siege battle at 0 defense must go to the graveyard immediately, even while one of its own triggered abilities is still on the stack — the engine kept it on the battlefield instead.

CR 310.12b is why the carve-out is Siege-shaped: a Siege's intrinsic "when the last defense counter is removed from this permanent, exile it, then you may cast it transformed" has to find its source still on the battlefield when it resolves. A battle with any other battle type has no such intrinsic and therefore needs no grace period.

## Observable in play today

Re-derived independently from `data/mtgjson/AtomicCards.json` (MTGJSON 5.3.0+20260830) and from the engine's own `card-data.json`:

| | count |
|---|---|
| battle cards | 39 |
| Sieges | 37 |
| **non-Sieges** | **2** |

Both non-Sieges are `Battle — Control Point`: **Occupation of Kulrath** and **Occupation of Llanowar**. Each carries "When this battle enters, you may discard a card. If you do, draw a card." — an ability of its own that sits on the stack precisely while its defense can reach 0. This is the exact shape the deferral wrongly protected.

## One Siege predicate, not two

The Siege test goes through a single `has_siege_type` helper (CR 205.3q + CR 310.3), which *replaces* the existing open-coded subtype scan in `check_battle_protector` rather than adding a second one — so the two Siege predicates in this SBA sweep cannot drift apart. It reads layer-derived `card_types`, so a type-changing effect that grants or removes the Siege battle type is honored.

## Tests pin both halves

In `crates/engine/tests/integration/rules/battle.rs`:

- a **Siege** at 0 defense with its own trigger on the stack **survives** — the CR 704.5v regression guard;
- a **non-Siege** at 0 defense with its own trigger on the stack is **put into the graveyard** — CR 704.5w, the fix.

A change that simply deleted the exemption passes the second and fails the first, which is the point of keeping both.

## Conflict resolution

The only conflict with #8528 was in the test file, and it was a citation-versus-content overlap: #8528 corrects a doc comment to `CR 310.9 + CR 310.9a`, while this branch added tests immediately above it still carrying the pre-renumbering `CR 310.8 + CR 310.8a`. Resolved as a union — this branch's tests plus #8528's corrected citation. Verified afterwards across the whole file, not just the hunk: zero remaining `310.8[a-z]` / `310.11[ab]`, eight each of the corrected `310.9[a-z]` / `310.12[ab]`, and every CR id in the file greps clean against `docs/MagicCompRules.txt`.

https://claude.ai/code/session_01JSZ2G5sVMGvVPFWX7beFCH
