### PR TITLE
feat(engine): open a duration channel on Effect::CreateEmblem

### DIFF
--- a/crates/engine/src/ai_support/targeted_exchange.rs
+++ b/crates/engine/src/ai_support/targeted_exchange.rs
@@ -1736,6 +1736,7 @@ mod tests {
                 Effect::CreateEmblem {
                     statics: vec![grant_fight_static()],
                     triggers: vec![],
+                    duration: None,
                 },
             ),
         ));
@@ -1749,6 +1750,7 @@ mod tests {
                 Effect::CreateEmblem {
                     statics: vec![],
                     triggers: vec![emblem_trigger],
+                    duration: None,
                 },
             ),
         ));
@@ -1765,6 +1767,7 @@ mod tests {
                 Effect::CreateEmblem {
                     statics: vec![],
                     triggers: vec![trigger_unless_pay],
+                    duration: None,
                 },
             ),
         ));

--- a/crates/engine/src/game/ability_rw.rs
+++ b/crates/engine/src/game/ability_rw.rs
@@ -3410,8 +3410,13 @@ fn legacy_effect(x: &Effect) -> bool {
             // so the termination permission contributes nothing to this walk.
             end_cost: _,
         } => odur(duration) || otf(target) || static_abilities.iter().any(legacy_static_definition),
-        Effect::CreateEmblem { statics, triggers } => {
-            statics.iter().any(legacy_static_definition)
+        Effect::CreateEmblem {
+            statics,
+            triggers,
+            duration,
+        } => {
+            odur(duration)
+                || statics.iter().any(legacy_static_definition)
                 || triggers.iter().any(legacy_trigger_definition)
         }
         Effect::ForceAttack {

--- a/crates/engine/src/game/ability_rw.rs
+++ b/crates/engine/src/game/ability_rw.rs
@@ -5701,10 +5701,25 @@ fn rw_effect(
         | Effect::AddRestriction { .. }
         | Effect::ReduceNextSpellCost { .. }
         | Effect::GrantNextSpellAbility { .. }
-        | Effect::CreateEmblem { .. }
         | Effect::CreateDamageReplacement { .. }
         | Effect::Regenerate { .. }
         | Effect::GrantCastingPermission { .. } => (RwProfile::empty(), None),
+        // CR 114.4: the emblem's own abilities are the EMBLEM's, not this
+        // ability's, so its statics/triggers contribute no read/write facts
+        // here (the boundary-carrier rule `ability_visit` states). The stated
+        // window is the exception: `Duration::ForAsLongAs { condition }` reads
+        // game state, and `rw_duration` descends it. Merged rather than elided
+        // for the same reason `legacy_effect` above feeds this field to `odur`
+        // — `{ .. }` would drop a populated condition's read profile with no
+        // compile error, understating this effect for the CR 603.3b
+        // same-event ordering-parity system this file serves.
+        Effect::CreateEmblem { duration, .. } => {
+            let mut p = RwProfile::empty();
+            if let Some(d) = duration {
+                p.merge(rw_duration(d));
+            }
+            (p, None)
+        }
 
         // ---- Choice wrappers (union descent, §2) ----
         Effect::ChooseOneOf { chooser, branches } => {

--- a/crates/engine/src/game/dungeon.rs
+++ b/crates/engine/src/game/dungeon.rs
@@ -940,6 +940,7 @@ pub fn room_effects(
                         room_door: None,
                     }],
                     triggers: Vec::new(),
+                    duration: None,
                 },
                 source_id,
                 controller,

--- a/crates/engine/src/game/effects/create_emblem.rs
+++ b/crates/engine/src/game/effects/create_emblem.rs
@@ -75,7 +75,17 @@ pub fn resolve(
     events: &mut Vec<GameEvent>,
 ) -> Result<(), EffectError> {
     let (statics, triggers) = match &ability.effect {
-        Effect::CreateEmblem { statics, triggers } => (statics, triggers),
+        Effect::CreateEmblem {
+            statics,
+            triggers,
+            // CR 611.2a: the emblem's stated window. Provably `None` at every
+            // construction site today, so there is no window to apply and the
+            // `grant_emblem` call below is complete. THIS IS THE SITE THAT MUST
+            // CHANGE when a producer starts populating the field: `_` binds
+            // rather than wildcards, so a populated window would be dropped here
+            // with no compile error and the emblem would silently outlive it.
+            duration: _,
+        } => (statics, triggers),
         _ => return Err(EffectError::MissingParam("CreateEmblem".into())),
     };
 
@@ -170,6 +180,7 @@ mod tests {
             Effect::CreateEmblem {
                 statics: vec![graveyard_play],
                 triggers: Vec::new(),
+                duration: None,
             },
             vec![],
             ObjectId(100),
@@ -193,6 +204,7 @@ mod tests {
             Effect::CreateEmblem {
                 statics: vec![ninja_pump_static()],
                 triggers: Vec::new(),
+                duration: None,
             },
             vec![],
             ObjectId(100),
@@ -239,6 +251,7 @@ mod tests {
             Effect::CreateEmblem {
                 statics: vec![ninja_pump_static()],
                 triggers: Vec::new(),
+                duration: None,
             },
             vec![],
             source_id,
@@ -267,6 +280,7 @@ mod tests {
             Effect::CreateEmblem {
                 statics: vec![ninja_pump_static()],
                 triggers: Vec::new(),
+                duration: None,
             },
             vec![],
             ObjectId(100),
@@ -285,6 +299,7 @@ mod tests {
             Effect::CreateEmblem {
                 statics: vec![ninja_pump_static()],
                 triggers: Vec::new(),
+                duration: None,
             },
             vec![],
             ObjectId(100),
@@ -405,6 +420,7 @@ mod tests {
             Effect::CreateEmblem {
                 statics: Vec::new(),
                 triggers: vec![trig.clone()],
+                duration: None,
             },
             vec![],
             ObjectId(100),
@@ -457,6 +473,7 @@ mod tests {
             Effect::CreateEmblem {
                 statics: vec![static_def],
                 triggers: Vec::new(),
+                duration: None,
             },
             vec![],
             ObjectId(100),

--- a/crates/engine/src/game/layers.rs
+++ b/crates/engine/src/game/layers.rs
@@ -16010,7 +16010,12 @@ mod tests {
         let effect = crate::parser::oracle_effect::parse_effect(
             "You get an emblem with \"Mountains you control have '{T}: This land deals 1 damage to any target.'\"",
         );
-        let crate::types::ability::Effect::CreateEmblem { statics, triggers } = effect else {
+        let crate::types::ability::Effect::CreateEmblem {
+            statics,
+            triggers,
+            duration: _,
+        } = effect
+        else {
             panic!("expected CreateEmblem effect from Koth's emblem text");
         };
         assert!(triggers.is_empty(), "Koth emblem is a static grant");

--- a/crates/engine/src/game/mana_abilities.rs
+++ b/crates/engine/src/game/mana_abilities.rs
@@ -6115,6 +6115,7 @@ mod tests {
                 Effect::CreateEmblem {
                     statics: vec![granting_static(draw_one())],
                     triggers: vec![],
+                    duration: None,
                 },
             ),
             (

--- a/crates/engine/src/game/printed_cards.rs
+++ b/crates/engine/src/game/printed_cards.rs
@@ -3515,6 +3515,7 @@ mod tests {
         let emblem = Effect::CreateEmblem {
             statics: vec![emblem_static],
             triggers: vec![emblem_trigger],
+            duration: None,
         };
         walk_effect(&emblem, &mut names);
 

--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -7677,7 +7677,11 @@ fn demote_lifetimes_in_effect(effect: &mut Effect) {
                 demote_lifetimes_in_static(static_def);
             }
         }
-        Effect::CreateEmblem { statics, triggers } => {
+        Effect::CreateEmblem {
+            statics,
+            triggers,
+            duration: _,
+        } => {
             for static_def in statics.iter_mut() {
                 demote_lifetimes_in_static(static_def);
             }
@@ -8427,7 +8431,11 @@ fn render_effect_descriptions(effect: &mut Effect, card_name: &str) {
                 render_static_descriptions(st, card_name);
             }
         }
-        Effect::CreateEmblem { statics, triggers } => {
+        Effect::CreateEmblem {
+            statics,
+            triggers,
+            duration: _,
+        } => {
             for st in statics.iter_mut() {
                 render_static_descriptions(st, card_name);
             }

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -7017,6 +7017,7 @@ fn try_parse_no_max_hand_size_effect(tp: TextPair<'_>) -> Option<Effect> {
         statics: vec![StaticDefinition::new(StaticMode::NoMaximumHandSize)
             .description("You have no maximum hand size.".to_string())],
         triggers: Vec::new(),
+        duration: None,
     })
 }
 
@@ -24349,6 +24350,7 @@ fn try_parse_emblem_creation(lower: &str, original: &str) -> Option<Effect> {
         return Some(Effect::CreateEmblem {
             statics: Vec::new(),
             triggers,
+            duration: None,
         });
     }
 
@@ -24369,6 +24371,7 @@ fn try_parse_emblem_creation(lower: &str, original: &str) -> Option<Effect> {
         Some(Effect::CreateEmblem {
             statics: static_defs,
             triggers: Vec::new(),
+            duration: None,
         })
     } else {
         // Fallback: create an emblem with an unimplemented static.
@@ -24377,6 +24380,7 @@ fn try_parse_emblem_creation(lower: &str, original: &str) -> Option<Effect> {
                 StaticDefinition::new(StaticMode::EmblemStatic).description(inner.to_string())
             ],
             triggers: Vec::new(),
+            duration: None,
         })
     }
 }

--- a/crates/engine/src/parser/oracle_effect/tests.rs
+++ b/crates/engine/src/parser/oracle_effect/tests.rs
@@ -21142,7 +21142,11 @@ fn effect_emblem_tamiyo_field_researcher_hand_free_cast() {
             "You get an emblem with \"You may cast spells from your hand without paying their mana costs.\"",
         );
     match e {
-        Effect::CreateEmblem { statics, triggers } => {
+        Effect::CreateEmblem {
+            statics,
+            triggers,
+            duration: _,
+        } => {
             assert!(triggers.is_empty());
             assert_eq!(statics.len(), 1);
             assert!(
@@ -21197,7 +21201,11 @@ fn effect_emblem_with_whenever_trigger_extracts_trigger_definition() {
             "You get an emblem with \"Whenever you cast a spell, this emblem deals 5 damage to any target.\"",
         );
     match e {
-        Effect::CreateEmblem { statics, triggers } => {
+        Effect::CreateEmblem {
+            statics,
+            triggers,
+            duration: _,
+        } => {
             assert!(
                 statics.is_empty(),
                 "trigger-only emblem should not install statics, got {statics:?}"
@@ -21289,7 +21297,11 @@ fn effect_emblem_with_static_still_parses_as_static() {
     // even after the trigger-first dispatch.
     let e = parse_effect("You get an emblem with \"Ninjas you control get +1/+1.\"");
     match e {
-        Effect::CreateEmblem { statics, triggers } => {
+        Effect::CreateEmblem {
+            statics,
+            triggers,
+            duration: _,
+        } => {
             assert_eq!(statics.len(), 1);
             assert!(triggers.is_empty());
         }
@@ -21309,7 +21321,12 @@ fn effect_koth_emblem_grants_activated_ability_to_mountains() {
     let e = parse_effect(
             "You get an emblem with \"Mountains you control have '{T}: This land deals 1 damage to any target.'\"",
         );
-    let Effect::CreateEmblem { statics, triggers } = e else {
+    let Effect::CreateEmblem {
+        statics,
+        triggers,
+        duration: _,
+    } = e
+    else {
         panic!("expected CreateEmblem, got {e:?}");
     };
     assert!(

--- a/crates/engine/src/parser/oracle_ir/ast.rs
+++ b/crates/engine/src/parser/oracle_ir/ast.rs
@@ -2438,11 +2438,23 @@ fn apply_duration_to_effect(effect: &mut Effect, duration: &Duration) {
 ///   | rg -n 'duration: (Option<)?Duration'
 /// ```
 ///
-/// At the time of writing that returns SEVEN duration-bearing variants —
+/// At the time of writing that returns EIGHT duration-bearing variants —
 /// GenericEffect, CastFromZone, BecomeCopy, GainActivatedAbilitiesOfTarget,
-/// ForceAttack, ForceBlock, and PreventDamage (whose field is named
-/// `prevention_duration`, which is exactly why an eye-enumeration missed it).
-/// All seven are members. Two more are members without an embedded field:
+/// ForceAttack, ForceBlock, PreventDamage (whose field is named
+/// `prevention_duration`, which is exactly why an eye-enumeration missed it),
+/// and CreateEmblem.
+///
+/// SEVEN of the eight are members. `CreateEmblem` is the deliberate NON-member,
+/// recorded here rather than left to a future eye-enumeration: a stated prefix
+/// governs the lifetime of the effect it prefixes, but an emblem is a separate
+/// object in the command zone (CR 114.1 + CR 114.2) and the prefix does not set
+/// that object's lifetime, so distributing it onto `CreateEmblem.duration`
+/// would stamp the wrong subject. That field is written by the emblem's own
+/// parser branch, never by this distributor. Whether an emblem's window is ever
+/// prefix-governed is a CR 611.2a-vs-CR 114 question deferred until a real card
+/// raises it; until then this variant stays in the catch-all BY DECISION.
+///
+/// Two more are members without an embedded field:
 /// `GrantCastingPermission { permission: CastingPermission::PlayFromExile { .. } }`,
 /// and `AddRestriction`, whose expiry derives from `AbilityDefinition.duration`
 /// in `add_restriction::fill_runtime_fields` (CR 514.2).

--- a/crates/engine/src/parser/oracle_ir/doc.rs
+++ b/crates/engine/src/parser/oracle_ir/doc.rs
@@ -1358,7 +1358,9 @@ fn stamp_effect_printed_slot(effect: &mut Effect, slot: usize, kind: PrintedItem
             }
         }
         Effect::CreateEmblem {
-            statics, triggers, ..
+            statics,
+            triggers,
+            duration: _,
         } => {
             for sd in statics {
                 stamp_static_printed_slot(sd, slot, kind);

--- a/crates/engine/src/parser/oracle_tests.rs
+++ b/crates/engine/src/parser/oracle_tests.rs
@@ -26056,7 +26056,12 @@ fn gideon_of_the_trials_emblem_full_parse() {
         );
     }
 
-    let Effect::CreateEmblem { statics, triggers } = &*r.abilities[2].effect else {
+    let Effect::CreateEmblem {
+        statics,
+        triggers,
+        duration: _,
+    } = &*r.abilities[2].effect
+    else {
         panic!(
             "third loyalty ability must create an emblem, got {:?}",
             r.abilities[2].effect
@@ -28046,6 +28051,7 @@ fn render_net_reaches_every_nested_description_carrier() {
     parsed.abilities.push(carrier(Effect::CreateEmblem {
         statics: vec![static_def("emblem_static")],
         triggers: vec![trigger_def("emblem_trigger")],
+        duration: None,
     }));
     tags.extend(["emblem_static", "emblem_trigger"]);
 

--- a/crates/engine/src/parser/swallow_check.rs
+++ b/crates/engine/src/parser/swallow_check.rs
@@ -952,7 +952,11 @@ fn effect_has_internal_optionality(effect: &Effect) -> bool {
         } => end_cost.is_some() || static_abilities.iter().any(static_definition_has_optional),
         Effect::ChooseOneOf { branches, .. } => branches.iter().any(def_tree_has_optional),
         Effect::CreateDelayedTrigger { effect, .. } => def_tree_has_optional(effect),
-        Effect::CreateEmblem { statics, triggers } => {
+        Effect::CreateEmblem {
+            statics,
+            triggers,
+            duration: _,
+        } => {
             statics.iter().any(static_definition_has_optional)
                 || triggers.iter().any(trigger_tree_has_optional)
         }

--- a/crates/engine/src/parser/swallow_evidence.rs
+++ b/crates/engine/src/parser/swallow_evidence.rs
@@ -244,9 +244,10 @@ const DESCRIPTION_KEY: &str = "description";
 ///   AbilityDefinition.duration                        <- the definition's own slot
 ///   Effect::BecomeCopy.duration                       ┐
 ///   Effect::GainActivatedAbilitiesOfTarget.duration   │
-///   Effect::GenericEffect.duration                    ├ the 6 Effect carriers
-///   Effect::ForceAttack.duration                      │
+///   Effect::GenericEffect.duration                    │
+///   Effect::ForceAttack.duration                      ├ the 7 Effect carriers
 ///   Effect::CastFromZone.duration                     │
+///   Effect::CreateEmblem.duration                     │ <- always `None` today
 ///   Effect::PreventDamage.prevention_duration         ┘ <- NOT named `duration`
 ///   CastingPermission::ExileWithAltCost.duration      ┐ CastingPermission
 ///   CastingPermission::PlayFromExile.duration         ┘

--- a/crates/engine/src/parser/swallow_evidence.rs
+++ b/crates/engine/src/parser/swallow_evidence.rs
@@ -245,8 +245,9 @@ const DESCRIPTION_KEY: &str = "description";
 ///   Effect::BecomeCopy.duration                       ┐
 ///   Effect::GainActivatedAbilitiesOfTarget.duration   │
 ///   Effect::GenericEffect.duration                    │
-///   Effect::ForceAttack.duration                      ├ the 7 Effect carriers
-///   Effect::CastFromZone.duration                     │
+///   Effect::ForceAttack.duration                      │ <- bare `Duration`
+///   Effect::ForceBlock.duration                       ├ <- bare `Duration`
+///   Effect::CastFromZone.duration                     │   the 8 Effect carriers
 ///   Effect::CreateEmblem.duration                     │ <- always `None` today
 ///   Effect::PreventDamage.prevention_duration         ┘ <- NOT named `duration`
 ///   CastingPermission::ExileWithAltCost.duration      ┐ CastingPermission
@@ -258,6 +259,13 @@ const DESCRIPTION_KEY: &str = "description";
 /// other direction: `"prevention_duration":"UntilEndOfTurn"` does NOT contain the
 /// substring `"duration":"UntilEndOfTurn"` (the character before `duration` is `_`, not
 /// `"`), so the marker was blind to every damage-prevention shield's duration.
+///
+/// `Effect::ForceBlock.duration` was absent from this list before `CreateEmblem`
+/// was added, so the list read 6 where the command returned 7. Re-derived from the
+/// command rather than incremented by hand — the same eye-enumeration hazard the
+/// `duration_governs` doc in `oracle_ir/ast.rs` records. Neither omission changed
+/// `DURATION_KEYS` itself: both fields are literally named `duration`, so the key
+/// set was correct while the inventory justifying it was not.
 const DURATION_KEYS: &[&str] = &["duration", "prevention_duration"];
 
 /// The JSON key at which a `WheneverEventExpiry`-typed field is serialized

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -16037,6 +16037,21 @@ pub enum Effect {
         /// `collect_matching_triggers` admits them.
         #[serde(default)]
         triggers: Vec<TriggerDefinition>,
+        /// CR 611.2a: the stated window on the emblem's granted abilities.
+        ///
+        /// `None` is not "missing": CR 611.2a makes an unstated duration last
+        /// until the end of the game. That coincides with an emblem's own
+        /// lifetime — CR 114.1 defines the emblem and CR 114.2 puts it in the
+        /// command zone, and no rule provides a way to remove it — so every
+        /// emblem the engine produces today is correctly `None`, not a
+        /// placeholder. (The persistence is an argument from the ABSENCE of a
+        /// removal rule; CR 114 nowhere states it, so do not cite 114.1 for it.)
+        ///
+        /// No producer sets this yet. It is written where a card states a window
+        /// on the emblem it creates; the consumer is `create_emblem::resolve`,
+        /// which must read it before an emblem can expire (CR 514.2).
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        duration: Option<Duration>,
     },
     /// CR 118.1: Pay a cost during effect resolution. Carries the unified
     /// `AbilityCost` taxonomy directly (no parallel `PaymentCost` hierarchy) so
@@ -35231,6 +35246,85 @@ mod monarch_subject_axis_tests {
             "a non-default subject must be serialized: {json}"
         );
         assert_eq!(serde_json::from_str::<Effect>(&json).unwrap(), targeted);
+    }
+
+    /// CR 611.2a + CR 114.1: `Effect::CreateEmblem` gained a `duration` slot.
+    /// Every pre-existing `{"type":"CreateEmblem","statics":[...],"triggers":[...]}`
+    /// row in `card-data.json` (and in persisted saved-game state) predates that
+    /// field, so it must keep deserializing — to `None`, which CR 611.2a already
+    /// defines as "until the end of the game", which coincides with an emblem's
+    /// own lifetime — and must re-serialize byte-identically.
+    ///
+    /// Revert-failing on `skip_serializing_if`, MEASURED: dropping it makes the
+    /// re-serialize emit `"duration":null` and assertion (a) fails, so every
+    /// existing emblem row would churn on the next export.
+    ///
+    /// `#[serde(default)]` is NOT independently revert-failing here, and this
+    /// says so rather than claiming a guard it does not have: serde already
+    /// treats an absent key for an `Option<T>` field as `None`, so removing the
+    /// attribute leaves this test green (verified by removing it and re-running).
+    /// It is kept for consistency with the six of ten sibling `Option<Duration>`
+    /// fields that carry the pair — chiefly `CastFromZone.duration`, the governing
+    /// analogue — and because it keeps the load contract explicit at the declaration.
+    ///
+    /// The `Some(..)` assertion is the paired POSITIVE reach-guard: an absence
+    /// assertion alone is also satisfied by a serializer that never emits the
+    /// field at all, so it would pass against a dead predicate.
+    #[test]
+    fn create_emblem_round_trips_without_a_duration_key() {
+        // (a) The empty row — the shape `parse_emblem`'s trigger branch emits.
+        const EMPTY_ROW: &str = r#"{"type":"CreateEmblem","statics":[],"triggers":[]}"#;
+        let empty: Effect = serde_json::from_str(EMPTY_ROW).unwrap();
+        assert_eq!(
+            empty,
+            Effect::CreateEmblem {
+                statics: vec![],
+                triggers: vec![],
+                duration: None,
+            }
+        );
+        assert_eq!(serde_json::to_string(&empty).unwrap(), EMPTY_ROW);
+
+        // (b) POSITIVE REACH-GUARD: a populated duration MUST emit the key, or
+        //     assertion (a) is vacuous and B2b's writes would vanish on export.
+        let stated = Effect::CreateEmblem {
+            statics: vec![],
+            triggers: vec![],
+            duration: Some(Duration::UntilEndOfTurn),
+        };
+        let stated_json = serde_json::to_string(&stated).unwrap();
+        assert!(
+            stated_json.contains("\"duration\""),
+            "a stated CR 611.2a window must be serialized: {stated_json}"
+        );
+        assert_eq!(
+            serde_json::from_str::<Effect>(&stated_json).unwrap(),
+            stated
+        );
+
+        // (c) Hostile fixture: a POPULATED row. A `skip_serializing_if` bug can
+        //     hide behind the empty-vec case, so round-trip a real static and a
+        //     real trigger too, and pin that no `duration` key appears.
+        let populated = Effect::CreateEmblem {
+            statics: vec![StaticDefinition::new(StaticMode::NoMaximumHandSize)],
+            triggers: vec![TriggerDefinition::new(TriggerMode::SpellCast)],
+            duration: None,
+        };
+        let populated_json = serde_json::to_string(&populated).unwrap();
+        assert!(
+            !populated_json.contains("\"duration\""),
+            "an unstated window must not emit a key: {populated_json}"
+        );
+        assert_eq!(
+            serde_json::from_str::<Effect>(&populated_json).unwrap(),
+            populated
+        );
+        assert_eq!(
+            serde_json::to_string(&serde_json::from_str::<Effect>(&populated_json).unwrap())
+                .unwrap(),
+            populated_json,
+            "a populated emblem row must re-serialize byte-identically"
+        );
     }
 
     /// A non-default subject must survive the round trip, or the card-data

--- a/crates/engine/src/types/ability_visit.rs
+++ b/crates/engine/src/types/ability_visit.rs
@@ -780,7 +780,11 @@ where
         }
         // BOUNDARY CARRIER (CR 114.1): an emblem is a distinct object in the
         // command zone; its abilities are the emblem's, not this ability's.
-        Effect::CreateEmblem { statics, triggers } => {
+        Effect::CreateEmblem {
+            statics,
+            triggers,
+            duration: _,
+        } => {
             if scope == ResolutionScope::IncludeRegisteredLater {
                 for static_def in statics {
                     visit_static_scoped(static_def, scope, visit)?;

--- a/crates/engine/tests/integration/kaito_integration.rs
+++ b/crates/engine/tests/integration/kaito_integration.rs
@@ -152,6 +152,7 @@ fn setup_kaito_on_battlefield(phase: Phase) -> (GameRunner, ObjectId) {
             Effect::CreateEmblem {
                 statics: vec![ninja_pump_static()],
                 triggers: Vec::new(),
+                duration: None,
             },
         )
         .cost(AbilityCost::Loyalty { amount: 1 });

--- a/crates/engine/tests/integration/rules/casting.rs
+++ b/crates/engine/tests/integration/rules/casting.rs
@@ -1974,6 +1974,7 @@ fn tamiyo_emblem_allows_free_cast_from_hand() {
         Effect::CreateEmblem {
             statics: vec![emblem_static],
             triggers: Vec::new(),
+            duration: None,
         },
         vec![],
         source_id,

--- a/crates/phase-ai/src/policies/planeswalker_loyalty.rs
+++ b/crates/phase-ai/src/policies/planeswalker_loyalty.rs
@@ -326,6 +326,7 @@ mod tests {
             Effect::CreateEmblem {
                 statics: Vec::new(),
                 triggers: Vec::new(),
+                duration: None,
             },
         );
         assert_score(


### PR DESCRIPTION
## What

Adds `duration: Option<Duration>` to `Effect::CreateEmblem` and threads it through the 33 sites the compiler forces.

**Zero behavioural delta. Zero cards change coverage status.** The field is written `None` at all five production construction sites and nothing reads it yet. This is infrastructure for a later phase; it is deliberately inert.

## Why `None` is correct rather than a placeholder

CR 611.2a: *"If no duration is stated, it lasts until the end of the game."* That coincides with an emblem's own lifetime, so every emblem the engine produces today is genuinely `None`.

The slot exists so a card stating a window on the emblem it creates has somewhere to put it. Without it such a window can only be dropped — and per CR 611.2a a dropped window is a **permanent** effect, not a missing one.

## Serde

`#[serde(default, skip_serializing_if = "Option::is_none")]`, matching the governing analogue `Effect::CastFromZone.duration` (same enum, same field name, same type) and six of the ten sibling `Option<Duration>` fields.

Measured, not assumed:
- Existing serialized rows re-serialize **byte-identically** → no `card-data.json` or saved-game churn.
- `Effect::CreateEmblem` appears in **zero** golden snapshots. Positive control: `GenericEffect` appears in **36 of 303**, so the zero is a real result rather than a broken instrument.

## Three decisions that are not mechanical

**`ability_rw.rs` — bind, don't discard.** `legacy_effect` feeds the field to the existing `odur` helper rather than `duration: _`, mirroring the `GenericEffect` arm immediately above it. Behaviour is identical today (`odur(None) == false`), but a future `ForAsLongAs` window would be silently under-reported by `_` with no compile error.

**`oracle_ir/ast.rs` — a contract that would otherwise have been breached silently.** `duration_governs` documents a closed set derived from a stated command. That command returned 7 before this change and returns 8 after. The doc is updated to eight and records why `CreateEmblem` is a deliberate **non-member**: a printed prefix governs the effect it prefixes, but an emblem is a separate command-zone object (CR 114.1 + CR 114.2) whose lifetime that prefix does not set, so distributing onto it would stamp the wrong subject.

Worth flagging for review: that file notes `PreventDamage` was once missed by eye-enumeration, and **nothing in the build catches this class** — `duration_arms_match_governed_set` states its own limitation, and the exhaustiveness guarantee fires on a new *variant*, never a new *field*. The decision is therefore recorded in code rather than left implicit.

**`oracle_ir/doc.rs` — restore a documented invariant.** `stamp_effect_printed_slot` promises an exhaustive match with no `_` arm, but carried a vestigial `..` on this variant that defeated that promise. Removed; the arm now binds every field.

Also updated: `swallow_evidence.rs`'s duration-carrier inventory, which declares itself a derived-not-guessed closed set, from six `Effect` carriers to seven. Its `DURATION_KEYS` constant was already correct.

## Testing

One discriminating test (`create_emblem_round_trips_without_a_duration_key`) with four assertions, including a **paired positive reach-guard** — asserting only that `None` emits no key is also satisfied by a serializer that never emits the field at all, so the guard proves a `Some(..)` *does* emit it.

Its doc states which attribute is actually revert-failing (`skip_serializing_if` — measured by removing it and observing the failure) and which is kept for consistency rather than as a guard (`default`, since serde already treats an absent key for `Option<T>` as `None`), instead of claiming both.

Everything else here is regression guarding, and is labelled as such rather than dressed up as discrimination.

## Verification

- `cargo check --workspace --all-targets` — **exit 0**. Both flags are load-bearing: 22 of the 33 sites are test code and one is in `phase-ai` inside `#[cfg(test)]`, so a plain `cargo check` would report green over a broken tree.
- `cargo test -p phase-engine --lib types::ability` — **156 passed, 0 failed**.
- `cargo fmt --all`, `check-cr-citation-anchors.sh`, `check-parser-combinators.sh` — all clean.
- `git diff -- '*.snap'` empty. No parser dispatch introduced (no `contains`/`starts_with`/`find`/`split_once`).

One pre-existing warning is left untouched: `phase-ai/src/bin/ai_gate.rs:628` (unused `link`) is identical at HEAD, is not in this diff, and has no relation to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Added support for optional durations on emblem abilities, allowing future effects to define how long granted abilities remain active.
  - Preserved compatibility for existing saved data and configurations that do not specify an emblem duration.
  - Improved handling of nested duration information when determining event-context prompts and ordering behavior.

- **Tests**
  - Expanded coverage for duration serialization, parsing, traversal, and emblem-related rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->