### PR TITLE
fix(engine): prompt for the count of an "up to N" draw (#8543)

### DIFF
--- a/crates/engine/src/game/effects/draw.rs
+++ b/crates/engine/src/game/effects/draw.rs
@@ -246,8 +246,46 @@ pub fn resolve(
             // resolves as a zero-count draw.
             if max > 0 {
                 let drawing_player = super::resolve_player_for_context_ref(state, ability, target);
-                prompt_up_to_draw_count(state, ability, target, drawing_player, max);
-                return Ok(());
+                // CR 121.3: "if an effect says that a player can't draw cards
+                // and another effect offers that player the choice to draw a
+                // card, that player can't choose to do so." CR 121.3a extends
+                // that to a chooser who is not the drawer and keys the test on
+                // the DRAWER — which is why `drawing_player`, not
+                // `ability.controller`, is the subject here (Arcane Denial's
+                // exact shape).
+                //
+                // GATE, DO NOT CLAMP. The test is `== 0`, not
+                // `0..=allowed_draw_count(..)`. CR 121.3 withholds the choice
+                // only when an effect says the player can't draw cards *at all*;
+                // a `PerTurnDrawLimit` with draws still remaining says no such
+                // thing, so "up to two" under a one-per-turn limit must still
+                // offer 2 and then deliver 1. CR 101.2's "can't" precedence is
+                // applied per individual draw downstream by
+                // `apply_draw_after_replacement`, which calls
+                // `allowed_draw_count` itself; clamping the ANNOUNCEMENT here
+                // would apply the same restriction twice, at the wrong layer.
+                //
+                // With `max > 0`, `min(max, remaining) == 0` holds exactly when
+                // `remaining == 0`, so the `max` argument is not load-bearing to
+                // the gate — this asks "may this player draw at all right now".
+                //
+                // NOT `can_draw_at_least_one`, which looks like the helper for
+                // this and is not: it also answers false for an empty library
+                // and for a replacement-removed draw, and CR 121.3's FIRST
+                // sentence requires the choice to stay open in both of those
+                // cases. Using it here would silently reintroduce the
+                // library-size clamp this menu must never have.
+                if allowed_draw_count(state, drawing_player, max) > 0 {
+                    prompt_up_to_draw_count(state, ability, target, drawing_player, max);
+                    return Ok(());
+                }
+                // Falls through to the mandatory path, exactly as a printed
+                // `Draw { Fixed(max) }` under the same prohibition does: the
+                // draw sequence runs, `apply_draw_after_replacement` clamps
+                // every unit to zero, and `EffectResolved { kind: Draw }` still
+                // fires. No CR 704.5b exposure — `attempted_empty_library` is
+                // gated on `allowed_count > 0`, so a forbidden draw records no
+                // empty-library attempt.
             }
         }
     }
@@ -311,6 +349,10 @@ pub fn resolve(
 /// pure magnitude with nothing to select. (The object-selecting `up_to`
 /// resolvers, `sacrifice` and `search_library`, derive their count from the
 /// chosen objects instead and so need a different prompt.)
+///
+/// Callers must have already cleared the CR 121.3 gate (`allowed_draw_count > 0`
+/// for `drawing_player`): this builds the menu unconditionally and does not
+/// re-check whether the choice may be offered at all.
 ///
 /// Three properties CR 608.2d requires of the offer:
 ///

--- a/crates/engine/src/game/effects/draw.rs
+++ b/crates/engine/src/game/effects/draw.rs
@@ -3,7 +3,9 @@ use std::collections::HashSet;
 use crate::game::quantity::resolve_quantity_with_targets;
 use crate::game::replacement::{self, ReplacementResult};
 use crate::game::static_abilities::prohibition_scope_matches_player;
-use crate::types::ability::{Effect, EffectError, EffectKind, ResolvedAbility};
+use crate::types::ability::{
+    AbilityDefinition, Effect, EffectError, EffectKind, QuantityExpr, ResolvedAbility, TargetFilter,
+};
 use crate::types::events::{GameEvent, PlayerActionKind};
 use crate::types::game_state::{DrawSequenceOrigin, GameState, PendingDrawDelivery};
 use crate::types::identifiers::ObjectId;
@@ -223,6 +225,33 @@ pub fn resolve(
     ability: &ResolvedAbility,
     events: &mut Vec<GameEvent>,
 ) -> Result<(), EffectError> {
+    // CR 608.2d: "Draw up to N" is encoded as `count: UpTo { max }`, and the
+    // magnitude is a choice the DRAWING player announces while the effect is
+    // applied — not a value the game state determines. `peel_up_to` splits the
+    // wrapper into its upper-bound expression and the may-draw-fewer flag so
+    // the prompt below can honour it.
+    //
+    // The generic resolver cannot do this: `game/quantity.rs` folds
+    // `UpTo { max } => recurse(max)`, which ANSWERS the choice as the upper
+    // bound. Before this guard existed, `resolve` read the count through that
+    // transparent path and Arcane Denial's "Its controller may draw up to two
+    // cards" always drew exactly two, with both 0 and 1 unreachable (#8543).
+    if let Effect::Draw { count, target } = &ability.effect {
+        let (max_expr, up_to) = count.peel_up_to();
+        if up_to {
+            // CR 107.1b: a calculation yielding a negative number uses zero.
+            let max = resolve_quantity_with_targets(state, max_expr, ability).max(0) as u32;
+            // A zero upper bound has exactly one legal answer, so it needs no
+            // round-trip; it falls through to the mandatory path below and
+            // resolves as a zero-count draw.
+            if max > 0 {
+                let drawing_player = super::resolve_player_for_context_ref(state, ability, target);
+                prompt_up_to_draw_count(state, ability, target, drawing_player, max);
+                return Ok(());
+            }
+        }
+    }
+
     let (num_cards, drawing_player) = match &ability.effect {
         // CR 107.1b: Resolve with full ability context so `QuantityRef::Variable { "X" }`
         // finds the caster-chosen X on the ability.
@@ -230,12 +259,10 @@ pub fn resolve(
         // chosen during spell announcement and is in `ability.targets` —
         // `target_player()` reads it back, falling back to controller for
         // context-ref filters that don't surface a target slot.
-        // CR 608.2d: "Draw up to N" is encoded as `count: UpTo { max }`.
-        // Generic resolution sees `UpTo` transparently as `max`, so this
-        // call already returns the upper-bound count. By the time we reach
-        // here the engine has already resolved the chosen count via the
-        // player choice mechanism in `engine_resolution_choices` and
-        // baked it into the ProposedEvent::Draw count.
+        // CR 608.2d: any `UpTo` count that reaches here is either the
+        // already-answered `Fixed` branch the prompt above installed, or an
+        // `UpTo` whose maximum resolved to 0. Both are mandatory counts, so
+        // reading them through the transparent generic resolver is correct.
         Effect::Draw { count, target } => (
             // CR 107.1b: a calculation yielding a negative number uses zero
             // instead. Clamp before the `as u32` cast — an unclamped negative
@@ -274,6 +301,93 @@ pub fn resolve(
     });
 
     Ok(())
+}
+
+/// CR 608.2d: open the resolution-time count choice for an "up to N" draw.
+///
+/// Offers every legal answer (0..=`max`) as a branch of the existing
+/// `WaitingFor::ChooseOneOfBranch` round-trip. This is the same shape
+/// `stickers::prompt_count_choice` uses — the other resolver whose `up_to` is a
+/// pure magnitude with nothing to select. (The object-selecting `up_to`
+/// resolvers, `sacrifice` and `search_library`, derive their count from the
+/// chosen objects instead and so need a different prompt.)
+///
+/// Three properties CR 608.2d requires of the offer:
+///
+/// * **Not clamped to library size.** CR 121.3: "If there are no cards in a
+///   player's library and an effect offers that player the choice to draw a
+///   card, that player can choose to do so." CR 608.2d carries the same
+///   exemption from its own "can't choose an option that's illegal or
+///   impossible" restriction. Choosing more cards than the library holds is a
+///   legal announcement; the shortfall is settled later by CR 704.5b (a player
+///   who attempted to draw from an empty library loses at the next state-based
+///   check), not by narrowing this menu.
+/// * **Choosing 0 resolves.** The `Fixed { value: 0 }` branch re-enters
+///   `resolve`, runs a zero-count draw sequence, and emits
+///   `EffectResolved { kind: Draw }`. An ability that never resolved emits no
+///   such event, so "drew nothing by choice" stays distinguishable from "did
+///   not happen".
+/// * **The chooser is the drawing player, not the ability's controller.** For
+///   Arcane Denial ("Its controller may draw up to two cards") the countered
+///   spell's controller decides. Passing that player as the sole chooser also
+///   keeps the branch's own player resolution consistent: whichever rung of
+///   `resolve_player_for_context_ref` the filter takes,
+///   `choose_one_of::resolve_branch` has already seeded the branch's scoped
+///   player and appended `TargetRef::Player(chooser)` to the inherited parent
+///   targets, so every rung converges on this same player.
+fn prompt_up_to_draw_count(
+    state: &mut GameState,
+    ability: &ResolvedAbility,
+    target: &TargetFilter,
+    drawing_player: crate::types::player::PlayerId,
+    max: u32,
+) {
+    let branches = (0..=max)
+        .map(|amount| {
+            let mut branch = AbilityDefinition::new(
+                // Preserve the parent's ability kind so a delayed-trigger draw
+                // (Arcane Denial) stays a triggered ability in the branch.
+                ability.kind,
+                Effect::Draw {
+                    // The branch IS the announced answer, so it carries a plain
+                    // count — re-entering `resolve` with it cannot re-prompt.
+                    count: QuantityExpr::Fixed {
+                        value: amount as i32,
+                    },
+                    target: target.clone(),
+                },
+            );
+            branch.description = Some(match amount {
+                0 => "Draw no cards".to_string(),
+                1 => "Draw 1 card".to_string(),
+                n => format!("Draw {n} cards"),
+            });
+            branch
+        })
+        .collect();
+
+    super::choose_one_of::prompt_next(
+        state,
+        super::choose_one_of::PromptRequest {
+            controller: ability.controller,
+            source_id: ability.source_id,
+            branches,
+            parent_targets: ability.targets.clone(),
+            context: ability.context.clone(),
+            // CR 608.2c: the trailing instructions of this chain ("…, then
+            // discard a card") are parked by `resolve_ability_chain`'s generic
+            // pause path, which already lists `WaitingFor::ChooseOneOfBranch` in
+            // `waits_for_resolution_choice`. Handing them over here as well
+            // would run the tail twice.
+            continuation: None,
+            // CR 614.5 + CR 616.1f: a replacement effect "gets only one
+            // opportunity to affect an event". Carry the already-applied keys
+            // into the branch so the answered draw cannot re-invoke a
+            // replacement this instruction has already consumed.
+            replacement_applied: ability.replacement_applied.clone(),
+            players: vec![drawing_player],
+        },
+    );
 }
 
 /// CR 121.2: Begin one draw instruction — "if a player is instructed to draw

--- a/crates/engine/src/game/quantity.rs
+++ b/crates/engine/src/game/quantity.rs
@@ -2160,13 +2160,19 @@ fn fold_compose(expr: &QuantityExpr, recurse: impl Fn(&QuantityExpr) -> i32) -> 
             base.saturating_pow(exp)
         }
         // CR 107.1c + CR 608.2d: Generic resolvers see UpTo transparently as
-        // its upper bound — the 4 effect-specific resolvers (Draw,
-        // Sacrifice, Discard, SearchLibrary) peel the wrapper via
-        // `QuantityExpr::peel_up_to` to extract the "may pick fewer" flag
-        // before reaching arithmetic. Treating it transparently here keeps
-        // legacy serde round-trips correct and makes accidental composition
-        // (e.g., `DivideRounded { inner: UpTo { max: ... } }`) collapse to a
-        // sensible bound rather than panicking.
+        // its upper bound. Extracting the "may pick fewer" permission is the
+        // caller's job, via `QuantityExpr::peel_up_to`, BEFORE the count reaches
+        // arithmetic — this fold returns an `i32` and structurally cannot carry
+        // the flag. Enumerating the resolvers that do so here has already gone
+        // stale once (the pre-#8543 list named `Draw`, which did not peel, and
+        // omitted several that did), so grep for the callers instead:
+        //
+        //     grep -rn "\.peel_up_to()" crates/engine/src/
+        //
+        // Treating it transparently here keeps legacy serde round-trips correct
+        // and makes accidental composition (e.g.,
+        // `DivideRounded { inner: UpTo { max: ... } }`) collapse to a sensible
+        // bound rather than panicking.
         QuantityExpr::UpTo { max } => recurse(max),
         // "The difference between A and B" is an unsigned-magnitude Oracle
         // templating convention — it has no dedicated Comprehensive Rules

--- a/crates/engine/src/game/resolution_prompt.rs
+++ b/crates/engine/src/game/resolution_prompt.rs
@@ -167,13 +167,25 @@ fn resolution_probe_verdict(
 /// a NEW `QuantityExpr` variant must be classified before it compiles, so an
 /// `UpTo` can never be smuggled in under a newly-added wrapper.
 ///
-/// MEASURED DISCREPANCY, and the reason this guard exists at all:
-/// `game/quantity.rs` resolves `UpTo { max } => recurse(max)` — it SILENTLY
-/// ANSWERS the CR 107.1c / CR 608.2d resolution-time count choice as the maximum
-/// rather than surfacing it. Only the resolvers that call
-/// `QuantityExpr::peel_up_to` honour the flag, and none of the six allow-listed
-/// classes does. So an unguarded arm would probe choice-free on an ability whose
-/// resolution opens a count prompt.
+/// WHY THIS GUARD EXISTS, and why it is right in BOTH directions — which is the
+/// point, because the two allow-listed groups now behave differently:
+///
+/// * `Draw` genuinely prompts. Since #8543 `draw::resolve` peels the wrapper via
+///   `QuantityExpr::peel_up_to` and opens a `ChooseOneOfBranch` count choice, so
+///   the guard AGREES with the probe and merely reaches the same verdict without
+///   paying for a whole-`GameState` clone.
+/// * The remaining allow-listed quantity arms (`GainLife`, `LoseLife`,
+///   `DealDamage`, `PutCounter`, `Token`) do NOT peel. `game/quantity.rs` folds
+///   `UpTo { max } => recurse(max)`, SILENTLY ANSWERING the CR 107.1c /
+///   CR 608.2d resolution-time count choice as the maximum rather than surfacing
+///   it. For those the guard is load-bearing: without it the probe would observe
+///   no prompt and report choice-free on an ability whose resolution is supposed
+///   to open a count choice.
+///
+/// So the guard stays on EVERY quantity-carrying arm regardless of whether that
+/// arm's resolver has been fixed yet. It is fail-closed — it can only turn a
+/// verdict into `MayPrompt`, never the reverse — so a resolver gaining a real
+/// prompt never invalidates it.
 fn quantity_offers_up_to_choice(q: &QuantityExpr) -> bool {
     match q {
         QuantityExpr::UpTo { .. } => true,
@@ -263,9 +275,18 @@ fn effect_offers_choice(e: &Effect) -> bool {
             quantity_offers_up_to_choice(count)
         }
         // HEAD's own arm shape, kept verbatim (single arm + inner `if`, no match
-        // guard). CR 608.2d: an "up to N" draw is a resolution-time COUNT choice
-        // the probe would ANSWER rather than surface, because the count is read,
-        // not prompted, inside `draw::resolve`.
+        // guard). CR 608.2d: an "up to N" draw is a resolution-time COUNT choice.
+        //
+        // The arm's JUSTIFICATION CHANGED at #8543 while its verdict did not.
+        // It was written because the probe would ANSWER the choice rather than
+        // surface it — the count was read, not prompted, inside `draw::resolve`.
+        // `draw::resolve` now peels the wrapper and opens a real
+        // `ChooseOneOfBranch` count prompt, so the probe WOULD observe it and
+        // reach `MayPrompt` on its own. The arm is kept because it reaches that
+        // verdict from the AST alone, skipping the probe's whole-`GameState`
+        // clone, and because it is fail-closed: it is still the only thing
+        // standing between an `UpTo` and a choice-free verdict should the
+        // prompt ever regress.
         Effect::Draw { count, target: _ } => {
             quantity_offers_up_to_choice(count)
         }
@@ -634,8 +655,10 @@ pub(crate) fn chain_offers_choice(a: &ResolvedAbility) -> bool {
     // CR 608.2d + CR 107.1c: an "up to N" REPEAT COUNT is a resolution-time choice
     // exactly like an "up to N" damage/draw/counter count, and it is answered in the
     // same silent way — `game/quantity.rs` resolves `UpTo { max } => recurse(max)`,
-    // taking the maximum, and none of the six allow-listed classes calls
-    // `QuantityExpr::peel_up_to`. This field was previously bound `_` and justified as
+    // taking the maximum, and nothing peels a REPEAT count via
+    // `QuantityExpr::peel_up_to` (unlike `Effect::Draw`'s own count, which
+    // `draw::resolve` peels and prompts on since #8543 — the repeat axis was not
+    // part of that fix). This field was previously bound `_` and justified as
     // "pure quantity eval (game/quantity.rs)", which cites the very mechanism
     // `quantity_offers_up_to_choice`'s own doc comment exists to distrust: the count is
     // READ, not prompted. An allow-listed repeated ability carrying an `UpTo` repeat
@@ -1469,11 +1492,13 @@ mod tests {
     /// ARM, not only `Draw`.
     ///
     /// `game/quantity.rs` resolves `UpTo { max }` as the maximum instead of
-    /// prompting, and none of the six allow-listed classes calls
-    /// `QuantityExpr::peel_up_to`. So an unguarded arm reports choice-free on an
-    /// ability whose resolution opens a count choice — a fail-OPEN, not a
-    /// coverage gap. Both directions are asserted per arm so neither can go
-    /// vacuous.
+    /// prompting, and of the allow-listed classes only `Draw` peels it via
+    /// `QuantityExpr::peel_up_to` and prompts (since #8543). For the other five
+    /// an unguarded arm reports choice-free on an ability whose resolution is
+    /// supposed to open a count choice — a fail-OPEN, not a coverage gap. `Draw`
+    /// stays in the case list precisely so the guard is pinned independently of
+    /// whether its resolver happens to prompt today. Both directions are
+    /// asserted per arm so neither can go vacuous.
     #[test]
     fn an_up_to_count_is_may_prompt_on_every_quantity_carrying_arm() {
         let state = probe_board();

--- a/crates/engine/tests/integration/issue_8543_up_to_draw_count_choice.rs
+++ b/crates/engine/tests/integration/issue_8543_up_to_draw_count_choice.rs
@@ -1,0 +1,296 @@
+//! CR 608.2d: the magnitude of an "up to N" draw is a resolution-time choice
+//! made by the drawing player — every count in `0..=N` must be reachable.
+//!
+//! Reported against Arcane Denial, whose real Oracle text (verified against
+//! `data/mtgjson/AtomicCards.json`) reads:
+//!
+//! > Counter target spell. Its controller may draw up to two cards at the
+//! > beginning of the next turn's upkeep.
+//! > You draw a card at the beginning of the next turn's upkeep.
+//!
+//! The parse was already correct — the count lowered to
+//! `UpTo { max: Fixed { value: 2 } }`. The defect was entirely below the parser:
+//! `draw::resolve` read the count through `resolve_quantity_with_targets`, the
+//! TRANSPARENT resolver, and `game/quantity.rs` folds `UpTo { max }` to `max`.
+//! So no choice was ever opened and the draw silently resolved at the upper
+//! bound: Arcane Denial always drew exactly two, with both 0 and 1 unreachable.
+//!
+//! These tests are deliberately pitched at the BUILDING BLOCK — a bare
+//! `Effect::Draw { count: UpTo { .. } }` resolving through the production cast
+//! pipeline — rather than replaying one card, because the bug belongs to every
+//! "up to N" draw. A parser-level shape test cannot see this defect at all: the
+//! AST was already right.
+
+use engine::game::scenario::{GameRunner, GameScenario, P0, P1};
+use engine::types::ability::{Effect, QuantityExpr, TargetFilter};
+use engine::types::actions::GameAction;
+use engine::types::game_state::WaitingFor;
+use engine::types::identifiers::ObjectId;
+use engine::types::phase::Phase;
+
+/// Deep enough that the count choice, not the library, bounds every draw in the
+/// matrix below. The boundary tests set their own shallower libraries.
+const DEEP_LIBRARY: &[&str] = &[
+    "Lib A", "Lib B", "Lib C", "Lib D", "Lib E", "Lib F", "Lib G", "Lib H",
+];
+
+fn hand_size(runner: &GameRunner, player: engine::types::player::PlayerId) -> usize {
+    runner
+        .state()
+        .players
+        .iter()
+        .find(|p| p.id == player)
+        .expect("player exists")
+        .hand
+        .len()
+}
+
+/// A free instant whose only instruction is `draw up to {max} cards`.
+fn up_to_draw_spell(scenario: &mut GameScenario, max: i32) -> ObjectId {
+    scenario
+        .add_spell_to_hand(P0, "Up To Draw Witness", true)
+        .with_ability(Effect::Draw {
+            count: QuantityExpr::up_to(QuantityExpr::Fixed { value: max }),
+            target: TargetFilter::Controller,
+        })
+        .id()
+}
+
+/// A free instant whose only instruction is a MANDATORY `draw {count} cards` —
+/// the negative control for the `up_to` guard.
+fn fixed_draw_spell(scenario: &mut GameScenario, count: i32) -> ObjectId {
+    scenario
+        .add_spell_to_hand(P0, "Fixed Draw Witness", true)
+        .with_ability(Effect::Draw {
+            count: QuantityExpr::Fixed { value: count },
+            target: TargetFilter::Controller,
+        })
+        .id()
+}
+
+fn scenario_with_library(library: &[&str]) -> GameScenario {
+    let mut scenario = GameScenario::new_n_player(2, 42);
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.with_library_top(P0, library);
+    // P1 never draws here, but an empty library would let an unrelated
+    // state-based loss end the game mid-test.
+    scenario.with_library_top(P1, DEEP_LIBRARY);
+    scenario
+}
+
+/// Pass priority until the count choice opens (or the engine stops elsewhere).
+fn advance_to_choice(runner: &mut GameRunner) {
+    for _ in 0..60 {
+        match &runner.state().waiting_for {
+            WaitingFor::ChooseOneOfBranch { .. } => return,
+            WaitingFor::Priority { .. } => {
+                if runner.act(GameAction::PassPriority).is_err() {
+                    return;
+                }
+            }
+            _ => return,
+        }
+    }
+}
+
+/// Read the open count menu, assert it offers exactly `0..=max`, and return the
+/// index whose label announces `chosen`.
+///
+/// Resolving the index BY LABEL rather than assuming `index == chosen` is what
+/// makes the assertion non-vacuous: it pins the menu's count-to-branch mapping
+/// instead of trusting positional coincidence. That the two then agree is
+/// asserted separately.
+fn count_branch_index(runner: &GameRunner, max: u32, chosen: u32) -> usize {
+    let WaitingFor::ChooseOneOfBranch {
+        player,
+        branch_descriptions,
+        ..
+    } = &runner.state().waiting_for
+    else {
+        panic!(
+            "CR 608.2d: an \"up to {max}\" draw must open a count choice, got {:?}",
+            runner.state().waiting_for
+        );
+    };
+    assert_eq!(
+        *player, P0,
+        "CR 608.2d: the DRAWING player announces the count"
+    );
+    assert_eq!(
+        branch_descriptions.len(),
+        (max + 1) as usize,
+        "an \"up to {max}\" draw must offer every count 0..={max}, got {branch_descriptions:?}"
+    );
+    let wanted = match chosen {
+        0 => "Draw no cards".to_string(),
+        1 => "Draw 1 card".to_string(),
+        n => format!("Draw {n} cards"),
+    };
+    let index = branch_descriptions
+        .iter()
+        .position(|label| label == &wanted)
+        .unwrap_or_else(|| panic!("no branch labelled {wanted:?} in {branch_descriptions:?}"));
+    assert_eq!(
+        index, chosen as usize,
+        "the count menu must be ordered 0..={max}"
+    );
+    index
+}
+
+/// Cast an "up to `max`" draw, select `chosen`, and report `(before, after)`
+/// hand sizes measured across the choice only.
+///
+/// The baseline is taken AT THE PROMPT, after the spell itself has left hand for
+/// the stack, so the delta is exactly the cards drawn.
+fn draw_up_to(library: &[&str], max: i32, chosen: u32) -> (GameRunner, usize, usize) {
+    let mut scenario = scenario_with_library(library);
+    let spell = up_to_draw_spell(&mut scenario, max);
+    let mut runner = scenario.build();
+
+    runner.cast(spell).commit();
+    advance_to_choice(&mut runner);
+
+    let index = count_branch_index(&runner, max as u32, chosen);
+    let before = hand_size(&runner, P0);
+    runner
+        .act(GameAction::ChooseBranch { index })
+        .expect("selecting a draw count must succeed");
+    let after = hand_size(&runner, P0);
+    (runner, before, after)
+}
+
+/// THE REGRESSION. Every count in `0..=N` is selectable and draws exactly that
+/// many cards, for several N. Before the fix no prompt opened at all and the
+/// draw always resolved at N.
+#[test]
+fn every_count_from_zero_to_the_maximum_is_selectable_and_draws_exactly_that_many() {
+    for max in 1..=3i32 {
+        for chosen in 0..=(max as u32) {
+            let (_runner, before, after) = draw_up_to(DEEP_LIBRARY, max, chosen);
+            assert_eq!(
+                after - before,
+                chosen as usize,
+                "selecting {chosen} on an \"up to {max}\" draw must draw exactly {chosen} card(s)"
+            );
+        }
+    }
+}
+
+/// CR 608.2d: choosing zero RESOLVES the draw — it is not the same as the
+/// ability failing to resolve. The resolution completes and hands priority
+/// back with an empty stack.
+#[test]
+fn choosing_zero_resolves_the_draw_rather_than_leaving_it_pending() {
+    let (mut runner, before, after) = draw_up_to(DEEP_LIBRARY, 2, 0);
+
+    assert_eq!(after, before, "selecting 0 must draw no cards");
+    runner.advance_until_stack_empty();
+    assert!(
+        runner.state().stack.is_empty(),
+        "the zero-count branch must resolve the ability off the stack, not strand it"
+    );
+    assert!(
+        !matches!(
+            runner.state().waiting_for,
+            WaitingFor::ChooseOneOfBranch { .. }
+        ),
+        "the count choice must be consumed by the selection"
+    );
+}
+
+/// A MANDATORY `Draw { count: Fixed }` of the same magnitude must NOT prompt.
+/// The negative control for the `up_to` guard: without it, a passing matrix
+/// above could just mean every draw now prompts.
+#[test]
+fn a_mandatory_fixed_draw_opens_no_count_choice() {
+    let mut scenario = scenario_with_library(DEEP_LIBRARY);
+    let spell = fixed_draw_spell(&mut scenario, 2);
+    let mut runner = scenario.build();
+
+    let before = hand_size(&runner, P0);
+    runner.cast(spell).resolve();
+
+    assert!(
+        !matches!(
+            runner.state().waiting_for,
+            WaitingFor::ChooseOneOfBranch { .. }
+        ),
+        "a fixed-count draw is not a CR 608.2d choice and must not prompt"
+    );
+    // The spell left hand for the stack, so a 2-card draw nets +1.
+    assert_eq!(
+        hand_size(&runner, P0),
+        before + 1,
+        "a mandatory \"draw two cards\" must draw exactly two"
+    );
+}
+
+/// The boundary where the chosen count equals the library exactly: all of it is
+/// drawn and the player is still in the game (CR 704.5b loses only on an
+/// ATTEMPTED draw from an empty library, which has not happened yet).
+#[test]
+fn choosing_the_whole_library_draws_all_of_it() {
+    let (runner, before, after) = draw_up_to(&["Only A", "Only B"], 2, 2);
+
+    assert_eq!(after - before, 2, "both remaining cards must be drawn");
+    assert!(
+        runner.state().players[0].library.is_empty(),
+        "the library must be exhausted exactly"
+    );
+    assert!(
+        !runner.state().players[0].is_eliminated,
+        "emptying a library is not itself a loss (CR 704.5b needs an attempted draw)"
+    );
+}
+
+/// CR 121.3: "If there are no cards in a player's library and an effect offers
+/// that player the choice to draw a card, that player can choose to do so."
+/// CR 608.2d carries the same exemption from its own "can't choose an illegal or
+/// impossible option" restriction.
+///
+/// So the menu must NOT be clamped to library size: a player may legally
+/// announce more cards than they can draw. This is the one case where narrowing
+/// the offer would look like a helpful safety check and be a rules violation.
+///
+/// Announcing 3 against a one-card library is therefore legal, is carried out as
+/// far as it can go, and then loses the game — the assertions below pin all
+/// three, because a menu that offered 3 but silently truncated the instruction
+/// to 1 would satisfy the first assertion alone.
+#[test]
+fn the_count_menu_is_not_clamped_to_library_size() {
+    let mut scenario = scenario_with_library(&["Only One"]);
+    let spell = up_to_draw_spell(&mut scenario, 3);
+    let mut runner = scenario.build();
+
+    runner.cast(spell).commit();
+    advance_to_choice(&mut runner);
+
+    // The decisive assertion: four options (0,1,2,3) against a one-card library.
+    let index = count_branch_index(&runner, 3, 3);
+    runner
+        .act(GameAction::ChooseBranch { index })
+        .expect("announcing more cards than the library holds is a legal CR 608.2d choice");
+
+    let player = &runner.state().players[0];
+    // CR 121.2: the instruction performs three INDIVIDUAL draws. The first
+    // delivers the only card; the other two are attempted against an empty
+    // library and deliver nothing.
+    assert!(
+        player.library.is_empty(),
+        "the one available card must actually be drawn, not skipped"
+    );
+    // CR 704.5b: "If a player attempted to draw a card from a library with no
+    // cards in it since the last time state-based actions were checked, that
+    // player loses the game." This is what makes the over-announcement real
+    // rather than silently truncated to the library size.
+    assert!(
+        player.drew_from_empty_library,
+        "the counts beyond the library must be ATTEMPTED, not clamped away"
+    );
+    assert!(
+        player.is_eliminated,
+        "CR 704.5b: attempting to draw from an empty library loses the game"
+    );
+    // The hand is not asserted here: a player who has left the game no longer
+    // has one, so hand size cannot witness the delivered card at this point.
+}

--- a/crates/engine/tests/integration/issue_8543_up_to_draw_count_choice.rs
+++ b/crates/engine/tests/integration/issue_8543_up_to_draw_count_choice.rs
@@ -22,11 +22,13 @@
 //! AST was already right.
 
 use engine::game::scenario::{GameRunner, GameScenario, P0, P1};
-use engine::types::ability::{Effect, QuantityExpr, TargetFilter};
+use engine::types::ability::{Effect, EffectKind, QuantityExpr, TargetFilter};
 use engine::types::actions::GameAction;
+use engine::types::events::GameEvent;
 use engine::types::game_state::WaitingFor;
 use engine::types::identifiers::ObjectId;
 use engine::types::phase::Phase;
+use engine::types::statics::{ProhibitionScope, StaticMode};
 
 /// Deep enough that the count choice, not the library, bounds every draw in the
 /// matrix below. The boundary tests set their own shallower libraries.
@@ -293,4 +295,178 @@ fn the_count_menu_is_not_clamped_to_library_size() {
     );
     // The hand is not asserted here: a player who has left the game no longer
     // has one, so hand size cannot witness the delivered card at this point.
+}
+
+// ---------------------------------------------------------------------------
+// CR 121.3: an effect that says a player can't draw cards withholds the CHOICE,
+// not merely the cards. These pin the gate that sits in front of the menu.
+// ---------------------------------------------------------------------------
+
+/// Attach a battlefield permanent carrying `mode` so `allowed_draw_count` sees
+/// it (`battlefield_active_statics` reads the battlefield only).
+fn add_draw_prohibition(scenario: &mut GameScenario, mode: StaticMode) {
+    scenario
+        .add_creature(P0, "Draw Prohibition Witness", 1, 1)
+        .with_static(mode);
+}
+
+fn resolved_a_draw(outcome: &engine::game::scenario::CastOutcome) -> bool {
+    outcome.events().iter().any(|event| {
+        matches!(
+            event,
+            GameEvent::EffectResolved {
+                kind: EffectKind::Draw,
+                ..
+            }
+        )
+    })
+}
+
+/// CR 121.3: "if an effect says that a player can't draw cards and another
+/// effect offers that player the choice to draw a card, that player can't
+/// choose to do so." CR 121.3a keys the test on the player who would DRAW.
+///
+/// Offering "Draw 1 card" under a `CantDraw` static and then delivering nothing
+/// is a choice-fidelity defect, not an illegal-draw one — `allowed_draw_count`
+/// is the single enforcement authority downstream and always clamped the
+/// outcome to zero. What was wrong was the menu, so that is what is asserted.
+#[test]
+fn a_cant_draw_prohibition_withholds_the_count_choice_entirely() {
+    let mut scenario = scenario_with_library(DEEP_LIBRARY);
+    add_draw_prohibition(
+        &mut scenario,
+        StaticMode::CantDraw {
+            who: ProhibitionScope::AllPlayers,
+        },
+    );
+    let spell = up_to_draw_spell(&mut scenario, 2);
+    let mut runner = scenario.build();
+
+    let outcome = runner.cast(spell).resolve();
+
+    assert!(
+        !matches!(
+            outcome.final_waiting_for(),
+            WaitingFor::ChooseOneOfBranch { .. }
+        ),
+        "CR 121.3: a player who can't draw cards must not be offered the count choice"
+    );
+    assert_eq!(
+        outcome.hand_drawn(P0),
+        0,
+        "no cards may be drawn under a CantDraw static"
+    );
+    // The distinguishability property the resolver's doc comment makes
+    // load-bearing: resolving at zero is NOT the same as never resolving.
+    assert!(
+        resolved_a_draw(&outcome),
+        "the ability must still RESOLVE at zero, distinguishably from not resolving at all"
+    );
+}
+
+/// POSITIVE CONTROL for the test above. The identical fixture minus the
+/// prohibition MUST open the menu — otherwise "no prompt appeared" would be
+/// satisfied by a broken fixture rather than by the CR 121.3 gate.
+#[test]
+fn the_same_fixture_without_a_prohibition_does_offer_the_count_choice() {
+    let mut scenario = scenario_with_library(DEEP_LIBRARY);
+    let spell = up_to_draw_spell(&mut scenario, 2);
+    let mut runner = scenario.build();
+
+    runner.cast(spell).commit();
+    advance_to_choice(&mut runner);
+
+    // Asserts the menu is exactly 0..=2 and locates the "Draw 2 cards" branch.
+    let index = count_branch_index(&runner, 2, 2);
+    runner
+        .act(GameAction::ChooseBranch { index })
+        .expect("the unprohibited count choice must be selectable");
+    assert_eq!(
+        hand_size(&runner, P0),
+        2,
+        "the unprohibited fixture must actually draw the announced two cards"
+    );
+}
+
+/// THE JUDGEMENT CALL, pinned. CR 121.3 withholds the choice only when an
+/// effect says the player can't draw cards *at all*. A `PerTurnDrawLimit` with
+/// draws still remaining (Spirit of the Labyrinth, nothing drawn yet) says no
+/// such thing, so "up to two" must still OFFER two — and then deliver one,
+/// because CR 101.2's "can't" precedence is applied per individual draw
+/// (CR 121.2) downstream, not to the announcement.
+///
+/// Clamping the menu to the remaining allowance would make this test offer only
+/// 0..=1, which is the behaviour this asserts against.
+#[test]
+fn a_partial_per_turn_draw_limit_still_offers_the_full_announcement_range() {
+    let mut scenario = scenario_with_library(DEEP_LIBRARY);
+    add_draw_prohibition(
+        &mut scenario,
+        StaticMode::PerTurnDrawLimit {
+            who: ProhibitionScope::AllPlayers,
+            max: 1,
+        },
+    );
+    let spell = up_to_draw_spell(&mut scenario, 2);
+    let mut runner = scenario.build();
+    assert_eq!(
+        runner.state().players[0].cards_drawn_this_turn,
+        0,
+        "precondition: the one permitted draw is still available"
+    );
+
+    runner.cast(spell).commit();
+    advance_to_choice(&mut runner);
+
+    // The decisive assertion: three options (0,1,2) despite only one draw
+    // being deliverable this turn.
+    let index = count_branch_index(&runner, 2, 2);
+    let before = hand_size(&runner, P0);
+    runner
+        .act(GameAction::ChooseBranch { index })
+        .expect("announcing two under a one-per-turn limit is a legal CR 608.2d choice");
+
+    assert_eq!(
+        hand_size(&runner, P0) - before,
+        1,
+        "CR 121.2 + CR 101.2: the limit applies per individual draw, so exactly one lands"
+    );
+}
+
+/// The other side of the same limit: once it is exhausted the effect DOES say
+/// the player can't draw cards, so CR 121.3 withholds the choice. This is why
+/// the gate tests `allowed_draw_count == 0` rather than keying on `CantDraw`
+/// alone.
+#[test]
+fn an_exhausted_per_turn_draw_limit_withholds_the_count_choice() {
+    let mut scenario = scenario_with_library(DEEP_LIBRARY);
+    add_draw_prohibition(
+        &mut scenario,
+        StaticMode::PerTurnDrawLimit {
+            who: ProhibitionScope::AllPlayers,
+            max: 1,
+        },
+    );
+    let spell = up_to_draw_spell(&mut scenario, 2);
+    let mut runner = scenario.build();
+    runner.state_mut().players[0].cards_drawn_this_turn = 1;
+
+    let outcome = runner.cast(spell).resolve();
+
+    assert!(
+        !matches!(
+            outcome.final_waiting_for(),
+            WaitingFor::ChooseOneOfBranch { .. }
+        ),
+        "an exhausted per-turn limit is \"can't draw cards\" right now (CR 121.3)"
+    );
+    assert_eq!(
+        outcome.hand_drawn(P0),
+        0,
+        "no further draw is permitted this turn"
+    );
+    assert!(
+        resolved_a_draw(&outcome),
+        "the ability must still resolve at zero"
+    );
 }

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -826,6 +826,7 @@ mod issue_841_selvala_explorer_returned;
 mod issue_8455_town_greeter;
 mod issue_847_braids_cabal_minion;
 mod issue_852_torrential_gearhulk;
+mod issue_8543_up_to_draw_count_choice;
 mod issue_859_weathered_wayfarer;
 mod issue_860_luminarch_aspirant;
 mod issue_861_first_sliver_cascade;


### PR DESCRIPTION
Closes #8543.

"Draw up to N" always drew exactly N. Arcane Denial's *"Its controller may draw up to two cards"* drew two with 0 and 1 unreachable — the player was never asked.

## Why the generic resolver could not do this

`game/quantity.rs` folds the wrapper transparently:

```rust
UpTo { max } => recurse(max)
```

That *answers* the choice as its upper bound. `draw.rs` read the count through that path and never called `peel_up_to`, so the magnitude — which CR 608.2d makes a choice the drawing player announces while the effect is applied — was decided by the resolver instead of the player. Eleven production call sites use `.peel_up_to()`; `draw.rs` was not one of them.

`resolve` now peels the wrapper first and offers `0..=max` through the existing `WaitingFor::ChooseOneOfBranch`.

## Shape follows `stickers::prompt_count_choice`, not `sacrifice` / `search_library`

Those two turn `up_to` into an **object selection** and derive the count from what was picked. A draw has nothing to pick, so stickers — the one existing pure-magnitude count prompt — is the right precedent. Consequences: **zero new engine surface**, so frontend, AI and serde need no change (AI's `candidates.rs` already enumerates every branch index).

- Chooser is the **drawing** player, not the controller.
- `continuation: None` — `ChooseOneOfBranch` is already in `waits_for_resolution_choice`, so the chain's generic pause path parks any *"…, then discard a card"* tail. Passing it again would run it twice.
- A zero upper bound has exactly one legal answer, so it skips the round-trip and falls through to the mandatory path (CR 107.1b clamps a negative calculation to zero).

## No clamping to library size

CR 121.3 is the authority: *"If there are no cards in a player's library and an effect offers that player the choice to draw…"* — the choice is offered over the printed range, not the drawable one. A player may announce more than their library holds and lose to CR 704.5b. The tests pin that rather than assume it.

## Verification

- **Negative control:** with the guard disabled, all 4 up-to tests fail and the mandatory-draw control still passes — so the tests discriminate rather than passing against both versions.
- `cargo clippy -p phase-engine --all-targets -- -D warnings` clean; `cargo fmt --check` clean.
- Engine lib **20584 passed / 0 failed**; new tests **5/5**.
- Full integration under nextest: **6239 passed / 1 failed**, the sole failure being `game_state_stack_budget::four_player_commander_action_fits_a_bounded_stack` — the documented pre-existing macOS-arm64-only SIGABRT, cfg-gated so CI never runs it.
- Every CR id grepped from `docs/MagicCompRules.txt` (effective August 7, 2026) before use, with negative controls returning 0.

One test initially failed and corrected the assertion rather than the code: announcing 3 draws against a 1-card library *did* draw the card, then lost the game to CR 704.5b, which cleared the hand — so hand size could never witness the delivery. It now asserts `drew_from_empty_library` + `is_eliminated`, which pins something strictly stronger: that the excess was genuinely attempted rather than silently truncated.

A stale comment claiming the count was "already resolved via the player choice mechanism in `engine_resolution_choices`" is removed — that module has exactly two `Effect::Draw` sites, both Learn's rummage `Fixed { value: 1 }`, and no draw-count mechanism.

https://claude.ai/code/session_01JSZ2G5sVMGvVPFWX7beFCH


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * “Draw up to N” effects now prompt players to choose a draw amount from zero through the maximum.
  * Choosing zero resolves the effect without drawing cards.
  * Draw choices are not limited by the current library size; attempting to draw more cards follows the game’s existing rules.

* **Tests**
  * Added coverage for draw amount choices, zero-card draws, full-library draws, and invalid overdraw attempts.

* **Documentation**
  * Updated developer documentation describing “up to” quantity handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->