### PR TITLE
fix(release): allow cold-cache builds to finish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,10 +82,11 @@ jobs:
     needs: [resolve-release-ref]
     runs-on: ubuntu-latest
     # Card-data generation grows with the card/deck corpus: this job hit 28m for
-    # v0.4.0 and crossed the prior 30m ceiling for v0.5.0 (killed mid-frontend
-    # build, stranding the release). Raised to 60m for headroom — the ceiling
-    # only bills the failure case, so a normal ~30m run still ends at ~30m.
-    timeout-minutes: 60
+    # v0.4.0 crossed the prior 30m ceiling, and v0.75.0 consumed the 60m
+    # ceiling just before its R2 upload finished, stranding that release.
+    # A normal run still ends near 30m, so 90m only affects genuinely stalled
+    # builds while allowing cold caches and larger card/deck corpora to finish.
+    timeout-minutes: 90
     outputs:
       card_data_sha256: ${{ steps.card-data-hash.outputs.card_data_sha256 }}
       card_data_hash16: ${{ steps.card-data-hash.outputs.hash }}


### PR DESCRIPTION
## Summary
- raise the release web build timeout from 60 to 90 minutes
- preserve the normal-run duration while preventing cold-cache releases from being cancelled during artifact upload

## Evidence
- v0.75.0 run 33968333691 was cancelled at 60:11, 35 seconds into `Upload data to R2`; all prior build steps passed.

## Verification
- Ruby YAML parse
- `git diff --check`
- repository pre-commit release/parser/CR gates