### PR TITLE
fix(parser): bind "that creature's power" to the clause's own target (#8460)

### DIFF
--- a/crates/engine/src/parser/oracle_effect/lower.rs
+++ b/crates/engine/src/parser/oracle_effect/lower.rs
@@ -10344,6 +10344,30 @@ pub(super) fn apply_where_x_effect_expression(
     effect: &mut Effect,
     where_x_expression: Option<&str>,
 ) {
+    // CR 115.1 + CR 608.2c: this clause announces its own "target creature", so
+    // a bare demonstrative "that creature's power/toughness" in its where-clause
+    // names that announced target — there is no earlier instruction and no cost
+    // referent for it to bind to. The shared quantity grammar lowers the
+    // context-free phrase to `ObjectScope::CostPaidObject` (the CR 608.2k
+    // cost/trigger-referent sense it carries on Hamletback Goliath and
+    // Shadowheart, Dark Justiciar), so the announced-target reading has to be
+    // restored here at the lowering seam, where the clause's own target slot is
+    // in scope. Read before the `match` takes `effect` mutably.
+    //
+    // Same rule and same two helpers as the `Effect::GenericEffect` arm below,
+    // which already does this for a targeted continuous grant (Xenagos, God of
+    // Revels); this covers the magnitude carriers (Thickest in the Thicket,
+    // Soul's Might, Nantuko Mentor). Gating on a CREATURE-typed announced target
+    // is what keeps a genuine cost/trigger referent untouched — Minsc & Boo,
+    // Timeless Heroes' reflexive "~ deals X damage to any target, where X is
+    // that creature's power" announces `TargetFilter::Any`, which names no
+    // creature for the demonstrative to bind to, so it keeps `CostPaidObject`
+    // and still reads the sacrificed creature.
+    let rebind_magnitude_target_anaphor =
+        where_x_is_demonstrative_target_creature_stat(where_x_expression)
+            && effect
+                .target_filter()
+                .is_some_and(target_filter_names_creature);
     // CR 107.3c: set when the clause DEFINES X but the definition is not
     // representable. Recorded here and converted to a gap node after the match
     // (the arms hold a mutable borrow of `effect`'s fields).
@@ -10408,6 +10432,9 @@ pub(super) fn apply_where_x_effect_expression(
         | Effect::SkipNextTurn { count: amount, .. }
         | Effect::Surveil { count: amount, .. } => {
             bind_where_x_quantity(amount, where_x_expression, &mut unbound_where_x);
+            if rebind_magnitude_target_anaphor {
+                rebind_cost_paid_object_pt_to_target(amount);
+            }
         }
         // Multi-slot carriers: a where-X clause defines ONE X, and every slot that
         // references it must bind to the same expression (CR 107.3i: X has a single value
@@ -10606,6 +10633,10 @@ pub(super) fn apply_where_x_effect_expression(
                     *toughness = bound_toughness;
                 }
                 _ => unbound_where_x = where_x_expression.map(str::to_string),
+            }
+            if rebind_magnitude_target_anaphor {
+                rebind_cost_paid_object_pt_value_to_target(power);
+                rebind_cost_paid_object_pt_value_to_target(toughness);
             }
         }
         Effect::PreventDamage {
@@ -11043,6 +11074,39 @@ pub(super) fn rebind_cost_paid_object_pt_to_target(expr: &mut QuantityExpr) {
             rebind_cost_paid_object_pt_to_target(left);
             rebind_cost_paid_object_pt_to_target(right);
         }
+    }
+}
+
+/// CR 613.4c: `PtValue` counterpart of [`rebind_cost_paid_object_pt_to_target`].
+/// A layer-7 pump magnitude is a `PtValue`, whose only quantity-bearing form is
+/// `PtValue::Quantity`; a fixed or placeholder magnitude carries no object scope
+/// to rebind. Exhaustive so a new `PtValue` form has to be classified here.
+fn rebind_cost_paid_object_pt_value_to_target(value: &mut PtValue) {
+    match value {
+        PtValue::Quantity(expr) => rebind_cost_paid_object_pt_to_target(expr),
+        PtValue::Fixed(_) | PtValue::Variable(_) => {}
+    }
+}
+
+/// CR 115.1 + CR 208.1: does this announced target slot name a CREATURE — the
+/// "target creature" noun phrase that a bare demonstrative "that creature" can
+/// take as its antecedent?
+///
+/// A conjunction narrows the candidate set, so ONE creature-typed conjunct makes
+/// the whole slot a creature ("another target creature" = creature AND not the
+/// source). A disjunction widens it, so EVERY branch must be creature-typed
+/// before the slot is guaranteed to name a creature ("target creature or player"
+/// is not). A negation names what the target is *not*, so it never supplies an
+/// antecedent. Every remaining filter (`Any`, the player scopes, the stack and
+/// context refs) names no creature noun either.
+fn target_filter_names_creature(filter: &TargetFilter) -> bool {
+    match filter {
+        TargetFilter::Typed(typed) => typed.type_filters.contains(&TypeFilter::Creature),
+        TargetFilter::And { filters } => filters.iter().any(target_filter_names_creature),
+        TargetFilter::Or { filters } => {
+            !filters.is_empty() && filters.iter().all(target_filter_names_creature)
+        }
+        _ => false,
     }
 }
 
@@ -13334,6 +13398,7 @@ mod where_x_tests {
         DigSource, Duration, Effect, FilterProp, ObjectScope, PlayerScope, PtValue, QuantityExpr,
         QuantityRef, StaticDefinition, TargetFilter, TriggerDefinition, TypeFilter, TypedFilter,
     };
+    use crate::types::counter::CounterType;
     use crate::types::triggers::TriggerMode;
     use crate::types::zones::Zone;
 
@@ -13848,6 +13913,146 @@ mod where_x_tests {
         assert!(
             exprs.iter().all(has_event_context_amount),
             "rewritten expression should contain the where-X event amount in every branch: {exprs:?}"
+        );
+    }
+
+    /// CR 115.1 + CR 608.2c: a clause that announces its own "target creature"
+    /// supplies the antecedent for a bare demonstrative "that creature's power",
+    /// so the magnitude must read the ANNOUNCED TARGET, not the CR 608.2k
+    /// cost/trigger referent the context-free phrase lowers to.
+    ///
+    /// Drives the gate's target axis across the shapes that actually ship: a
+    /// creature-typed slot rebinds (Thickest in the Thicket, Soul's Might); a
+    /// bare `Any` slot (Minsc & Boo, Timeless Heroes' reflexive "deals X damage
+    /// to any target") and a player slot (its "draw X cards" sibling) name no
+    /// creature and must keep `CostPaidObject`, which is what makes them still
+    /// read the sacrificed creature.
+    #[test]
+    fn where_x_target_creature_anaphor_rebinds_only_for_a_creature_typed_target() {
+        fn put_counter(target: TargetFilter) -> Effect {
+            Effect::PutCounter {
+                counter_type: CounterType::Plus1Plus1,
+                count: QuantityExpr::Ref {
+                    qty: QuantityRef::Variable {
+                        name: "X".to_string(),
+                    },
+                },
+                target,
+            }
+        }
+        fn bound_count(effect: &Effect) -> &QuantityExpr {
+            let Effect::PutCounter { count, .. } = effect else {
+                panic!("expected PutCounter");
+            };
+            count
+        }
+        fn power(scope: ObjectScope) -> QuantityExpr {
+            QuantityExpr::Ref {
+                qty: QuantityRef::Power { scope },
+            }
+        }
+
+        let creature = TargetFilter::Typed(TypedFilter::new(TypeFilter::Creature));
+        for (label, target, expected) in [
+            ("target creature", creature.clone(), ObjectScope::Target),
+            (
+                "another target creature",
+                TargetFilter::And {
+                    filters: vec![
+                        creature.clone(),
+                        TargetFilter::Not {
+                            filter: Box::new(TargetFilter::SelfRef),
+                        },
+                    ],
+                },
+                ObjectScope::Target,
+            ),
+            ("any target", TargetFilter::Any, ObjectScope::CostPaidObject),
+            (
+                "a player",
+                TargetFilter::Controller,
+                ObjectScope::CostPaidObject,
+            ),
+            (
+                "the source itself",
+                TargetFilter::SelfRef,
+                ObjectScope::CostPaidObject,
+            ),
+        ] {
+            let mut effect = put_counter(target);
+            super::apply_where_x_effect_expression(&mut effect, Some("that creature's power"));
+            assert_eq!(
+                bound_count(&effect),
+                &power(expected),
+                "{label}: demonstrative anaphor bound to the wrong object scope"
+            );
+        }
+    }
+
+    /// CR 613.4c: the same rule on the layer-7 pump magnitude, whose value is a
+    /// `PtValue` rather than a bare `QuantityExpr` (Nantuko Mentor: "Target
+    /// creature gets +X/+X until end of turn, where X is that creature's
+    /// power"). Both halves of the P/T pair must move together.
+    #[test]
+    fn where_x_target_creature_anaphor_rebinds_pump_magnitude() {
+        let mut effect = Effect::Pump {
+            power: PtValue::Variable("X".to_string()),
+            toughness: PtValue::Variable("X".to_string()),
+            target: TargetFilter::Typed(TypedFilter::new(TypeFilter::Creature)),
+        };
+
+        super::apply_where_x_effect_expression(&mut effect, Some("that creature's power"));
+
+        let expected = PtValue::Quantity(QuantityExpr::Ref {
+            qty: QuantityRef::Power {
+                scope: ObjectScope::Target,
+            },
+        });
+        let Effect::Pump {
+            power, toughness, ..
+        } = effect
+        else {
+            panic!("expected Pump");
+        };
+        assert_eq!(power, expected, "pump power must read the announced target");
+        assert_eq!(
+            toughness, expected,
+            "pump toughness must read the announced target"
+        );
+    }
+
+    /// CR 608.2k: the gate's OTHER axis. A participle cost referent ("the
+    /// sacrificed creature's power" — Shadowheart, Dark Justiciar) is not the
+    /// bare demonstrative, so a creature-typed target slot must NOT drag it onto
+    /// the announced target; it stays the cost/trigger referent.
+    #[test]
+    fn where_x_participle_cost_referent_is_not_rebound_by_a_creature_target() {
+        let mut effect = Effect::PutCounter {
+            counter_type: CounterType::Plus1Plus1,
+            count: QuantityExpr::Ref {
+                qty: QuantityRef::Variable {
+                    name: "X".to_string(),
+                },
+            },
+            target: TargetFilter::Typed(TypedFilter::new(TypeFilter::Creature)),
+        };
+
+        super::apply_where_x_effect_expression(
+            &mut effect,
+            Some("the sacrificed creature's power"),
+        );
+
+        let Effect::PutCounter { count, .. } = effect else {
+            panic!("expected PutCounter");
+        };
+        assert_eq!(
+            count,
+            QuantityExpr::Ref {
+                qty: QuantityRef::Power {
+                    scope: ObjectScope::CostPaidObject,
+                },
+            },
+            "a participle cost referent must keep the CR 608.2k scope"
         );
     }
 

--- a/crates/engine/src/parser/oracle_tests.rs
+++ b/crates/engine/src/parser/oracle_tests.rs
@@ -28557,3 +28557,109 @@ fn cyclops_gladiator_if_you_do_damage_back_reads_targets_power_not_sources() {
          attacking Cyclops's own power — got {back_amount:?}"
     );
 }
+
+/// CR 115.1 + CR 608.2c + CR 608.2k: card-exact census of every per-object
+/// power/toughness scope the parser emits for the "where X is that creature's
+/// power/toughness" class (issue #8460).
+///
+/// Each row is a real card's VERBATIM Oracle text run through the production
+/// parser, and the expectation is the full multiset of `Power`/`Toughness`
+/// scopes in its parse — so a scope that moves anywhere in the card, not just
+/// at the node under test, reds this table.
+///
+/// The two halves of the table are the two readings of the same English phrase:
+///
+/// * `Target` — the clause announces its own "target creature", so CR 115.1
+///   makes that announced target the antecedent (Thickest in the Thicket,
+///   Soul's Might, Nantuko Mentor).
+/// * `CostPaidObject` — the antecedent is the CR 608.2k referent named by the
+///   ability's cost or trigger condition, with no announced creature target for
+///   the demonstrative to bind to instead. **Minsc & Boo, Timeless Heroes is the
+///   named non-regression constraint for #8460**: its reflexive "~ deals X
+///   damage to any target, where X is that creature's power" announces
+///   `TargetFilter::Any`, and X must keep reading the creature sacrificed by the
+///   −2 ability. Hamletback Goliath (trigger referent) and Shadowheart, Dark
+///   Justiciar (sacrifice cost) hold the same reading from the other two
+///   directions.
+#[test]
+fn where_x_that_creature_stat_binds_target_only_when_the_clause_announces_one() {
+    /// Collect every `QuantityRef::Power`/`Toughness` scope in a parse, in
+    /// document order. Serializing the whole `ParsedAbilities` reaches nodes no
+    /// hand-written index chain would (sub-abilities, else-branches, granted
+    /// definitions), so a scope that moves anywhere is visible here.
+    fn power_scopes(value: &serde_json::Value, out: &mut Vec<String>) {
+        match value {
+            serde_json::Value::Object(map) => {
+                if let (Some(serde_json::Value::String(kind)), Some(scope)) =
+                    (map.get("type"), map.get("scope"))
+                {
+                    if kind == "Power" || kind == "Toughness" {
+                        if let Some(serde_json::Value::String(name)) = scope.get("type") {
+                            out.push(format!("{kind}/{name}"));
+                        }
+                    }
+                }
+                for nested in map.values() {
+                    power_scopes(nested, out);
+                }
+            }
+            serde_json::Value::Array(items) => {
+                for nested in items {
+                    power_scopes(nested, out);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    let cases: &[(&str, &[&str], &str, &[&str])] = &[
+        (
+            "Thickest in the Thicket",
+            &["Enchantment"],
+            "When this enchantment enters, put X +1/+1 counters on target creature, where X is that creature's power.\nAt the beginning of your end step, draw two cards if you control the creature with the greatest power or tied for the greatest power.",
+            &["Power/Target"],
+        ),
+        (
+            "Soul's Might",
+            &["Sorcery"],
+            "Put X +1/+1 counters on target creature, where X is that creature's power.",
+            &["Power/Target"],
+        ),
+        (
+            "Nantuko Mentor",
+            &["Creature"],
+            "{2}{G}, {T}: Target creature gets +X/+X until end of turn, where X is that creature's power.",
+            &["Power/Target", "Power/Target"],
+        ),
+        (
+            "Minsc & Boo, Timeless Heroes",
+            &["Planeswalker"],
+            "When Minsc & Boo enters and at the beginning of your upkeep, you may create Boo, a legendary 1/1 red Hamster creature token with trample and haste.\n[+1]: Put three +1/+1 counters on up to one target creature with trample or haste.\n[\u{2212}2]: Sacrifice a creature. When you do, Minsc & Boo deals X damage to any target, where X is that creature's power. If the sacrificed creature was a Hamster, draw X cards.\nMinsc & Boo, Timeless Heroes can be your commander.",
+            &["Power/CostPaidObject", "Power/CostPaidObject"],
+        ),
+        (
+            "Hamletback Goliath",
+            &["Creature"],
+            "Whenever another creature enters, you may put X +1/+1 counters on this creature, where X is that creature's power.",
+            &["Power/CostPaidObject"],
+        ),
+        (
+            "Shadowheart, Dark Justiciar",
+            &["Creature"],
+            "{1}{B}, {T}, Sacrifice another creature: Draw X cards, where X is that creature's power.",
+            &["Power/CostPaidObject"],
+        ),
+    ];
+
+    for (name, types, oracle, expected) in cases {
+        let types: Vec<String> = types.iter().map(|t| (*t).to_string()).collect();
+        let parsed = parse_oracle_text(oracle, name, &[], &types, &[]);
+        let value = serde_json::to_value(&parsed).expect("ParsedAbilities must serialize");
+        let mut scopes = Vec::new();
+        power_scopes(&value, &mut scopes);
+        assert_eq!(
+            scopes, *expected,
+            "{name}: per-object power/toughness scopes changed"
+        );
+    }
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -1151,6 +1151,7 @@ mod the_kingpin_of_crime_combat_damage;
 mod the_notary_hobbits;
 mod the_ur_dragon_eminence;
 mod the_who_opponent_guess_resolution;
+mod thickest_in_the_thicket_target_anaphor_8460;
 mod thor_god_of_thunder;
 mod thorna_and_twigtooth_shared_x_relay_6956;
 mod thought_distortion;

--- a/crates/engine/tests/integration/thickest_in_the_thicket_target_anaphor_8460.rs
+++ b/crates/engine/tests/integration/thickest_in_the_thicket_target_anaphor_8460.rs
@@ -1,0 +1,166 @@
+//! Regression for GitHub issue #8460 — "where X is that creature's power" on a
+//! clause that announces its OWN target creature.
+//!
+//! Oracle (Thickest in the Thicket): "When this enchantment enters, put X +1/+1
+//! counters on target creature, where X is that creature's power."
+//!
+//! The bug: `parse_event_context_refs` lowers the context-free phrase "that
+//! creature's power" to `QuantityRef::Power { scope: ObjectScope::CostPaidObject }`
+//! — the CR 608.2k cost/trigger-referent sense it correctly carries on
+//! Hamletback Goliath ("whenever another creature enters ... where X is that
+//! creature's power") and Shadowheart, Dark Justiciar (a sacrifice cost). On a
+//! clause that announces its own "target creature" there is no cost referent and
+//! no earlier instruction, so CR 115.1 makes the announced target the antecedent.
+//!
+//! At runtime `ObjectScope::CostPaidObject` walks cost-paid object -> effect
+//! context object -> TRIGGER-EVENT SOURCE. For an ETB trigger that third slot is
+//! the entering permanent itself, so X read Thickest's own power: 0 for an
+//! ordinary enchantment (the reported "every creature effectively gets +0/+0"),
+//! and 4 while Bello, Bard of the Brambles animated it as a 4/4 (the reporter's
+//! "oddly, this works if you target Thickest itself" — it coincided with the
+//! right answer only because target and source were the same object).
+//!
+//! These tests parse the real Oracle text through the production parser path and
+//! drive the full cast pipeline, so they exercise parser + runtime end-to-end.
+//! Reverting the lowering-seam rebind returns the pre-fix `CostPaidObject` scope
+//! and every assertion below drops to 0 counters.
+
+use engine::game::scenario::{GameScenario, P0, P1};
+use engine::types::counter::CounterType;
+use engine::types::phase::Phase;
+
+const THICKEST_IN_THE_THICKET: &str =
+    "When this enchantment enters, put X +1/+1 counters on target creature, \
+where X is that creature's power.\n\
+At the beginning of your end step, draw two cards if you control the creature \
+with the greatest power or tied for the greatest power.";
+
+const SOULS_MIGHT: &str =
+    "Put X +1/+1 counters on target creature, where X is that creature's power.";
+
+/// CR 115.1 + CR 608.2c: the ETB trigger's "that creature" is the creature it
+/// announced as a target, so a targeted 3/3 gets exactly 3 counters.
+///
+/// Two independent discriminators sit in this one board:
+///   * 0 counters means X still resolved through `CostPaidObject`, whose ETB
+///     fallback is the entering enchantment (power 0) — the reported bug.
+///   * 7 counters would mean X read the untargeted decoy rather than the
+///     announced target.
+#[test]
+fn thickest_in_the_thicket_counters_equal_the_targeted_creatures_power() {
+    let mut scenario = GameScenario::new_n_player(2, 42);
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let enchantment = scenario
+        .add_spell_to_hand_from_oracle(
+            P0,
+            "Thickest in the Thicket",
+            false,
+            THICKEST_IN_THE_THICKET,
+        )
+        .as_enchantment()
+        .id();
+    let target = scenario.add_creature(P0, "Targeted Beast", 3, 3).id();
+    // Power 7, never targeted — discriminates "the announced target" from "some
+    // creature on the battlefield".
+    let decoy = scenario.add_creature(P1, "Untargeted Ogre", 7, 7).id();
+
+    let mut runner = scenario.build();
+    let outcome = runner.cast(enchantment).target_object(target).resolve();
+
+    outcome.assert_counters(target, CounterType::Plus1Plus1, 3);
+    outcome.assert_counters(decoy, CounterType::Plus1Plus1, 0);
+}
+
+/// CR 608.2h: X is calculated once, as the ability resolves (the card's own
+/// ruling: "The value of X is calculated only once, as Thickest in the Thicket's
+/// first ability resolves"). A creature already carrying counters therefore
+/// contributes its CURRENT power, not its printed power — a 2/2 with three
+/// +1/+1 counters is a 5/5 and gains five more counters.
+#[test]
+fn thickest_in_the_thicket_reads_the_targets_current_power() {
+    let mut scenario = GameScenario::new_n_player(2, 42);
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let enchantment = scenario
+        .add_spell_to_hand_from_oracle(
+            P0,
+            "Thickest in the Thicket",
+            false,
+            THICKEST_IN_THE_THICKET,
+        )
+        .as_enchantment()
+        .id();
+    let target = scenario
+        .add_creature(P0, "Counter-Laden Beast", 2, 2)
+        .with_plus_counters(3)
+        .id();
+
+    let mut runner = scenario.build();
+    let outcome = runner.cast(enchantment).target_object(target).resolve();
+
+    // 3 pre-existing + 5 (its current power) = 8.
+    outcome.assert_counters(target, CounterType::Plus1Plus1, 8);
+}
+
+/// The same clause with no trigger at all (Soul's Might, a plain sorcery). It
+/// shares the exact effect node — `PutCounter { count: Power{..}, target:
+/// creature }` — and isolates the rebind from any trigger-event machinery: with
+/// no cost referent, no effect-context object AND no trigger event, the pre-fix
+/// `CostPaidObject` ladder had nothing at all to read and produced 0.
+#[test]
+fn souls_might_counters_equal_the_targeted_creatures_power() {
+    let mut scenario = GameScenario::new_n_player(2, 42);
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let spell = scenario
+        .add_spell_to_hand_from_oracle(P0, "Soul's Might", false, SOULS_MIGHT)
+        .id();
+    let target = scenario.add_creature(P0, "Mighty Beast", 4, 4).id();
+    let decoy = scenario.add_creature(P1, "Untargeted Ogre", 9, 9).id();
+
+    let mut runner = scenario.build();
+    let outcome = runner.cast(spell).target_object(target).resolve();
+
+    outcome.assert_counters(target, CounterType::Plus1Plus1, 4);
+    outcome.assert_counters(decoy, CounterType::Plus1Plus1, 0);
+}
+
+/// The reporter's own accidental diagnostic, made discriminating. They noticed
+/// the card "will work if you target Thickest in the Thicket itself while Bello,
+/// Bard of the Brambles is making it a 4/4 creature, giving it +4/+4" — i.e. the
+/// count was right exactly when the announced target and the ability's source
+/// happened to be the same object.
+///
+/// This models that board (an animated Thickest — same verbatim Oracle text,
+/// entering as a 4/4 enchantment creature) but targets a DIFFERENT creature, so
+/// source power (4) and target power (3) disagree. Under the pre-fix
+/// `CostPaidObject` scope the ETB trigger-event-source fallback reads the
+/// entering permanent and yields 4; the announced target's power is 3.
+#[test]
+fn animated_thickest_reads_the_target_not_the_animated_source() {
+    let mut scenario = GameScenario::new_n_player(2, 42);
+    scenario.at_phase(Phase::PreCombatMain);
+
+    // CR 205.1b + CR 613.4b: an enchantment that is also a 4/4 creature — the
+    // board Bello, Bard of the Brambles produces for a mana-value-4 enchantment.
+    let enchantment = scenario
+        .add_creature_to_hand_from_oracle(
+            P0,
+            "Thickest in the Thicket",
+            4,
+            4,
+            THICKEST_IN_THE_THICKET,
+        )
+        .as_enchantment()
+        .as_creature()
+        .id();
+    let target = scenario.add_creature(P0, "Targeted Beast", 3, 3).id();
+
+    let mut runner = scenario.build();
+    let outcome = runner.cast(enchantment).target_object(target).resolve();
+
+    outcome.assert_counters(target, CounterType::Plus1Plus1, 3);
+    // The animated source is not the antecedent and receives nothing.
+    outcome.assert_counters(enchantment, CounterType::Plus1Plus1, 0);
+}


### PR DESCRIPTION
Fixes #8460. Last open member of the #8496 cluster.

Thickest in the Thicket — *"When this enchantment enters, put X +1/+1 counters on target creature, where X is that creature's power."* — put the wrong number of counters on the target.

## What X resolved against

`parse_event_context_refs` lowers the context-free phrase *"that creature's power"* to `QuantityRef::Power { scope: ObjectScope::CostPaidObject }` — the CR 608.2k cost/trigger referent. That is the **correct** reading on Hamletback Goliath and Shadowheart, Dark Justiciar, where the demonstrative genuinely points at a sacrificed or otherwise previously-referenced object.

It is wrong here. The clause announces its own `target creature` (CR 115.1), and there is no earlier instruction in the clause for the demonstrative to bind to (CR 608.2c), so the antecedent is the announced target. The fix restores the announced-target reading at the lowering seam, where the clause's own target slot is in scope — the same place and the same two helpers the `Effect::GenericEffect` arm already uses for a targeted continuous grant (Xenagos, God of Revels). This extends that to the magnitude carriers.

## The reporter's accidental diagnostic

The issue notes it "works if you target Thickest in the Thicket itself while Bello, Bard of the Brambles is making it a 4/4." That observation is the whole cause.

The `CostPaidObject` runtime arm is a three-rung ladder: `cost_paid_object` → `effect_context_object` → `read_trigger_event_source_pt`. Thickest's ETB trigger has neither of the first two, so X fell to the third rung and read the **trigger-event source — Thickest itself**: 0 for a plain enchantment, and 4 while Bello animated it. Self-targeting produced the right answer only because target and source were the same object.

That third rung is the #8496 cluster signature: a fallback that turns a missing referent into a *plausible wrong number* rather than an honest zero.

The diagnosis predicts something sharper than the report — with Bello active, **any** target should get +4/+4, not just a self-target. That prediction was tested and observed.

## Minsc & Boo does not regress

#8496 records that an earlier proposed gate for this issue would have *introduced* two regressions, so this was a hard requirement. Three independent proofs:

1. **Whole-database projection** — both printings (`minsc & boo…` and `a-minsc & boo…`) are byte-identical pre vs post.
2. **Card-exact parser census** asserting the full multiset of per-object P/T scopes: `["Power/CostPaidObject", "Power/CostPaidObject"]`. Its reflexive clause announces `TargetFilter::Any`, which names no creature, so the creature-typed gate holds and it keeps reading the sacrificed creature.
3. **Building-block test** — `TargetFilter::Any` and player-scoped targets keep `CostPaidObject`.

Gating on a *creature-typed announced target* is precisely what keeps a genuine cost/trigger referent untouched.

## Blast radius

24 effect nodes across 35,798 cards carry `Power`/`Toughness{CostPaidObject}` under a bare "that creature's power/toughness" where-clause. **3 flip, 21 hold.**

Whole-database projection, input digest identical across both runs:

```
PRE/POST cards: 35798 / 35798 — key sets identical
CARDS WHOSE PARSE CHANGED: 3
  Nantuko Mentor (2 values) · Soul's Might (1) · Thickest in the Thicket (1)
  all 4 changed values: "CostPaidObject" -> "Target"
positive control (comparator detects a planted change): True
```

Independently confirmed by the lead against current `card-data.json`: all three flip candidates presently carry `Power/CostPaidObject`, and both Minsc & Boo printings carry exactly the two-element `CostPaidObject` multiset the non-regression test pins.

The lane also found and fixed a real semantic drift in the inherited census script — it used `all()` on `And` filters where the Rust predicate uses `any()`. The flip set was unchanged, but the script was wrong before the projection caught it.

## Tests

Negative controls carry the weight here: each half of the gate was disabled independently and had to go red at *exactly* the claim under test, which is what separates a test that checks the fix from one that merely passes beside it.

https://claude.ai/code/session_01JSZ2G5sVMGvVPFWX7beFCH


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected interpretation of “that creature’s power/toughness” so it refers to the explicitly announced creature target when appropriate.
  * Improved power and toughness calculations across triggered abilities, sorcery effects, and animated enchantments.
* **Tests**
  * Added regression coverage for target references in parsing and runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->