### PR TITLE
docs(parser): warn at both parse_type_phrase declarations

### DIFF
--- a/crates/engine/src/parser/oracle_nom/target.rs
+++ b/crates/engine/src/parser/oracle_nom/target.rs
@@ -36,8 +36,32 @@ pub fn parse_declared_target_prefix(input: &str) -> OracleResult<'_, ()> {
 /// Parse a type phrase into a `TargetFilter`.
 ///
 /// Handles: optional "non" prefix, optional supertype, optional color prefix,
-/// core type(s) joined by " or ", and optional controller suffix. This is the
-/// nom equivalent of `oracle_target::parse_type_phrase`.
+/// core type(s) joined by " or ", and optional controller suffix.
+///
+/// # CR 109.2: NOT interchangeable with the other `parse_type_phrase`
+///
+/// `crate::parser::oracle_target::parse_type_phrase` has the SAME NAME and
+/// reads the same grammatical slot, but it is a DIFFERENT reader — it is not a
+/// legacy copy of this one, and this is not a drop-in nom port of it. Two ways
+/// that bites:
+///
+/// 1. **The return shape is TRANSPOSED.** This returns `OracleResult`, whose
+///    `Ok` is `(remainder, filter)`; the other returns `(filter, remainder)`.
+///    Both are a 2-tuple of a `TargetFilter` and a `&str`, so transposing the
+///    destructuring still TYPE-CHECKS wherever the binding names are not
+///    load-bearing. Never transpose it.
+/// 2. **The type-list join differs.** This joins on `" or "` ONLY
+///    (`parse_type_list`); the other folds all seven `TYPE_SEPARATORS` forms
+///    (`", and/or "`, `", and "`, `", or "`, `", "`, `"or "`, `"and/or "`,
+///    `"and "`). Measured: `"creatures and planeswalkers they control"` SPLITS
+///    here — `Typed{Creature}` plus the remainder `" and planeswalkers …"` —
+///    and FOLDS there into one `Or[..]` consumed whole. This reader also
+///    carries no ownership / token / combat-relation grammar.
+///
+/// So the choice of reader silently changes which cards a caller accepts. Pin
+/// it by fully-qualified path at every call site rather than by whichever
+/// `use` is in scope — `oracle_nom/quantity.rs` makes it an explicit typed
+/// parameter (`TypePhraseGrammar`) for exactly this reason.
 pub fn parse_type_phrase(input: &str) -> OracleResult<'_, TargetFilter> {
     // Optional "non" prefix (consumed separately from type negation)
     let (rest, non_prefix) = opt(parse_non_prefix).parse(input)?;

--- a/crates/engine/src/parser/oracle_nom/target.rs
+++ b/crates/engine/src/parser/oracle_nom/target.rs
@@ -38,30 +38,16 @@ pub fn parse_declared_target_prefix(input: &str) -> OracleResult<'_, ()> {
 /// Handles: optional "non" prefix, optional supertype, optional color prefix,
 /// core type(s) joined by " or ", and optional controller suffix.
 ///
-/// # CR 109.2: NOT interchangeable with the other `parse_type_phrase`
+/// # Not interchangeable with the other `parse_type_phrase`
 ///
-/// `crate::parser::oracle_target::parse_type_phrase` has the SAME NAME and
-/// reads the same grammatical slot, but it is a DIFFERENT reader — it is not a
-/// legacy copy of this one, and this is not a drop-in nom port of it. Two ways
-/// that bites:
-///
-/// 1. **The return shape is TRANSPOSED.** This returns `OracleResult`, whose
-///    `Ok` is `(remainder, filter)`; the other returns `(filter, remainder)`.
-///    Both are a 2-tuple of a `TargetFilter` and a `&str`, so transposing the
-///    destructuring still TYPE-CHECKS wherever the binding names are not
-///    load-bearing. Never transpose it.
-/// 2. **The type-list join differs.** This joins on `" or "` ONLY
-///    (`parse_type_list`); the other folds all seven `TYPE_SEPARATORS` forms
-///    (`", and/or "`, `", and "`, `", or "`, `", "`, `"or "`, `"and/or "`,
-///    `"and "`). Measured: `"creatures and planeswalkers they control"` SPLITS
-///    here — `Typed{Creature}` plus the remainder `" and planeswalkers …"` —
-///    and FOLDS there into one `Or[..]` consumed whole. This reader also
-///    carries no ownership / token / combat-relation grammar.
-///
-/// So the choice of reader silently changes which cards a caller accepts. Pin
-/// it by fully-qualified path at every call site rather than by whichever
-/// `use` is in scope — `oracle_nom/quantity.rs` makes it an explicit typed
-/// parameter (`TypePhraseGrammar`) for exactly this reason.
+/// `crate::parser::oracle_target::parse_type_phrase` has the same name and
+/// reads the same grammatical slot, but it is a different reader — it is not a
+/// legacy copy of this one, and this is not a drop-in nom port of it. Their
+/// accepted grammars diverge, so the choice of reader changes which cards a
+/// caller accepts. The measured differences are tabulated on the private
+/// `TypePhraseGrammar` enum in `oracle_nom/quantity.rs`, which selects between
+/// them as an explicit typed parameter; this reader is its `Strict` arm, and
+/// reports an unrecognized phrase as `Err`.
 pub fn parse_type_phrase(input: &str) -> OracleResult<'_, TargetFilter> {
     // Optional "non" prefix (consumed separately from type negation)
     let (rest, non_prefix) = opt(parse_non_prefix).parse(input)?;

--- a/crates/engine/src/parser/oracle_target.rs
+++ b/crates/engine/src/parser/oracle_target.rs
@@ -2174,35 +2174,20 @@ fn parse_named_filter_terminator(input: &str) -> Result<(&str, ()), nom::Err<Ora
 /// Prefer `parse_type_phrase_with_ctx` when a `ParseContext` is available —
 /// it enables relative-player scope resolution for "that player controls".
 ///
-/// # CR 109.2: NOT interchangeable with the other `parse_type_phrase`
+/// # Not interchangeable with the other `parse_type_phrase`
 ///
-/// [`crate::parser::oracle_nom::target::parse_type_phrase`] has the SAME NAME
-/// and reads the same grammatical slot, but it is a DIFFERENT reader. Three
-/// ways that bites:
+/// [`crate::parser::oracle_nom::target::parse_type_phrase`] has the same name
+/// and reads the same grammatical slot, but it is a different reader, and their
+/// accepted grammars diverge — the measured differences are tabulated on the
+/// private `TypePhraseGrammar` enum in `oracle_nom/quantity.rs`, which selects
+/// between them as an explicit typed parameter; this reader is its `Legacy` arm.
 ///
-/// 1. **The return shape is TRANSPOSED.** This returns `(filter, remainder)`;
-///    the other returns `OracleResult`, whose `Ok` is `(remainder, filter)`.
-///    Both are a 2-tuple of a `TargetFilter` and a `&str`, so transposing the
-///    destructuring still TYPE-CHECKS wherever the binding names are not
-///    load-bearing. Never transpose it.
-/// 2. **This one is INFALLIBLE.** There is no `Err` to propagate: on a phrase
-///    it does not recognize ("those creatures", "them") it returns an EMPTY
-///    `TypedFilter` plus the WHOLE input — NOT `TargetFilter::Any`, so an
-///    `Any` guard does NOT catch it. A caller that declines unrecognized input
-///    needs an emptiness check (or a whole-clause remainder check), not an
-///    `Any` check. The other reader simply fails with `Err`.
-/// 3. **The type-list join differs.** This folds all seven `TYPE_SEPARATORS`
-///    forms (`", and/or "`, `", and "`, `", or "`, `", "`, `"or "`,
-///    `"and/or "`, `"and "`); the other joins on `" or "` ONLY. Measured:
-///    `"creatures and planeswalkers they control"` FOLDS here into one
-///    `Or[..]` consumed whole, and SPLITS there into `Typed{Creature}` plus
-///    the remainder `" and planeswalkers …"`. This reader also carries
-///    ownership / token / combat-relation grammar the other one does not.
-///
-/// So the choice of reader silently changes which cards a caller accepts. Pin
-/// it by fully-qualified path at every call site rather than by whichever
-/// `use` is in scope — `oracle_nom/quantity.rs` makes it an explicit typed
-/// parameter (`TypePhraseGrammar`) for exactly this reason.
+/// One consequence is load-bearing for every caller: this reader is
+/// INFALLIBLE. There is no `Err` to propagate — an unrecognized phrase
+/// ("those creatures", "them") comes back as an empty `TypedFilter` plus the
+/// whole input, which is NOT `TargetFilter::Any`. A caller that means to
+/// decline unrecognized input needs an emptiness check (or a whole-clause
+/// remainder check); an `Any` guard will not catch it.
 pub fn parse_type_phrase(text: &str) -> (TargetFilter, &str) {
     parse_type_phrase_with_ctx(text, &mut ParseContext::default())
 }

--- a/crates/engine/src/parser/oracle_target.rs
+++ b/crates/engine/src/parser/oracle_target.rs
@@ -2173,6 +2173,36 @@ fn parse_named_filter_terminator(input: &str) -> Result<(&str, ()), nom::Err<Ora
 ///
 /// Prefer `parse_type_phrase_with_ctx` when a `ParseContext` is available —
 /// it enables relative-player scope resolution for "that player controls".
+///
+/// # CR 109.2: NOT interchangeable with the other `parse_type_phrase`
+///
+/// [`crate::parser::oracle_nom::target::parse_type_phrase`] has the SAME NAME
+/// and reads the same grammatical slot, but it is a DIFFERENT reader. Three
+/// ways that bites:
+///
+/// 1. **The return shape is TRANSPOSED.** This returns `(filter, remainder)`;
+///    the other returns `OracleResult`, whose `Ok` is `(remainder, filter)`.
+///    Both are a 2-tuple of a `TargetFilter` and a `&str`, so transposing the
+///    destructuring still TYPE-CHECKS wherever the binding names are not
+///    load-bearing. Never transpose it.
+/// 2. **This one is INFALLIBLE.** There is no `Err` to propagate: on a phrase
+///    it does not recognize ("those creatures", "them") it returns an EMPTY
+///    `TypedFilter` plus the WHOLE input — NOT `TargetFilter::Any`, so an
+///    `Any` guard does NOT catch it. A caller that declines unrecognized input
+///    needs an emptiness check (or a whole-clause remainder check), not an
+///    `Any` check. The other reader simply fails with `Err`.
+/// 3. **The type-list join differs.** This folds all seven `TYPE_SEPARATORS`
+///    forms (`", and/or "`, `", and "`, `", or "`, `", "`, `"or "`,
+///    `"and/or "`, `"and "`); the other joins on `" or "` ONLY. Measured:
+///    `"creatures and planeswalkers they control"` FOLDS here into one
+///    `Or[..]` consumed whole, and SPLITS there into `Typed{Creature}` plus
+///    the remainder `" and planeswalkers …"`. This reader also carries
+///    ownership / token / combat-relation grammar the other one does not.
+///
+/// So the choice of reader silently changes which cards a caller accepts. Pin
+/// it by fully-qualified path at every call site rather than by whichever
+/// `use` is in scope — `oracle_nom/quantity.rs` makes it an explicit typed
+/// parameter (`TypePhraseGrammar`) for exactly this reason.
 pub fn parse_type_phrase(text: &str) -> (TargetFilter, &str) {
     parse_type_phrase_with_ctx(text, &mut ParseContext::default())
 }


### PR DESCRIPTION
## Summary

Replaces #7401 on a non-protected path, per the maintainer review there:

> **Recommendation: close this PR and open the doc-comment version against the two `parse_type_phrase` declarations.** The content is wanted; the path is not available to it.

#7401 documented this in `.claude/skills/oracle-parser/SKILL.md`, which `.agents/pr-review-policy.toml` classifies as a `[hard_stops]` path. This puts the warning on the two declarations instead — where someone picking an import actually looks, and where it travels with the code under rename. #7401 is closed in favour of this.

Revised in `10490c2a` after review. Both blocks are now **pointers** at `TypePhraseGrammar` rather than their own copy of its comparison table.

## What each declaration gets

`oracle_nom::target::parse_type_phrase` and `oracle_target::parse_type_phrase` share a name and read the same grammatical slot, but they are different readers whose accepted grammars diverge — so the choice of reader changes which cards a caller accepts. Each declaration now says that, names which `TypePhraseGrammar` arm it is, and points at that enum for the measured differences.

Two things are stated at the declarations rather than deferred:

- **The Strict summary was false.** It described itself as "the nom equivalent of `oracle_target::parse_type_phrase`" — the claim most likely to invite the wrong import. Corrected, not appended around.
- **Legacy's infallibility, as a caller-facing remedy.** An unrecognized phrase returns an empty `TypedFilter` plus the whole input, not `TargetFilter::Any`, so declining it needs an emptiness or whole-clause remainder check rather than an `Any` guard. `TypePhraseGrammar` documents that mechanism only for `parse_objects_source`; the ~328 production Legacy call sites outside `quantity.rs` never pass through it.

## Correction to an earlier version of this description

A previous revision claimed a transposed destructuring "still type-checks — the compiler will not catch it." **That was wrong.** Compiled against exact models of both signatures: a swapped import fails `E0277` (`?` on a bare tuple) or `E0308`, and a transposed destructuring fails `E0599`/`E0609` as soon as either binding is used. The only case that compiles is when both bindings are dead. That item has been removed from both doc blocks.

## Verification

Comment-only — every changed line is a `///` line; the diff filtered to non-comment changes is empty.

Claims re-derived from source rather than carried over from #7401:

- Signatures: `oracle_nom/target.rs:41`, `oracle_target.rs:2176`.
- Infallibility: Legacy delegates to `parse_type_phrase_with_ctx`, whose sole fall-through exit is `(filter, &text[pos..])` — no `Result`, and no `TargetFilter::Any` constructed anywhere in the body.
- Grammar divergence: `TYPE_SEPARATORS` (`oracle_target.rs:2924`) vs. Strict's `" or "`-only `parse_type_list` (`oracle_nom/target.rs:239`).

`cargo fmt --all` clean; `cargo check -p phase-engine` clean. `cargo doc` with `-D warnings` adds no new diagnostics at these lines — the Legacy-side intra-doc link targets a public item and resolves, while the Strict side references its `pub(crate)` sibling as a plain code span, which would otherwise emit `private_intra_doc_links` from a public item. (`TypePhraseGrammar` is a private enum, so it is referenced in backticks rather than linked.)

## Follow-up

The review's rename proposal is the real fix and is agreed — deliberately not in this PR. Scoped at **328 production call sites across 30 files**, compiler-verified crate-locally, with four traps that need handling deliberately (a Strict alias in the one file importing both readers, a `prelude` glob feeding ~66 sites, function-pointer positions that must not be renamed, and the prefix-sharing `parse_type_phrase_with_ctx`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
