### PR TITLE
fix(engine): park a spell's resolution frame beneath its child stack

### DIFF
--- a/crates/engine/src/game/engine_replacement.rs
+++ b/crates/engine/src/game/engine_replacement.rs
@@ -47,6 +47,57 @@ fn maybe_drain_each_player_copy_chosen(state: &mut GameState, events: &mut Vec<G
     }
 }
 
+/// CR 608.3a / CR 608.3c + CR 400.7d + CR 616.1f: complete a permanent spell's
+/// parked resolution frame once the child stack its own entry raised has retired.
+///
+/// The parked frame is that child's structural PARENT, so it becomes the active
+/// frame only here — after this resume's drain stages have settled. `subject` is
+/// the object whose replacement this resume answered; the frame completes only
+/// when it is that same object's, so an unrelated parked spell is never touched.
+/// `active_spell_resolution` stays top-only: this reads the frame the drain just
+/// exposed and never reaches through a live child. This function is the SINGLE
+/// settle authority for that completion — call sites add no `Priority` guard of
+/// their own.
+///
+/// This mirrors the existing completion authority at the ZoneChange Execute site
+/// below, which cannot serve the counter path: it runs before the counter drain
+/// and keys on `zone_change_object_id`, which is `None` when the resumed event is
+/// an AddCounter.
+///
+/// KNOWN RESIDUAL — do not "fix" it here (measured):
+/// On a Devour-shape entrant (CR 702.82a/c) the counter drain exposes the entry's
+/// CR 614.13a eligibility snapshot, not the parent, so this helper correctly
+/// no-ops and the entry strands exactly as it does without this change. Retiring
+/// that snapshot here removes the strand and VIOLATES CR 614.13a: the snapshot is
+/// the eligible-pool filter in `game::effects::sacrifice` (`is_none_or` — vacuous
+/// once cleared), and the sacrifice that consumes it has not run at this program
+/// point, so the devourer becomes legal fodder for its own Devour. Measured on
+/// both arms. The blocking shape is `[PostReplacement(sacrifice, Ready),
+/// SpellResolution(parent), ChangeZone(snapshot)]`, in which
+/// `ResolutionStack::active_post_replacement_parent_slot` — top, or exactly one
+/// below — cannot resolve, so neither the sacrifice nor the snapshot's own
+/// retirement authority can run while the parent sits between them. The fix is an
+/// ordering change at the capture site in `stack.rs`, not a retirement call here.
+fn finish_spell_resolution_exposed_by_child(
+    state: &mut GameState,
+    subject: Option<ObjectId>,
+    events: &mut Vec<GameEvent>,
+) {
+    if !matches!(state.waiting_for, WaitingFor::Priority { .. }) {
+        return;
+    }
+    if !state
+        .active_spell_resolution()
+        .is_some_and(|ctx| Some(ctx.object_id) == subject)
+    {
+        return;
+    }
+    let ctx = state
+        .take_active_spell_resolution()
+        .expect("matching spell-resolution frame was checked above");
+    apply_pending_spell_resolution(state, &ctx, events);
+}
+
 /// CR 614.13a + CR 702.82a/c: matches the broad as-enters shape of a Devour
 /// sacrifice replacement — a `Moved` (ETB-style) event whose post-effect is a
 /// `Sacrifice` over a `Typed`/`Any` scope filter (the chooser-driven "sacrifice
@@ -239,6 +290,16 @@ fn handle_replacement_choice_inner(
         .pending_replacement
         .as_ref()
         .and_then(|pending| pending.sacrifice_provenance);
+    // CR 122.1 + CR 616.1f: the object whose counter placement this resume answers.
+    // Captured here, with the file's other `parked_*` reads, because
+    // `continue_replacement` below consumes the pending record. The Execute arm's
+    // own `zone_change_object_id` cannot serve: it is `None` on the counter path
+    // (the Execute payload is an AddCounter event, not a ZoneChange) and it is
+    // out of scope in the Prevented arm.
+    let parked_affected_object_id = state
+        .pending_replacement
+        .as_ref()
+        .and_then(|pending| pending.proposed.affected_object_id());
     // A replacement-paused zone move belongs to its logical owner by both the
     // pre-move incarnation and the exact proposed event. Capture this before
     // `continue_replacement` consumes the pending record.
@@ -1226,6 +1287,24 @@ fn handle_replacement_choice_inner(
             // advances the typed phase owner exactly once.
             if matches!(waiting_for, WaitingFor::Priority { .. }) {
                 state.waiting_for = waiting_for;
+
+                // CR 608.3a + CR 616.1f: the parked entry context is the structural PARENT
+                // of every drain stage above. Complete it only once they have all retired
+                // and it owns the top — after the counter/batch/copy-token/continuation
+                // stages, and before the shared continuation boundary, which must not
+                // observe a frame no priority-time drain is allowed to touch.
+                //
+                // Placed AFTER the line above, deliberately: this arm reconciles
+                // `state.waiting_for` with its arm-local ONLY there, and three stages
+                // between the counter drain and this block assign a returned value
+                // straight into the arm-local (the deferred-step-trigger resume, the cost
+                // move resume, and the interrupted cost payment). Before that line the
+                // helper's `state.waiting_for` guard would be reading a value stale by up
+                // to three stages; after it, the guard reads this arm's settled
+                // authority. The helper's own guard remains the single settle authority —
+                // this call site adds none.
+                finish_spell_resolution_exposed_by_child(state, parked_affected_object_id, events);
+
                 super::engine::resume_pending_continuation_if_priority(state, events)?;
                 waiting_for = state.waiting_for.clone();
             }
@@ -1404,6 +1483,10 @@ fn handle_replacement_choice_inner(
                 // CR 101.4 + CR 616.1: resume an `EachPlayerCopyChosen` walk whose
                 // counter placement was prevented — advance to the next player.
                 maybe_drain_each_player_copy_chosen(state, events);
+                // Same position as the Execute arm's call in program terms: this block
+                // RETURNS at the next line, so "after every drain of this arm" and "here"
+                // are the same point.
+                finish_spell_resolution_exposed_by_child(state, parked_affected_object_id, events);
                 return Ok(state.waiting_for.clone());
             }
             if pending_was_counter_move {

--- a/crates/engine/src/game/stack.rs
+++ b/crates/engine/src/game/stack.rs
@@ -2029,6 +2029,12 @@ pub fn resolve_top(state: &mut GameState, events: &mut Vec<GameEvent>) {
                             else {
                                 unreachable!("matched ProposedEvent::ZoneChange above");
                             };
+                            // CR 614.1c + CR 616.1: everything this permanent spell's own entry raises
+                            // from here on is its CHILD. Record the boundary before the delivery producer
+                            // runs so the parked PendingSpellResolution is installed beneath that child
+                            // stack rather than on top of it.
+                            let entry_child_stack_start =
+                                state.resolution_stack.capture_child_boundary();
                             match zone_pipeline::deliver(
                                 state,
                                 approved,
@@ -2055,15 +2061,47 @@ pub fn resolve_top(state: &mut GameState, events: &mut Vec<GameEvent>) {
                                 // so the choice-answer resume can complete Aura
                                 // attachment / cast-link stamps — mirrors the
                                 // ReplacementResult::NeedsChoice arm below.
+                                //
+                                // CR 616.1 + CR 616.1f + CR 614.1c: the ONLY pause that
+                                // reaches this arm is the delivery tail's
+                                // enters-with-counters step, which pushed a
+                                // CounterAdditions frame onto the stack top
+                                // (`apply_etb_counters`'s pause branch). `deliver` is
+                                // called with `CallerEpilogue`, which disables
+                                // `apply_zone_delivery_tail`'s own post-replacement drain,
+                                // so every other mid-entry prompt surfaces at the caller
+                                // epilogue below instead. `active_counter_additions` is
+                                // top-only by design, so this parent must be INSERTED
+                                // BENEATH that child; pushing it on top makes every resume
+                                // drain read `None` and strands both frames until
+                                // `start_next_turn`'s CR 514.3a + CR 500.1 turn-wrap
+                                // assert.
+                                //
+                                // KNOWN RESIDUAL (deliberate): a Devour-shape entrant
+                                // (CR 702.82a/c) also has a CR 614.13a
+                                // eligibility-snapshot ChangeZone frame beneath the counter
+                                // queue, and the sacrifice that consumes that snapshot
+                                // lives in a PostReplacement frame raised by
+                                // `replace_event` ABOVE this capture — i.e. BELOW the
+                                // parked parent. The counter child still drains; the parent
+                                // is then buried under the snapshot and does not complete.
+                                // Do NOT "fix" that by retiring the snapshot from the
+                                // completion helper: the snapshot IS the eligible-pool
+                                // filter (`game/effects/sacrifice.rs`, `is_none_or`), and
+                                // retiring it early was measured to let the devourer
+                                // sacrifice itself, in violation of CR 614.13a.
                                 zone_pipeline::ZoneDeliveryResult::NeedsChoice(_) => {
-                                    state.push_spell_resolution(pending_spell_resolution_snapshot(
-                                        state,
-                                        &entry,
-                                        ability.as_deref(),
-                                        casting_variant,
-                                        actual_mana_spent,
-                                        &spell_targets,
-                                    ));
+                                    state.push_spell_resolution_after_child(
+                                        pending_spell_resolution_snapshot(
+                                            state,
+                                            &entry,
+                                            ability.as_deref(),
+                                            casting_variant,
+                                            actual_mana_spent,
+                                            &spell_targets,
+                                        ),
+                                        entry_child_stack_start,
+                                    );
                                     events.push(GameEvent::StackResolved {
                                         object_id: entry.id,
                                     });
@@ -2201,6 +2239,19 @@ pub fn resolve_top(state: &mut GameState, events: &mut Vec<GameEvent>) {
                     // `ability == None` are not silently de-kicked when a replacement
                     // needs a player choice. `engine_replacement` restores this onto
                     // the permanent unconditionally after the choice resolves.
+                    //
+                    // AUDITED (do not "fix" without a repro): this push is deliberately
+                    // plain. `replace_event`'s CR 616.1f repeat can in principle apply a
+                    // real applier before returning NeedsChoice, so a child frame is
+                    // structurally possible — but two measured fixtures reach here with
+                    // only this SpellResolution frame resident (a MayCopy enter-as-copy
+                    // spell, and a permanent carrying two self-`Moved` replacements), the
+                    // only test on this path
+                    // (`cost_zone_pipeline.rs::mimeoplasm_forced_exile_cost_resumes_after_…`)
+                    // asserts this frame owns the TOP, and `Ordering::Less` cannot be shown
+                    // unreachable across `replace_event`'s applier fan-out. Adopting
+                    // `push_spell_resolution_after_child` here needs a fixture that measures
+                    // a resident child plus its own `Less` analysis first.
                     state.push_spell_resolution(pending_spell_resolution_snapshot(
                         state,
                         &entry,
@@ -2413,6 +2464,17 @@ pub fn resolve_top(state: &mut GameState, events: &mut Vec<GameEvent>) {
             // target for the PersistChosenAttribute resume (CR 608.3c /
             // CR 303.4a). Do not push SpellResolution on top of an
             // AbilityContinuation (Tribute/Siege resume is top-only).
+            //
+            // The plain push is REQUIRED here. This is the caller epilogue's own
+            // prompt, and its answer path (`handle_persist_chosen_attribute_choice`)
+            // reads `active_spell_resolution()` — TOP-ONLY — with no preceding
+            // post-replacement dispatch retire, so this frame must own the top while
+            // the resident PostReplacement frame sits beneath it. A boundary insert
+            // would put this frame BELOW that frame, drop the CR 608.3a / CR 608.3c /
+            // CR 400.7d epilogue, and fall into the Enchant-filter consult that path
+            // explicitly forbids as a spell-path fallback (CR 303.4a). Site A above
+            // inserts beneath its child for the same reason in mirror image: there the
+            // answer path reads the CHILD top-only, here it reads the PARENT.
             if state.has_post_replacement_drain() {
                 state.clear_post_replacement_source();
                 if let Some(wf) = super::engine_replacement::apply_pending_post_replacement_effect(

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -21966,10 +21966,47 @@ impl GameState {
         self.resolution_stack.active_spell_resolution_mut()
     }
 
-    /// Parks permanent-spell completion context above the replacement choice
-    /// that suspended its entry.
+    /// Parks permanent-spell completion context as the active frame. This is the
+    /// NO-CHILD case only: a call site that follows a producer which may have
+    /// raised a resolution frame must use `push_spell_resolution_after_child`,
+    /// which parks the parent BENEATH that child stack. Pushing on top of a live
+    /// child makes every top-only resume accessor read `None` and strands both
+    /// frames.
     pub fn push_spell_resolution(&mut self, pending: PendingSpellResolution) {
         self.resolution_stack.push_spell_resolution(pending);
+    }
+
+    /// Park permanent-spell completion context beneath the complete child stack
+    /// its own delivery raised. The recorded depth is structural, not a search for
+    /// a buried parent.
+    ///
+    /// CR 616.1 / CR 616.1f + CR 614.1c: the delivery tail's enters-with-counters
+    /// step can pause on an ordering choice among applicable counter replacements,
+    /// and the queue that owns the remaining work is read TOP-ONLY. That queue is
+    /// therefore a CHILD of the resolving spell, and the CR 608.3a completion
+    /// context parked for it must never sit above it.
+    pub fn push_spell_resolution_after_child(
+        &mut self,
+        pending: PendingSpellResolution,
+        child_stack_start: ChildStackDepth,
+    ) {
+        match self
+            .resolution_stack
+            .capture_child_boundary()
+            .cmp(&child_stack_start)
+        {
+            std::cmp::Ordering::Less => {
+                panic!("spell delivery removed a parent before it could be parked")
+            }
+            std::cmp::Ordering::Equal => self.push_spell_resolution(pending),
+            std::cmp::Ordering::Greater => self
+                .resolution_stack
+                .insert_parent_at_child_boundary(
+                    super::resolution::ResolutionFrame::SpellResolution(pending),
+                    child_stack_start,
+                )
+                .expect("parked spell resolution must be inserted below its child stack"),
+        }
     }
 
     /// Consumes exactly the active permanent-spell completion context. Child

--- a/crates/engine/src/types/resolution.rs
+++ b/crates/engine/src/types/resolution.rs
@@ -2516,8 +2516,11 @@ impl ResolutionStack {
         }
     }
 
-    /// Parks permanent-spell completion context above the replacement choice
-    /// that suspended its entry.
+    /// Parks permanent-spell completion context on the stack TOP. Callers that
+    /// follow a producer which may have raised a child frame must go through
+    /// `GameState::push_spell_resolution_after_child` instead, which inserts the
+    /// parent at the recorded child boundary; a parent above its own live child
+    /// makes every top-only resume accessor read `None`.
     pub fn push_spell_resolution(&mut self, pending: PendingSpellResolution) {
         self.push_inner(ResolutionFrame::SpellResolution(pending));
     }

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -1102,6 +1102,7 @@ mod spark_double_as_enters;
 mod spear_of_bashenga_attacks_monarch_5249;
 mod special_action_x_runtime;
 mod specialize_runtime;
+mod spell_resolution_child_boundary;
 mod spellstutter_sprite_counter_with_x;
 mod spelunking_shockland_order;
 mod sphinx_of_uthuun_etb_pile_separation;

--- a/crates/engine/tests/integration/spell_resolution_child_boundary.rs
+++ b/crates/engine/tests/integration/spell_resolution_child_boundary.rs
@@ -1,0 +1,474 @@
+//! CR 616.1 / CR 616.1f + CR 608.3a: a permanent spell whose Stack→Battlefield
+//! delivery pauses on an enters-with-counters ordering choice must park its
+//! `PendingSpellResolution` BENEATH the `CounterAdditions` child that pause
+//! raised — never on top of it.
+//!
+//! `active_counter_additions()` is top-only by design, so a parent pushed above
+//! its own live child makes every resume drain in `engine_replacement`'s Execute
+//! and Prevented arms read `None`. Both frames then survive the turn and
+//! `start_next_turn` trips its CR 514.3a + CR 500.1 wrap assert.
+//!
+//! Goes RED if the site-A boundary insert in `game/stack.rs` is reverted to the
+//! plain `push_spell_resolution` (Test 1, Test 4), or if the completion helper's
+//! call sites in `game/engine_replacement.rs` are removed (Test 2).
+
+use engine::game::scenario::{GameRunner, GameScenario, P0};
+use engine::types::ability::{Effect, TargetFilter};
+use engine::types::actions::GameAction;
+use engine::types::counter::CounterType;
+use engine::types::game_state::{GameState, WaitingFor};
+use engine::types::identifiers::ObjectId;
+use engine::types::mana::{ManaCost, ManaCostShard, ManaType, ManaUnit};
+use engine::types::phase::Phase;
+use engine::types::replacements::ReplacementEvent;
+use engine::types::zones::Zone;
+
+// Verbatim Oracle text (Scryfall `cards/named?exact=`). Paraphrases can take a
+// different parser branch and go green while the real card stays broken.
+const REYHAN: &str = "Reyhan enters with three +1/+1 counters on it.\nWhenever a creature you control dies or is put into the command zone, if it had one or more +1/+1 counters on it, you may put that many +1/+1 counters on target creature.\nPartner";
+const OZOLITH: &str = "If one or more +1/+1 counters would be put on an artifact or creature you control, that many plus one +1/+1 counters are put on it instead.";
+const CORPSEJACK: &str = "If one or more +1/+1 counters would be put on a creature you control, twice that many +1/+1 counters are put on it instead.";
+const HARDENED: &str = "If one or more +1/+1 counters would be put on a creature you control, that many plus one +1/+1 counters are put on it instead.";
+const VELOCIPEDE: &str = "Trample\nEach other Vehicle and creature you control enters with an additional +1/+1 counter on it if its mana value is 4 or less. Otherwise, it enters with three additional +1/+1 counters on it.\nCrew 3";
+const THRINAX: &str = "Devour 1 (As this creature enters, you may sacrifice any number of creatures. It enters with that many +1/+1 counters on it.)\nEach other creature you control enters with an additional X +1/+1 counters on it, where X is the number of +1/+1 counters on this creature.";
+
+/// Six units, enough for Reyhan's `{1}{B}{G}` and Bloodspore Thrinax's
+/// `{2}{G}{G}` without staging a mana-payment sub-prompt.
+fn stage_mana(scenario: &mut GameScenario) {
+    scenario.with_mana_pool(
+        P0,
+        vec![
+            ManaUnit::new(ManaType::Green, ObjectId(9_990), false, vec![]),
+            ManaUnit::new(ManaType::Green, ObjectId(9_991), false, vec![]),
+            ManaUnit::new(ManaType::Blue, ObjectId(9_992), false, vec![]),
+            ManaUnit::new(ManaType::Blue, ObjectId(9_993), false, vec![]),
+            ManaUnit::new(ManaType::Blue, ObjectId(9_994), false, vec![]),
+            ManaUnit::new(ManaType::Black, ObjectId(9_995), false, vec![]),
+        ],
+    );
+}
+
+/// The depth-1 fixture: Reyhan (CR 614.1c, enters with three +1/+1 counters)
+/// cast into an ADDITIVE (Ozolith) x MULTIPLICATIVE (Corpsejack Menace) pair.
+/// The two classes do not commute, so CR 616.1 raises a real ordering choice
+/// rather than auto-resolving a degenerate one.
+fn depth_one_fixture() -> (GameRunner, ObjectId) {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.add_artifact_from_oracle(P0, "Ozolith, the Shattered Spire", OZOLITH);
+    scenario.add_creature_from_oracle(P0, "Corpsejack Menace", 4, 4, CORPSEJACK);
+    let reyhan = scenario
+        .add_creature_to_hand_from_oracle(P0, "Reyhan, Last of the Abzan", 0, 0, REYHAN)
+        .id();
+    stage_mana(&mut scenario);
+    (scenario.build(), reyhan)
+}
+
+fn plus_counters(state: &GameState, object: ObjectId) -> u32 {
+    state
+        .objects
+        .get(&object)
+        .and_then(|obj| obj.counters.get(&CounterType::Plus1Plus1).copied())
+        .unwrap_or(0)
+}
+
+fn frame_kinds(state: &GameState) -> Vec<String> {
+    state
+        .resolution_stack
+        .iter()
+        .map(|frame| format!("{:?}", frame.kind()))
+        .collect()
+}
+
+#[test]
+fn parked_spell_resolution_sits_beneath_its_etb_counter_child() {
+    let (mut runner, reyhan) = depth_one_fixture();
+    let outcome = runner.cast(reyhan).resolve();
+    let state = outcome.state();
+
+    // Paired positive reach-guards, asserted BEFORE the discriminating claim: a
+    // fixture that never raised the prompt would make the claim vacuously false
+    // on both sides of the fix.
+    assert!(
+        matches!(
+            outcome.final_waiting_for(),
+            WaitingFor::ReplacementChoice { .. }
+        ),
+        "CR 616.1 ordering prompt must be open — an Additive+Multiplicative pair is \
+         order-material; got {:?}",
+        outcome.final_waiting_for()
+    );
+    assert!(
+        state.resolution_stack.len() >= 2,
+        "both the parked parent and its ETB-counter child must be resident; frames={:?}",
+        frame_kinds(state)
+    );
+
+    // The discriminating assertions: RED with the site-A boundary insert
+    // reverted to the plain push, GREEN with it.
+    assert!(
+        state.active_counter_additions().is_some(),
+        "the ETB-counter child must own the resolution-stack top while the CR 616.1 \
+         ordering choice is open; a SpellResolution parent above it makes every resume \
+         drain read None (engine_replacement.rs Execute/Prevented arms); frames={:?}",
+        frame_kinds(state)
+    );
+    // `active_spell_resolution` is TOP-ONLY: `None` means "does not own the top",
+    // never "has been completed". That is exactly the claim here, and it is
+    // paired with the positive read above on the same instant.
+    assert!(
+        state.active_spell_resolution().is_none(),
+        "the parked parent must NOT own the top; frames={:?}",
+        frame_kinds(state)
+    );
+}
+
+/// Answers the CR 616.1 prompt with `index`, then reads the state that action
+/// returned. Returns `(resolution_stack_len, counters_on_reyhan)`.
+///
+/// The read must be IMMEDIATE: a `PassPriority` first would let
+/// `sweep_and_recover_priority_boundary_rest`'s live funnel consume a `len == 1`
+/// residual and silently drop the CR 608.3a epilogue, turning this test green
+/// against the very bug it guards.
+fn answer_ordering_choice(index: usize) -> (usize, u32, Vec<String>, WaitingFor) {
+    let (mut runner, reyhan) = depth_one_fixture();
+    let outcome = runner.cast(reyhan).resolve();
+    assert!(
+        matches!(
+            outcome.final_waiting_for(),
+            WaitingFor::ReplacementChoice { .. }
+        ),
+        "reach-guard: the CR 616.1 ordering prompt must be open before it can be answered"
+    );
+
+    runner
+        .act(GameAction::ChooseReplacement { index })
+        .expect("answering the CR 616.1 ordering choice must be a legal action");
+
+    let state = runner.state();
+    (
+        state.resolution_stack.len(),
+        plus_counters(state, reyhan),
+        frame_kinds(state),
+        state.waiting_for.clone(),
+    )
+}
+
+#[test]
+fn answering_the_etb_counter_ordering_choice_drains_the_resolution_stack() {
+    let (len_first, counters_first, frames_first, waiting_first) = answer_ordering_choice(0);
+    let (len_second, counters_second, frames_second, waiting_second) = answer_ordering_choice(1);
+
+    // The revert-failing assertion: without the completion helper's call sites a
+    // lone `SpellResolution` frame is left resident (`len == 1`).
+    assert_eq!(
+        len_first, 0,
+        "both frames must retire once the choice is answered; frames={frames_first:?}"
+    );
+    assert_eq!(
+        len_second, 0,
+        "both frames must retire once the choice is answered; frames={frames_second:?}"
+    );
+    assert!(matches!(waiting_first, WaitingFor::Priority { .. }));
+    assert!(matches!(waiting_second, WaitingFor::Priority { .. }));
+
+    // CR 616.1f order-materiality — this doubles as the multi-authority hostile
+    // fixture: two competing replacement authorities on one event whose answer
+    // is order-dependent. Equal totals would mean the fixture is NOT
+    // order-material and the prompt above was reached for the wrong reason.
+    assert_ne!(
+        counters_first, counters_second,
+        "the two orderings must produce different totals, or the fixture is not \
+         order-material and Test 1's prompt was reached for the wrong reason"
+    );
+    assert_eq!(
+        counters_first, 8,
+        "Ozolith applied first: (3 + 1) * 2 under the CR 616.1f repeat"
+    );
+    assert_eq!(
+        counters_second, 7,
+        "Corpsejack Menace applied first: 3 * 2 + 1 under the CR 616.1f repeat"
+    );
+}
+
+/// Drives the real phase pipeline across the turn boundary. `advance_to_phase`
+/// cannot be used: it breaks the moment `waiting_for` is not `Priority`, which a
+/// `DeclareAttackers` window is, producing a silent no-advance that reads as
+/// "no panic".
+fn wrap_the_turn(runner: &mut GameRunner) {
+    let start_turn = runner.state().turn_number;
+    for step in 0..200 {
+        if runner.state().turn_number > start_turn {
+            return;
+        }
+        let action = match &runner.state().waiting_for {
+            WaitingFor::Priority { .. } => GameAction::PassPriority,
+            WaitingFor::DeclareAttackers { .. } => GameAction::DeclareAttackers {
+                attacks: vec![],
+                bands: vec![],
+            },
+            WaitingFor::DeclareBlockers { .. } => GameAction::DeclareBlockers {
+                assignments: vec![],
+            },
+            other => panic!("turn wrap stuck at {other:?} (step {step})"),
+        };
+        runner
+            .act(action)
+            .unwrap_or_else(|err| panic!("turn wrap action refused at step {step}: {err:?}"));
+    }
+    panic!("turn wrap loop exhausted without advancing the turn");
+}
+
+#[test]
+fn turn_boundary_after_a_paused_etb_counter_entry_does_not_strand_the_resolution_stack() {
+    let (mut runner, reyhan) = depth_one_fixture();
+    let outcome = runner.cast(reyhan).resolve();
+    assert!(
+        matches!(
+            outcome.final_waiting_for(),
+            WaitingFor::ReplacementChoice { .. }
+        ),
+        "reach-guard: the CR 616.1 ordering prompt must be open"
+    );
+    runner
+        .act(GameAction::ChooseReplacement { index: 0 })
+        .expect("answering the CR 616.1 ordering choice must be a legal action");
+
+    let start_turn = runner.state().turn_number;
+    // CR 514.3a + CR 500.1: on unpatched `main` this reaches `start_next_turn`'s
+    // assert with a non-empty resolution stack.
+    wrap_the_turn(&mut runner);
+    assert!(
+        runner.state().turn_number > start_turn,
+        "reach-guard: the turn must actually have advanced before the verdict is read"
+    );
+    assert!(
+        runner.state().resolution_stack.is_empty(),
+        "the resolution stack must not survive the turn wrap; frames={:?}",
+        frame_kinds(runner.state())
+    );
+}
+
+#[test]
+fn devour_entrant_parks_its_resolution_frame_beneath_its_whole_child_stack() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.add_artifact_from_oracle(P0, "Thunderous Velocipede", VELOCIPEDE);
+    scenario.add_creature_from_oracle(P0, "Corpsejack Menace", 4, 4, CORPSEJACK);
+    scenario.add_enchantment_from_oracle(P0, "Hardened Scales", HARDENED);
+    // The intended Devour victim — not the only legal one, and nothing here
+    // depends on the pool's membership because the choice is never answered.
+    scenario.add_creature(P0, "Grizzly Bears", 2, 2);
+    let thrinax = {
+        let mut builder = scenario.add_creature_to_hand(P0, "Bloodspore Thrinax", 2, 2);
+        // The keyword hint MUST be the colon form: `Keyword`'s `FromStr` splits
+        // on `:`, and the space form yields no synthesized `Moved` + `Sacrifice`
+        // replacement — the fixture would silently degrade to the depth-1 shape
+        // and every assertion below would pass for the wrong reason.
+        builder.from_oracle_text_with_keywords(&["devour:1"], THRINAX);
+        builder.with_mana_cost(ManaCost::Cost {
+            generic: 2,
+            shards: vec![ManaCostShard::Green, ManaCostShard::Green],
+        });
+        builder.id()
+    };
+    stage_mana(&mut scenario);
+    let mut runner = scenario.build();
+
+    // Positive reach-guards, asserted BEFORE the claim. Keyed on all three of
+    // event / valid_card / a Sacrifice execute, so the `valid_card` sibling the
+    // degraded fixture keeps cannot satisfy it. `iter_all` is `pub(crate)`;
+    // `iter_unchecked` is the public equivalent.
+    assert!(
+        runner.state().objects[&thrinax]
+            .replacement_definitions
+            .iter_unchecked()
+            .any(|def| def.event == ReplacementEvent::Moved
+                && def.valid_card == Some(TargetFilter::SelfRef)
+                && def
+                    .execute
+                    .as_ref()
+                    .is_some_and(|ability| matches!(*ability.effect, Effect::Sacrifice { .. }))),
+        "synthesize_devour must have produced the CR 702.82a as-enters sacrifice \
+         replacement — a fixture without it degrades to the ordinary depth-1 shape"
+    );
+
+    let outcome = runner.cast(thrinax).resolve();
+    let state = outcome.state();
+    assert!(
+        matches!(
+            outcome.final_waiting_for(),
+            WaitingFor::ReplacementChoice { .. }
+        ),
+        "reach-guard: the CR 616.1 ordering prompt must be open; got {:?}",
+        outcome.final_waiting_for()
+    );
+
+    // The discriminating claim at depth 3: the boundary insert is
+    // depth-agnostic — the parent parks beneath its WHOLE child stack, not just
+    // beneath a single child.
+    assert!(
+        state.resolution_stack.len() >= 3,
+        "the Devour snapshot frame and the counter child must BOTH be resident above \
+         the parent; frames={:?}",
+        frame_kinds(state)
+    );
+    assert!(
+        state.active_counter_additions().is_some(),
+        "the counter child must own the top at depth 3, exactly as at depth 1 — the \
+         boundary insert is depth-agnostic; frames={:?}",
+        frame_kinds(state)
+    );
+    assert!(
+        state.active_spell_resolution().is_none(),
+        "the parked parent must NOT own the top; frames={:?}",
+        frame_kinds(state)
+    );
+
+    // This test deliberately STOPS before answering the choice. Answering it
+    // reaches a deferred residual: the counter child retires, the parent is left
+    // buried beneath the still-live CR 614.13a Devour eligibility snapshot, and
+    // the turn wrap panics — the same panic `main` produces, with one fewer
+    // stranded frame and the counter work completed. Do not extend this test
+    // past this point without re-measuring.
+}
+
+#[test]
+fn two_additive_counter_replacements_commute_and_raise_no_ordering_choice() {
+    // Negative sibling: Ozolith (+1) and Hardened Scales (+1) are both ADDITIVE,
+    // so `CommuteClass::commutes_with` returns true, CR 616.1 is degenerate, and
+    // the choice auto-resolves. Proves the pause in Test 1 is genuinely
+    // CR 616.1-gated rather than raised by any two applicable replacements.
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.add_artifact_from_oracle(P0, "Ozolith, the Shattered Spire", OZOLITH);
+    scenario.add_enchantment_from_oracle(P0, "Hardened Scales", HARDENED);
+    let reyhan = scenario
+        .add_creature_to_hand_from_oracle(P0, "Reyhan, Last of the Abzan", 0, 0, REYHAN)
+        .id();
+    stage_mana(&mut scenario);
+    let mut runner = scenario.build();
+    let outcome = runner.cast(reyhan).resolve();
+    let state = outcome.state();
+
+    assert!(
+        matches!(state.waiting_for, WaitingFor::Priority { .. }),
+        "two commuting Additive replacements must not raise a CR 616.1 prompt; got {:?}",
+        state.waiting_for
+    );
+    assert!(
+        state.resolution_stack.is_empty(),
+        "no pause means no parked frame; frames={:?}",
+        frame_kinds(state)
+    );
+    assert_eq!(
+        plus_counters(state, reyhan),
+        5,
+        "CR 614.1c three counters, then +1 and +1 in either order"
+    );
+}
+
+#[test]
+fn a_single_counter_replacement_authority_raises_no_ordering_choice() {
+    // Single authority: `candidates.len() == 1` and non-optional, so there is
+    // nothing to order and no pause.
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.add_artifact_from_oracle(P0, "Ozolith, the Shattered Spire", OZOLITH);
+    let reyhan = scenario
+        .add_creature_to_hand_from_oracle(P0, "Reyhan, Last of the Abzan", 0, 0, REYHAN)
+        .id();
+    stage_mana(&mut scenario);
+    let mut runner = scenario.build();
+    let outcome = runner.cast(reyhan).resolve();
+    let state = outcome.state();
+
+    assert!(matches!(state.waiting_for, WaitingFor::Priority { .. }));
+    assert!(
+        state.resolution_stack.is_empty(),
+        "frames={:?}",
+        frame_kinds(state)
+    );
+    assert_eq!(plus_counters(state, reyhan), 4, "3 + 1");
+}
+
+#[test]
+fn a_permanent_spell_that_raises_no_child_still_resolves_and_drains() {
+    // No child raised at all: a vanilla creature has no enters-with-counters
+    // replacement, so the delivery tail never pauses, site A is never reached,
+    // and the resolution stack must be empty on both sides of the fix. The
+    // direct guard that the site-A change is inert on entries that do not pause.
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.add_artifact_from_oracle(P0, "Ozolith, the Shattered Spire", OZOLITH);
+    scenario.add_creature_from_oracle(P0, "Corpsejack Menace", 4, 4, CORPSEJACK);
+    let bears = {
+        let mut builder = scenario.add_creature_to_hand(P0, "Grizzly Bears", 2, 2);
+        builder.with_mana_cost(ManaCost::Cost {
+            generic: 1,
+            shards: vec![ManaCostShard::Green],
+        });
+        builder.id()
+    };
+    stage_mana(&mut scenario);
+    let mut runner = scenario.build();
+    let outcome = runner.cast(bears).resolve();
+    let state = outcome.state();
+
+    assert!(matches!(state.waiting_for, WaitingFor::Priority { .. }));
+    outcome.assert_zone(&[bears], Zone::Battlefield);
+    assert!(
+        state.resolution_stack.is_empty(),
+        "an entry that raises no child must leave nothing parked; frames={:?}",
+        frame_kinds(state)
+    );
+    assert_eq!(
+        plus_counters(state, bears),
+        0,
+        "no enters-with-counters replacement means the doublers never fire"
+    );
+}
+
+#[test]
+fn an_out_of_range_ordering_answer_is_refused_and_leaves_the_frames_nested() {
+    // Empty / decline path: the answer is rejected before any drain runs, so the
+    // prompt stays open and both frames stay resident in the CORRECTED order —
+    // the parent still beneath its child, nothing stranded.
+    let (mut runner, reyhan) = depth_one_fixture();
+    let outcome = runner.cast(reyhan).resolve();
+    let candidate_count = match outcome.final_waiting_for() {
+        WaitingFor::ReplacementChoice {
+            candidate_count, ..
+        } => *candidate_count,
+        other => panic!("reach-guard: the CR 616.1 ordering prompt must be open; got {other:?}"),
+    };
+    assert!(
+        candidate_count >= 2,
+        "an ordering choice needs two candidates"
+    );
+
+    let refused = runner.act(GameAction::ChooseReplacement {
+        index: candidate_count,
+    });
+    assert!(
+        refused.is_err(),
+        "an out-of-range replacement index must be refused"
+    );
+
+    let state = runner.state();
+    assert!(
+        matches!(state.waiting_for, WaitingFor::ReplacementChoice { .. }),
+        "the prompt must still be open after a refused answer; got {:?}",
+        state.waiting_for
+    );
+    assert!(
+        state.active_counter_additions().is_some(),
+        "the child must still own the top; frames={:?}",
+        frame_kinds(state)
+    );
+    assert!(
+        state.active_spell_resolution().is_none(),
+        "the parent must still be parked beneath it; frames={:?}",
+        frame_kinds(state)
+    );
+}


### PR DESCRIPTION
Fixes the production `turns.rs:1114` panic from the turn-7 crash bundle (game `6e72ddac-c6be-4966-86a5-c18ef1c261e8`, build v0.74.0 / 73bd9bd, diagnostic tag `ai-getAction-panic`).

## The defect

A permanent spell whose ETB counter replacement raises a CR 616.1 ordering choice parked its `SpellResolution` frame **above** the `CounterAdditions` child its own delivery had just raised. `active_counter_additions()` is top-only by design — *"a buried counter queue is a parent dependency, never a fallback"* — so every resume drain in `engine_replacement.rs` read `None`, the `ContinueZoneDeliveryTail` post-action never fired, both frames stranded, and the Cleanup→Untap wrap tripped the `start_next_turn` assert.

`stack.rs`'s `ZoneDeliveryResult::NeedsChoice` arm called `push_spell_resolution` — an unconditional top push — immediately after `zone_pipeline` parked the child. The parent landed on top of its own live dependency.

## The fix

Adds `GameState::push_spell_resolution_after_child`, modelled on the shipped `push_change_zone_iteration_after_child` with the same three-way `Ordering` dispatch; captures the child boundary immediately before `zone_pipeline::deliver`; routes that one site through it; and completes the exposed parent from both arms of `handle_replacement_choice_inner` via a new `finish_spell_resolution_exposed_by_child`.

Sites B and C keep the plain push. **Site C requires it** — its answer path `handle_persist_chosen_attribute_choice` reads `active_spell_resolution()` top-only. The unifying rule both rest on: *the frame that the answer path reads top-only must own the top.*

The completion call sits inside the settle block **after** `state.waiting_for = waiting_for;`. Before that assignment `state.waiting_for` is unreconciled — three stages in the arm assign a returned value into the arm-local without writing state — so the guard would read a stale value. It still precedes `resume_pending_continuation_if_priority`, whose tail runs unconditionally and whose settle predicate requires `active_spell_resolution().is_none()`.

## Evidence the tests are load-bearing

Both negative controls were run and restored byte-exact (delta SHA256 re-matched).

**C1** — site A restored to the plain push, everything else intact → `5 passed; 3 failed`:

| test | frames observed |
|---|---|
| `parked_spell_resolution_sits_beneath_its_etb_counter_child` | `["CounterAdditions", "SpellResolution"]` |
| `devour_entrant_parks_its_resolution_frame_beneath_its_whole_child_stack` | `["PostReplacement", "ChangeZone", "CounterAdditions", "SpellResolution"]` |
| `an_out_of_range_ordering_answer_is_refused_and_leaves_the_frames_nested` | `["CounterAdditions", "SpellResolution"]` |

**C2** — both helper call sites removed → `7 passed; 1 failed`, residual `["SpellResolution"]`, `left: 1 / right: 0`.

## Verification

`clippy --all-targets -D warnings` exit 0 · integration suite `6242 passed; 0 failed; 3 ignored` · `check-resolution-frame-boundaries.sh` PASS · `cargo fmt --check` clean · CR-annotation gate clean across 13 numbers.

> **Local-only note:** an unfiltered `cargo test` on macOS aarch64 aborts (`stack overflow` / SIGABRT / exit 101) in `game_state_stack_budget::four_player_commander_action_fits_a_bounded_stack`, printing **no** `test result:` line and **zero** `FAILED` lines. That test is `#![cfg(all(target_arch = "aarch64", target_os = "macos"))]`, so CI never compiles it. I confirmed it is pre-existing by running it at the base commit with this change absent — identical abort.

## Deferred, with a filed issue

The depth-3 Devour composite still strands (same panic as `main`, one fewer frame, and the CR 616.1f counter work now completes — strictly less lost work). It is a three-frame deadlock, not a missing call: `active_post_replacement_parent_slot` reaches the top or exactly one frame below, so with the parent in the middle nothing can act. Full analysis, the rejected remedies and the discriminating assertion a future author needs are in **#8561** and verbatim in the commit body.

## Reviewer notes — disclosed from implementation review, non-blocking

- **The Prevented-arm call site ships unexercised.** C2 turns red only through the Execute arm. Reviewed by reading: it sits inside `if state.active_counter_additions().is_some()` which `return`s, so it cannot pre-empt the CR 608.3e graveyard fallback.
- **Subject derivation is broader than its comment says.** `pending.proposed.affected_object_id()` resolves an object for ~15 `ProposedEvent` kinds, not just `AddCounter`, so the helper can fire for any replacement event affecting the same object as a top-resident `SpellResolution` frame. On such shapes the frame previously survived to `recover_orphaned_spell_resolution_at_priority_boundary`, which takes it **without** running the CR 608.3a/608.3c/400.7d epilogue — so the epilogue now runs where it was formerly dropped. Plausibly a fix; flagged because it is a scope widening beyond the counter path and no test covers it.
- The wrapper's `Equal` and `Less` arms are uncovered; `Less` is a deliberate invariant `panic!` mirroring the shipped sibling.

https://claude.ai/code/session_01BamYUbga2PkJ3hH6MpWJFy


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed permanent spell resolutions that pause for enters-with-counters choices, ensuring choices resolve in the correct order before the spell completes.
  * Improved nested resolution handling so paused prompts resume reliably without leaving stale state.
  * Corrected control tracking for spells whose controller changes while they remain on the stack.
  * Invalid choices are rejected without disrupting active resolution.
  * Resolutions remain stable across turn transitions and when no applicable replacement effects exist.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->