### PR TITLE
fix(engine): mill cost is unpayable with too few cards in library (#8529)

### DIFF
--- a/crates/engine/src/game/cost_payability.rs
+++ b/crates/engine/src/game/cost_payability.rs
@@ -698,9 +698,16 @@ impl AbilityCost {
                 .len()
                     >= *count as usize
             }
-            // CR 701.13b: A player can mill fewer than N cards if their library
-            // has fewer than N; the cost is always payable.
-            AbilityCost::Mill { .. } => true,
+            // CR 701.17b: "the player can't pay a cost that includes milling a
+            // number of cards greater than the number of cards in their
+            // library." The same rule's "if instructed to do so, they mill as
+            // many as possible" allowance governs milling as an *effect* and
+            // must not be read onto a cost. `count` is a plain `u32`, so no
+            // quantity resolution is needed.
+            AbilityCost::Mill { count } => state
+                .players
+                .get(player.0 as usize)
+                .is_some_and(|p| p.library.len() >= *count as usize),
             // CR 701.43b: A permanent can be exerted even if it's not tapped
             // or has already been exerted; the cost itself is always payable.
             // CR 701.43c (off-battlefield) is enforced at payment time.
@@ -1531,10 +1538,45 @@ mod tests {
         assert!(!unpayable.is_payable(&state, P0, ObjectId(0)));
     }
 
+    /// CR 701.17b: a Mill cost is payable iff the library holds at least
+    /// `count` cards. The predicate is swept across its whole input range
+    /// against one fixed 4-card library so the boundary is pinned from both
+    /// sides: below it, at it, and above it. The previous behaviour returned
+    /// `true` unconditionally and is falsified by every `count > 4` row.
+    ///
+    /// The empty-library row is the case the old comment got backwards — it
+    /// claimed a short library still pays "as many as possible", which is the
+    /// rule for milling as an *effect*, not as a cost.
     #[test]
-    fn mill_exert_always_payable() {
+    fn mill_payable_iff_library_holds_count() {
+        let mut scenario = GameScenario::new();
+        scenario.with_library_top(P0, &["Top A", "Top B", "Top C", "Top D"]);
+        let state = &scenario.state;
+
+        for count in 0..=4 {
+            assert!(
+                AbilityCost::Mill { count }.is_payable(state, P0, ObjectId(0)),
+                "mill {count} must be payable from a 4-card library"
+            );
+        }
+        for count in 5..=8 {
+            assert!(
+                !AbilityCost::Mill { count }.is_payable(state, P0, ObjectId(0)),
+                "mill {count} exceeds a 4-card library and must be unpayable"
+            );
+        }
+
+        // Empty library: only the degenerate zero-card mill remains payable.
+        let empty = new_state();
+        assert!(AbilityCost::Mill { count: 0 }.is_payable(&empty, P0, ObjectId(0)));
+        assert!(!AbilityCost::Mill { count: 1 }.is_payable(&empty, P0, ObjectId(0)));
+    }
+
+    /// CR 701.43b: exert is payable regardless of the source's tapped state,
+    /// so an empty library (which now blocks a Mill cost) leaves it untouched.
+    #[test]
+    fn exert_always_payable() {
         let state = new_state();
-        assert!(AbilityCost::Mill { count: 5 }.is_payable(&state, P0, ObjectId(0)));
         assert!(AbilityCost::Exert.is_payable(&state, P0, ObjectId(0)));
     }
 


### PR DESCRIPTION
Fixes #8529.

`cost_payability.rs` reported every `AbilityCost::Mill` as payable unconditionally, under a comment citing a rule that does not exist and stating the inverse of the rule that does.

```rust
// CR 701.13b: A player can mill fewer than N cards if their library
// has fewer than N; the cost is always payable.
AbilityCost::Mill { .. } => true,
```

## Cause

CR 701.17b packs two opposite dispositions into one paragraph:

> A player can't mill a number of cards greater than the number of cards in their library. If given the choice to do so, they can't choose to take that action. **If instructed to do so, they mill as many as possible.** Similarly, **the player can't pay a cost that includes milling a number of cards greater than the number of cards in their library.**

The "mill as many as possible" allowance governs milling as an *effect*. The closing sentence governs milling as a *cost*. The arm took the effect clause and applied it to the cost branch.

The citation compounded it: CR 701.13 is **Exile**, so `CR 701.13b` named no rule at all. Both numbers were re-verified by grepping `docs/MagicCompRules.txt` rather than recalled.

## The engine already disagreed with itself

The unless-pay payment path refuses when the library is short — `engine_payment_choices.rs:749`, `if library_len < count as usize` — and its test `unless_mill_cost_with_empty_library_fires_effect` pins that behaviour. Only the pre-gate said "always payable", so activation and payment gave **opposite answers for the same cost**.

The shortfall branch the issue also named follows from the same defect: the activation-cost detour routes payment through `effects::mill::apply_mill_after_replacement`, which clamps with `.min(player.library.len())`. That clamp is right for an effect, so an under-library activation was offered and then silently paid *less than its stated cost* instead of being refused. Fixing the pre-gate closes both, and effect-side milling is untouched.

## Blast radius

Re-derived from `card-data.json` (35,798 cards) by two independent instruments that agree — a structural walk of every parsed ability tree, and a byte-level scan discriminating `AbilityCost::Mill` (`count` is a bare `u32`) from `Effect::Mill` (`count` is a `QuantityExpr` object). The partition is exhaustive: **8 cost cards + 622 effect nodes = 630 total Mill nodes.**

Charmed Pendant · Deep Spawn · Deranged Assistant · Manakin and Millikin · Millikin · Rot Farm Skeleton · Sinister Concoction · The Warring Triad

Rot Farm Skeleton is where it bites hardest — "{2}{B}{G}, Mill four cards: Return this card from your graveyard to the battlefield" is activated in the late game precisely when the library is short.

## Tests

`mill_payable_iff_library_holds_count` sweeps the predicate across its whole input range against one fixed 4-card library — payable for counts 0–4, unpayable for 5–8 — so the boundary is pinned from both sides rather than sampled at a single point, plus an empty-library pair where only the degenerate zero-card mill survives. Every `count > 4` row falsifies the old unconditional `true`.

The previous test `mill_exert_always_payable` asserted the defect and is replaced; its exert half is preserved as `exert_always_payable`.

https://claude.ai/code/session_01JSZ2G5sVMGvVPFWX7beFCH
