### PR TITLE
ci: run the CR citation anchor gate (#8527)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,20 @@ jobs:
         # priority table mirrors the `// Priority` slots in oracle.rs.
         run: ./scripts/check-skill-doc.sh
 
+      - name: CR citation anchor gate
+        # A CR citation is anchored by its rule number. A line coordinate into
+        # docs/MagicCompRules.txt is not an anchor: that file is gitignored,
+        # every checkout fetches its own copy, and the offsets move with every
+        # fetch -- so a committed coordinate is stale on arrival and points at
+        # an unrelated rule, which is worse than no annotation (#8515).
+        #
+        # Whole-tree, not diff-based, so a coordinate cannot survive by living
+        # in a file the PR does not touch. The script self-checks its own
+        # detector against planted text on every run and reports what it
+        # declined, so a PASS states what it matched rather than claiming the
+        # tree is clean of every possible coordinate form.
+        run: ./scripts/check-cr-citation-anchors.sh
+
       - name: Engine authority gate
         # (A) Diff-based: new engine code must use single-authority helpers
         #     (keyword queries via game/keywords.rs) instead of raw state pokes.


### PR DESCRIPTION
Fixes #8527.

`scripts/check-cr-citation-anchors.sh` has been in the tree since the #8515 line-coordinate cleanup and is referenced by **nothing** — no workflow, no Tiltfile resource, no git hook:

```
$ grep -rl "check-cr-citation-anchors" .github/workflows/ Tiltfile .githooks/ .pre-commit-config.yaml
(no matches)
```

A 16 KB check that never runs cannot protect the cleanup it was written for.

## What it guards

A CR citation is anchored by its rule **number**. A line coordinate into `docs/MagicCompRules.txt` is not an anchor: that file is gitignored, every checkout fetches its own copy, and the offsets move with every fetch — so a committed coordinate is stale on arrival and silently points at an unrelated rule, which is worse than no annotation.

That is not hypothetical. Earlier today a reviewer and I disagreed about whether `310.9d` exists, each quoting "the same file"; their copy predated the August 7 renumbering. Offsets into a document that drifts per checkout have the same failure mode with none of the visibility.

## Placement

Wired into the Rust lint job beside the other whole-tree script gates (`check-prelowered-ratchet.sh`, `check-skill-doc.sh`). Whole-tree rather than diff-based deliberately: a stale coordinate would otherwise survive indefinitely by living in a file no PR happens to touch.

## Measured before wiring, not after

A gate that goes red on arrival is worse than no gate, so I ran it on current `main` first:

```
cr-citation-anchors: walked 3538 source files, read 66555 lines that cite a rule,
                     matched 0 under crates client
cr-citation-anchors: PASS
```

Runtime is **64s** on a dev machine under load average 40 — a rounding error next to the clippy step it sits behind, and likely faster on an uncontended runner.

## Why this gate is trustworthy

It self-checks its own detector on every run: it plants text, asserts the verdict path returns exit 1 over a matched tree and 0 over a clean one, and then **reports the planted coordinate it deliberately declined**.

```
self-check — verdict path over planted text: exit 1, walked 1 source files,
             read 17 lines that cite a rule, matched 10
self-check — citation-free walk: exit 2, ... matched 0
self-check — exit status read from outside: matched tree exit 1, clean tree exit 0
self-check OK
```

So its PASS says what it matched, not that the tree is free of every possible coordinate form. A gate that can state what it does **not** cover is the opposite of one that passes vacuously — and vacuous passes are the failure mode this repo keeps hitting (#8521, #8532).

## Scope

This checks that a citation is anchored by a rule number rather than a line offset. It does **not** check that the cited rule exists — nothing does, which is #8545.

https://claude.ai/code/session_01JSZ2G5sVMGvVPFWX7beFCH


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a CI validation step to ensure CR citations use stable rule-number anchors instead of line-based references.
  * The validation scans the full repository and includes a self-check to confirm the detector behaves as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->