### PR TITLE
test(engine): shorten the slowest test drives

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -26,8 +26,11 @@ slow-timeout = { period = "60s", terminate-after = 4 }
 # that witness (the first evicting beat, index 72) rather than at its 120-beat cap. Its cost is
 # `apply()` itself: the drive already takes the priority fast path, so the only beats still
 # paying an enumeration are the non-priority windows, and there is no test-side reduction left.
-# It lands past the 240s kill on a hosted runner sharing the box with three other test threads
-# (PR #8301, shard 2/4).
+# Alone on an idle machine it runs about 112s; a CI shard runs it beside three other test
+# threads, and there it landed past the 240s kill (PR #8301, shard 2/4). Re-time it alone before
+# assuming this override is still earned:
+#   cargo nextest run -p phase-engine \
+#     -E 'test(=loop_shortcut::an_evicting_beat_mints_without_growing_the_ring)'
 #
 # What this override does and nothing more: it raises the hard kill for this one test to ten
 # 60s periods. The test stays in the 60s slow-warn population, which is the signal to keep.

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -21,14 +21,16 @@ fail-fast = false
 fail-fast = false
 slow-timeout = { period = "60s", terminate-after = 4 }
 
-# `loop_shortcut::an_evicting_beat_mints_without_growing_the_ring` drives 120
-# beats of a four-player Commander dump through production `apply()` until the
-# loop-detect ring reaches capacity. Measured at ~140s on an M-series laptop
-# with a warm cache (both on main and on a branch, so it is the drive, not a
-# regression), it lands past the 240s kill on a hosted runner sharing the box
-# with three other test threads (PR #8301, shard 2/4). Give that one drive the
-# room it needs instead of letting it fail unrelated PRs at the threshold; the
-# hang guard stays in force for everything else.
+# `loop_shortcut::an_evicting_beat_mints_without_growing_the_ring` drives a four-player
+# Commander dump through production `apply()` until the loop-detect ring evicts, stopping at
+# that witness (the first evicting beat, index 72) rather than at its 120-beat cap. Its cost is
+# `apply()` itself: the drive already takes the priority fast path, so the only beats still
+# paying an enumeration are the non-priority windows, and there is no test-side reduction left.
+# It lands past the 240s kill on a hosted runner sharing the box with three other test threads
+# (PR #8301, shard 2/4).
+#
+# What this override does and nothing more: it raises the hard kill for this one test to ten
+# 60s periods. The test stays in the 60s slow-warn population, which is the signal to keep.
 [[profile.ci.overrides]]
 filter = 'test(=loop_shortcut::an_evicting_beat_mints_without_growing_the_ring)'
 slow-timeout = { period = "60s", terminate-after = 10 }

--- a/crates/engine/src/ai_support/swarm.rs
+++ b/crates/engine/src/ai_support/swarm.rs
@@ -545,3 +545,40 @@ fn player_life(state: &GameState, player: PlayerId) -> i32 {
         .find(|candidate| candidate.id == player)
         .map_or(0, |candidate| candidate.life)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::identifiers::ObjectId;
+    use std::collections::HashMap;
+
+    /// The refusal is `count > SWARM_WITNESS_MAX_DECLARATIONS`, so a product landing exactly on
+    /// the cap is affordable and must be admitted. The integration fixture only exercises a
+    /// product above the bound, which a `>=` here would still refuse — leaving which side of the
+    /// comparison the boundary falls on unpinned.
+    #[test]
+    fn the_declaration_cap_is_admitted_and_only_the_count_past_it_is_refused() {
+        let blocker = ObjectId(1);
+        // Each blocker contributes `legal targets + 1`, the +1 being "does not block".
+        let product_with = |choices: usize| {
+            let targets = HashMap::from([(
+                blocker,
+                (0..choices)
+                    .map(|i| ObjectId(i as u64 + 2))
+                    .collect::<Vec<_>>(),
+            )]);
+            checked_declaration_product(&[blocker], &targets)
+        };
+
+        assert_eq!(
+            product_with(SWARM_WITNESS_MAX_DECLARATIONS - 1),
+            Some(SWARM_WITNESS_MAX_DECLARATIONS),
+            "a declaration product equal to the cap is affordable and must be admitted"
+        );
+        assert_eq!(
+            product_with(SWARM_WITNESS_MAX_DECLARATIONS),
+            None,
+            "one declaration past the cap must be refused"
+        );
+    }
+}

--- a/crates/engine/src/analysis/resource.rs
+++ b/crates/engine/src/analysis/resource.rs
@@ -7597,13 +7597,16 @@ mod tests {
         use crate::types::actions::GameAction;
         use crate::types::game_state::WaitingFor;
 
-        // CR 117.3d: at a priority window this policy always passes, so dispatch the pass
-        // instead of enumerating the whole per-viewer candidate set to find it. The gate is the
-        // enumerator's own hatch predicate, so this arm stays inside the subset that hatch
-        // asserts equivalent to a simulated pass; every other shape falls through below.
+        // CR 117.3d: at a priority window this policy always passes, so dispatch the pass instead
+        // of enumerating the whole per-viewer candidate set to find it. This reproduces both halves
+        // of the enumerator's hatch — its structural predicate and the submitter identity it
+        // authorizes (CR 723.5) — so this arm stays inside the subset that hatch asserts equivalent
+        // to a simulated pass; every other shape falls through below.
         if let WaitingFor::Priority { player } = state.waiting_for {
             if crate::game::priority::pass_priority_structurally_legal(state, player) {
-                return crate::game::engine::apply(state, player, GameAction::PassPriority)
+                let actor =
+                    crate::game::turn_control::authorized_submitter_for_player(state, player);
+                return crate::game::engine::apply(state, actor, GameAction::PassPriority)
                     .map(|_| ())
                     .map_err(|e| format!("apply err (PassPriority): {e:?}"));
             }

--- a/crates/engine/src/analysis/resource.rs
+++ b/crates/engine/src/analysis/resource.rs
@@ -7639,7 +7639,8 @@ mod tests {
         let Some(action) = chosen.cloned() else {
             return Err(format!("empty action list at {:?}", state.waiting_for));
         };
-        crate::game::engine::apply(state, who, action.clone())
+        let actor = crate::game::turn_control::authorized_submitter_for_player(state, who);
+        crate::game::engine::apply(state, actor, action.clone())
             .map(|_| ())
             .map_err(|e| format!("apply err ({action:?}): {e:?}"))
     }

--- a/crates/engine/src/analysis/resource.rs
+++ b/crates/engine/src/analysis/resource.rs
@@ -7597,6 +7597,17 @@ mod tests {
         use crate::types::actions::GameAction;
         use crate::types::game_state::WaitingFor;
 
+        // CR 117.3d: at a priority window this policy always passes, so dispatch the pass
+        // instead of enumerating the whole per-viewer candidate set to find it. The gate is the
+        // enumerator's own hatch predicate, so this arm stays inside the subset that hatch
+        // asserts equivalent to a simulated pass; every other shape falls through below.
+        if let WaitingFor::Priority { player } = state.waiting_for {
+            if crate::game::priority::pass_priority_structurally_legal(state, player) {
+                return crate::game::engine::apply(state, player, GameAction::PassPriority)
+                    .map(|_| ())
+                    .map_err(|e| format!("apply err (PassPriority): {e:?}"));
+            }
+        }
         let actor = state
             .waiting_for
             .acting_player()
@@ -18316,46 +18327,7 @@ mod tests {
     #[test]
     fn drawgo_turn_structure_yields_no_basis_b_signature() {
         use crate::game::scenario::GameScenario;
-        use crate::types::actions::GameAction;
-        use crate::types::game_state::{LoopDetectionMode, WaitingFor};
-
-        /// One beat of the shared dump drive policy (`tests/integration/loop_shortcut.rs`'s
-        /// `dump_drive_one_beat`): at `Priority` always pass — the mandatory triggers resolve
-        /// and re-trigger, which IS the loop when there is one — and otherwise take the first
-        /// legal non-terminal action.
-        fn drive_one_beat(state: &mut GameState) -> Result<(), String> {
-            let actor = state
-                .waiting_for
-                .acting_player()
-                .into_iter()
-                .chain(state.players.iter().map(|p| p.id))
-                .find_map(|p| {
-                    let (actions, _costs, _grouped) =
-                        crate::ai_support::legal_actions_for_viewer(state, p);
-                    (!actions.is_empty()).then_some((p, actions))
-                });
-            let Some((who, actions)) = actor else {
-                return Err(format!("no legal actor at {:?}", state.waiting_for));
-            };
-            let forbidden =
-                |a: &GameAction| matches!(a, GameAction::Concede { .. } | GameAction::Debug(_));
-            let chosen = if matches!(state.waiting_for, WaitingFor::Priority { .. }) {
-                actions
-                    .iter()
-                    .find(|a| matches!(a, GameAction::PassPriority))
-            } else {
-                actions
-                    .iter()
-                    .find(|a| !matches!(a, GameAction::PassPriority) && !forbidden(a))
-                    .or_else(|| actions.iter().find(|a| !forbidden(a)))
-            };
-            let Some(action) = chosen.cloned() else {
-                return Err(format!("empty action list at {:?}", state.waiting_for));
-            };
-            crate::game::engine::apply(state, who, action.clone())
-                .map(|_| ())
-                .map_err(|e| format!("apply err ({action:?}): {e:?}"))
-        }
+        use crate::types::game_state::LoopDetectionMode;
 
         let mut scenario = GameScenario::new_n_player(2, 7);
         scenario.at_phase(Phase::PreCombatMain);
@@ -18440,7 +18412,7 @@ mod tests {
                     flattened_some += 1;
                 }
             }
-            if drive_one_beat(&mut state).is_err() {
+            if dump_drive_one_beat(&mut state).is_err() {
                 break;
             }
         }

--- a/crates/engine/tests/integration/fantastic_four_bounded_loop.rs
+++ b/crates/engine/tests/integration/fantastic_four_bounded_loop.rs
@@ -316,6 +316,25 @@ fn drive_f4_to_offer_at(state: &mut GameState, cap: u32, seat: PlayerId) -> Opti
     None
 }
 
+/// The tracked F4 dump driven to its bounded offer once per process, handed out as an owned
+/// clone. Nextest runs one test per process, so this collapses the repeated identical drives
+/// INSIDE a test and shares nothing across tests.
+///
+/// Eligible only where the pre-drive board is the unmodified fixture and the drive takes the
+/// default seat and cap: a case that edits the board first, drives at another seat or cap, or
+/// wants a second INDEPENDENT execution of the drive, loads and drives its own. Callers pass the
+/// clone straight to `f4_allocation_offer`, whose drive then finds the offer already standing and
+/// returns at beat 0.
+fn f4_at_offer() -> GameState {
+    static MEMO: std::sync::OnceLock<GameState> = std::sync::OnceLock::new();
+    MEMO.get_or_init(|| {
+        let mut state = load_f4();
+        drive_f4_to_offer(&mut state, 400).expect("the bounded offer fires (see R1)");
+        state
+    })
+    .clone()
+}
+
 fn offer_parts(
     state: &GameState,
 ) -> (
@@ -5890,7 +5909,7 @@ fn p4_row_1b_an_authored_non_canonical_distribution_is_accepted() {
 
     // ── (a) UNEQUAL PARTS over all three victims ──
     {
-        let mut state = load_f4();
+        let mut state = f4_at_offer();
         let offer = f4_allocation_offer(&mut state);
         let count = offer.max_count;
         assert!(
@@ -5922,7 +5941,7 @@ fn p4_row_1b_an_authored_non_canonical_distribution_is_accepted() {
 
     // ── (b) A PROPER SUBSET omitting the PRE-ANNOUNCED seat ──
     {
-        let mut state = load_f4();
+        let mut state = f4_at_offer();
         let offer = f4_allocation_offer(&mut state);
         let count = offer.max_count;
         let declared: Vec<PlayerId> = offer
@@ -5972,7 +5991,7 @@ fn p4_row_1b_an_authored_non_canonical_distribution_is_accepted() {
     // exception does not excuse. Without it the conjunct ranges over the empty set across the
     // whole matrix: row (1) declares every victim, and arm (b)'s only omission is excused.
     {
-        let mut state = load_f4();
+        let mut state = f4_at_offer();
         let offer = f4_allocation_offer(&mut state);
         let count = offer.max_count;
         let omitted = *offer
@@ -6019,7 +6038,7 @@ fn p4_row_1b_an_authored_non_canonical_distribution_is_accepted() {
 
     // The omitted seat's zero in (c) is an AXIS, not a dead reading: the same seat reads a
     // strictly positive loss under row (1)'s allocation on the same board.
-    let mut control = load_f4();
+    let mut control = f4_at_offer();
     let control_offer = f4_allocation_offer(&mut control);
     assert_eq!(
         control_offer.max_count, count_probe,
@@ -6076,7 +6095,7 @@ fn p4_row_1b_an_authored_non_canonical_distribution_is_accepted() {
 #[test]
 fn p4_row_1c_a_segment_starting_at_the_last_index_realizes_nothing_but_stays_announced() {
     let drive = |allocation_of: &dyn Fn(&F4Allocation) -> Vec<(PlayerId, u32)>| {
-        let mut state = load_f4();
+        let mut state = f4_at_offer();
         let offer = f4_allocation_offer(&mut state);
         let count = offer.max_count;
         let allocation = allocation_of(&offer);
@@ -7227,7 +7246,7 @@ fn the_responders_element_agrees_with_the_producers_other_two_call_sites() {
 
     // ── MAIN LEG: the proposer's own preview of this declaration, through `preview_interaction`,
     //    the responder's published element for the same declaration.
-    let mut state = load_f4();
+    let mut state = f4_at_offer();
     let offer = f4_allocation_offer(&mut state);
     let allocation: Vec<(PlayerId, u32)> =
         offer.legal_seats.iter().copied().zip(SEGMENTS).collect();
@@ -7285,7 +7304,7 @@ fn the_responders_element_agrees_with_the_producers_other_two_call_sites() {
 
     // ── SECOND LEG: when the declaration IS the canonical split at a count the offer publishes
     //    an element for, the responder's element agrees with THAT element too.
-    let mut canonical_state = load_f4();
+    let mut canonical_state = f4_at_offer();
     let canonical_offer = f4_allocation_offer(&mut canonical_state);
     let sampled = canonical_offer
         .published_preview

--- a/crates/engine/tests/integration/fantastic_four_bounded_loop.rs
+++ b/crates/engine/tests/integration/fantastic_four_bounded_loop.rs
@@ -252,12 +252,14 @@ fn f4_drive_one_beat(state: &mut GameState) -> Result<(), String> {
 
 fn f4_drive_one_beat_at(state: &mut GameState, seat: PlayerId) -> Result<(), String> {
     // CR 117.3d: at a priority window this policy always passes, so dispatch the pass instead of
-    // enumerating the whole per-viewer candidate set to find it. The gate is the enumerator's own
-    // hatch predicate, so this arm stays inside the subset that hatch asserts equivalent to a
-    // simulated pass; every other shape falls through to the enumerating path below.
+    // enumerating the whole per-viewer candidate set to find it. This reproduces both halves of the
+    // enumerator's hatch — its structural predicate and the submitter identity it authorizes (CR
+    // 723.5) — so this arm stays inside the subset that hatch asserts equivalent to a simulated
+    // pass; every other shape falls through to the enumerating path below.
     if let WaitingFor::Priority { player } = state.waiting_for {
         if engine::game::priority::pass_priority_structurally_legal(state, player) {
-            return apply(state, player, GameAction::PassPriority)
+            let actor = engine::game::turn_control::authorized_submitter_for_player(state, player);
+            return apply(state, actor, GameAction::PassPriority)
                 .map(|_| ())
                 .map_err(|e| format!("apply err (PassPriority): {e:?}"));
         }

--- a/crates/engine/tests/integration/fantastic_four_bounded_loop.rs
+++ b/crates/engine/tests/integration/fantastic_four_bounded_loop.rs
@@ -251,6 +251,17 @@ fn f4_drive_one_beat(state: &mut GameState) -> Result<(), String> {
 }
 
 fn f4_drive_one_beat_at(state: &mut GameState, seat: PlayerId) -> Result<(), String> {
+    // CR 117.3d: at a priority window this policy always passes, so dispatch the pass instead of
+    // enumerating the whole per-viewer candidate set to find it. The gate is the enumerator's own
+    // hatch predicate, so this arm stays inside the subset that hatch asserts equivalent to a
+    // simulated pass; every other shape falls through to the enumerating path below.
+    if let WaitingFor::Priority { player } = state.waiting_for {
+        if engine::game::priority::pass_priority_structurally_legal(state, player) {
+            return apply(state, player, GameAction::PassPriority)
+                .map(|_| ())
+                .map_err(|e| format!("apply err (PassPriority): {e:?}"));
+        }
+    }
     let who = state
         .waiting_for
         .acting_player()

--- a/crates/engine/tests/integration/fantastic_four_bounded_loop.rs
+++ b/crates/engine/tests/integration/fantastic_four_bounded_loop.rs
@@ -253,9 +253,9 @@ fn f4_drive_one_beat(state: &mut GameState) -> Result<(), String> {
 fn f4_drive_one_beat_at(state: &mut GameState, seat: PlayerId) -> Result<(), String> {
     // CR 117.3d: at a priority window this policy always passes, so dispatch the pass instead of
     // enumerating the whole per-viewer candidate set to find it. This reproduces both halves of the
-    // enumerator's hatch — its structural predicate and the submitter identity it authorizes (CR
-    // 723.5) — so this arm stays inside the subset that hatch asserts equivalent to a simulated
-    // pass; every other shape falls through to the enumerating path below.
+    // enumerator's hatch — its structural predicate and the submitter identity it authorizes
+    // (CR 723.5) — so this arm stays inside the subset that hatch asserts equivalent to a
+    // simulated pass; every other shape falls through to the enumerating path below.
     if let WaitingFor::Priority { player } = state.waiting_for {
         if engine::game::priority::pass_priority_structurally_legal(state, player) {
             let actor = engine::game::turn_control::authorized_submitter_for_player(state, player);
@@ -296,7 +296,8 @@ fn f4_drive_one_beat_at(state: &mut GameState, seat: PlayerId) -> Result<(), Str
             state.waiting_for
         )
     })?;
-    apply(state, who, action.clone())
+    let actor = engine::game::turn_control::authorized_submitter_for_player(state, who);
+    apply(state, actor, action.clone())
         .map(|_| ())
         .map_err(|e| format!("apply err ({action:?}): {e:?}"))
 }

--- a/crates/engine/tests/integration/loop_counter_growth.rs
+++ b/crates/engine/tests/integration/loop_counter_growth.rs
@@ -76,6 +76,12 @@ fn setup_2p_optional_charge_growth(mode: LoopDetectionMode) -> (GameRunner, Obje
     (runner, kickoff, engine_creature)
 }
 
+/// Beats driven before this fixture is taken to be non-marking. The floor is the beat at
+/// which the Interactive sibling marks; the same fixture is driven to this same cap there
+/// and asserted to mark, so that test passing is what holds this bound. Beyond one full
+/// loop period the cascade repeats, so extra beats observe nothing new.
+const MARK_SEARCH_BEATS: usize = 200;
+
 /// Drive `PassPriority`/`OrderTriggers` beats, collecting every emitted event, until
 /// `controller`'s revocable-∞ capability is marked (Path C is a SILENT mark — it never
 /// changes `waiting_for`, so callers poll `unbounded_resources` directly). Returns the
@@ -123,7 +129,7 @@ fn live_optional_charge_growth_marks_counter_advantage_no_gameover() {
         setup_2p_optional_charge_growth(LoopDetectionMode::Interactive);
     let _ = runner.cast(kickoff).resolve();
 
-    let (events, marked) = drive_until_marked_collecting(&mut runner, P0, 500);
+    let (events, marked) = drive_until_marked_collecting(&mut runner, P0, MARK_SEARCH_BEATS);
     assert!(
         marked,
         "the optional charge-growth cascade must reach the Path-C revocable-∞ mark \
@@ -184,7 +190,7 @@ fn live_charge_growth_off_never_marks() {
 
     // Drive a bounded number of beats; Off must never mark, and (being a beneficial
     // no-loss loop) must never reach a GameOver.
-    let (events, marked) = drive_until_marked_collecting(&mut runner, P0, 500);
+    let (events, marked) = drive_until_marked_collecting(&mut runner, P0, MARK_SEARCH_BEATS);
     assert!(
         !marked,
         "Off must never mark a revocable-∞ capability (Interactive-only, #4603)"

--- a/crates/engine/tests/integration/loop_shortcut.rs
+++ b/crates/engine/tests/integration/loop_shortcut.rs
@@ -7028,13 +7028,15 @@ fn dump_drive_one_beat(
     pin: Option<PlayerId>,
 ) -> Result<Vec<GameEvent>, String> {
     // CR 117.3d: at a priority window this policy always passes, so dispatch the pass instead of
-    // enumerating the whole per-viewer candidate set to find it — on the 152-entry `dellian`
-    // stack that scan is a real per-beat cost. The gate is the enumerator's own hatch predicate,
-    // so this arm stays inside the subset that hatch asserts equivalent to a simulated pass;
-    // every other shape falls through to the enumerating path below.
+    // enumerating the whole per-viewer candidate set to find it — on the 152-entry `dellian` stack
+    // that scan is a real per-beat cost. This reproduces both halves of the enumerator's hatch —
+    // its structural predicate and the submitter identity it authorizes (CR 723.5) — so this arm
+    // stays inside the subset that hatch asserts equivalent to a simulated pass; every other shape
+    // falls through to the enumerating path below.
     if let WaitingFor::Priority { player } = state.waiting_for {
         if engine::game::priority::pass_priority_structurally_legal(state, player) {
-            return apply(state, player, GameAction::PassPriority)
+            let actor = engine::game::turn_control::authorized_submitter_for_player(state, player);
+            return apply(state, actor, GameAction::PassPriority)
                 .map(|r| r.events)
                 .map_err(|e| format!("apply err (PassPriority): {e:?}"));
         }

--- a/crates/engine/tests/integration/loop_shortcut.rs
+++ b/crates/engine/tests/integration/loop_shortcut.rs
@@ -7067,7 +7067,8 @@ fn dump_drive_one_beat(
     let Some(action) = chosen else {
         return Err(format!("empty action list at {:?}", state.waiting_for));
     };
-    apply(state, who, action.clone())
+    let actor = engine::game::turn_control::authorized_submitter_for_player(state, who);
+    apply(state, actor, action.clone())
         .map(|r| r.events)
         .map_err(|e| format!("apply err ({action:?}): {e:?}"))
 }
@@ -7848,7 +7849,8 @@ fn combat_drive_one_beat(state: &mut GameState) -> Result<Vec<GameEvent>, String
                 .filter(|(n, _)| *n > 0)
                 .map(|(_, a)| a.clone());
             if let Some(action) = biggest {
-                return apply(state, who, action.clone())
+                let actor = engine::game::turn_control::authorized_submitter_for_player(state, who);
+                return apply(state, actor, action.clone())
                     .map(|r| r.events)
                     .map_err(|e| format!("apply err ({action:?}): {e:?}"));
             }

--- a/crates/engine/tests/integration/loop_shortcut.rs
+++ b/crates/engine/tests/integration/loop_shortcut.rs
@@ -7027,6 +7027,18 @@ fn dump_drive_one_beat(
     state: &mut GameState,
     pin: Option<PlayerId>,
 ) -> Result<Vec<GameEvent>, String> {
+    // CR 117.3d: at a priority window this policy always passes, so dispatch the pass instead of
+    // enumerating the whole per-viewer candidate set to find it — on the 152-entry `dellian`
+    // stack that scan is a real per-beat cost. The gate is the enumerator's own hatch predicate,
+    // so this arm stays inside the subset that hatch asserts equivalent to a simulated pass;
+    // every other shape falls through to the enumerating path below.
+    if let WaitingFor::Priority { player } = state.waiting_for {
+        if engine::game::priority::pass_priority_structurally_legal(state, player) {
+            return apply(state, player, GameAction::PassPriority)
+                .map(|r| r.events)
+                .map_err(|e| format!("apply err (PassPriority): {e:?}"));
+        }
+    }
     let Some((who, actions)) = dump_beat_actor(state) else {
         return Err(format!("no legal actor at {:?}", state.waiting_for));
     };
@@ -14171,21 +14183,6 @@ fn ring_membership_delta<'a, T>(
     (minted, dropped)
 }
 
-/// `dump_drive_one_beat`'s policy with its `Priority` arm taken directly. That policy is
-/// unconditionally "pass" at a `Priority` window, so routing through the enumerator costs a full
-/// per-viewer candidate scan — on the 152-entry `dellian` stack, the dominant cost of a long
-/// drive — only to find the `PassPriority` the policy already chose. `apply` performs the real
-/// legality check itself (`game::priority::pass_priority_legality`), so nothing is skipped but
-/// the enumeration. Every other window still goes through the shared driver unchanged.
-fn drive_one_beat_passing_fast(state: &mut GameState, pin: Option<PlayerId>) -> Result<(), String> {
-    if let WaitingFor::Priority { player } = state.waiting_for {
-        return apply(state, player, GameAction::PassPriority)
-            .map(|_| ())
-            .map_err(|e| format!("pass err: {e:?}"));
-    }
-    dump_drive_one_beat(state, pin).map(|_| ())
-}
-
 /// CR 732.2a. ROUTE ⓔ — EVICTION AT `LOOP_DETECT_RING_CAP`: a beat that MINTS WITHOUT GROWING.
 ///
 /// `answer_beat_frames_carry_the_synced_window_and_the_offer_certificate_is_exact` reads a beat's
@@ -14238,7 +14235,7 @@ fn an_evicting_beat_mints_without_growing_the_ring() {
             break;
         }
         let before: Vec<_> = state.loop_detect_ring.iter().cloned().collect();
-        if drive_one_beat_passing_fast(&mut state, pin).is_err() {
+        if dump_drive_one_beat(&mut state, pin).is_err() {
             break;
         }
         beats_run = beat + 1;
@@ -14354,7 +14351,7 @@ fn a_clearing_beat_rebuilds_the_ring_inside_the_same_beat() {
             .map(|_| ())
             .map_err(|e| format!("resolve-all err: {e:?}"))
         } else {
-            drive_one_beat_passing_fast(&mut state, pin)
+            dump_drive_one_beat(&mut state, pin).map(|_| ())
         };
         if outcome.is_err() {
             break;

--- a/crates/engine/tests/integration/user_capture_probes.rs
+++ b/crates/engine/tests/integration/user_capture_probes.rs
@@ -149,14 +149,16 @@ struct MintFrame {
 /// The Dina chain opens no player choices, so no preference ordering is needed.
 fn dina_drive_one_beat(state: &mut GameState) -> Result<String, String> {
     // CR 117.3d: at a priority window this policy always passes, so dispatch the pass instead of
-    // enumerating the whole per-viewer candidate set to find it. The gate is the enumerator's own
-    // hatch predicate, so this arm stays inside the subset that hatch asserts equivalent to a
-    // simulated pass; every other shape falls through to the enumerating path below.
+    // enumerating the whole per-viewer candidate set to find it. This reproduces both halves of the
+    // enumerator's hatch — its structural predicate and the submitter identity it authorizes (CR
+    // 723.5) — so this arm stays inside the subset that hatch asserts equivalent to a simulated
+    // pass; every other shape falls through to the enumerating path below.
     if let WaitingFor::Priority { player } = state.waiting_for {
         if engine::game::priority::pass_priority_structurally_legal(state, player) {
             let action = GameAction::PassPriority;
             let label = format!("{action:?}");
-            return apply(state, player, action)
+            let actor = engine::game::turn_control::authorized_submitter_for_player(state, player);
+            return apply(state, actor, action)
                 .map(|_| label)
                 .map_err(|e| format!("apply err (PassPriority): {e:?}"));
         }

--- a/crates/engine/tests/integration/user_capture_probes.rs
+++ b/crates/engine/tests/integration/user_capture_probes.rs
@@ -150,9 +150,9 @@ struct MintFrame {
 fn dina_drive_one_beat(state: &mut GameState) -> Result<String, String> {
     // CR 117.3d: at a priority window this policy always passes, so dispatch the pass instead of
     // enumerating the whole per-viewer candidate set to find it. This reproduces both halves of the
-    // enumerator's hatch — its structural predicate and the submitter identity it authorizes (CR
-    // 723.5) — so this arm stays inside the subset that hatch asserts equivalent to a simulated
-    // pass; every other shape falls through to the enumerating path below.
+    // enumerator's hatch — its structural predicate and the submitter identity it authorizes
+    // (CR 723.5) — so this arm stays inside the subset that hatch asserts equivalent to a
+    // simulated pass; every other shape falls through to the enumerating path below.
     if let WaitingFor::Priority { player } = state.waiting_for {
         if engine::game::priority::pass_priority_structurally_legal(state, player) {
             let action = GameAction::PassPriority;
@@ -189,7 +189,8 @@ fn dina_drive_one_beat(state: &mut GameState) -> Result<String, String> {
         )
     })?;
     let label = format!("{action:?}");
-    apply(state, who, action.clone())
+    let actor = engine::game::turn_control::authorized_submitter_for_player(state, who);
+    apply(state, actor, action.clone())
         .map(|_| label)
         .map_err(|e| format!("apply err ({action:?}): {e:?}"))
 }

--- a/crates/engine/tests/integration/user_capture_probes.rs
+++ b/crates/engine/tests/integration/user_capture_probes.rs
@@ -148,6 +148,19 @@ struct MintFrame {
 /// Generic mandatory-chain beat: pass at `Priority`, otherwise take the first legal action.
 /// The Dina chain opens no player choices, so no preference ordering is needed.
 fn dina_drive_one_beat(state: &mut GameState) -> Result<String, String> {
+    // CR 117.3d: at a priority window this policy always passes, so dispatch the pass instead of
+    // enumerating the whole per-viewer candidate set to find it. The gate is the enumerator's own
+    // hatch predicate, so this arm stays inside the subset that hatch asserts equivalent to a
+    // simulated pass; every other shape falls through to the enumerating path below.
+    if let WaitingFor::Priority { player } = state.waiting_for {
+        if engine::game::priority::pass_priority_structurally_legal(state, player) {
+            let action = GameAction::PassPriority;
+            let label = format!("{action:?}");
+            return apply(state, player, action)
+                .map(|_| label)
+                .map_err(|e| format!("apply err (PassPriority): {e:?}"));
+        }
+    }
     let who = state
         .waiting_for
         .acting_player()


### PR DESCRIPTION
## Summary

Four test drivers rebuilt the engine's whole per-viewer candidate set on every beat only to pick
`PassPriority` out of it. One integration file re-drove the same four-player board to the same
fixture state once per test in it. One detector test drove 500 beats to assert something its own
sibling settles far earlier. None of that work is load-bearing, and all of it sits on the
critical path of the slowest tests in the suite.

Each unit reduces a *counted* quantity — enumerations avoided, drives not repeated, beats not
driven past the point where the two modes being compared can still differ. Wall clock is
reported afterwards with the load it was measured under, never as the claim, because membership
in a 60-second slow list is a function of machine load as much as of the test.

This change originally also rebuilt the swarm declaration-cap fixture, the CI timeout that was
blocking the merge queue. #8553 landed a better fix for that first — it derives the fixture size
from the exported cap constant instead of hardcoding one, so it tracks a future cap change — and
that unit is dropped here rather than rebased over the top of it. One thing #8553 leaves open is
kept: the cap refuses on `count > MAX`, so a product landing exactly *on* the cap is affordable,
and nothing pinned which side of that comparison the boundary falls on.

## Files changed

- `crates/engine/tests/integration/fantastic_four_bounded_loop.rs` — process-scoped memo for the
  driven board, plus a priority fast path in its driver
- `crates/engine/tests/integration/loop_shortcut.rs` — priority fast path; a duplicate driver deleted
- `crates/engine/tests/integration/user_capture_probes.rs` — priority fast path
- `crates/engine/src/analysis/resource.rs` — priority fast path; a byte-duplicate nested driver deleted
- `crates/engine/tests/integration/loop_counter_growth.rs` — the two charge-growth tests share one
  named beat cap instead of a hardcoded 500
- `crates/engine/src/ai_support/swarm.rs` — one inline unit test pinning the cap boundary
- `.config/nextest.toml` — justification restated on the one existing override; no value changed

## Track

Developer

## LLM

Model: claude-opus-5
Tier: Frontier
Thinking: high

## Implementation method (required)

Method: /engine-implementer

## CR references

Two added, each verified against `docs/MagicCompRules.txt` with its subject checked, not just its
existence:

- `CR 117.3d` — "If a player has priority and chooses not to take any actions, that player
  passes." This is the subject of the priority fast path: the driver's policy always passes, so it
  dispatches the pass rather than enumerating the candidate set to find it.
- `CR 723.5` — "While controlling another player, a player makes all choices and decisions the
  controlled player is allowed to make." This is the subject of the submitter identity that fast
  path resolves: under a controlled turn, the seat holding priority and the player authorized to
  submit for it are different players.

## Verification

- [x] Required checks ran clean, or the exact CI-owned alternative is stated below.
- [x] Gate A output below is for the current committed head.
- [x] Final review-impl below is clean for the current committed head.
- [x] Both anchors cite existing analogous code at the same seam.

- `cargo fmt --all -- --check` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean (exit 0)
- `cargo nextest run --workspace` — 30914 passed, 47 skipped, 0 failed
- `./scripts/check-parser-combinators.sh` — Gate A PASS, Gate G PASS
- `./scripts/check-cr-citation-anchors.sh` — PASS (exit 0), 3557 files walked, 67590 citing lines read, 0 matched

No parser file is in scope: the change touches four test files, two engine modules, and one
config comment.

## Gate A

Gate A PASS head=cd1672da939d605ed205b32449c8ba6308331d97 base=d6d28370c09242182488cac72e16e5a84941885f

No file under `crates/engine/src/parser/` is in scope, so this PASS is reported for what it is:
the gate ran over its usual population and this change put nothing into it.

## Anchored on

- `crates/engine/src/game/priority.rs` and `crates/engine/src/game/turn_control.rs` — the
  enumerator's hatch is a conjunction of `pass_priority_structurally_legal` and an actor equal to
  `authorized_submitter_for_player`, which is also the authority `apply` itself enforces through
  `check_actor_authorization`. The fast arm resolves both halves, so it stays inside the subset
  that hatch already asserts equivalent to a simulated pass
- `crates/engine/tests/integration/pass_priority_structural_legality.rs` — `accept_tally` and
  `pass_and_expect_ok` already resolve the submitter this way; the fast arms follow that precedent
  rather than inventing one

## Singletons

Ten slow-list members sit outside the modules the cluster change touches. Each was profiled
in isolation before anything was touched (`--test-threads 1`, load
recorded per run), against the figure the original whole-workspace enumeration produced for
it:

| test | enumerated | isolated |
|---|---|---|
| `adapter_contract_fixtures::shortcut_allocation_submission_fixture_matches_curated_client_contract` | 60.2s | 14.7s |
| `commander_driver_cap_beyond_one_batch_exercises_remaining_arithmetic` | 93.0s | 48.9s |
| `community_ai_scenarios_choose_expected_action_type` | 179.1s | 21.0s |
| `game::effects::token::tests::no_catalog_preset_leaks_the_placeholder_into_unparsed_lines` | 65.5s | 12.8s |
| `kiora_self_library_peek_cast::unbounded_resolution_window_casts_past_the_former_255_cap` | 154.2s | 42.5s |
| `loop_counter_growth::live_charge_growth_off_never_marks` | 143.2s | 51.9s |
| `policies::tests::sac_outlet_drain_repro::the_covers_class_still_activates_with_or_without_search` | 112.4s | 21.5s |
| `policies::tests::sac_outlet_drain_repro::the_covers_class_stops_when_an_opponent_takes_the_payoff` | 165.5s | 30.9s |
| `token_storm_scaling_gate::token_storm_declare_attackers_gate` | 60.5s | 21.1s |
| `wba_loop_firewall_interposition::departure_observing_triggers_keep_the_veto` | 63.6s | 22.6s |

Every one is under the 60s threshold in isolation. The enumerated figures were produced by a
30688-test parallel run, and membership at a wall-clock threshold under that much concurrency
is a function of load as much as of the test — so eight of these ten have no drive worth
shortening, and shaving their own work would move their loaded time very little. That is not
a claim that they are harmless: CI's kill is wall time under CI's load, and this repo has
already had a 240s kill fire. It is a claim about which lever moves them, and the lever is
total concurrent load, which is what the cluster change above reduces.

Two have real drive cost, and only one of those can be shortened without deleting what it
tests:

- `unbounded_resolution_window_casts_past_the_former_255_cap` drives 256 casts through the
  production re-offer path over a 258-card pool. The iteration count *is* the assertion — the
  test exists to cross `u8::MAX`, where the old `try_into().unwrap_or(u8::MAX)` truncated. Any
  shrink below 256 removes the guard. Left alone.
- `live_charge_growth_off_never_marks` is the one changed here. It asserts the Off detector
  never marks, so it never returns early and always burns its full beat cap, while its
  Interactive sibling on the identical fixture returns as soon as the mark lands. Both now
  share one named cap, so the Interactive test — same fixture, same cap, asserting it *does*
  mark — is what holds the bound: a cap below the mark point fails there rather than quietly
  weakening the Off assertion.

## Final review-impl

Final review-impl PASS head=3facd83f5c41e8c2bc5f51c7505d1ec80ce590aa

The tip is `cd1672da9`. The two commits since that reviewed head are the repair the third
round asked for and one commit-message correction — no other content. CI gates the tip.

Three rounds. Each returned something the previous one had missed, and the code is clean as it
now stands.

The first, against the pre-rebase head, found that the four priority fast arms gated on
`pass_priority_structurally_legal` alone while the enumerator's hatch is a conjunction that also
pins the actor to `authorized_submitter_for_player`. Under a controlled turn those are different
players, so the arm would return `WrongPlayer` beside a comment claiming it stayed inside the
hatch's subset.

The second read the delta and returned no code findings; its two findings were false statements
in commit bodies, corrected in the messages before the tip was pushed, because a squash-merge
carries those verbatim onto `main`.

The third read the reshape and found the first round's repair had been declared complete too
early: it mapped each driver's fast arm but left the fallback path submitting the seat it had
enumerated for, so two of the four drivers still failed the same way one line further down. That
is fixed by resolving the submitter at every `apply` in these drivers rather than reasoning per
driver about whether a seat scan happens to land on the right player. The same round found
`CR 723.5` had wrapped as `(CR` / `723.5)` in two comments, which hides it from the
`grep -rn "CR \d"` lookup the annotation convention names; both are rewrapped.

## Where the slow list stands

The opening enumeration of this work found 57 tests over the 60-second threshold. **I am not
reporting a figure against it, because the comparison does not survive its own conditions.**
Three whole-workspace runs of the same command now exist:

| run | tests | load at start | wall | over 60s |
|---|---|---|---|---|
| the opening enumeration | 30688 | not recorded | — | 57 |
| after the cluster change | 30855 | 4.61 / 8.29 / 11.00 | 725.2s | 21 |
| this tree | 30914 | 16.00 / 23.41 / 41.19 | 934.0s | 33 |

The last two differ by 12 tests on a threshold, and by a 29% difference in total wall clock at
three to four times the load. Nothing between them makes a test slower: the swarm fixture is
faster on `main` than it was, and the only drive this change shortened left the list. The count
moved because the machine did. Reporting 57 → 21 would have been picking the friendlier of two
runs of the same code.

What the run does establish, load-independently:

- **30914 passed, 47 skipped, 0 failed.** That is the gate, and it does not move with load.
- The three tests this change touches are **not on the list**, in the higher-loaded of the two
  runs, which makes that conservative: `live_charge_growth_off_never_marks` (the drive shortened
  here), `swarm_witness_caps_before_enumerating_many_flying_attackers` (fixed on `main` by #8553),
  and the new `the_declaration_cap_is_admitted_and_only_the_count_past_it_is_refused`.
- The per-test isolated figures in the table above are the load-robust evidence, and the one
  drive changed here went 51.9s to 11.0s measured that way — the second reading taken at *four
  times* the load of the first.

Threshold membership across runs is not a usable metric for this work. Per-test isolated timing
is, which is why the singleton table above is stated that way and why nothing here is claimed
from a count of the slow list.

## Claimed parse impact

None. No parser code is touched.

## Scope Expansion

Narrowed, not expanded. The swarm fixture unit that opened this change is dropped because #8553
fixed the same test first and fixed it better. The only thing carried out of it is a boundary
this repository did not otherwise test, and it is carried as one inline unit test on
`checked_declaration_product` rather than as a second integration fixture — reaching that
boundary through combat would mean enumerating the whole 4096-declaration product just to assert
it was permitted, which is the opposite of what this change is for.

## Validation Failures

None.

## CI Failures

None in this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved handling of priority windows for faster action processing and reduced unnecessary action evaluation.

* **Bug Fixes**
  * Improved action submission validation by consistently using the authorized submitter.
  * Corrected a rules reference in test documentation.

* **Tests**
  * Expanded coverage for declaration limits, bounded loops, resource analysis, and priority handling.
  * Reused prepared test scenarios to make integration checks more efficient and consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->