### PR TITLE
fix(engine): route the dealt-damage recipient through the player-filter classifiers (#8578)

### DIFF
--- a/crates/engine/src/game/filter.rs
+++ b/crates/engine/src/game/filter.rs
@@ -1668,6 +1668,14 @@ pub(crate) fn filter_prop_contains(
         FilterProp::AnyOf { props } => props.iter().any(|p| filter_prop_contains(p, leaf)),
         // CR 109.4: the object-axis crossing into the player axis.
         FilterProp::ControllerMatches { player } => player_filter_contains(player, leaf),
+        // CR 109.4 + CR 120.1: same object-axis-into-player-axis crossing. The
+        // recipient scope is an `Option<PlayerFilter>` that can itself nest a
+        // `TargetFilter` (e.g. `OpponentDealtDamage { source }`), so it must be
+        // routed rather than treated as a leaf. `None` = any recipient, which
+        // nests nothing.
+        FilterProp::DealtDamageThisTurn { recipient, .. } => recipient
+            .as_ref()
+            .is_some_and(|scope| player_filter_contains(scope, leaf)),
         // Leaves: no nested `TargetFilter`. (Props carrying only a `QuantityExpr`
         // magnitude are leaves HERE by the scope rule documented on
         // `filter_contains` — the quantity authority classifies those.)
@@ -1737,7 +1745,6 @@ pub(crate) fn filter_prop_contains(
         | FilterProp::NotHistoric
         | FilterProp::InAnyZone { .. }
         | FilterProp::WasDealtDamageThisTurn
-        | FilterProp::DealtDamageThisTurn { .. }
         | FilterProp::EnteredThisTurn
         | FilterProp::ControlledContinuouslySinceTurnBegan
         | FilterProp::ZoneChangedThisTurn { .. }
@@ -12052,6 +12059,17 @@ mod tests {
                     count: Box::new(QuantityExpr::Fixed { value: 1 }),
                 }),
             }],
+            // CR 120.1: the damage-recipient scope is the same object-axis ->
+            // player-axis crossing, and the player scope can nest a source
+            // filter of its own, so the anaphor must be seen through both hops.
+            vec![FilterProp::DealtDamageThisTurn {
+                kind: DamageKindFilter::Any,
+                recipient: Some(PlayerFilter::OpponentDealtDamage {
+                    kind: DamageKindFilter::Any,
+                    source: Some(Box::new(TargetFilter::LastCreated)),
+                    min_sources: 1,
+                }),
+            }],
         ] {
             assert!(
                 filter_contains_last_created(&typed(props.clone())),
@@ -12068,6 +12086,20 @@ mod tests {
             FilterProp::Token,
         ])));
         assert!(!filter_contains_last_created(&typed(Vec::new())));
+        // A recipient scope that nests nothing, and an absent one, must both
+        // stay unseen — the new arm routes a payload, it does not report one.
+        assert!(!filter_contains_last_created(&typed(vec![
+            FilterProp::DealtDamageThisTurn {
+                kind: DamageKindFilter::Any,
+                recipient: Some(PlayerFilter::OpponentLostLife),
+            },
+        ])));
+        assert!(!filter_contains_last_created(&typed(vec![
+            FilterProp::DealtDamageThisTurn {
+                kind: DamageKindFilter::Any,
+                recipient: None,
+            },
+        ])));
         // The `LastZoneChanged` twin shares the traversal, so it must see the
         // same nesting and not confuse the two ledgers.
         assert!(filter_contains_last_zone_changed(&typed(vec![

--- a/crates/engine/src/game/layers.rs
+++ b/crates/engine/src/game/layers.rs
@@ -3793,6 +3793,12 @@ fn filter_prop_reads_life(prop: &FilterProp) -> bool {
         // `PlayerFilter` — route it (`ControllerMatches{OpponentLostLife}` anthem
         // flips its affected set at a life-loss site).
         FilterProp::ControllerMatches { player } => player_filter_reads_life(player),
+        // CR 109.4 + CR 120.1: the recipient scope is an `Option<PlayerFilter>`
+        // that can nest a life-reading predicate, so it routes here rather than
+        // counting as payload-free. `None` = any recipient, which reads nothing.
+        FilterProp::DealtDamageThisTurn { recipient, .. } => {
+            recipient.as_ref().is_some_and(player_filter_reads_life)
+        }
         // The six TargetFilter-bearing props all route their nested filter
         // (deref coercion → &TargetFilter). Field names differ; unified here.
         FilterProp::CanEnchant { target: f }
@@ -3874,7 +3880,6 @@ fn filter_prop_reads_life(prop: &FilterProp) -> bool {
         | FilterProp::PowerExceedsBase
         | FilterProp::InAnyZone { .. }
         | FilterProp::WasDealtDamageThisTurn
-        | FilterProp::DealtDamageThisTurn { .. }
         | FilterProp::EnteredThisTurn
         | FilterProp::ControlledContinuouslySinceTurnBegan
         | FilterProp::ZoneChangedThisTurn { .. }
@@ -23292,6 +23297,24 @@ mod tests {
                 min_sources: 1,
             }
         ));
+        // CR 120.1: the damage-recipient scope routes through the same player
+        // classifier, so a life-reading recipient must be reported. Grouping the
+        // arm with the payload-free props would under-report the layer
+        // dependency at a life-change site.
+        assert!(filter_prop_reads_life(&FilterProp::DealtDamageThisTurn {
+            kind: DamageKindFilter::Any,
+            recipient: Some(PlayerFilter::OpponentLostLife),
+        }));
+        // Negative controls: a recipient that reads no life, and no recipient at
+        // all, so the positive above is not passing vacuously.
+        assert!(!filter_prop_reads_life(&FilterProp::DealtDamageThisTurn {
+            kind: DamageKindFilter::Any,
+            recipient: Some(PlayerFilter::Opponent),
+        }));
+        assert!(!filter_prop_reads_life(&FilterProp::DealtDamageThisTurn {
+            kind: DamageKindFilter::Any,
+            recipient: None,
+        }));
         // CR 608.2c: exclusion anchor recurses.
         assert!(player_filter_reads_life(&PlayerFilter::AllExcept {
             exclude: Box::new(PlayerFilter::OpponentGainedLife),


### PR DESCRIPTION
Closes #8578.

`FilterProp::DealtDamageThisTurn.recipient` is an `Option<PlayerFilter>`, and a `PlayerFilter` can itself nest a `TargetFilter` (`OpponentDealtDamage { source }`, `ControlsCount { filter }`, `TrackedSetPossessor { filter }`) or read life (`OpponentLostLife`, `PlayerAttribute`). Both classifiers treated the variant as a payload-free leaf, so a nested anaphor or life-reading predicate under the recipient scope was invisible to them.

## Change

`filter_prop_contains` now delegates the recipient to `player_filter_contains`, and `filter_prop_reads_life` delegates it to `player_filter_reads_life`. This is the same object-axis-into-player-axis crossing that `FilterProp::ControllerMatches` already makes in both functions, and the new arm sits beside it rather than introducing a new pattern.

`None` means any recipient, which nests nothing and reads nothing, so it stays false in both classifiers.

The variant moves out of the payload-free leaf or-pattern into an explicit arm, so the exhaustive match makes the change compiler-checked rather than reviewer-checked.

## CR annotations

Both grep-verified against `docs/MagicCompRules.txt` before being written:

- **CR 109.4** (line 594) — controller determination; the object-axis crossing into the player axis, the rule already cited on the adjacent `ControllerMatches` arm.
- **CR 120.1** (line 1087) — "Objects can deal damage to battles, creatures, planeswalkers, and players... An object that deals damage is the source of that damage" — the recipient/source relationship this arm routes.

## Tests

Both existing tests gain the positive case plus two negative controls, so the arm is shown to route a payload rather than to report one:

- positive: a recipient nesting `OpponentDealtDamage { source: LastCreated }`, which must now be seen through both hops
- negative: a recipient scope that nests nothing
- negative: an absent (`None`) recipient

The negative controls matter here specifically — without them a delegation that unconditionally returned `true` would pass the positive case.
