### PR TITLE
Make lookup_key the single card-name resolution authority (delete the parallel splitter)

### DIFF
--- a/crates/engine/src/database/bracket_lists.rs
+++ b/crates/engine/src/database/bracket_lists.rs
@@ -98,6 +98,19 @@ impl BracketLists {
         }
     }
 
+    /// True when `name` (case-insensitively) appears on any curated list.
+    ///
+    /// Callers that must decide whether a name is a *whole* printed card name
+    /// use this alongside the card-database indexes: the curated lists key on
+    /// the raw lowercased printed name with no index membership, so a
+    /// lists-only card is known here and nowhere else.
+    pub fn contains(&self, name: &str) -> bool {
+        let key = name.to_lowercase();
+        self.mass_land_denial.contains(&key)
+            || self.extra_turns.contains(&key)
+            || self.efficient_tutors.contains(&key)
+    }
+
     /// Iterate every distinct card name across all four lists, used by the
     /// export pipeline to warn on names that don't match any printed card.
     pub fn all_names(&self) -> impl Iterator<Item = &str> {

--- a/crates/engine/src/database/card_db.rs
+++ b/crates/engine/src/database/card_db.rs
@@ -444,8 +444,50 @@ impl CardDatabase {
     /// single-face fast path. `lookup_key` collapses combined names to their
     /// front face, so without this pre-split a back-face signal would be
     /// silently dropped whenever the front face is in the export map.
+    ///
+    /// The split accepts both the canonical spaced form (`"A // B"`) and the
+    /// hand-typed glued form (`"A//B"`), matching the set of composite forms
+    /// [`Self::lookup_key`] resolves. Splitting on the spaced form alone would
+    /// leave a glued composite name aggregating only its front face's signals,
+    /// silently losing a back-face Game Changer / mass-land-denial / extra-turn
+    /// signal in Commander bracket classification.
+    ///
+    /// A single-faced card whose printed name literally contains `//`
+    /// (`"SP//dr, Piloted by Peni"`) must NOT be split, so the whole-name
+    /// lookup is tried first — the same false-positive guard, and the same
+    /// ordering, that `lookup_key` documents. "Whole name" here spans every
+    /// source this function reads, `bracket_lists` included, since a curated
+    /// list entry may name a card the export map does not carry, and the
+    /// unaccented-alias index, which `lookup_key` folds through before it
+    /// splits.
     pub fn bracket_signals_for(&self, name: &str) -> BracketSignals {
-        if let Some((a, b)) = name.split_once(" // ") {
+        // Exact-match guard only: a name that is ITSELF an indexed card must
+        // not be split. Deliberately not `lookup_key`, which collapses a
+        // composite name to its front face and would therefore report every
+        // composite name whose front face is indexed as a "whole name",
+        // suppressing the very aggregation this function exists to perform.
+        let lower = name.to_lowercase();
+        // `bracket_lists` is a third source of whole printed names: it keys on
+        // the raw lowercased name with no index membership, so a curated-list
+        // card that is absent from the export map is known ONLY here. Omitting
+        // it would split such a name on its literal `//` into two nonexistent
+        // faces and report all-false, dropping its real signal. It takes the
+        // ORIGINAL `name`, not `lower`: `contains` owns its own case folding,
+        // so passing the pre-folded copy would fold twice and imply the lookup
+        // is case-sensitive to a future caller.
+        // The unaccented-alias index is a fourth whole-name source, and
+        // `lookup_key` folds through it BEFORE it splits on `//`. Omitting it
+        // here would make the two functions disagree about what is a composite
+        // name — the exact failure `lookup_key`'s doc warns is wrong by
+        // construction — for a single-faced card whose printed name carries
+        // both `//` and a diacritic, typed unaccented.
+        let is_indexed_whole_name = self.face_index.contains_key(&lower)
+            || self.cards.contains_key(&lower)
+            || self.bracket_lists.contains(name)
+            || self
+                .name_alias_index
+                .contains_key(&fold_card_name_key(name));
+        if let Some((a, b)) = name.split_once("//").filter(|_| !is_indexed_whole_name) {
             let sa = self.signals_for_single_face(a.trim());
             let sb = self.signals_for_single_face(b.trim());
             return BracketSignals {
@@ -472,7 +514,52 @@ impl CardDatabase {
         }
     }
 
-    fn lookup_key(&self, name: &str) -> String {
+    /// Single authority for resolving any caller-supplied card name — including
+    /// a multi-face composite name (`"Front // Back"`) — to a key in
+    /// `face_index` / `cards`. Every name-keyed accessor on `CardDatabase`
+    /// routes through here; no caller may re-implement `//` splitting.
+    ///
+    /// Resolution order is significant and must be preserved:
+    /// 1. Exact (lowercased) match. This MUST precede the `//` split so a
+    ///    single-faced card whose printed name literally contains `//`
+    ///    (`"SP//dr, Piloted by Peni"`) is not mistaken for a composite name.
+    /// 2. Unaccented alias fold, for decklists typed without diacritics.
+    /// 3. `//` split, taking the **front** face — both the canonical spaced
+    ///    form (`"A // B"`) and the hand-typed glued form (`"A//B"`) — then
+    ///    retrying steps 1 and 2 against that front segment.
+    ///
+    /// Collapsing to the front face is correct for decklist *identity*
+    /// resolution: a composite name denotes exactly one card. CR 709.2: although
+    /// split cards have two castable halves, each split card is only one card,
+    /// so a deck entry for `"Fire // Ice"` is one copy of that card, not two.
+    /// It is deliberately lossy in the other direction — the back half is not
+    /// reachable through this function, and CR 709.4a (each split card has two
+    /// names, and an effect choosing a name must choose one half, not both)
+    /// means name-choice effects must not be routed through this collapse.
+    /// Callers that genuinely need per-face data for a composite name must
+    /// split the name themselves and query each face, the way
+    /// [`Self::bracket_signals_for`] does; do not widen `lookup_key` to return
+    /// multiple keys. Such a caller must accept the SAME composite forms this
+    /// function does (spaced and glued) and apply the same exact-match-first
+    /// guard, or it will disagree with `lookup_key` about what is a composite
+    /// name — `bracket_signals_for` is the worked example.
+    ///
+    /// `data/card-data.json` stores each face under its own key and contains no
+    /// composite `"A // B"` keys, so composite-name support rests entirely on
+    /// the `//` branch below with no data-level backstop. The regression
+    /// barrier is therefore the test set in this module —
+    /// `combined_face_name_lookup_resolves_front_face`,
+    /// `glued_combined_face_name_resolves_front_face`,
+    /// `single_face_name_containing_double_slash_resolves_to_itself` (the
+    /// false-positive guard, issue #4790), and
+    /// `name_lookup_accepts_unaccented_aliases`. Any refactor of this function
+    /// must keep all four passing.
+    ///
+    /// `pub(crate)` so in-crate name-keyed code (notably deck validation, which
+    /// keys copy counts and coverage buckets by resolved name) can reuse this
+    /// one resolution instead of re-implementing the `//` split with a
+    /// different — and therefore wrong — ordering.
+    pub(crate) fn lookup_key(&self, name: &str) -> String {
         let lower = name.to_lowercase();
         if self.face_index.contains_key(&lower) || self.cards.contains_key(&lower) {
             return lower;
@@ -1289,6 +1376,97 @@ mod tests {
         assert!(
             sig.game_changer,
             "back-face partner signal must survive lookup_key's front-face collapse"
+        );
+    }
+
+    #[test]
+    fn bracket_signals_for_glued_combined_name_picks_up_back_face_signal() {
+        // Regression: the pre-split accepted only the spaced " // " form, so a
+        // hand-typed glued composite name ("Front//Back") fell through to the
+        // single-face fast path, where lookup_key collapses it to the front
+        // face — silently dropping a back-face Game Changer signal from
+        // Commander bracket classification. The split must accept every
+        // composite form lookup_key resolves.
+        let json = r#"{
+            "halana, kessig ranger": {
+                "name": "Halana, Kessig Ranger",
+                "mana_cost": { "type": "NoCost" },
+                "card_type": { "supertypes": [], "core_types": ["Creature"], "subtypes": [] },
+                "power": null, "toughness": null, "loyalty": null, "defense": null,
+                "oracle_text": null, "abilities": [], "triggers": [],
+                "static_abilities": [], "replacements": [], "keywords": [],
+                "bracket_signals": {
+                    "game_changer": false, "mass_land_denial": false,
+                    "extra_turn": false, "efficient_tutor": false
+                }
+            },
+            "alena, trapper founder": {
+                "name": "Alena, Trapper Founder",
+                "mana_cost": { "type": "NoCost" },
+                "card_type": { "supertypes": [], "core_types": ["Creature"], "subtypes": [] },
+                "power": null, "toughness": null, "loyalty": null, "defense": null,
+                "oracle_text": null, "abilities": [], "triggers": [],
+                "static_abilities": [], "replacements": [], "keywords": [],
+                "bracket_signals": {
+                    "game_changer": true, "mass_land_denial": false,
+                    "extra_turn": false, "efficient_tutor": false
+                }
+            }
+        }"#;
+        let db = CardDatabase::from_json_str(json).unwrap();
+        assert!(
+            db.bracket_signals_for("Halana, Kessig Ranger//Alena, Trapper Founder")
+                .game_changer,
+            "glued composite name must aggregate both faces, like the spaced form"
+        );
+    }
+
+    #[test]
+    fn bracket_signals_for_single_face_name_containing_double_slash_is_not_split() {
+        // The false-positive guard (issue #4790) applied to bracket signals:
+        // "SP//dr, Piloted by Peni" is ONE indexed card whose printed name
+        // contains "//". Splitting it would look up two nonexistent faces and
+        // report all-false, losing its real signal.
+        let json = r#"{
+            "sp//dr, piloted by peni": {
+                "name": "SP//dr, Piloted by Peni",
+                "mana_cost": { "type": "NoCost" },
+                "card_type": { "supertypes": [], "core_types": ["Creature"], "subtypes": [] },
+                "power": null, "toughness": null, "loyalty": null, "defense": null,
+                "oracle_text": null, "abilities": [], "triggers": [],
+                "static_abilities": [], "replacements": [], "keywords": [],
+                "bracket_signals": {
+                    "game_changer": true, "mass_land_denial": false,
+                    "extra_turn": false, "efficient_tutor": false
+                }
+            }
+        }"#;
+        let db = CardDatabase::from_json_str(json).unwrap();
+        assert!(
+            db.bracket_signals_for("SP//dr, Piloted by Peni")
+                .game_changer,
+            "an indexed whole name containing // must not be split into faces"
+        );
+    }
+
+    #[test]
+    fn bracket_signals_for_glued_single_face_name_known_only_to_bracket_lists_is_not_split() {
+        use crate::database::bracket_lists::BracketLists;
+        // Glued-form twin of the spaced-form fallback test below, for the
+        // false-positive guard: "SP//dr, Piloted by Peni" is ONE printed card
+        // whose name contains "//", and here it is known only to the curated
+        // lists (empty export map). The whole-name guard must consult
+        // `bracket_lists` too, or the name is split into two nonexistent faces
+        // and its real mass-land-denial signal is lost.
+        let lists = BracketLists::from_json_str(
+            r#"{"version":"t","mass_land_denial":["SP//dr, Piloted by Peni"]}"#,
+        )
+        .unwrap();
+        let db = CardDatabase::default().with_bracket_lists(lists);
+        assert!(
+            db.bracket_signals_for("SP//dr, Piloted by Peni")
+                .mass_land_denial,
+            "a lists-only whole name containing // must not be split into faces"
         );
     }
 

--- a/crates/engine/src/game/deck_loading.rs
+++ b/crates/engine/src/game/deck_loading.rs
@@ -217,12 +217,29 @@ where
 
 /// Resolve a flat name list into DeckEntry entries using the card database.
 /// Groups duplicate names and skips unresolvable names.
+///
+/// CR 709.2 / CR 712.1: grouping compares the RESOLVED face name, never the
+/// caller's raw spelling. A decklist may name one physical card by its
+/// composite name (`"Fire // Ice"`), its glued composite (`"Fire//Ice"`), its
+/// front-face name (`"Fire"`), or an unaccented alias, and every one of those
+/// is one copy of the same card. Comparing the already-resolved
+/// `entry.card.name` against the raw input would never match those spellings
+/// against each other and would emit several `DeckEntry` values for one card —
+/// the same name-identity error `deck_validation::same_card` documents.
+/// `db.get_face_by_name` performs the resolution (it routes through
+/// `CardDatabase::lookup_key`), so the comparison must happen after it.
 fn resolve_names(db: &CardDatabase, names: &[String]) -> Vec<DeckEntry> {
     let mut entries: Vec<DeckEntry> = Vec::new();
     for name in names {
-        if let Some(index) = entries.iter().position(|entry| entry.card.name == *name) {
+        let Some(face) = db.get_face_by_name(name) else {
+            continue;
+        };
+        if let Some(index) = entries
+            .iter()
+            .position(|entry| entry.card.name.eq_ignore_ascii_case(&face.name))
+        {
             entries[index].count += 1;
-        } else if let Some(face) = db.get_face_by_name(name) {
+        } else {
             // CR 202.3d + CR 709.4b: build through the single authority so the
             // split-card off-stack override is stamped consistently with the
             // server transport resolver.
@@ -1289,6 +1306,55 @@ mod tests {
             rarities: Default::default(),
             attraction_lights: vec![],
         }
+    }
+
+    fn single_face_card_json(name: &str) -> serde_json::Value {
+        serde_json::json!({
+            "name": name,
+            "mana_cost": { "type": "NoCost" },
+            "card_type": { "supertypes": [], "core_types": ["Instant"], "subtypes": [] },
+            "power": null,
+            "toughness": null,
+            "loyalty": null,
+            "defense": null,
+            "oracle_text": null,
+            "non_ability_text": null,
+            "flavor_name": null,
+            "keywords": [],
+            "abilities": [],
+            "triggers": [],
+            "static_abilities": [],
+            "replacements": [],
+            "color_override": null,
+            "scryfall_oracle_id": null
+        })
+    }
+
+    #[test]
+    fn resolve_names_groups_mixed_spellings_of_one_card() {
+        // CR 709.2 / CR 712.1: a composite name, its glued form, and its
+        // front-face name are three spellings of ONE physical card. Grouping
+        // must compare the RESOLVED face name — comparing the resolved
+        // `entry.card.name` against the raw input never matches these against
+        // each other and emits several entries for one card.
+        let mut cards = serde_json::Map::new();
+        cards.insert("fire".to_string(), single_face_card_json("Fire"));
+        let db =
+            CardDatabase::from_json_str(&serde_json::Value::Object(cards).to_string()).unwrap();
+
+        let entries = resolve_names(
+            &db,
+            &[
+                "Fire // Ice".to_string(),
+                "Fire".to_string(),
+                "Fire//Ice".to_string(),
+                "fire".to_string(),
+            ],
+        );
+
+        assert_eq!(entries.len(), 1, "four spellings are one card, not several");
+        assert_eq!(entries[0].card.name, "Fire");
+        assert_eq!(entries[0].count, 4, "every spelling contributes one copy");
     }
 
     #[test]

--- a/crates/engine/src/game/deck_validation.rs
+++ b/crates/engine/src/game/deck_validation.rs
@@ -1623,7 +1623,12 @@ fn evaluate_tiny_leaders(
         if !is_commander_entry(db, request, name) {
             for color in card_color_identity(face) {
                 if !commander_identity.contains(&color) {
-                    identity_violations.insert(name.to_string());
+                    // Resolved face name, not the caller's raw spelling — the
+                    // same convention `color_identity_violations` documents and
+                    // the sibling `basic_land_type_violations` /
+                    // `tiny_identity_violations` inserts below already follow,
+                    // so the `BTreeSet` dedups a card listed under two spellings.
+                    identity_violations.insert(face.name.clone());
                     break;
                 }
             }
@@ -8106,7 +8111,18 @@ mod tests {
     #[test]
     fn deck_coverage_counts_one_card_once_across_mixed_spellings() {
         let mut cards = Map::new();
-        insert_planechase_card(&mut cards, "Fire", &[], &["Instant"]);
+        // `Fire` must be UNSUPPORTED here: `copies` is carried only by
+        // `UnsupportedCard`, so a fully-supported fixture leaves the copy-count
+        // assertion below with nothing to run against. Same construction as
+        // `insert_unsupported_scheme_card`, which `archenemy_rejects_unsupported_scheme`
+        // already pins through the same `card_face_gaps` predicate.
+        let mut fire = planechase_card_json("Fire", &[], &["Instant"]);
+        fire["abilities"] = serde_json::to_value(vec![crate::types::AbilityDefinition::new(
+            crate::types::AbilityKind::Spell,
+            crate::types::Effect::unimplemented("deck_coverage_test", "unsupported test card"),
+        )])
+        .unwrap();
+        cards.insert("fire".to_string(), fire);
         insert_planechase_card(&mut cards, "Plains", &["Basic"], &["Land"]);
         let db = CardDatabase::from_json_str(&Value::Object(cards).to_string()).unwrap();
 
@@ -8130,12 +8146,15 @@ mod tests {
             coverage.total_unique,
             "every unique card must land in exactly one bucket"
         );
-        for card in &coverage.unsupported_cards {
-            assert_eq!(
-                card.copies, 4,
-                "the single entry carries the whole playset, not a per-spelling share"
-            );
-        }
+        assert_eq!(
+            coverage.unsupported_cards.len(),
+            1,
+            "the unsupported fixture must reach the bucket the copy count lives in"
+        );
+        assert_eq!(
+            coverage.unsupported_cards[0].copies, 4,
+            "the single entry carries the whole playset, not a per-spelling share"
+        );
     }
 
     #[test]

--- a/crates/engine/src/game/deck_validation.rs
+++ b/crates/engine/src/game/deck_validation.rs
@@ -98,7 +98,7 @@ pub fn signature_spell_selection_policy(
     }
 
     let commander_identity = request.commander.first().and_then(|name| {
-        db.get_face_by_name(resolve_card_name(db, name))
+        db.get_face_by_name(name)
             .filter(|face| face.is_oathbreaker)
             .map(card_color_identity)
     });
@@ -107,7 +107,7 @@ pub fn signature_spell_selection_policy(
             .main_deck
             .iter()
             .filter_map(|name| {
-                let face = db.get_face_by_name(resolve_card_name(db, name))?;
+                let face = db.get_face_by_name(name)?;
                 (is_instant_or_sorcery(face)
                     && card_color_identity(face)
                         .iter()
@@ -146,7 +146,7 @@ pub fn companion_candidates(db: &CardDatabase, request: &DeckCompatibilityReques
         .iter()
         .enumerate()
         .filter_map(|(index, name)| {
-            let face = db.get_face_by_name(resolve_card_name(db, name))?;
+            let face = db.get_face_by_name(name)?;
             let mut remaining_main = request.main_deck.clone();
             remaining_main.remove(index);
             let companion = DeckEntry::from_resolved_face(db, face, 1);
@@ -229,6 +229,12 @@ fn default_one() -> usize {
 }
 
 /// Engine coverage summary for a deck: how many unique cards are fully supported.
+///
+/// The three fields satisfy `supported_unique + unsupported_cards.len() ==
+/// total_unique` by construction: `total_unique` counts only cards that
+/// resolved to a database face, since a card with no face lands in neither
+/// coverage bucket. Names that do not resolve at all are reported separately as
+/// unknown cards, not folded into this ratio.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DeckCoverage {
     pub total_unique: usize,
@@ -617,8 +623,7 @@ fn evaluate_constructed(
         if unknown_cards.contains(name) {
             continue;
         }
-        let resolved = resolve_card_name(db, name);
-        match db.legality_status(resolved, legality_format) {
+        match db.legality_status(name, legality_format) {
             Some(LegalityStatus::Legal) => {}
             // CR 100.2b: A card on a format's restricted list is legal but
             // a deck may contain at most one copy of it. Vintage is the
@@ -631,10 +636,17 @@ fn evaluate_constructed(
                 restricted_canonical.insert(canonical_deck_count_key(db, name));
             }
             Some(status) => {
-                illegal_cards.insert(format!("{name} ({})", status_label(status)));
+                illegal_cards.insert(format!(
+                    "{} ({})",
+                    display_name(db, name),
+                    status_label(status)
+                ));
             }
             None => {
-                illegal_cards.insert(format!("{name} (not legal in {format_label})"));
+                illegal_cards.insert(format!(
+                    "{} (not legal in {format_label})",
+                    display_name(db, name)
+                ));
             }
         }
     }
@@ -719,7 +731,7 @@ fn evaluate_planechase(
     let mut planes = 0usize;
     let mut phenomena = 0usize;
     for name in &request.planar_deck {
-        let Some(face) = db.get_face_by_name(resolve_card_name(db, name)) else {
+        let Some(face) = db.get_face_by_name(name) else {
             continue;
         };
         let canonical = face.name.to_lowercase();
@@ -825,7 +837,7 @@ fn validate_scheme_deck(db: &CardDatabase, scheme_deck: &[String], reasons: &mut
     let mut non_scheme = BTreeSet::new();
     let mut unsupported = BTreeSet::new();
     for name in scheme_deck {
-        let Some(face) = db.get_face_by_name(resolve_card_name(db, name)) else {
+        let Some(face) = db.get_face_by_name(name) else {
             continue;
         };
         *counts.entry(face.name.to_lowercase()).or_insert(0) += 1;
@@ -988,8 +1000,7 @@ fn request_without_sideboard(request: &DeckCompatibilityRequest) -> DeckCompatib
 fn deck_entries_for_names(db: &CardDatabase, names: &[String]) -> Vec<DeckEntry> {
     let mut entries: Vec<DeckEntry> = Vec::new();
     for name in names {
-        let resolved = resolve_card_name(db, name);
-        let Some(face) = db.get_face_by_name(resolved) else {
+        let Some(face) = db.get_face_by_name(name) else {
             continue;
         };
         if let Some(entry) = entries
@@ -1026,7 +1037,7 @@ fn validate_commander_companion(
     }
 
     let companion_name = &request.companion[0];
-    let Some(face) = db.get_face_by_name(resolve_card_name(db, companion_name)) else {
+    let Some(face) = db.get_face_by_name(companion_name) else {
         return;
     };
     let companion = DeckEntry::from_resolved_face(db, face, 1);
@@ -1141,16 +1152,7 @@ fn evaluate_commander_with_format(
     // staging area) and enforce CR 903.5e at game load by dropping them —
     // see `load_deck_into_state` in `deck_loading.rs`.
 
-    let represented_in_main = request
-        .commander
-        .iter()
-        .filter(|name| {
-            request
-                .main_deck
-                .iter()
-                .any(|card| card.eq_ignore_ascii_case(name))
-        })
-        .count();
+    let represented_in_main = commanders_represented_in_main(db, request);
     let total_cards = request.main_deck.len() + (request.commander.len() - represented_in_main);
     if !deck_size.accepts(total_cards) {
         reasons.push(format!(
@@ -1160,8 +1162,9 @@ fn evaluate_commander_with_format(
     }
 
     // CR 903.5b: Other than basic lands, each card in a Commander deck must have
-    // a different English name. Canonicalization (CR 201.3) is handled inside
-    // the shared helper.
+    // a different English name. Canonicalization to one bucket per PHYSICAL
+    // card (CR 709.2 / CR 712.1 for multi-face cards) is handled inside the
+    // shared helper.
     //
     // CR 903.13f(2) displaces that rule for Commander Draft — "A player's deck
     // may include any number of cards from that player's card pool with the
@@ -1187,21 +1190,23 @@ fn evaluate_commander_with_format(
             if unknown_cards.contains(name) {
                 continue;
             }
-            if rules.skip_commander_legality
-                && request
-                    .commander
-                    .iter()
-                    .any(|commander| commander.eq_ignore_ascii_case(name))
-            {
+            if rules.skip_commander_legality && is_commander_entry(db, request, name) {
                 continue;
             }
-            match db.legality_status(resolve_card_name(db, name), legality_format) {
+            match db.legality_status(name, legality_format) {
                 Some(status) if status.is_legal() => {}
                 Some(status) => {
-                    illegal_cards.insert(format!("{name} ({})", status_label(status)));
+                    illegal_cards.insert(format!(
+                        "{} ({})",
+                        display_name(db, name),
+                        status_label(status)
+                    ));
                 }
                 None => {
-                    illegal_cards.insert(format!("{name} (not legal in {format_label})"));
+                    illegal_cards.insert(format!(
+                        "{} (not legal in {format_label})",
+                        display_name(db, name)
+                    ));
                 }
             }
         }
@@ -1218,7 +1223,7 @@ fn evaluate_commander_with_format(
     // the commander(s)' combined color identity.
     let mut commander_identity = HashSet::new();
     for name in &request.commander {
-        if let Some(face) = db.get_face_by_name(resolve_card_name(db, name)) {
+        if let Some(face) = db.get_face_by_name(name) {
             commander_identity.extend(card_color_identity(face));
         }
     }
@@ -1227,12 +1232,13 @@ fn evaluate_commander_with_format(
         &request.main_deck,
         &commander_identity,
         unknown_cards,
-        |name| {
-            request
-                .commander
-                .iter()
-                .any(|c| c.eq_ignore_ascii_case(name))
-        },
+        // `same_card` compares resolved keys, not raw spellings: a DFC
+        // commander listed in the command zone by its composite name
+        // ("Tovolar, Dire Overlord // Tovolar, the Midnight Scourge") and in
+        // the 99 by its front name is the same card. Without this the
+        // commander escapes the command-zone skip and is reported as a
+        // CR 903.5c violation against its own color identity.
+        |name| is_commander_entry(db, request, name),
     );
     if !identity_violations.is_empty() {
         reasons.push(summarize_cards(
@@ -1303,7 +1309,7 @@ fn evaluate_brawl(
     // Validate commander eligibility: legendary creature OR legendary planeswalker
     if request.commander.len() == 1 {
         let name = &request.commander[0];
-        if let Some(face) = db.get_face_by_name(resolve_card_name(db, name)) {
+        if let Some(face) = db.get_face_by_name(name) {
             if !is_brawl_commander_eligible(face) {
                 reasons.push(format!(
                     "{format_label} commander must be a legendary creature or legendary planeswalker: {name}"
@@ -1324,16 +1330,7 @@ fn evaluate_brawl(
     let deck_size = FormatConfig::for_format(game_format)
         .expect("evaluate_brawl is only dispatched for a Brawl-family GameFormat")
         .deck_size;
-    let represented_in_main = request
-        .commander
-        .iter()
-        .filter(|name| {
-            request
-                .main_deck
-                .iter()
-                .any(|card| card.eq_ignore_ascii_case(name))
-        })
-        .count();
+    let represented_in_main = commanders_represented_in_main(db, request);
     let total_cards = request.main_deck.len() + (request.commander.len() - represented_in_main);
     if !deck_size.accepts(total_cards) {
         reasons.push(format!(
@@ -1342,8 +1339,9 @@ fn evaluate_brawl(
         ));
     }
 
-    // CR 903.5b (Brawl variant): singleton rule, basic lands exempt, canonicalized
-    // via CR 201.3 in the shared helper.
+    // CR 903.5b (Brawl variant): singleton rule, basic lands exempt,
+    // canonicalized to one bucket per physical card (CR 709.2 / CR 712.1) in
+    // the shared helper.
     let counts = combined_copy_counts(db, request);
     let singleton_violations =
         copy_limit_violations(db, &counts, resolved_copy_limit(request, game_format));
@@ -1361,13 +1359,20 @@ fn evaluate_brawl(
         if unknown_cards.contains(name) {
             continue;
         }
-        match db.legality_status(resolve_card_name(db, name), legality_format) {
+        match db.legality_status(name, legality_format) {
             Some(status) if status.is_legal() => {}
             Some(status) => {
-                illegal_cards.insert(format!("{name} ({})", status_label(status)));
+                illegal_cards.insert(format!(
+                    "{} ({})",
+                    display_name(db, name),
+                    status_label(status)
+                ));
             }
             None => {
-                illegal_cards.insert(format!("{name} (not legal in {format_label})"));
+                illegal_cards.insert(format!(
+                    "{} (not legal in {format_label})",
+                    display_name(db, name)
+                ));
             }
         }
     }
@@ -1383,26 +1388,19 @@ fn evaluate_brawl(
     // the commander's color identity.
     if request.commander.len() == 1 {
         let cmd_name = &request.commander[0];
-        if let Some(face) = db.get_face_by_name(resolve_card_name(db, cmd_name)) {
+        if let Some(face) = db.get_face_by_name(cmd_name) {
             let commander_identity = card_color_identity(face);
-            let mut identity_violations = BTreeSet::new();
-            for name in &request.main_deck {
-                if name.eq_ignore_ascii_case(cmd_name) {
-                    continue;
-                }
-                if unknown_cards.contains(name.as_str()) {
-                    continue;
-                }
-                if let Some(card_face) = db.get_face_by_name(resolve_card_name(db, name)) {
-                    let card_colors = card_color_identity(card_face);
-                    for color in &card_colors {
-                        if !commander_identity.contains(color) {
-                            identity_violations.insert(name.clone());
-                            break;
-                        }
-                    }
-                }
-            }
+            // Same CR 903.5c subset check as the other command-zone formats —
+            // share the one authority instead of re-deriving it, so the
+            // command-zone skip and the violation keys stay resolved on both
+            // sides here too.
+            let identity_violations = color_identity_violations(
+                db,
+                &request.main_deck,
+                &commander_identity,
+                unknown_cards,
+                |name| same_card(db, name, cmd_name),
+            );
             if !identity_violations.is_empty() {
                 reasons.push(summarize_cards(
                     &format!("Cards outside {format_label} commander's color identity"),
@@ -1525,7 +1523,7 @@ fn evaluate_tiny_leaders(
         let mut ineligible_commanders = BTreeSet::new();
         let mut commander_bans = BTreeSet::new();
         for name in &request.commander {
-            let Some(face) = db.get_face_by_name(resolve_card_name(db, name)) else {
+            let Some(face) = db.get_face_by_name(name) else {
                 continue;
             };
             if !is_tiny_leader_eligible(face) {
@@ -1547,8 +1545,8 @@ fn evaluate_tiny_leaders(
         }
 
         if request.commander.len() == 2 {
-            let face_a = db.get_face_by_name(resolve_card_name(db, &request.commander[0]));
-            let face_b = db.get_face_by_name(resolve_card_name(db, &request.commander[1]));
+            let face_a = db.get_face_by_name(&request.commander[0]);
+            let face_b = db.get_face_by_name(&request.commander[1]);
             if let (Some(a), Some(b)) = (face_a, face_b) {
                 // CR 903.13f(3) is scoped to Commander Draft. Tiny Leaders has
                 // no `CommanderVariantRules` and no draft set code, so it
@@ -1572,16 +1570,7 @@ fn evaluate_tiny_leaders(
         ));
     }
 
-    let represented_in_main = request
-        .commander
-        .iter()
-        .filter(|name| {
-            request
-                .main_deck
-                .iter()
-                .any(|card| card.eq_ignore_ascii_case(name))
-        })
-        .count();
+    let represented_in_main = commanders_represented_in_main(db, request);
     let total_cards = request.main_deck.len() + (request.commander.len() - represented_in_main);
     if total_cards != 50 {
         reasons.push(format!(
@@ -1605,7 +1594,7 @@ fn evaluate_tiny_leaders(
 
     let mut commander_identity = HashSet::new();
     for name in &request.commander {
-        if let Some(face) = db.get_face_by_name(resolve_card_name(db, name)) {
+        if let Some(face) = db.get_face_by_name(name) {
             commander_identity.extend(card_color_identity(face));
         }
     }
@@ -1620,8 +1609,7 @@ fn evaluate_tiny_leaders(
         if unknown_cards.contains(name) {
             continue;
         }
-        let resolved = resolve_card_name(db, name);
-        let Some(face) = db.get_face_by_name(resolved) else {
+        let Some(face) = db.get_face_by_name(name) else {
             continue;
         };
 
@@ -1632,11 +1620,7 @@ fn evaluate_tiny_leaders(
             category_bans.insert(face.name.clone());
         }
 
-        if !request
-            .commander
-            .iter()
-            .any(|commander| commander.eq_ignore_ascii_case(name))
-        {
+        if !is_commander_entry(db, request, name) {
             for color in card_color_identity(face) {
                 if !commander_identity.contains(&color) {
                     identity_violations.insert(name.to_string());
@@ -1652,7 +1636,7 @@ fn evaluate_tiny_leaders(
             }
         }
 
-        if !tiny_leaders_cost_identity_ok(db, resolved) {
+        if !tiny_leaders_cost_identity_ok(db, name) {
             tiny_identity_violations.insert(face.name.clone());
         }
     }
@@ -1849,7 +1833,7 @@ fn evaluate_oathbreaker(
         ));
     } else {
         let name = &request.commander[0];
-        if let Some(face) = db.get_face_by_name(resolve_card_name(db, name)) {
+        if let Some(face) = db.get_face_by_name(name) {
             if !face.is_oathbreaker {
                 reasons.push(format!(
                     "{name}: Oathbreaker must be a legendary Planeswalker"
@@ -1859,7 +1843,7 @@ fn evaluate_oathbreaker(
     }
 
     let oathbreaker_identity = request.commander.first().and_then(|ob_name| {
-        db.get_face_by_name(resolve_card_name(db, ob_name))
+        db.get_face_by_name(ob_name)
             .filter(|face| face.is_oathbreaker)
             .map(|face| {
                 card_color_identity(face)
@@ -1876,7 +1860,7 @@ fn evaluate_oathbreaker(
         ));
     } else {
         let sig_name = &request.signature_spell[0];
-        if let Some(face) = db.get_face_by_name(resolve_card_name(db, sig_name)) {
+        if let Some(face) = db.get_face_by_name(sig_name) {
             if !is_instant_or_sorcery(face) {
                 reasons.push(format!(
                     "{sig_name}: signature spell must be an instant or sorcery"
@@ -1898,15 +1882,16 @@ fn evaluate_oathbreaker(
 
     // Oathbreaker RC: exactly 60 cards total (main + commander + signature spell,
     // de-duplicating any that appear in both main and a command-zone slot).
-    let commander_represented = request
-        .commander
-        .iter()
-        .filter(|n| request.main_deck.iter().any(|c| names_match(c, n)))
-        .count();
+    // CR 709.2 / CR 712.1: both slots compare resolved card identities, not raw
+    // spellings, because a split or double-faced card is one physical card,
+    // so a composite-named ("Front // Back") Oathbreaker or signature spell
+    // listed in the main deck by its front face is recognized as the same
+    // physical card instead of being counted twice.
+    let commander_represented = commanders_represented_in_main(db, request);
     let sig_represented = request
         .signature_spell
         .iter()
-        .filter(|n| request.main_deck.iter().any(|c| names_match(c, n)))
+        .filter(|n| request.main_deck.iter().any(|c| same_card(db, c, n)))
         .count();
     let total_cards = request.main_deck.len()
         + (request
@@ -1924,8 +1909,12 @@ fn evaluate_oathbreaker(
     }
 
     // Oathbreaker RC: singleton (basic lands exempt, consistent with other
-    // singleton command-zone formats). `all_deck_cards` now includes `signature_spell`
-    // so a card in both the main deck and signature-spell slot is caught here.
+    // singleton command-zone formats). `construction_deck_cards` includes
+    // `signature_spell`, so a genuine second copy of a card in both the main
+    // deck and the signature-spell slot is caught here. Counts are keyed by
+    // resolved card identity (CR 709.2 / CR 712.1: one physical card) rather
+    // than by raw spelling, so the two spellings of one multi-face card share
+    // a bucket.
     let counts = combined_copy_counts(db, request);
     let singleton_violations = copy_limit_violations(
         db,
@@ -1953,8 +1942,7 @@ fn evaluate_oathbreaker(
             if unknown_cards.contains(name) {
                 continue;
             }
-            let resolved = resolve_card_name(db, name);
-            let Some(face) = db.get_face_by_name(resolved) else {
+            let Some(face) = db.get_face_by_name(name) else {
                 continue;
             };
             for color in basic_land_type_colors(face) {
@@ -2031,8 +2019,7 @@ fn evaluate_momir(
         if unknown_cards.contains(name) {
             continue;
         }
-        let resolved = resolve_card_name(db, name);
-        let Some(face) = db.get_face_by_name(resolved) else {
+        let Some(face) = db.get_face_by_name(name) else {
             continue;
         };
         // CR 205.4a + CR 305: Snow + Basic supertypes on a Land.
@@ -2333,13 +2320,13 @@ fn quick_constructed_check(
     let mut counts: HashMap<String, u32> = HashMap::new();
     let mut restricted = HashSet::new();
     for name in construction_deck_cards(request) {
-        let resolved = resolve_card_name(db, name);
-        if db.get_face_by_name(resolved).is_none() {
+        let resolved = db.lookup_key(name);
+        if db.get_face_by_name(&resolved).is_none() {
             return QuickCheckResult::unknown(name);
         }
         let canonical = canonical_deck_count_key(db, name);
         *counts.entry(canonical.clone()).or_insert(0) += 1;
-        match db.legality_status(resolved, legality_format) {
+        match db.legality_status(&resolved, legality_format) {
             Some(LegalityStatus::Legal) => {}
             Some(LegalityStatus::Restricted) => {
                 restricted.insert(canonical);
@@ -2409,7 +2396,7 @@ fn quick_commander_check(
     if let Some(unknown_companion) = request
         .companion
         .iter()
-        .find(|name| db.get_face_by_name(resolve_card_name(db, name)).is_none())
+        .find(|name| db.get_face_by_name(name).is_none())
     {
         return QuickCheckResult::unknown(unknown_companion);
     }
@@ -2420,16 +2407,7 @@ fn quick_commander_check(
         return QuickCheckResult::incompatible(reason);
     }
 
-    let represented_in_main = request
-        .commander
-        .iter()
-        .filter(|name| {
-            request
-                .main_deck
-                .iter()
-                .any(|card| card.eq_ignore_ascii_case(name))
-        })
-        .count();
+    let represented_in_main = commanders_represented_in_main(db, request);
     let total_cards = request.main_deck.len() + (request.commander.len() - represented_in_main);
     // CR 903.5a: the format's `DeckSizeRule` is the single authority for
     // min-vs-exact; this seam must not re-derive it with `!=`.
@@ -2442,7 +2420,7 @@ fn quick_commander_check(
 
     let mut commander_identity = HashSet::new();
     for name in &request.commander {
-        let Some(face) = db.get_face_by_name(resolve_card_name(db, name)) else {
+        let Some(face) = db.get_face_by_name(name) else {
             return QuickCheckResult::unknown(name);
         };
         if !(rules.eligible)(face) {
@@ -2451,8 +2429,8 @@ fn quick_commander_check(
         commander_identity.extend(card_color_identity(face));
     }
     if request.commander.len() == 2 {
-        let face_a = db.get_face_by_name(resolve_card_name(db, &request.commander[0]));
-        let face_b = db.get_face_by_name(resolve_card_name(db, &request.commander[1]));
+        let face_a = db.get_face_by_name(&request.commander[0]);
+        let face_b = db.get_face_by_name(&request.commander[1]);
         if let (Some(a), Some(b)) = (face_a, face_b) {
             // CR 903.13f(3): the summary-path twin of the full validator's
             // pairing check; same per-variant axis, same source.
@@ -2465,25 +2443,22 @@ fn quick_commander_check(
         }
     }
 
-    let mut counts: HashMap<String, u32> = HashMap::new();
+    // CR 903.5b copy counting is the full validator's `combined_copy_counts`,
+    // not a second inline tally: that helper keys every listing by RESOLVED
+    // card identity (CR 709.2 / CR 712.1 — one physical card per multi-face
+    // card), so re-deriving counts here would make the summary path reach a
+    // different singleton verdict than the full path for the same decklist.
+    let counts = combined_copy_counts(db, request);
     for name in construction_deck_cards(request) {
-        let resolved = resolve_card_name(db, name);
-        let Some(face) = db.get_face_by_name(resolved) else {
+        let resolved = db.lookup_key(name);
+        let Some(face) = db.get_face_by_name(&resolved) else {
             return QuickCheckResult::unknown(name);
         };
-        *counts
-            .entry(canonical_deck_count_key(db, name))
-            .or_insert(0) += 1;
         // CR 903.13e: `None` means the format has no constructed legality
         // table, so there is nothing to check.
         if let Some(legality_format) = legality_format {
-            if !rules.skip_commander_legality
-                || !request
-                    .commander
-                    .iter()
-                    .any(|commander| commander.eq_ignore_ascii_case(name))
-            {
-                match db.legality_status(resolved, legality_format) {
+            if !rules.skip_commander_legality || !is_commander_entry(db, request, name) {
+                match db.legality_status(&resolved, legality_format) {
                     Some(status) if status.is_legal() => {}
                     Some(status) => {
                         return QuickCheckResult::incompatible(format!(
@@ -2499,11 +2474,7 @@ fn quick_commander_check(
                 }
             }
         }
-        if request
-            .commander
-            .iter()
-            .any(|commander| commander.eq_ignore_ascii_case(name))
-        {
+        if is_commander_entry(db, request, name) {
             continue;
         }
         for color in card_color_identity(face) {
@@ -2519,12 +2490,11 @@ fn quick_commander_check(
     // its format legality separately without contributing to the starting
     // deck's size or singleton count.
     for name in &request.companion {
-        let resolved = resolve_card_name(db, name);
         // CR 903.13e: as above — no legality table, nothing to check.
         let Some(legality_format) = legality_format else {
             break;
         };
-        match db.legality_status(resolved, legality_format) {
+        match db.legality_status(name, legality_format) {
             Some(status) if status.is_legal() => {}
             Some(status) => {
                 return QuickCheckResult::incompatible(format!(
@@ -2571,7 +2541,7 @@ fn quick_brawl_check(
         ));
     }
     let name = &request.commander[0];
-    let Some(face) = db.get_face_by_name(resolve_card_name(db, name)) else {
+    let Some(face) = db.get_face_by_name(name) else {
         return QuickCheckResult::unknown(name);
     };
     if !is_brawl_commander_eligible(face) {
@@ -2780,28 +2750,48 @@ fn evaluate_selected_format(
 }
 
 fn evaluate_deck_coverage(db: &CardDatabase, request: &DeckCompatibilityRequest) -> DeckCoverage {
-    // Count copies per card name for the tooltip severity indicator
+    // One canonical key drives all three outputs — the copy counts, the unique
+    // set, and `total_unique`. `canonical_deck_count_key` is the single
+    // copy-count authority in this module (shared with `combined_copy_counts`,
+    // and therefore with the CR 100.2a copy-limit verdict), so coverage and
+    // copy limits can never bucket the same card differently. Keying by
+    // `lookup_key` here instead would diverge for the ~30 cards `oracle-gen`
+    // stores under a hidden `[oracle-id]` key (minted by
+    // `oracle_gen::insert_hidden_multiface`, preserved by
+    // `CardDatabase::export_subset_json`),
+    // whose storage key is not `name.to_lowercase()`.
+    //
+    // Each key keeps one raw spelling for display/lookup, so a decklist mixing
+    // a composite name ("Fire // Ice"), a glued one ("Fire//Ice"), a front-face
+    // name ("Fire"), and an unaccented alias ("Nazgul") resolves to a single
+    // entry counted once — not N entries each claiming the full copy count.
     let mut copy_counts: HashMap<String, usize> = HashMap::new();
+    let mut unique_names: HashMap<String, &str> = HashMap::new();
     for name in all_deck_cards(request) {
-        let resolved = resolve_card_name(db, name);
-        *copy_counts.entry(resolved.to_lowercase()).or_insert(0) += 1;
+        let canonical = canonical_deck_count_key(db, name);
+        *copy_counts.entry(canonical.clone()).or_insert(0) += 1;
+        unique_names.entry(canonical).or_insert(name);
     }
 
-    let unique_names: HashSet<&str> = all_deck_cards(request).collect();
     let mut unsupported_cards = Vec::new();
     let mut supported_count = 0usize;
+    // An unresolvable name (typo, un-exported card) belongs to NEITHER coverage
+    // bucket — `card_face_gaps` needs a face to inspect. Counting it in
+    // `total_unique` anyway would silently break the deck builder's
+    // supported/total ratio and the
+    // `supported_unique + unsupported_cards.len() == total_unique` invariant, so
+    // it is excluded from the total instead. Unknown cards are surfaced to the
+    // user separately, through `collect_unknown_cards`.
+    let mut resolved_unique = 0usize;
 
-    for name in &unique_names {
-        let resolved = resolve_card_name(db, name);
-        if let Some(face) = db.get_face_by_name(resolved) {
+    for (canonical, name) in &unique_names {
+        if let Some(face) = db.get_face_by_name(name) {
+            resolved_unique += 1;
             let gaps = crate::game::coverage::card_face_gaps(face);
             if gaps.is_empty() {
                 supported_count += 1;
             } else {
-                let copies = copy_counts
-                    .get(&face.name.to_lowercase())
-                    .copied()
-                    .unwrap_or(1);
+                let copies = copy_counts.get(canonical).copied().unwrap_or(1);
                 let parse_details = crate::game::coverage::build_parse_details_for_face(face);
                 unsupported_cards.push(UnsupportedCard {
                     name: face.name.clone(),
@@ -2818,7 +2808,7 @@ fn evaluate_deck_coverage(db: &CardDatabase, request: &DeckCompatibilityRequest)
     unsupported_cards.sort_by(|a, b| a.name.cmp(&b.name));
 
     DeckCoverage {
-        total_unique: unique_names.len(),
+        total_unique: resolved_unique,
         supported_unique: supported_count,
         unsupported_cards,
     }
@@ -2837,9 +2827,8 @@ fn evaluate_format_legality(
     for format in LegalityFormat::ALL {
         let mut worst = LegalityStatus::Legal;
         for name in &unique_names {
-            let resolved = resolve_card_name(db, name);
             let status = db
-                .legality_status(resolved, format)
+                .legality_status(name, format)
                 .unwrap_or(LegalityStatus::NotLegal);
             match status {
                 LegalityStatus::Banned => {
@@ -2903,12 +2892,17 @@ fn color_identity_violations(
         if is_command_zone_card(name.as_str()) || unknown_cards.contains(name.as_str()) {
             continue;
         }
-        if let Some(face) = db.get_face_by_name(resolve_card_name(db, name)) {
+        if let Some(face) = db.get_face_by_name(name) {
             if card_color_identity(face)
                 .iter()
                 .any(|color| !identity.contains(color))
             {
-                violations.insert(name.clone());
+                // Insert the resolved face name, not the caller's raw spelling,
+                // so the `BTreeSet` actually dedups a card listed under two
+                // spellings (composite + front face, or accented + unaccented).
+                // Matches the sibling `basic_type_violations` loop in
+                // `evaluate_oathbreaker`, which already keys by `face.name`.
+                violations.insert(face.name.clone());
             }
         }
     }
@@ -2954,8 +2948,7 @@ fn collect_color_identity(db: &CardDatabase, request: &DeckCompatibilityRequest)
     let unique_names: HashSet<&str> = all_deck_cards(request).collect();
 
     for name in unique_names {
-        let resolved = resolve_card_name(db, name);
-        if let Some(face) = db.get_face_by_name(resolved) {
+        if let Some(face) = db.get_face_by_name(name) {
             colors.extend(card_color_identity(face));
         }
     }
@@ -2976,7 +2969,7 @@ fn collect_main_deck_color_distribution(
     let mut counts = HashMap::new();
 
     for name in &request.main_deck {
-        let Some(face) = db.get_face_by_name(resolve_card_name(db, name)) else {
+        let Some(face) = db.get_face_by_name(name) else {
             continue;
         };
         for color in card_color_identity(face) {
@@ -3015,10 +3008,73 @@ fn mana_color_letter(color: &ManaColor) -> String {
     .to_string()
 }
 
-/// Returns true if the card is in the database, handling DFC names like "Front // Back"
-/// by also trying just the front face name.
+/// Returns true if the card is in the database. Composite multi-face names
+/// ("Front // Back", glued or spaced) and unaccented aliases are resolved by
+/// `CardDatabase::lookup_key` inside the accessor — this function must not
+/// pre-split the name itself (see `lookup_key`'s ordering contract).
 fn card_is_known(db: &CardDatabase, name: &str) -> bool {
-    db.get_face_by_name(resolve_card_name(db, name)).is_some()
+    db.get_face_by_name(name).is_some()
+}
+
+/// Single authority for "are these two decklist entries the same card?".
+///
+/// Two spellings denote the same card when they resolve to the same database
+/// key, which is what `CardDatabase::lookup_key` decides — composite multi-face
+/// names (`"Front // Back"`, spaced or glued) collapse to their front face, and
+/// unaccented aliases fold to the indexed name.
+///
+/// CR 709.2 (although split cards have two castable halves, each split card is
+/// only one card) and CR 712.1 + CR 712.8a (a double-faced card is one card
+/// with two faces; outside the battlefield and stack — which includes every
+/// deck-construction zone — it has only its front face's characteristics) are
+/// what authorize collapsing a composite spelling and a front-face spelling to
+/// one identity. This is deliberately NOT CR 201.3: interchangeable names are
+/// two separately printed cards pinned together by a printed indicator
+/// (CR 201.3c), a different mechanic that this module does not implement. A
+/// split card and a DFC each have two *distinct* names (CR 709.4a, CR 201.4d),
+/// so they are not interchangeable-name cards — they collapse here because they
+/// are one physical card, not because their names are equated.
+///
+/// Raw
+/// `eq_ignore_ascii_case` is NOT equivalent and must not be used for
+/// name-identity decisions in this module: a commander listed in the command
+/// zone by its composite name and in the 99 by its front name is one card, and
+/// the raw comparison reports it as two.
+///
+/// Every CR 903.5a deck-size, CR 903.5b singleton, CR 903.5c color-identity,
+/// and commander-legality-skip decision routes through here so the module can
+/// never resolve a name two different ways.
+fn same_card(db: &CardDatabase, left: &str, right: &str) -> bool {
+    db.lookup_key(left) == db.lookup_key(right)
+}
+
+/// CR 903.5a: a commander is part of the 100, so a decklist that names it in
+/// both the command zone and the main deck describes ONE physical card. Counts
+/// how many command-zone entries are also present in the main deck, comparing
+/// resolved keys via `same_card` (CR 709.2 / CR 712.1 one-physical-card
+/// identity) so a composite/front-face spelling split is not mistaken for two
+/// distinct cards.
+fn commanders_represented_in_main(db: &CardDatabase, request: &DeckCompatibilityRequest) -> usize {
+    request
+        .commander
+        .iter()
+        .filter(|name| {
+            request
+                .main_deck
+                .iter()
+                .any(|card| same_card(db, card, name))
+        })
+        .count()
+}
+
+/// True when `name` denotes one of the deck's commanders under any spelling.
+/// Shared by the CR 903.5b singleton exemption, the CR 903.5c color-identity
+/// skip, and the commander legality skip.
+fn is_commander_entry(db: &CardDatabase, request: &DeckCompatibilityRequest, name: &str) -> bool {
+    request
+        .commander
+        .iter()
+        .any(|commander| same_card(db, commander, name))
 }
 
 /// Combined copy counts across main deck + sideboard + commander, keyed by the
@@ -3026,14 +3082,24 @@ fn card_is_known(db: &CardDatabase, name: &str) -> bool {
 /// `"Delver of Secrets // Insectile Aberration"`/`"Delver of Secrets"` are
 /// counted as the same card.
 ///
-/// CR 201.3 + CR 100.2a: Canonical key for aggregating deck copy counts.
+/// CR 100.2a (no more than four of any card with a particular English name) and
+/// CR 903.5b (each card in a Commander deck must have a different English name)
+/// both count PHYSICAL cards, so the bucket must be one per physical card. A
+/// multi-face card is one card — CR 709.2 for split cards, CR 712.1 + CR 712.8a
+/// for double-faced cards, which have only their front face's characteristics
+/// in every deck-construction zone — so both of its spellings key to one
+/// bucket. That collapse comes from the one-card rule, NOT from CR 201.3:
+/// a split card has two names (CR 709.4a) and a DFC's back face is a separately
+/// choosable name (CR 201.4d), so these faces are not interchangeable names in
+/// the CR 201.3 sense (which requires a printed indicator per CR 201.3c).
+///
 /// Uses the indexed face name when the card resolves so alias spellings
 /// ("Nazgul" vs "Nazgûl") merge into one bucket for copy-limit checks.
 fn canonical_deck_count_key(db: &CardDatabase, name: &str) -> String {
-    let resolved = resolve_card_name(db, name);
-    db.get_face_by_name(resolved)
+    let resolved = db.lookup_key(name);
+    db.get_face_by_name(&resolved)
         .map(|face| face.name.to_lowercase())
-        .unwrap_or_else(|| resolved.to_lowercase())
+        .unwrap_or(resolved)
 }
 
 fn combined_copy_counts(
@@ -3220,9 +3286,7 @@ pub fn max_deck_copies(
     if format_config
         .format
         .legality_format()
-        .and_then(|legality_format| {
-            db.legality_status(resolve_card_name(db, name), legality_format)
-        })
+        .and_then(|legality_format| db.legality_status(name, legality_format))
         .is_some_and(|status| status == LegalityStatus::Restricted)
     {
         return DeckCopyLimit::UpTo(1);
@@ -3434,21 +3498,6 @@ pub fn draft_set_concessions_for<'a>(
         .fold(DraftSetConcessions::default(), DraftSetConcessions::union)
 }
 
-/// Resolves a card name to the key used in the database. For DFC names like "Front // Back",
-/// returns the front face name if that's how it's indexed.
-fn resolve_card_name<'a>(db: &CardDatabase, name: &'a str) -> &'a str {
-    if let Some((front, _)) = name.split_once("//") {
-        let front = front.trim();
-        if db.get_face_by_name(front).is_some() {
-            return front;
-        }
-    }
-    if db.get_face_by_name(name).is_some() {
-        return name;
-    }
-    name
-}
-
 /// Every card reference, including dedicated companion. Use this for card-data
 /// lookup, coverage, and legality reporting; use `construction_deck_cards`
 /// for ordinary deck-size and copy calculations.
@@ -3471,6 +3520,24 @@ fn construction_deck_cards(request: &DeckCompatibilityRequest) -> impl Iterator<
         .chain(request.commander.iter())
         .chain(request.signature_spell.iter())
         .map(String::as_str)
+}
+
+/// The name to SHOW the user for a decklist spelling — the resolved face name,
+/// falling back to the raw spelling when the card is unknown. Presentation and
+/// dedup only: this enforces no game rule and intentionally carries no CR
+/// annotation. The identity it displays is decided upstream by `same_card` /
+/// `canonical_deck_count_key`, which carry the rule citations.
+///
+/// Every `illegal_cards`-style `BTreeSet` must key on this rather than on the
+/// caller's raw spelling, or one physical card listed under several spellings
+/// ("Fire // Ice", "Fire//Ice", "Fire") is reported as several separate illegal
+/// cards, inflating the reason string and burning the `summarize_cards` name
+/// cap on duplicates of one card. Matches the dedup `color_identity_violations`
+/// performs by keying on `face.name`.
+fn display_name(db: &CardDatabase, name: &str) -> String {
+    db.get_face_by_name(name)
+        .map(|face| face.name.clone())
+        .unwrap_or_else(|| name.to_string())
 }
 
 fn status_label(status: LegalityStatus) -> &'static str {
@@ -6730,7 +6797,8 @@ mod tests {
         assert!(validate_deck_for_format(&db, &request).is_ok());
     }
 
-    // --- Sideboard size + combined copy-limit tests (CR 100.2a, CR 100.4a, CR 201.3) ---
+    // --- Sideboard size + combined copy-limit tests (CR 100.2a, CR 100.4a,
+    // plus CR 709.2 / CR 712.1 one-physical-card canonicalization) ---
 
     #[test]
     fn constructed_sideboard_of_15_is_accepted() {
@@ -6840,7 +6908,8 @@ mod tests {
     #[test]
     fn combined_copies_case_insensitive() {
         // Regression for B1: "Legal Standard" + "legal standard" must count as
-        // the same card (CR 201.3 / CR 100.2a canonicalization).
+        // the same card: CR 100.2a's limit is per English name, and case is not
+        // part of a name, so both spellings share one copy-count bucket.
         let db = CardDatabase::from_json_str(&test_db_json()).unwrap();
         let mut main = expand("Legal Standard", 3);
         main.extend(expand("legal standard", 2)); // lowercase
@@ -7964,6 +8033,385 @@ mod tests {
                 .any(|r| r.contains("Singleton violations")),
             "reasons: {:?}",
             check.reasons
+        );
+    }
+
+    /// Regression: deck validation must resolve every name through
+    /// `CardDatabase::lookup_key`, never through its own `//` split.
+    ///
+    /// The discriminating case is a single-faced card whose printed name
+    /// literally contains `//` (issue #4790's `"SP//dr, Piloted by Peni"`
+    /// class) whose front segment is ALSO a real card. `lookup_key` matches the
+    /// exact name first, so it resolves to the whole card; a split-first
+    /// ordering resolves to the front segment — the wrong card, with the wrong
+    /// legality. Today's corpus has no such collision, so this synthetic DB is
+    /// the only barrier keeping the two orderings from diverging again.
+    #[test]
+    fn deck_validation_resolves_a_double_slash_card_name_before_splitting_it() {
+        let mut cards = Map::new();
+        // Front segment collides with a real, differently-legal card.
+        let mut fire = planechase_card_json("Fire", &[], &["Instant"]);
+        fire["legalities"] = serde_json::json!({ "standard": "banned" });
+        cards.insert("fire".to_string(), fire);
+        insert_planechase_card(&mut cards, "Fire//Ice, the Whole Card", &[], &["Instant"]);
+        insert_planechase_card(&mut cards, "Plains", &["Basic"], &["Land"]);
+        let db = CardDatabase::from_json_str(&Value::Object(cards).to_string()).unwrap();
+
+        let whole = "Fire//Ice, the Whole Card";
+
+        // Every assertion below goes through a deck-validation wrapper, not
+        // `db` directly: `CardDatabase`'s own accessors already resolved
+        // through `lookup_key` before this change, so asserting on them cannot
+        // fail if the local `//` split is reinstated. `card_db.rs` covers those
+        // four cases in its own tests.
+
+        // Copy counting buckets by the resolved key, so the whole card and its
+        // colliding front segment stay distinct entries.
+        assert_ne!(
+            canonical_deck_count_key(&db, whole),
+            canonical_deck_count_key(&db, "Fire"),
+            "the whole card and its front segment must not share a count bucket"
+        );
+
+        // The unknown-card sweep must not report the whole card missing, and
+        // must resolve the front segment to the front card rather than to it.
+        assert!(card_is_known(&db, whole));
+        assert_eq!(
+            canonical_deck_count_key(&db, whole),
+            whole.to_lowercase(),
+            "the whole card must key by its own name, not its front segment"
+        );
+
+        // Legality on the dominant decklist path: a split-first ordering would
+        // report the front segment's `banned`, condemning a legal deck. Asserted
+        // through `evaluate_deck_compatibility`, the production entry point.
+        let request = DeckCompatibilityRequest {
+            main_deck: std::iter::repeat_n(whole.to_string(), 60).collect(),
+            default_deck_copy_limit: Some(DeckCopyLimit::Unlimited),
+            ..Default::default()
+        };
+        let legality = evaluate_format_legality(&db, &request);
+        assert_eq!(
+            legality.get("standard").map(String::as_str),
+            Some("legal"),
+            "legality must come from the whole card, not its front segment: {legality:?}"
+        );
+    }
+
+    /// Regression: coverage must report one entry per *card*, not one per
+    /// spelling. A decklist that mixes a composite name, a glued composite, and
+    /// the bare front-face name refers to a single card; keying the unique set
+    /// on raw strings counted it N times and gave each entry the full copy
+    /// count, so the supported/total ratio the deck-builder renders was wrong.
+    #[test]
+    fn deck_coverage_counts_one_card_once_across_mixed_spellings() {
+        let mut cards = Map::new();
+        insert_planechase_card(&mut cards, "Fire", &[], &["Instant"]);
+        insert_planechase_card(&mut cards, "Plains", &["Basic"], &["Land"]);
+        let db = CardDatabase::from_json_str(&Value::Object(cards).to_string()).unwrap();
+
+        let request = DeckCompatibilityRequest {
+            main_deck: vec![
+                "Fire // Ice".to_string(),
+                "Fire//Ice".to_string(),
+                "Fire".to_string(),
+                "fire".to_string(),
+            ],
+            ..Default::default()
+        };
+
+        let coverage = evaluate_deck_coverage(&db, &request);
+        assert_eq!(
+            coverage.total_unique, 1,
+            "four spellings of one card are one unique card"
+        );
+        assert_eq!(
+            coverage.supported_unique + coverage.unsupported_cards.len(),
+            coverage.total_unique,
+            "every unique card must land in exactly one bucket"
+        );
+        for card in &coverage.unsupported_cards {
+            assert_eq!(
+                card.copies, 4,
+                "the single entry carries the whole playset, not a per-spelling share"
+            );
+        }
+    }
+
+    #[test]
+    fn deck_coverage_excludes_unresolvable_names_from_both_buckets() {
+        // The mixed-spelling test above never reaches the `get_face_by_name ->
+        // None` arm, because every fixture there is a known card. Production
+        // decklists take that arm constantly (typos, un-exported cards), so
+        // this fixture drives it directly: an unknown name must land in neither
+        // coverage bucket AND must not inflate `total_unique`, or the deck
+        // builder's supported/total ratio silently disagrees with itself.
+        let mut cards = Map::new();
+        insert_planechase_card(&mut cards, "Plains", &["Basic"], &["Land"]);
+        let db = CardDatabase::from_json_str(&Value::Object(cards).to_string()).unwrap();
+
+        let request = DeckCompatibilityRequest {
+            main_deck: vec![
+                "Plains".to_string(),
+                "Totally Not A Real Card Xyzzy".to_string(),
+            ],
+            ..Default::default()
+        };
+
+        let coverage = evaluate_deck_coverage(&db, &request);
+        assert_eq!(
+            coverage.total_unique, 1,
+            "the unresolvable name is not a card the engine can rate"
+        );
+        assert_eq!(
+            coverage.supported_unique + coverage.unsupported_cards.len(),
+            coverage.total_unique,
+            "every counted card must land in exactly one bucket"
+        );
+    }
+
+    /// A DFC commander whose two faces are each indexed under their own key,
+    /// the way `data/card-data.json` stores every multi-face card (it holds no
+    /// composite `"A // B"` keys at all). Both faces are mono-red so the deck's
+    /// CR 903.5c identity is unambiguous.
+    fn dfc_commander_db() -> CardDatabase {
+        let mut cards = Map::new();
+        let mut front =
+            planechase_card_json("Tovolar, Dire Overlord", &["Legendary"], &["Creature"]);
+        front["color_override"] = serde_json::json!(["Red"]);
+        cards.insert("tovolar, dire overlord".to_string(), front);
+        let mut back = planechase_card_json(
+            "Tovolar, the Midnight Scourge",
+            &["Legendary"],
+            &["Creature"],
+        );
+        back["color_override"] = serde_json::json!(["Red"]);
+        cards.insert("tovolar, the midnight scourge".to_string(), back);
+        insert_planechase_card(&mut cards, "Mountain", &["Basic"], &["Land"]);
+        CardDatabase::from_json_str(&Value::Object(cards).to_string()).unwrap()
+    }
+
+    /// CR 903.5a: the commander is one of the 100, so a decklist naming it in
+    /// the command zone by its composite name and in the 99 by its front face
+    /// describes ONE physical card and the deck is 100, not 101.
+    ///
+    /// This pins `commanders_represented_in_main`'s switch from
+    /// `eq_ignore_ascii_case` to `same_card` — the composite-aware deck-size
+    /// compare, and the one substantive rules change this PR makes to
+    /// `deck_validation`. Restoring the raw-spelling comparison makes
+    /// `represented_in_main` count 0 instead of 1, the deck reads 101, and the
+    /// deck-size reason below appears.
+    ///
+    /// Asserted on the deck-SIZE reason specifically rather than on
+    /// `reasons.is_empty()`: the singleton and netting behavior around the same
+    /// listing is command-zone netting, which is a separate change.
+    #[test]
+    fn a_composite_named_commander_listed_in_the_99_counts_toward_the_100_once() {
+        let db = dfc_commander_db();
+        // Command zone spells the composite name; the main deck lists the front
+        // face. One physical card, so total = main.len() + (1 - 1) = 100.
+        let mut main = vec!["Tovolar, Dire Overlord".to_string()];
+        main.extend(expand("Mountain", 99));
+        let request = DeckCompatibilityRequest {
+            main_deck: main,
+            commander: vec!["Tovolar, Dire Overlord // Tovolar, the Midnight Scourge".to_string()],
+            selected_format: Some(GameFormat::Commander),
+            player_count: default_player_count(),
+            ..Default::default()
+        };
+
+        // PREMISE: the two spellings really are different strings, so this is
+        // about resolution rather than a trivially equal comparison.
+        assert_ne!(request.commander[0], request.main_deck[0]);
+        assert_eq!(
+            commanders_represented_in_main(&db, &request),
+            1,
+            "the composite-named commander is the same physical card as the \
+             front-face listing in the 99"
+        );
+
+        let result = evaluate_deck_compatibility(&db, &request);
+        assert!(
+            !result
+                .selected_format_reasons
+                .iter()
+                .any(|reason| reason.contains("exactly 100 cards")),
+            "99 listings + 1 commander that is one of them is a legal 100, so no \
+             deck-size reason may be reported: {:?}",
+            result.selected_format_reasons
+        );
+    }
+
+    /// Control for the test above: when the command-zone card is genuinely NOT
+    /// in the 99, nothing is netted and the same 99 + 1 arithmetic must report
+    /// a 100-card deck too — so the test above cannot pass merely because the
+    /// deck-size check is inert.
+    #[test]
+    fn a_commander_absent_from_the_99_still_counts_toward_the_100() {
+        let db = dfc_commander_db();
+        // Commander absent from the 99: total = 99 + (1 - 0) = 100.
+        let mut main = Vec::new();
+        main.extend(expand("Mountain", 99));
+        let request = DeckCompatibilityRequest {
+            main_deck: main,
+            commander: vec!["Tovolar, Dire Overlord".to_string()],
+            selected_format: Some(GameFormat::Commander),
+            player_count: default_player_count(),
+            ..Default::default()
+        };
+
+        assert_eq!(
+            commanders_represented_in_main(&db, &request),
+            0,
+            "the commander is not listed in the 99, so nothing is represented"
+        );
+        let result = evaluate_deck_compatibility(&db, &request);
+        assert!(
+            !result
+                .selected_format_reasons
+                .iter()
+                .any(|reason| reason.contains("exactly 100 cards")),
+            "99 + a commander not among them is also exactly 100: {:?}",
+            result.selected_format_reasons
+        );
+    }
+
+    /// The commander exemption must not become a blanket amnesty: a SECOND
+    /// copy of the commander in the 99 is still a CR 903.5b violation, and the
+    /// deck is still 101 cards. Guards the deck-size compare in
+    /// `combined_copy_counts` against over-crediting.
+    #[test]
+    fn a_genuine_second_copy_of_the_commander_is_still_a_violation() {
+        let db = dfc_commander_db();
+        let mut main = vec![
+            "Tovolar, Dire Overlord".to_string(),
+            "Tovolar, Dire Overlord // Tovolar, the Midnight Scourge".to_string(),
+        ];
+        main.extend(expand("Mountain", 99));
+        let request = DeckCompatibilityRequest {
+            main_deck: main,
+            commander: vec!["Tovolar, Dire Overlord".to_string()],
+            selected_format: Some(GameFormat::Commander),
+            player_count: default_player_count(),
+            ..Default::default()
+        };
+
+        let result = evaluate_deck_compatibility(&db, &request);
+        assert_eq!(result.selected_format_compatible, Some(false));
+        assert!(
+            result
+                .selected_format_reasons
+                .iter()
+                .any(|reason| reason.contains("Singleton violations")),
+            "two real copies must still trip CR 903.5b: {:?}",
+            result.selected_format_reasons
+        );
+    }
+
+    /// Regression: a DFC commander listed in the command zone by its composite
+    /// name and in the 99 by its front name is one card. Comparing the raw
+    /// spellings let it escape the command-zone skip and be reported as a
+    /// CR 903.5c violation against its own color identity.
+    #[test]
+    fn commander_listed_under_two_spellings_is_not_its_own_identity_violation() {
+        let mut cards = Map::new();
+        let mut commander = planechase_card_json("Tovolar", &["Legendary"], &["Creature"]);
+        commander["color_override"] = serde_json::json!(["Red"]);
+        cards.insert("tovolar".to_string(), commander);
+        insert_planechase_card(&mut cards, "Plains", &["Basic"], &["Land"]);
+        let db = CardDatabase::from_json_str(&Value::Object(cards).to_string()).unwrap();
+
+        let identity: HashSet<ManaColor> = HashSet::new();
+        let violations = color_identity_violations(
+            &db,
+            &["Tovolar // Tovolar, the Midnight Scourge".to_string()],
+            &identity,
+            &BTreeSet::new(),
+            |name| db.lookup_key(name) == db.lookup_key("Tovolar"),
+        );
+        assert!(
+            violations.is_empty(),
+            "the commander must be skipped under any spelling: {violations:?}"
+        );
+
+        // And when a card genuinely violates, it is reported once under its
+        // resolved face name even if listed under two spellings.
+        let violations = color_identity_violations(
+            &db,
+            &[
+                "Tovolar // Tovolar, the Midnight Scourge".to_string(),
+                "Tovolar".to_string(),
+            ],
+            &identity,
+            &BTreeSet::new(),
+            |_| false,
+        );
+        assert_eq!(
+            violations.iter().cloned().collect::<Vec<_>>(),
+            vec!["Tovolar".to_string()],
+            "one card must produce exactly one violation entry"
+        );
+    }
+
+    /// An Oathbreaker DB whose Oathbreaker and signature spell are each
+    /// multi-face, with every face indexed under its own key the way
+    /// `data/card-data.json` stores multi-face cards (it holds no composite
+    /// `"A // B"` keys at all). Everything is mono-red so CR 903.5c and the
+    /// Oathbreaker RC color-identity rule are unambiguous.
+    fn dfc_oathbreaker_db() -> CardDatabase {
+        let mut cards = Map::new();
+        let mut ob_front = planechase_card_json("Ob Front", &["Legendary"], &["Planeswalker"]);
+        ob_front["color_override"] = serde_json::json!(["Red"]);
+        ob_front["is_oathbreaker"] = serde_json::json!(true);
+        cards.insert("ob front".to_string(), ob_front);
+        let mut ob_back = planechase_card_json("Ob Back", &["Legendary"], &["Planeswalker"]);
+        ob_back["color_override"] = serde_json::json!(["Red"]);
+        ob_back["is_oathbreaker"] = serde_json::json!(true);
+        cards.insert("ob back".to_string(), ob_back);
+
+        let mut sig_front = planechase_card_json("Sig Front", &[], &["Sorcery"]);
+        sig_front["color_override"] = serde_json::json!(["Red"]);
+        cards.insert("sig front".to_string(), sig_front);
+        let mut sig_back = planechase_card_json("Sig Back", &[], &["Sorcery"]);
+        sig_back["color_override"] = serde_json::json!(["Red"]);
+        cards.insert("sig back".to_string(), sig_back);
+
+        insert_planechase_card(&mut cards, "Mountain", &["Basic"], &["Land"]);
+        CardDatabase::from_json_str(&Value::Object(cards).to_string()).unwrap()
+    }
+
+    /// The signature-spell exemption must not become a blanket amnesty either:
+    /// a genuine SECOND copy of the signature spell in the 58 is still a
+    /// singleton violation. Guards the copy-count bucketing against
+    /// over-crediting on the new slot.
+    #[test]
+    fn a_genuine_second_copy_of_the_signature_spell_is_still_a_violation() {
+        let db = dfc_oathbreaker_db();
+
+        let mut main = vec![
+            "Ob Front".to_string(),
+            "Sig Front".to_string(),
+            "Sig Front // Sig Back".to_string(),
+        ];
+        main.extend(expand("Mountain", 57));
+
+        let request = DeckCompatibilityRequest {
+            main_deck: main,
+            commander: vec!["Ob Front".to_string()],
+            signature_spell: vec!["Sig Front".to_string()],
+            selected_format: Some(GameFormat::Oathbreaker),
+            player_count: default_player_count(),
+            ..Default::default()
+        };
+
+        let result = evaluate_deck_compatibility(&db, &request);
+        assert!(
+            result
+                .selected_format_reasons
+                .iter()
+                .any(|reason| reason.contains("Singleton violations")),
+            "two real copies must still trip the singleton rule: {:?}",
+            result.selected_format_reasons
         );
     }
 }

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -961,6 +961,7 @@ mod msh_wave5a_group1_classifier;
 mod msh_wave5a_group2_conditions;
 mod multi_layer_continuous_effect;
 mod multi_upkeep_triggers_suspend;
+mod multiface_composite_name_resolution;
 mod must_attack_player_attribution;
 mod mutable_pupa_perpetual_keyword_mirror;
 mod mycoloth_upkeep_trigger;

--- a/crates/engine/tests/integration/multiface_composite_name_resolution.rs
+++ b/crates/engine/tests/integration/multiface_composite_name_resolution.rs
@@ -1,0 +1,236 @@
+//! Composite-name resolution for multi-face cards, exercised across the crate
+//! boundary through `CardDatabase`'s public API.
+//!
+//! `CardDatabase::lookup_key` is `pub(crate)` by design — its doc comment is
+//! explicit that callers must not re-implement `//` splitting and that the
+//! function must not be widened. No `pub` seam was added for this file:
+//! `get_face_by_name` is ALREADY public and already routes every name through
+//! `lookup_key`, so composite resolution is observable from outside the crate
+//! as it stands. Asserting through it is also the stronger choice — it pins
+//! the behavior at the surface external code actually depends on, so renaming,
+//! inlining, or re-scoping `lookup_key` cannot silently break decklist loading
+//! while this file still compiles.
+//!
+//! Note that `get_by_name` is NOT usable here: `from_export_entries` builds
+//! `cards: HashMap::new()`, so the rules map is empty for any export-built
+//! database and that accessor returns `None` for every name, composite or not.
+//! Only the MTGJSON loader populates it.
+//!
+//! The three cards named here are the ones this mechanic unlocked. Their
+//! layouts and face names were verified against the Scryfall API rather than
+//! recalled: `Response // Resurgence` and `Rough // Tumble` are `split`,
+//! `Dowsing Dagger // Lost Vale` is `transform`. Both layouts are one physical
+//! card and must collapse to the front face identically.
+//!
+//! CR 709.2: although split cards have two castable halves, each split card is
+//! only one card — so a deck entry for `"Fire // Ice"` is one copy of that
+//! card, not two.
+//! CR 712.1: a double-faced card has a Magic card face on one side and either a
+//! Magic card face or half of an oversized card on the other; it, too, is one
+//! card.
+
+use std::collections::HashMap;
+
+use engine::database::card_db::CardDatabase;
+use engine::types::card::CardFace;
+
+/// Build a database whose keys are individual faces, mirroring
+/// `data/card-data.json`, which "stores each face under its own key and
+/// contains no composite `\"A // B\"` keys". That absence is the whole point:
+/// composite support rests entirely on name resolution, with no data-level
+/// backstop to mask a regression.
+fn db_with_faces(face_names: &[&str]) -> CardDatabase {
+    let mut map: HashMap<String, CardFace> = HashMap::new();
+    for name in face_names {
+        let face = CardFace {
+            name: (*name).to_string(),
+            ..CardFace::default()
+        };
+        map.insert(name.to_lowercase(), face);
+    }
+    let json = serde_json::to_string(&map).expect("faces must serialize");
+    CardDatabase::from_json_str(&json).expect("face-keyed export must load")
+}
+
+fn resolved_name<'a>(db: &'a CardDatabase, queried: &str) -> Option<&'a str> {
+    db.get_face_by_name(queried).map(|face| face.name.as_str())
+}
+
+/// CR 709.2 / CR 712.1: every spelling a decklist can plausibly use for a
+/// multi-face card resolves to the SAME single front face — the canonical
+/// spaced form, the hand-typed glued form, the front name alone, and any
+/// casing of each.
+#[test]
+fn every_composite_spelling_resolves_to_the_one_front_face() {
+    // Two split cards (CR 709.2) and one transforming DFC (CR 712.1); the
+    // layouts differ but the identity rule does not, so both must collapse
+    // identically.
+    let cases: [(&str, &str, &str); 3] = [
+        ("Response", "Resurgence", "Response"),
+        ("Rough", "Tumble", "Rough"),
+        ("Dowsing Dagger", "Lost Vale", "Dowsing Dagger"),
+    ];
+
+    for (front, back, expected) in cases {
+        let db = db_with_faces(&[front, back]);
+
+        for spelling in [
+            format!("{front} // {back}"),
+            format!("{front}//{back}"),
+            format!("{front} //{back}"),
+            format!("{front}// {back}"),
+            front.to_string(),
+            format!("{front} // {back}").to_lowercase(),
+            format!("{front} // {back}").to_uppercase(),
+        ] {
+            assert_eq!(
+                resolved_name(&db, &spelling),
+                Some(expected),
+                "{spelling:?} must resolve to the front face {expected:?}"
+            );
+        }
+
+        // PREMISE: the back face really is present under its own key, so the
+        // assertions above demonstrate a deliberate front-face collapse rather
+        // than the back face merely being absent from the database.
+        assert_eq!(
+            resolved_name(&db, back),
+            Some(back),
+            "{back:?} must still be reachable by its own name"
+        );
+    }
+}
+
+/// CR 709.4a: each split card has two names, and an effect instructing a player
+/// to choose a card name must choose one, not both. Composite resolution is
+/// deliberately lossy in that direction — the BACK half is not reachable
+/// through a composite name — so this pins the documented asymmetry rather than
+/// leaving it to be "fixed" by a future refactor that would break name-choice
+/// effects.
+#[test]
+fn composite_resolution_never_yields_the_back_face() {
+    let db = db_with_faces(&["Response", "Resurgence"]);
+
+    assert_eq!(
+        resolved_name(&db, "Response // Resurgence"),
+        Some("Response")
+    );
+    assert_ne!(
+        resolved_name(&db, "Response // Resurgence"),
+        Some("Resurgence"),
+        "a composite name must collapse to the FRONT face; routing name-choice \
+         effects through this collapse would violate CR 709.4a"
+    );
+    // Reversing the halves does not make the back face the answer: the name is
+    // resolved by position, not by membership.
+    assert_eq!(
+        resolved_name(&db, "Resurgence // Response"),
+        Some("Resurgence"),
+        "resolution takes whichever half is written first"
+    );
+}
+
+/// Issue #4790: `"SP//dr, Piloted by Peni"` is a SINGLE-faced card whose printed
+/// name literally contains `//`. Exact-match must precede the `//` split, or a
+/// legitimate name is mistaken for a composite one and resolves to a
+/// nonexistent `"SP"` face. This is the false-positive guard, asserted here at
+/// the public boundary.
+#[test]
+fn a_single_face_name_containing_a_double_slash_is_not_split() {
+    let db = db_with_faces(&["SP//dr, Piloted by Peni"]);
+
+    assert_eq!(
+        resolved_name(&db, "SP//dr, Piloted by Peni"),
+        Some("SP//dr, Piloted by Peni")
+    );
+    // PREMISE: no "sp" face exists, so a wrongly-split lookup would miss
+    // entirely rather than silently returning something plausible.
+    assert_eq!(resolved_name(&db, "SP"), None);
+}
+
+/// The exact-match-first ordering is not merely a nicety: when a card is
+/// printed with a `//` in its own name AND a same-named front face exists,
+/// the whole name must still win. Without the ordering this resolves to the
+/// wrong card rather than merely failing.
+#[test]
+fn an_exact_whole_name_match_beats_the_split_interpretation() {
+    let db = db_with_faces(&["SP//dr, Piloted by Peni", "SP"]);
+
+    assert_eq!(
+        resolved_name(&db, "SP//dr, Piloted by Peni"),
+        Some("SP//dr, Piloted by Peni"),
+        "the whole printed name must win over splitting it into \"SP\" // \"dr, …\""
+    );
+}
+
+/// Decklists are typed by hand and routinely drop diacritics. The alias fold
+/// must survive composite resolution, since both steps run inside the same
+/// lookup and a naive ordering would apply only one of them.
+#[test]
+fn unaccented_spellings_resolve_through_composite_names_too() {
+    let db = db_with_faces(&["Nazgûl", "Séance Board"]);
+
+    assert_eq!(resolved_name(&db, "Nazgul"), Some("Nazgûl"));
+    assert_eq!(
+        resolved_name(&db, "Nazgul // Seance Board"),
+        Some("Nazgûl"),
+        "the unaccented fold must apply to the front segment of a composite name"
+    );
+}
+
+/// A composite name naming a card that is not in the database must resolve to
+/// nothing, not to a partial or fabricated match — otherwise an unknown-card
+/// report would silently swallow typos.
+#[test]
+fn an_unknown_composite_name_resolves_to_nothing() {
+    let db = db_with_faces(&["Response", "Resurgence"]);
+
+    assert_eq!(resolved_name(&db, "Nonexistent // Card"), None);
+    assert_eq!(resolved_name(&db, "Nonexistent//Card"), None);
+}
+
+/// Composite resolution must not depend on the two halves being adjacent, or
+/// on either half being the only entry — a real database holds ~36k faces, and
+/// the front segment is looked up by key rather than by scanning neighbours.
+#[test]
+fn composite_resolution_is_unaffected_by_unrelated_cards_in_the_database() {
+    let db = db_with_faces(&[
+        "Lightning Bolt",
+        "Resurgence",
+        "Grizzly Bears",
+        "Response",
+        "Island",
+    ]);
+
+    assert_eq!(
+        resolved_name(&db, "Response // Resurgence"),
+        Some("Response")
+    );
+    // A composite name built from two REAL but unrelated faces still resolves
+    // to whichever is written first: resolution is by name, and the database
+    // has no notion of which faces belong to the same physical card.
+    assert_eq!(
+        resolved_name(&db, "Lightning Bolt // Island"),
+        Some("Lightning Bolt")
+    );
+}
+
+/// Whitespace around the separator is normalized, so a decklist that pads it
+/// (or that came through a formatter) still resolves. Guards the `trim()` on
+/// the front segment.
+#[test]
+fn surrounding_whitespace_does_not_defeat_composite_resolution() {
+    let db = db_with_faces(&["Rough", "Tumble"]);
+
+    for spelling in [
+        "Rough   //   Tumble",
+        "Rough\t//\tTumble",
+        "  Rough // Tumble",
+    ] {
+        assert_eq!(
+            resolved_name(&db, spelling),
+            Some("Rough"),
+            "{spelling:?} must resolve to the front face"
+        );
+    }
+}

--- a/crates/engine/tests/integration/multiface_composite_name_resolution.rs
+++ b/crates/engine/tests/integration/multiface_composite_name_resolution.rs
@@ -16,11 +16,16 @@
 //! database and that accessor returns `None` for every name, composite or not.
 //! Only the MTGJSON loader populates it.
 //!
-//! The three cards named here are the ones this mechanic unlocked. Their
-//! layouts and face names were verified against the Scryfall API rather than
-//! recalled: `Response // Resurgence` and `Rough // Tumble` are `split`,
-//! `Dowsing Dagger // Lost Vale` is `transform`. Both layouts are one physical
-//! card and must collapse to the front face identically.
+//! None of the three cards named here is newly unlocked — all three already
+//! resolve, because `data/card-data.json` keys every face individually (of its
+//! 35,798 keys exactly one contains `//`) and `lookup_key`'s `//`-splitting
+//! predates this file. These eight tests exist as a regression barrier around
+//! `lookup_key` becoming the sole name-resolution authority, not as evidence of
+//! newly supported cards. Their layouts and face names were verified against
+//! the Scryfall API rather than recalled: `Response // Resurgence` and
+//! `Rough // Tumble` are `split`, `Dowsing Dagger // Lost Vale` is `transform`.
+//! Both layouts are one physical card and must collapse to the front face
+//! identically.
 //!
 //! CR 709.2: although split cards have two castable halves, each split card is
 //! only one card — so a deck entry for `"Fire // Ice"` is one copy of that


### PR DESCRIPTION
## Summary

Makes `CardDatabase::lookup_key` the **single authority** for resolving a card name, and deletes the parallel splitter that disagreed with it.

`deck_validation::resolve_card_name` existed on `main` and split on `//` **before** trying the whole name — the opposite ordering from `lookup_key`, i.e. exactly the false-positive that `lookup_key`'s exact-match-first guard exists to prevent (issue #4790). Two mechanisms for one rule, disagreeing. This deletes it and routes every call site through the authority.

**CR 709.2**: although split cards have two castable halves, each split card is only one card. **CR 712.1**: a double-faced card is likewise one card.

## What actually changes

| | |
|---|---|
| **`resolve_card_name` deleted** (`deck_validation.rs`) | Its split-first ordering was the #4790 bug. Every former caller now passes the raw name to an accessor routing through `lookup_key` — strictly better, because it restores exact-match-first for names containing `//`. `split_once("//")` sites: **3 on `main` → 2**, both now in `card_db.rs` (the authority, plus `bracket_signals_for` as its documented per-face exception). |
| **Composite-aware CR 903.5a deck-size compare** | `commanders_represented_in_main` switches `eq_ignore_ascii_case` → `same_card`. A commander in the command zone as `"X // Y"` and in the 99 as `"X"` is ONE card, so the deck is 100, not 101. |
| **Identity consolidation** | Five raw-spelling comparisons across `evaluate_commander_with_format`, `evaluate_brawl`, `evaluate_tiny_leaders`, `evaluate_oathbreaker` and `quick_commander_check` collapse into `same_card`, `commanders_represented_in_main` and `is_commander_entry`. |
| **`resolve_names` grouping fix** (`deck_loading.rs`) | Groups by the RESOLVED face name, not the caller's raw spelling. On `main`, `["Fire // Ice", "Fire", "Fire//Ice", "fire"]` produces **three** `DeckEntry` values; now it produces one at count 4. |
| **`bracket_signals_for` glued-form aggregation** | Accepts the same composite forms as `lookup_key` with the same exact-match-first guard, so it cannot disagree about what is a composite name. |
| **CR annotation correction** | `canonical_deck_count_key` cited `CR 201.3` on `main`. CR 201.3c requires a printed interchangeable-names indicator, which a split card does not have (CR 709.4a gives it two genuinely distinct names). The collapse is CR 709.2 / CR 712.1. |

## What this PR does *not* do

**No cards are newly unlocked.** An earlier revision of this body claimed Response // Resurgence, Rough // Tumble and Dowsing Dagger // Lost Vale as "Cards unlocked" — that was **false**, and I verified it rather than defending it: `main`'s `lookup_key` is byte-identical to this PR's, so it already lowercases, misses the exact match, splits on `//`, and hits the front face. All three resolve on `main` today. The section has been removed.

That claim came from the pre-split PR body and I carried it forward without checking. Thanks to @ntindle for catching it.

## Tests

- **`a_composite_named_commander_listed_in_the_99_counts_toward_the_100_once`** — the discriminating test for the one substantive rules change here. Command zone spells the composite name, the 99 lists the front face; asserts `commanders_represented_in_main == 1` and that no deck-size reason is reported. **Reverting `same_card` → `eq_ignore_ascii_case` fails it**, while its control (`a_commander_absent_from_the_99_still_counts_toward_the_100`) still passes.
- **`deck_validation_resolves_a_double_slash_card_name_before_splitting_it`** — synthetic DB where `"Fire"` is banned in Standard and `"Fire//Ice, the Whole Card"` is legal, asserted through `canonical_deck_count_key`, `card_is_known` and `evaluate_format_legality`. Reinstating the deleted split-first `resolve_card_name` fails it.
- **`resolve_names_groups_mixed_spellings_of_one_card`** — fails on `main`, which produces three entries.
- `multiface_composite_name_resolution.rs` — 8 integration tests documenting the resolution contract at the public boundary (`get_face_by_name`). **These are a regression barrier, not evidence for this PR**: `lookup_key`'s body is unchanged here, so they pass on `main` too. Kept deliberately — the contract had no cross-crate coverage and the deletion above makes `lookup_key` the sole authority — but they are not what demonstrates this diff.

## Disclosed behavior change

`evaluate_deck_coverage` now returns `resolved_unique` rather than `unique_names.len()` for `total_unique`, so a deck with five unresolvable names reads `95/95` instead of `95/100`. This preserves the `supported_unique + unsupported_cards.len() == total_unique` invariant, and unknowns are surfaced separately. Consumers: `StatsPanel.tsx:122`/`:131`, `MyDecks.tsx:404`/`:428`, `aiDeckCatalog.ts:101-102`, `useFeedDeckList.ts:80`. Tested by `deck_coverage_excludes_unresolvable_names_from_both_buckets`. Happy to split this out if you would rather it land deliberately.

## Verification

- `cargo fmt --all` — clean
- `cargo clippy -p phase-engine --lib --tests -- -D warnings` — **exit 0**
- `cargo test -p phase-engine --lib` over `deck_validation`, `deck_loading`, `card_db` — all green
- `cargo test -p phase-engine --test integration` — 8 passed, plus both repo guards
- Every CR citation grep-verified against `docs/MagicCompRules.txt`

## Related

- **#8609** — CR 903.5a command-zone netting, stacked on this branch. **Merge this first.**
- **#8591** — Windows-only `ai_gate.rs` build fix, split out, green and independent.
- **#8596** — follow-up: composite resolution accepts unpaired halves (`"Lightning Bolt // Island"`), pre-existing on `main`, made visible by this PR's tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recognition of composite, double-faced, aliased, accented, and unaccented card names.
  * Deck entries now consistently combine alternate spellings of the same card.
  * Improved deck legality, color identity, commander, and coverage validation for composite card names.
  * Prevented single-faced card names containing “//” from being incorrectly split.
  * Improved case-insensitive matching for curated card-list checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->