### PR TITLE
fix(parser,engine): bind a passive-voice damage anaphor to the recipient (#8379)

### DIFF
--- a/crates/engine/src/game/effects/destroy.rs
+++ b/crates/engine/src/game/effects/destroy.rs
@@ -220,7 +220,37 @@ pub fn resolve(
     // destroy to the source, and there is no pool fallback below this loop —
     // substitution alone is sufficient and no early return is needed.
     // Bound before the loop: `destroy_single_object` takes `&mut GameState`.
-    let live_targets = ability.live_object_targets(state);
+    //
+    // CR 603.2 + CR 608.2k: an untargeted object anaphor on a triggered ability
+    // ("whenever ... is dealt damage, destroy IT") names an object carried by the
+    // trigger EVENT, not a target the controller chose, so `ability.targets` is
+    // empty and reading it alone destroys nothing. Resolve those referents
+    // through the shared `resolved_targets` authority, which handles every pure
+    // event-context filter uniformly via `is_pure_event_context_filter`.
+    //
+    // Deliberately the SHARED predicate rather than a handler-local
+    // `matches!(.., TriggeringSource | ..)` list: three such lists already exist
+    // (`effect.rs` covers only `TriggeringSource`; `change_zone.rs` and
+    // `attach.rs` cover `TriggeringSource | AttachedTo`) and they have diverged,
+    // because an omitted member is not a compile error — it degrades silently
+    // into "this effect does nothing". Routing through the single authority means
+    // a future event-context variant is picked up here for free.
+    //
+    // Gated on `ability.targets.is_empty()` so a genuinely targeted destroy still
+    // affects exactly the chosen targets (CR 608.2b).
+    let target_filter = match &ability.effect {
+        Effect::Destroy { target, .. } => Some(target),
+        _ => None,
+    };
+    let live_targets = match target_filter {
+        Some(filter)
+            if ability.targets.is_empty()
+                && crate::game::targeting::is_pure_event_context_filter(filter) =>
+        {
+            crate::game::targeting::resolved_targets(ability, filter, state)
+        }
+        _ => ability.live_object_targets(state),
+    };
     for target in &live_targets {
         if let TargetRef::Object(obj_id) = target {
             match destroy_single_object(state, *obj_id, ability.source_id, cant_regenerate, events)

--- a/crates/engine/src/game/targeting.rs
+++ b/crates/engine/src/game/targeting.rs
@@ -969,7 +969,7 @@ pub(crate) fn resolve_parent_slot_from_root(
         .nth(index)
 }
 
-fn is_pure_event_context_filter(target_filter: &TargetFilter) -> bool {
+pub(crate) fn is_pure_event_context_filter(target_filter: &TargetFilter) -> bool {
     matches!(
         target_filter,
         TargetFilter::TriggeringSpellController

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -514,8 +514,14 @@ pub(crate) fn replace_first_object_pronoun(body: &str, replacement: &str) -> Opt
 /// In trigger effects where the subject is a non-self filter (e.g. "a creature
 /// you control"), "it" refers to the triggering object (TriggeringSource).
 /// For self-triggers ("~ enters"), "it" stays SelfRef.
-/// For AttachedTo subjects ("equipped creature"), TriggeringSource is also correct
-/// because the triggering event's source IS the attached-to creature.
+/// For AttachedTo subjects ("equipped creature"), TriggeringSource is correct
+/// only when the trigger condition is ACTIVE-voice ("whenever equipped creature
+/// deals combat damage"), where the event's source IS the attached-to creature.
+/// On a PASSIVE-voice condition ("whenever equipped creature is dealt damage")
+/// the event's source is the damage DEALER, so the antecedent is the recipient;
+/// `trigger_object_pronoun_ref_for_condition` (oracle_trigger.rs) pins
+/// `ctx.object_pronoun_ref` to `EventTarget` for that class and the match below
+/// is never consulted.
 pub(crate) fn resolve_it_pronoun(ctx: &mut ParseContext) -> TargetFilter {
     if let Some(target) = ctx.object_pronoun_ref.clone() {
         return target;
@@ -35160,7 +35166,27 @@ pub(crate) fn parse_effect_chain_ir(
             .find_map(|clause| nearest_dig_rest_zone_in_clause(&clause.parsed));
         let mut chunk_ctx = ParseContext {
             subject: chunk_subject,
-            object_pronoun_ref: prior_typed_referent.then_some(TargetFilter::ParentTarget),
+            // CR 608.2k: precedence for a bare object anaphor, nearest antecedent
+            // first. A referent established by an EARLIER CLAUSE OF THIS CHAIN wins
+            // ("exile target creature. If you do, ... it") — that is the
+            // `ParentTarget` rung. Only when the chain has introduced no typed
+            // referent of its own does the anaphor reach back to the antecedent the
+            // TRIGGER CONDITION introduced (`ParseContext::object_pronoun_ref`, set
+            // by `oracle_trigger::trigger_object_pronoun_ref_for_condition`).
+            //
+            // The `.or_else` is load-bearing: this struct literal REPLACES the
+            // parent context rather than updating it, so a bare `then_some` silently
+            // dropped the trigger-level antecedent on every single-clause trigger
+            // body. That drop was invisible while the only producer was the
+            // spell-cast axis, because `resolve_it_pronoun`'s non-self-subject
+            // fallback independently returns the same `TriggeringSource` — the two
+            // paths agreed, so the discarded value was never observable. The
+            // passive-voice damage axis is the first producer whose answer
+            // (`EventTarget`) DISAGREES with that fallback, which is what made the
+            // drop visible (issue #8379).
+            object_pronoun_ref: prior_typed_referent
+                .then_some(TargetFilter::ParentTarget)
+                .or_else(|| ctx.object_pronoun_ref.clone()),
             card_name: ctx.card_name.clone(),
             // CR 707.9a + CR 603.1: propagate the trigger index from the parent
             // ctx — `current_trigger_index` is a property of the whole trigger

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -1499,8 +1499,22 @@ pub(crate) fn parse_trigger_line_with_index_ir(
         pending_meld_partner: meld_partner,
         pending_mana_symbol_count_color,
         actor: ctx.actor.clone(),
-        object_pronoun_ref: trigger_object_pronoun_ref_for_condition(condition_text)
-            .or_else(|| trigger_object_pronoun_ref_for_intervening_if(&if_condition)),
+        // CR 608.2k: nearest antecedent wins. An intervening-`if` that pins the
+        // source OFF the battlefield ("... if ~ is in your graveyard, return it")
+        // re-establishes the source card as the antecedent, and it sits nearer to
+        // the effect body than the trigger condition does — so it outranks the
+        // condition-derived antecedent, not the other way round.
+        //
+        // The two were previously ordered condition-first. That was unobservable
+        // while `parse_effect_chain_ir` discarded this field wholesale (see the
+        // `object_pronoun_ref` note in `oracle_effect/mod.rs`): the value never
+        // reached a resolver, so which of the two won could not be seen. Restoring
+        // the propagation makes the ordering load-bearing, and Managorger Phoenix
+        // ("Whenever you cast a spell, if ~ is in your graveyard, ... return it")
+        // is the card that discriminates them — the spell-cast axis would
+        // otherwise bind "return it" to the cast spell instead of the Phoenix.
+        object_pronoun_ref: trigger_object_pronoun_ref_for_intervening_if(&if_condition)
+            .or_else(|| trigger_object_pronoun_ref_for_condition(condition_text, &trigger_subject)),
         plural_object_pronoun_ref: trigger_plural_object_pronoun_ref_for_intervening_if(
             &if_condition,
         ),
@@ -10762,7 +10776,38 @@ fn extract_trigger_subject_for_context(
     subject
 }
 
-fn trigger_object_pronoun_ref_for_condition(condition_text: &str) -> Option<TargetFilter> {
+/// CR 120.1 + CR 120.2a + CR 120.2b + CR 120.10: the PASSIVE-voice damage verb
+/// phrase — "is/are dealt [combat|noncombat|excess] damage".
+///
+/// Two independent axes, one `alt()` each, rather than the five printed strings
+/// they expand to: grammatical number ("is " / "are ") and the CR 120.2a/120.2b
+/// damage class, widened by the CR 120.10 excess qualifier. All five
+/// combinations that appear in the printed corpus are covered by composing the
+/// axes; none is enumerated as a whole-phrase `tag`.
+///
+/// Voice is the whole point of this combinator. In the ACTIVE voice ("a creature
+/// DEALS damage") the trigger's grammatical subject is the damage SOURCE; in the
+/// PASSIVE voice ("a creature IS DEALT damage") the subject is the RECIPIENT.
+/// CR 120.1 makes that distinction load-bearing: "an object that deals damage is
+/// the source of that damage", and the recipient is the object that *receives*
+/// it. The two roles are carried by different fields of the same
+/// `GameEvent::DamageDealt`, so a bare object anaphor in the effect body binds to
+/// a different object depending only on voice.
+fn parse_passive_dealt_damage(input: &str) -> OracleResult<'_, ()> {
+    // Axis 1 — grammatical number.
+    let (input, _) = alt((tag("is "), tag("are "))).parse(input)?;
+    let (input, _) = tag("dealt ").parse(input)?;
+    // Axis 2 — CR 120.2a/120.2b damage class, plus the CR 120.10 excess
+    // qualifier. Absent on the bare form, which is the corpus majority.
+    let (input, _) = opt(alt((tag("combat "), tag("noncombat "), tag("excess ")))).parse(input)?;
+    let (input, _) = tag("damage").parse(input)?;
+    Ok((input, ()))
+}
+
+fn trigger_object_pronoun_ref_for_condition(
+    condition_text: &str,
+    trigger_subject: &TargetFilter,
+) -> Option<TargetFilter> {
     let lower = condition_text.to_lowercase();
     let after_keyword = alt((
         value((), tag::<_, _, OracleError<'_>>("whenever ")),
@@ -10787,6 +10832,43 @@ fn trigger_object_pronoun_ref_for_condition(condition_text: &str) -> Option<Targ
     .is_ok();
     if is_spell_cast_trigger {
         return Some(TargetFilter::TriggeringSource);
+    }
+
+    // CR 608.2k + CR 120.1: a PASSIVE-voice damage trigger condition ("whenever
+    // <subject> is dealt damage") makes its grammatical subject the damage
+    // RECIPIENT, so the effect body's untargeted object anaphor ("destroy it",
+    // "put a +1/+1 counter on it") names the damaged permanent — CR 608.2k's
+    // "specific untargeted object … previously referred to by that ability's …
+    // trigger condition". `TargetFilter::EventTarget` reads
+    // `GameEvent::DamageDealt.target`; the subject-derived
+    // `TargetFilter::TriggeringSource` fallback in `resolve_it_pronoun` reads
+    // `.source_id`, which on a passive-voice trigger is the damage DEALER — a
+    // different object entirely (Termination Facilitator destroyed the source of
+    // the damage instead of the bountied creature, issue #8379).
+    //
+    // The subject phrase is arbitrarily long ("a creature or planeswalker an
+    // opponent controls with a bounty counter on it"), so the verb phrase is
+    // found by scanning the shared word-boundary primitive rather than by
+    // anchoring at a fixed offset.
+    //
+    // Gated on the subject NOT being self-referential, mirroring the exclusion
+    // set both pronoun resolvers already apply (`resolve_it_pronoun`,
+    // `resolve_pronoun_target`): on a self-scoped enrage trigger ("whenever this
+    // creature is dealt damage") the recipient IS the source, and `SelfRef` /
+    // `ParentTarget` remain the more precise antecedents — they resolve without
+    // consulting the trigger event at all.
+    let subject_is_self_referential = matches!(
+        trigger_subject,
+        TargetFilter::SelfRef | TargetFilter::Any | TargetFilter::CostPaidObject
+    );
+    if !subject_is_self_referential
+        && crate::parser::oracle_nom::primitives::scan_at_word_boundaries(
+            after_keyword,
+            parse_passive_dealt_damage,
+        )
+        .is_some()
+    {
+        return Some(TargetFilter::EventTarget);
     }
 
     None

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -1139,6 +1139,7 @@ mod teamwork_aggregate_legal_actions;
 mod teamwork_origin_composition;
 mod teferi_time_raveler_sorcery_speed_lock;
 mod tempt_with_discovery;
+mod termination_facilitator_bounty_damage_8379;
 mod terra_herald_optional_prompt;
 mod terra_magical_adept_milled_enchantment;
 mod terror_of_the_peaks_issue_2911;

--- a/crates/engine/tests/integration/termination_facilitator_bounty_damage_8379.rs
+++ b/crates/engine/tests/integration/termination_facilitator_bounty_damage_8379.rs
@@ -1,0 +1,334 @@
+//! Issue #8379: Termination Facilitator must destroy the creature that WAS
+//! DEALT damage, not the source that dealt it.
+//!
+//! CR 120.1: "An object that deals damage is the source of that damage" — the
+//! recipient is the object that *receives* it. A PASSIVE-voice trigger
+//! condition ("whenever a creature ... is dealt damage") makes its grammatical
+//! subject the recipient, so the effect body's untargeted "it" (CR 608.2k)
+//! names the damaged permanent. Binding it to the damage SOURCE inverts the
+//! roles and destroys the wrong object.
+//!
+//! The reporter saw both halves of that single inversion in one game: the
+//! bountied creature survived AND the Outpost Siege that dealt the damage was
+//! destroyed instead. Both follow from one mis-bound anaphor.
+//!
+//! `valid_card` (which creature may trigger) was already correct; only the
+//! destroy target was wrong, which is why the card reported as `fully_parsed`.
+
+use engine::game::effects::deal_damage;
+use engine::game::scenario::{GameRunner, GameScenario, P0, P1};
+use engine::game::triggers::process_triggers;
+use engine::types::ability::{Effect, QuantityExpr, ResolvedAbility, TargetFilter, TargetRef};
+use engine::types::counter::CounterType;
+use engine::types::identifiers::ObjectId;
+use engine::types::triggers::TriggerMode;
+use engine::types::zones::Zone;
+
+const TERMINATION_FACILITATOR_ORACLE: &str = "{T}: Put a bounty counter on target creature or planeswalker. Activate only as a sorcery.\n\
+Whenever a creature or planeswalker an opponent controls with a bounty counter on it is dealt damage, destroy it.";
+
+/// The reporter's board: the damage came from the opponent's own permanent
+/// (Outpost Siege), so BOTH candidate objects are controlled by P1. A wrong
+/// binding therefore cannot be masked by controller filtering.
+fn bounty_board() -> (GameRunner, ObjectId, ObjectId) {
+    let mut scenario = GameScenario::new();
+    scenario.add_creature_from_oracle(
+        P0,
+        "Termination Facilitator",
+        1,
+        3,
+        TERMINATION_FACILITATOR_ORACLE,
+    );
+    let bountied = scenario.add_creature(P1, "Bountied Bear", 2, 2).id();
+    let dealer = scenario.add_creature(P1, "Siege Engine", 1, 4).id();
+    scenario.with_counter(bountied, CounterType::Generic("bounty".to_string()), 1);
+    (scenario.build(), bountied, dealer)
+}
+
+/// Where did this object end up? A destroyed permanent may have left the object
+/// map entirely, which is itself "in the graveyard" for this test's purposes —
+/// the same idiom `the_black_arrow_dragon_gated_destroy` uses.
+fn zone_of(runner: &GameRunner, object: ObjectId) -> Zone {
+    runner
+        .state()
+        .objects
+        .get(&object)
+        .map_or(Zone::Graveyard, |o| o.zone)
+}
+
+fn ping(source_id: ObjectId, target: ObjectId) -> ResolvedAbility {
+    ResolvedAbility::new(
+        Effect::DealDamage {
+            amount: QuantityExpr::Fixed { value: 1 },
+            target: TargetFilter::Any,
+            damage_source: None,
+            excess: None,
+        },
+        vec![TargetRef::Object(target)],
+        source_id,
+        P1,
+    )
+}
+
+/// THE RUNTIME HALF. A green AST assertion is not evidence that the right
+/// creature dies, so this drives real damage through `deal_damage::resolve` +
+/// `process_triggers` and asserts on final zones.
+///
+/// Pre-fix this fails on BOTH assertions at once — Siege Engine is in the
+/// graveyard and Bountied Bear is still on the battlefield — which is the
+/// single-defect claim stated as a test.
+#[test]
+fn bountied_creature_dies_and_the_damage_source_survives() {
+    let (mut runner, bountied, dealer) = bounty_board();
+
+    let mut events = Vec::new();
+    deal_damage::resolve(runner.state_mut(), &ping(dealer, bountied), &mut events)
+        .expect("damage to the bountied creature resolves");
+    process_triggers(runner.state_mut(), &events);
+    runner.advance_until_stack_empty();
+
+    assert_eq!(
+        zone_of(&runner, bountied),
+        Zone::Graveyard,
+        "the creature that WAS DEALT damage carries the bounty counter and must be destroyed"
+    );
+    assert_eq!(
+        zone_of(&runner, dealer),
+        Zone::Battlefield,
+        "the source that DEALT the damage must survive — destroying it was symptom (B) of #8379"
+    );
+}
+
+/// The trigger must not fire at all when the damaged permanent has no bounty
+/// counter. Without this, the test above would still pass if the fix
+/// over-fired and destroyed every damaged creature.
+#[test]
+fn an_unbountied_creature_dealt_damage_is_not_destroyed() {
+    let mut scenario = GameScenario::new();
+    scenario.add_creature_from_oracle(
+        P0,
+        "Termination Facilitator",
+        1,
+        3,
+        TERMINATION_FACILITATOR_ORACLE,
+    );
+    let plain = scenario.add_creature(P1, "Plain Bear", 2, 2).id();
+    let dealer = scenario.add_creature(P1, "Siege Engine", 1, 4).id();
+    let mut runner = scenario.build();
+
+    let mut events = Vec::new();
+    deal_damage::resolve(runner.state_mut(), &ping(dealer, plain), &mut events)
+        .expect("damage resolves");
+    process_triggers(runner.state_mut(), &events);
+    runner.advance_until_stack_empty();
+
+    assert_eq!(
+        zone_of(&runner, plain),
+        Zone::Battlefield,
+        "no bounty counter ⇒ the trigger's valid_card must not match"
+    );
+    assert_eq!(zone_of(&runner, dealer), Zone::Battlefield);
+}
+
+/// Extract the trigger's destroy/counter target filter from freshly parsed
+/// Oracle text.
+fn passive_damage_trigger_target(oracle: &str, card_name: &str) -> TargetFilter {
+    let parsed = engine::parser::oracle::parse_oracle_text(
+        oracle,
+        card_name,
+        &[],
+        &["Creature".to_string()],
+        &[],
+    );
+    parsed
+        .triggers
+        .iter()
+        .find_map(|t| {
+            let effect = t.execute.as_deref()?.effect.as_ref();
+            match effect {
+                Effect::Destroy { target, .. } | Effect::PutCounter { target, .. } => {
+                    Some((t.mode.clone(), target.clone()))
+                }
+                _ => None,
+            }
+        })
+        .map(|(mode, target)| {
+            assert_eq!(
+                mode,
+                TriggerMode::DamageReceived,
+                "{card_name} must parse as a passive damage trigger"
+            );
+            target
+        })
+        .unwrap_or_else(|| panic!("{card_name} must parse a damage-received trigger"))
+}
+
+/// THE CLASS, not the card. Every printed shape of "whenever <non-self
+/// subject> is dealt damage, <verb> it" must bind the recipient. The
+/// `AttachedTo` rows matter most: they are 7 of the 10 affected cards, and
+/// their subject is the enchanted/equipped creature, so the anaphor can never
+/// mean the Aura or Equipment.
+#[test]
+fn passive_damage_anaphor_binds_the_recipient_across_the_class() {
+    for (name, oracle) in [
+        (
+            "Termination Facilitator",
+            "Whenever a creature or planeswalker an opponent controls with a bounty counter on it is dealt damage, destroy it.",
+        ),
+        // CR 120.2a damage-class axis + `AttachedTo` subject (Hot Soup).
+        (
+            "Hot Soup",
+            "Whenever equipped creature is dealt damage, destroy it.",
+        ),
+        (
+            "Cracked Skull",
+            "When enchanted creature is dealt damage, destroy it.",
+        ),
+        // Unrestricted subject (Death Pits of Rath).
+        (
+            "Death Pits of Rath",
+            "Whenever a creature is dealt damage, destroy it.",
+        ),
+        // A non-Destroy body proves the binding is anaphor-scoped, not
+        // Destroy-scoped (Rite of Passage).
+        (
+            "Rite of Passage",
+            "Whenever a creature you control is dealt damage, put a +1/+1 counter on it.",
+        ),
+    ] {
+        assert_eq!(
+            passive_damage_trigger_target(oracle, name),
+            TargetFilter::EventTarget,
+            "{name}: the passive-voice anaphor must bind the damage RECIPIENT"
+        );
+    }
+}
+
+/// NEGATIVE CONTROL 1 — the ACTIVE-voice sibling must be untouched. Here the
+/// grammatical subject IS the damage source, so `TriggeringSource` stays
+/// correct. 40 cards in card-data.json depend on this staying put; if the fix
+/// keyed on "dealt damage" alone rather than on voice, this row goes red.
+#[test]
+fn active_voice_damage_anaphor_still_binds_the_dealer() {
+    let parsed = engine::parser::oracle::parse_oracle_text(
+        "Whenever a creature deals damage to you, destroy it.",
+        "Ashnod",
+        &[],
+        &["Creature".to_string()],
+        &[],
+    );
+    let (mode, target) = parsed
+        .triggers
+        .iter()
+        .find_map(|t| match t.execute.as_deref()?.effect.as_ref() {
+            Effect::Destroy { target, .. } => Some((t.mode.clone(), target.clone())),
+            _ => None,
+        })
+        .expect("active-voice damage trigger must parse");
+    assert_eq!(mode, TriggerMode::DamageDone);
+    assert_eq!(
+        target,
+        TargetFilter::TriggeringSource,
+        "active voice: the subject IS the dealer, so TriggeringSource must survive the fix"
+    );
+}
+
+/// NEGATIVE CONTROL 2 — a SELF-scoped passive trigger (the enrage class) keeps
+/// its `SelfRef` binding. The recipient and the source object coincide there,
+/// and `SelfRef` resolves without consulting the trigger event at all, so
+/// widening the new axis to self-referential subjects would be a strict
+/// robustness regression across a large class.
+#[test]
+fn self_scoped_passive_damage_trigger_keeps_selfref() {
+    let parsed = engine::parser::oracle::parse_oracle_text(
+        "Whenever this creature is dealt damage, put a +1/+1 counter on it.",
+        "Enrage Fixture",
+        &[],
+        &["Creature".to_string()],
+        &[],
+    );
+    let target = parsed
+        .triggers
+        .iter()
+        .find_map(|t| match t.execute.as_deref()?.effect.as_ref() {
+            Effect::PutCounter { target, .. } => Some(target.clone()),
+            _ => None,
+        })
+        .expect("self-scoped enrage trigger must parse");
+    assert_eq!(
+        target,
+        TargetFilter::SelfRef,
+        "a self-scoped passive trigger must not be widened to EventTarget"
+    );
+}
+
+/// THE DISCRIMINATOR: symptoms (A) and (B) are one defect, demonstrated by
+/// holding the board fixed and varying ONLY the destroy target's binding.
+///
+/// The reporter saw the bountied creature survive *and* the damage source die.
+/// Those are not two bugs — they are the two halves of one inverted reference.
+/// Driving the same `DamageReceived` trigger with each binding in turn shows the
+/// binding alone selects which object dies:
+///   `TriggeringSource` (the pre-fix parse) → the DEALER dies      = symptom (B)
+///   `EventTarget`      (the fixed parse)   → the RECIPIENT dies   = correct
+///
+/// This also pins the handler fix (`destroy::resolve` resolving an untargeted
+/// event-context referent). Before it, BOTH bindings destroyed nothing, so this
+/// test could not have distinguished them at all.
+#[test]
+fn the_destroy_binding_alone_selects_which_object_dies() {
+    for (binding, expect_recipient_dead, label) in [
+        (
+            TargetFilter::TriggeringSource,
+            false,
+            "TriggeringSource destroys the DEALER",
+        ),
+        (
+            TargetFilter::EventTarget,
+            true,
+            "EventTarget destroys the RECIPIENT",
+        ),
+    ] {
+        let mut scenario = GameScenario::new();
+        let recipient = scenario.add_creature(P1, "Recipient", 2, 2).id();
+        let dealer = scenario.add_creature(P1, "Dealer", 1, 4).id();
+        let mut runner = scenario.build();
+
+        let mut events = Vec::new();
+        deal_damage::resolve(runner.state_mut(), &ping(dealer, recipient), &mut events)
+            .expect("damage resolves");
+
+        // One ability, one event, one varying field: the destroy target.
+        let ability = ResolvedAbility::new(
+            Effect::Destroy {
+                target: binding,
+                cant_regenerate: false,
+            },
+            vec![],
+            recipient,
+            P0,
+        );
+        let damage_event = events
+            .iter()
+            .find(|e| matches!(e, engine::types::events::GameEvent::DamageDealt { .. }))
+            .cloned()
+            .expect("the damage event must be recorded");
+        let state = runner.state_mut();
+        // CR 603.2: the referent both bindings read comes from this one event.
+        state.current_trigger_event = Some(damage_event);
+        let mut out = Vec::new();
+        engine::game::effects::destroy::resolve(state, &ability, &mut out)
+            .expect("destroy resolves");
+
+        assert_eq!(
+            zone_of(&runner, recipient) == Zone::Graveyard,
+            expect_recipient_dead,
+            "{label}: recipient"
+        );
+        assert_eq!(
+            zone_of(&runner, dealer) == Zone::Graveyard,
+            !expect_recipient_dead,
+            "{label}: dealer"
+        );
+    }
+}


### PR DESCRIPTION
Fixes #8379.

Termination Facilitator — *"Whenever a creature or planeswalker an opponent controls with a bounty counter on it is dealt damage, destroy it."* — destroyed the **dealer** instead of the bountied creature.

## One inverted reference produces both reported symptoms

`Destroy { target: TriggeringSource }` on a `DamageReceived` trigger. `TriggeringSource` resolves through `extract_source_from_event` → `DamageDealt.source_id`, which is the dealer; the recipient is `EventTarget` → `DamageDealt.target`. Corrected binding is **`EventTarget`**.

A discriminator test holds the board fixed and varies only the binding: `TriggeringSource` kills the dealer, `EventTarget` kills the recipient. The two symptoms in the issue are one defect.

Note the issue's paraphrase ("any creature with a Bounty Counter") drops the *"an opponent controls"* restriction. That restriction was already parsed correctly (`controller: "Opponent"` in the trigger's `valid_card`) and is not part of this bug — the card text was re-read from `AtomicCards.json` rather than taken from the paraphrase.

## Three layers, each masking the next

1. **Parser** — `resolve_it_pronoun` is voice-blind. In a passive-voice clause ("*is dealt damage*") the subject is the recipient, not the source.
2. **Context propagation** — `parse_effect_chain_ir` builds a per-chunk `ParseContext` whose struct literal *replaced* `object_pronoun_ref`, discarding the trigger-level antecedent on every single-clause trigger body. This was unobservable: the only prior producer (the spell-cast axis) emitted `TriggeringSource`, which the subject fallback independently reproduced — the two agreed, so the drop had no visible consequence. Restoring it exposed a latent precedence inversion (an off-battlefield intervening-`if` is the *nearer* antecedent, CR 608.2k) that Managorger Phoenix discriminates; caught as a real regression and fixed rather than papered over.
3. **Handler** — `destroy::resolve` read `ability.targets` directly, so an untargeted event-context referent (targets empty by construction) destroyed **nothing**. Routed through the shared `resolved_targets` authority gated on `is_pure_event_context_filter`, rather than adding a fourth handler-local `matches!` list — the three that already exist (`effect.rs`, `change_zone.rs`, `attach.rs`) have diverged, which is #8496's "membership predicates aren't compile-checked" finding.

Layer 3 is the #8496 cluster's predicted hazard made concrete: after fixing 1–2 the AST asserted green while the runtime still did nothing. That is why the test suite drives the real resolution path.

## Blast radius, re-derived by the lead

Independently recomputed from `card-data.json` against `triggers[].mode` / `.execute`:

| | count |
|---|---|
| `DamageReceived` population | 124 |
| **carrying `TriggeringSource` in the execute subtree** | **10** |
| `DamageDone` (active-voice sibling) carrying it | 40 — **disjoint** |

The 10: cracked skull, cryoshatter, death pits of rath, frozen solid, hot soup, mire blight, mortal wound, rite of passage, sporogenic infection, termination facilitator.

All 10 are genuinely wrong. Seven are Auras/Equipment with an `AttachedTo` subject, where the event source is never the attached creature — a false claim in `resolve_it_pronoun`'s doc comment, corrected here.

Controls both ways: positive — Termination Facilitator is in the hit set and the active-voice `DamageDone` set is disjoint and pinned by a negative-control test as still correctly binding `TriggeringSource`; negative — `TriggeringSourceXYZ` returns 0.

## Verification

Full suite: `26852 tests run: 26851 passed (38 slow), 1 failed, 9 skipped`.

The sole failure is `game_state_stack_budget::four_player_commander_action_fits_a_bounded_stack`, SIGABRT in 0.242s — the known pre-existing macOS arm64 red on `main`, unrelated to this change and the only failure in the run.

Runtime evidence, not AST-only: the test drives `deal_damage::resolve` → `process_triggers` → `advance_until_stack_empty` and asserts final zones `bountied=Graveyard dealer=Battlefield`.

https://claude.ai/code/session_01JSZ2G5sVMGvVPFWX7beFCH


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed passive damage triggers so pronouns correctly refer to the creature that was damaged, rather than the creature dealing damage.
  - Corrected triggered destruction effects when no explicit target is selected, ensuring the intended event-related creature is destroyed.
  - Improved handling of trigger wording across active and passive damage conditions, including different damage types and grammatical forms.
  - Preserved correct behavior for active-voice triggers, self-referential effects, and untriggered creatures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->