### PR TITLE
test(engine): shrink swarm witness cap fixture from 4096 to 64 attackers (#8538)

### DIFF
--- a/crates/engine/tests/integration/swarm_combat_witness.rs
+++ b/crates/engine/tests/integration/swarm_combat_witness.rs
@@ -2,7 +2,9 @@ use engine::ai_support::{
     adversarial_swarm_witness, SwarmWitnessIndeterminate, SwarmWitnessResult,
 };
 #[cfg(feature = "test-support")]
-use engine::ai_support::{adversarial_swarm_witness_with_counters, SwarmWitnessCounters};
+use engine::ai_support::{
+    adversarial_swarm_witness_with_counters, SwarmWitnessCounters, SWARM_WITNESS_MAX_DECLARATIONS,
+};
 use engine::game::combat::AttackTarget;
 use engine::game::scenario::{GameScenario, P0, P1};
 use engine::types::ability::{
@@ -57,15 +59,30 @@ fn swarm_witness_fails_fast_after_multiblock_replacement() {
     );
 }
 
+/// The declaration cap is a product over *blockers* of `legal targets + 1`, so
+/// two reach blockers that can each block every flier need only
+/// `isqrt(cap)` attackers to exceed it: by the definition of an integer square
+/// root, `(isqrt(cap) + 1)^2 > cap`. That is the smallest fixture that reaches
+/// the capping branch through attacker multiplicity, and it stays smallest if
+/// the cap constant changes.
 #[cfg(feature = "test-support")]
 #[test]
 fn swarm_witness_caps_before_enumerating_many_flying_attackers() {
+    const BLOCKERS: u32 = 2;
+    let attacker_count = SWARM_WITNESS_MAX_DECLARATIONS.isqrt();
+    assert!(
+        (attacker_count + 1).pow(BLOCKERS) > SWARM_WITNESS_MAX_DECLARATIONS,
+        "fixture must exceed the declaration cap, not merely approach it"
+    );
+
     let mut scenario = GameScenario::new();
     scenario.at_phase(Phase::PreCombatMain);
-    let attackers: Vec<_> = (0..4096)
+    let attackers: Vec<_> = (0..attacker_count)
         .map(|_| scenario.add_creature(P0, "Flyer", 1, 1).flying().id())
         .collect();
-    scenario.add_creature(P1, "Reach", 0, 2).reach();
+    for _ in 0..BLOCKERS {
+        scenario.add_creature(P1, "Reach", 0, 2).reach();
+    }
     let mut runner = scenario.build();
     runner.advance_to_combat();
     let mut counters = SwarmWitnessCounters::default();
@@ -83,7 +100,9 @@ fn swarm_witness_caps_before_enumerating_many_flying_attackers() {
         SwarmWitnessCounters {
             root_clone_applies: 1,
             ..Default::default()
-        }
+        },
+        "the cap must be refused before streaming a single leaf, so no leaf is \
+         raised, validated, or cloned"
     );
 }
 


### PR DESCRIPTION
Closes #8538.

`swarm_witness_caps_before_enumerating_many_flying_attackers` has been hitting nextest's 240s terminate timeout in CI and taking unrelated PRs down with it — #8522, #8521 and #8534 are all parser or citation changes with no path to combat enumeration. Measured locally at **919.37s** for that one test, so it was not marginally over budget; it was 3.8x the kill bound.

## The cost was fixture size, not the code under test

`checked_declaration_product` (`crates/engine/src/ai_support/swarm.rs`) multiplies over *blockers*, each contributing `legal block targets + 1` (the `+1` being "does not block"), and refuses above `SWARM_WITNESS_MAX_DECLARATIONS = 4_096`:

```rust
let mut count = 1usize;
for blocker in blockers {
    count = count.checked_mul(targets.get(blocker).map_or(1, |choices| choices.len() + 1))?;
    if count > SWARM_WITNESS_MAX_DECLARATIONS {
        return None;
    }
}
```

With a **single** reach blocker that product is linear — `attackers + 1` — so tripping a 4096 cap required exactly 4096 attackers, the most expensive shape that reaches the branch at all. A **second** reach blocker makes the term quadratic, so `isqrt(cap)` attackers suffice: `(isqrt(n) + 1)^2 > n` holds by the definition of an integer square root. 64 attackers, 2 blockers, product 4225 > 4096.

The fixture derives its size from the exported constant rather than hardcoding 64, so it tracks a future cap change, and it asserts up front that it *exceeds* the cap rather than merely approaching it.

## The claim is not weakened

The flying/reach pairing stays load-bearing — without reach the blockers have no legal targets, the product collapses to 1, and the cap is never reached. The guarantee was already structural rather than wall-clock: the counters assertion pins `raw_leaves` / `legal_leaves` / `candidate_clone_applies` at zero, proving the cap is refused before a single leaf is raised, validated or cloned. That assertion now carries a message saying so, and the result assertion still pins `Indeterminate(DeclarationCap)`.

Discrimination was verified by **mutation, not inspection**: deleting the `count > SWARM_WITNESS_MAX_DECLARATIONS` guard turns the shrunk test red — `Indeterminate(TriggerOrReplacement)` where `Indeterminate(DeclarationCap)` is expected — because the witness then streams into leaves and hits a different abstention. Guard restored; all 11 tests in the module pass.

## Runtime

Debug profile, `RUST_MIN_STACK=16777216` to match the Tiltfile:

| | attackers | blockers | time |
|---|---|---|---|
| before | 4096 | 1 | 919.37s |
| after | 64 | 2 | 0.10s |

Whole `swarm_combat_witness` module now runs in 0.12s.

Test-only change; no CR citations added and no engine logic touched.

https://claude.ai/code/session_01JSZ2G5sVMGvVPFWX7beFCH
