### PR TITLE
fix(ai): cfg-gate the Unix-only `link` binding in ai_gate's symlink test

### DIFF
--- a/crates/phase-ai/src/bin/ai_gate.rs
+++ b/crates/phase-ai/src/bin/ai_gate.rs
@@ -625,6 +625,13 @@ mod tests {
         std::fs::create_dir_all(&dir).expect("scratch dir");
         let real = dir.join("baseline.json");
         std::fs::write(&real, "{}").expect("write");
+        // Every consumer of this path — the `symlink()` call below and both
+        // assertions in the `#[cfg(unix)]` block — is itself Unix-only, so an
+        // unconditional binding is an unused variable on Windows and `-D
+        // warnings` rejects it. Gate the binding alongside its uses rather than
+        // silencing it with a leading underscore, which would hide a genuinely
+        // dead binding if the Unix arms were ever removed.
+        #[cfg(unix)]
         let link = dir.join("link.json");
         #[cfg(unix)]
         std::os::unix::fs::symlink(&real, &link).expect("symlink");


### PR DESCRIPTION
## Summary

`same_file_sees_through_a_symlink` in `crates/phase-ai/src/bin/ai_gate.rs` binds `let link = dir.join("link.json")` unconditionally, but **every** consumer of it is Unix-only — the `symlink()` call and both assertions sit inside `#[cfg(unix)]` blocks. On Windows those uses compile out while the binding remains, so it is an unused variable, and `-D warnings` promotes it to a hard error:

```
error: unused variable: `link`
   --> crates\phase-ai\src\bin\ai_gate.rs:628:13
    |
628 |         let link = dir.join("link.json");
    |             ^^^^ help: if this is intentional, prefix it with an underscore: `_link`
    |
    = note: `-D unused-variables` implied by `-D warnings`
```

CI runs lint on `ubuntu-latest` only, so this never shows up in CI — it just breaks `cargo clippy` for anyone developing on Windows.

## Fix

Gate the binding alongside its uses:

```rust
#[cfg(unix)]
let link = dir.join("link.json");
```

Deliberately **not** `_link`: the underscore would silence the lint but would also hide a genuinely dead binding if the Unix arms were ever removed. Gating states the actual invariant — this path exists only where symlinks do.

The Unix code path is byte-identical, so behavior on Linux and macOS is unchanged.

## Verification

Measured on Windows, on this crate, before and after:

| | `cargo clippy -p phase-ai --bins --tests -- -D warnings` |
|---|---|
| `main` as-is | **exit 101** — `error: unused variable: link` at `ai_gate.rs:628` |
| with this fix | **exit 0**, clean |

`cargo fmt -p phase-ai` clean. The test's assertions are Unix-only, so they are unaffected by construction; this changes only whether the file compiles on Windows.

## Context

Split out of #8551, where it had been included as an unrelated drive-by fix. Originally introduced in f070cde60. That PR now contains only its own mechanic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cross-platform test compatibility by preventing unused-binding warnings on Windows while preserving symlink test coverage on Unix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->