### PR TITLE
ci(release): raise the Build WASM + Frontend job timeout to 120 minutes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,10 +82,11 @@ jobs:
     needs: [resolve-release-ref]
     runs-on: ubuntu-latest
     # Card-data generation grows with the card/deck corpus: this job hit 28m for
-    # v0.4.0 and crossed the prior 30m ceiling for v0.5.0 (killed mid-frontend
-    # build, stranding the release). Raised to 60m for headroom — the ceiling
-    # only bills the failure case, so a normal ~30m run still ends at ~30m.
-    timeout-minutes: 60
+    # v0.4.0, crossed the prior 30m ceiling for v0.5.0, and crossed 60m for
+    # v0.75.0 (card data 22m, WASM 14m, frontend 8m; killed twice mid-upload,
+    # stranding the release). Raised to 120m for headroom — the ceiling only
+    # bills the failure case, so a normal run still ends at its own length.
+    timeout-minutes: 120
     outputs:
       card_data_sha256: ${{ steps.card-data-hash.outputs.card_data_sha256 }}
       card_data_hash16: ${{ steps.card-data-hash.outputs.hash }}


### PR DESCRIPTION
## Summary

Raises the `Build WASM + Frontend` job's `timeout-minutes` in `release.yml` from 60 to 120 and updates the comment that records why the ceiling sits where it does.

Measured cause: the v0.75.0 release run ([33968333691](https://github.com/phase-rs/phase/actions/runs/33968333691)) was cancelled at the 60-minute ceiling twice — attempt 1 on the tag push (job 13:19:32→14:19:23Z, killed during the frontend build) and attempt 2 on a re-run of the failed jobs (14:27→15:27:26Z, killed during the R2 upload steps after the frontend build finished at 15:26:49Z). Step times were identical across both attempts and are not runner variance:

| step | v0.74.0 run | v0.75.0 (both attempts) |
|---|---|---|
| Generate card data and coverage report | 12m | 22m |
| Generate draft pools + locale card-art maps | cached | 6m + 3–5m |
| Build WASM | 11m | 14m |
| Build frontend | 6m | 7–8m |
| whole job | 34m | ≈62m |

Doubling follows the previous bump in this file (30 → 60); the ceiling only bills the failure case. The 10-minute growth of card-data generation between v0.74.0 and v0.75.0 and the draft-pool / art-map cache misses are worth their own look but are not changed here.

Effect: the new ceiling applies from the next tag. A recovery dispatch of `release.yml` runs from the tag's own ref, so v0.75.0 stays partial (server image and lobby Worker published; GitHub release, web image, and Pages deploy skipped) until the next release supersedes it.

`.github/workflows/**` is a hard-stop path under `.agents/pr-review-policy.toml`. This change was directed by the repository account owner (lgray); it is opened for maintainer review and no auto-merge is requested.

## Files changed

- `.github/workflows/release.yml` — `build-wasm` job: `timeout-minutes: 60` → `120`, comment updated (+2/−1 lines net in the comment, one value change).

## Track

Developer

## LLM

Model: claude-fable-5-1
Tier: Frontier
Thinking: high

## Implementation method (required)

Method: not-applicable — CI workflow configuration change; no engine code, parser, or tests touched.

## CR references

None.

## Verification

- [x] Required checks ran clean, or the exact CI-owned alternative is stated below.
- [x] Gate A output below is for the current committed head.
- [x] Final review-impl below is clean for the current committed head.
- [x] Both anchors cite existing analogous code at the same seam.

- `.githooks/pre-commit` at head `24c05eff7` — Gate A PASS, Gate G PASS, Gate P PASS, `check-cr-citation-anchors.sh` PASS (workflow-only diff; the workflow itself is exercised by the next tag push).
- Job step durations above read from `gh api repos/phase-rs/phase/actions/jobs/{101312533408,101321423933}` (attempts 1 and 2) and the v0.74.0 run's job.

## Gate A

Gate A PASS head=24c05eff7dc5a92e861f4ba1ed95dd6a3b73752f base=d6d28370c09242182488cac72e16e5a84941885f

## Anchored on

- .github/workflows/release.yml:84 — the existing comment recording the 30 → 60 bump and its rationale (same job, same seam)
- .github/workflows/release.yml:876 — another job in this file carrying an explicit `timeout-minutes` ceiling

## Final review-impl

not-applicable — one-value workflow configuration change; the review surface is the diff.

## Claimed parse impact

None.

## Scope Expansion

None.

## Validation Failures

None.

## CI Failures

None.
