### PR TITLE
Fix Maze of Ith: resolution-created replacements survive the CR 613.1 layer reset

### DIFF
--- a/crates/engine/src/game/effects/add_target_replacement.rs
+++ b/crates/engine/src/game/effects/add_target_replacement.rs
@@ -570,8 +570,16 @@ pub fn resolve(
                     // leave-play, host leave-play) remove this def on every
                     // CR 611.2b lapse, so base never accumulates a stale runtime
                     // rider. printed_cards.rs is the only intrinsic base-write
-                    // precedent; there is no additive-runtime base-push
-                    // precedent, so this exception is documented here.
+                    // precedent, and this is the only additive-runtime base push in
+                    // the tree, so the exception is documented here.
+                    //
+                    // Everything that is NOT one of these three classes now goes
+                    // through `GameObject::install_resolution_replacement` instead
+                    // (CR 611.2a) — the typed-provenance authority that survives the
+                    // CR 613.1 reset via the carried set rather than via a base copy.
+                    // The trio deliberately stays OUTSIDE it: a def that is both
+                    // base-resident and `Resolution`-stamped would be reseeded from
+                    // base AND carried from live, i.e. applied twice.
                     // A turn-bound die-exile rider must also survive a layer
                     // reset: a damaged creature can gain/lose characteristics
                     // or enter combat before it dies. Cleanup prunes this
@@ -609,10 +617,22 @@ pub fn resolve(
                         );
                     if let Some(obj) = state.objects.get_mut(&obj_id) {
                         if install_to_base {
+                            // CR 611.2b / CR 702.84a: the three hand-audited durable
+                            // classes stay BASE-resident and are reseeded into live
+                            // by every CR 613.1 pass. They must NOT be stamped
+                            // `Resolution`: that would place them in base AND in the
+                            // carried set, and apply them twice.
                             std::sync::Arc::make_mut(&mut obj.base_replacement_definitions)
                                 .push(replacement.clone());
+                            obj.replacement_definitions.push(replacement);
+                        } else {
+                            // CR 611.2a: everything else is a resolution-created
+                            // continuous effect with a stated window. The authority
+                            // stamps it `Resolution` when it carries an enforceable
+                            // expiry, and fails closed (live-only, today's behavior)
+                            // when it does not.
+                            obj.install_resolution_replacement(replacement);
                         }
-                        obj.replacement_definitions.push(replacement);
                         attached += 1;
                     }
                 }
@@ -1076,6 +1096,123 @@ mod tests {
         assert!(
             state.objects.get(&target).unwrap().replacement_definitions[0].is_consumed,
             "one-shot rider must consume after applying"
+        );
+    }
+
+    /// CR 611.2b + CR 611.2a + CR 613.1 (issue #8485, matrix row 21): the C4
+    /// restructure — the three hand-audited DURABLE classes keep the base push and
+    /// must NOT be stamped `Resolution` (that would put them in base AND in the
+    /// carried set, applying them twice); everything else goes through
+    /// `GameObject::install_resolution_replacement` instead.
+    ///
+    /// MULTI-AUTHORITY HOSTILE FIXTURE: the SAME host carries both arms at once — a
+    /// `ControllerControlsSource`-gated durable rider and an ordinary end-of-turn
+    /// rider — so one object exercises both sides of the restructure and a
+    /// mis-routed arm cannot hide behind the other.
+    #[test]
+    fn controller_gated_rider_is_not_carried_twice_across_a_layer_pass() {
+        use crate::types::ability::Effect;
+
+        let mut state = GameState::new_two_player(42);
+        let host = create_object(
+            &mut state,
+            CardId(0),
+            PlayerId(0),
+            "Locked Permanent".to_string(),
+            Zone::Battlefield,
+        );
+        let source = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Master Thief".to_string(),
+            Zone::Battlefield,
+        );
+        state
+            .objects
+            .get_mut(&host)
+            .unwrap()
+            .base_characteristics_initialized = true;
+
+        // ARM 1: the CR 611.2b durable class — a bare untap-prevention rider with a
+        // `WhileControllingHost` window, which `stamp_for_as_long_as_controlled_gate`
+        // turns into a `ControllerControlsSource` applicability gate.
+        let mut durable = ResolvedAbility::new(
+            Effect::AddTargetReplacement {
+                replacement: Box::new(ReplacementDefinition::new(ReplacementEvent::Untap)),
+                target: TargetFilter::Any,
+            },
+            vec![TargetRef::Object(host)],
+            source,
+            PlayerId(0),
+        );
+        durable.duration = Some(Duration::WhileControllingHost);
+        resolve(&mut state, &durable, &mut Vec::new()).unwrap();
+
+        // ARM 2: an ordinary end-of-turn rider on the SAME host.
+        let mut eot = ReplacementDefinition::new(ReplacementEvent::Moved)
+            .valid_card(TargetFilter::SelfRef)
+            .destination_zone(Zone::Graveyard);
+        eot.expiry = Some(RestrictionExpiry::EndOfTurn);
+        let transient = ResolvedAbility::new(
+            Effect::AddTargetReplacement {
+                replacement: Box::new(eot),
+                target: TargetFilter::Any,
+            },
+            vec![TargetRef::Object(host)],
+            source,
+            PlayerId(0),
+        );
+        resolve(&mut state, &transient, &mut Vec::new()).unwrap();
+
+        {
+            let obj = &state.objects[&host];
+            assert_eq!(
+                obj.base_replacement_definitions.len(),
+                1,
+                "only the durable arm is base-written"
+            );
+            assert_eq!(obj.replacement_definitions.len(), 2);
+            let gated = obj
+                .replacement_definitions
+                .iter_all()
+                .find(|d| d.event == ReplacementEvent::Untap)
+                .expect("the gated rider is installed");
+            assert!(
+                !gated.is_resolution_installed(),
+                "CR 611.2b: a base-resident durable rider must stay `Characteristic`"
+            );
+            let carried = obj
+                .replacement_definitions
+                .iter_all()
+                .find(|d| d.event == ReplacementEvent::Moved)
+                .expect("the EOT rider is installed");
+            assert!(
+                carried.is_resolution_installed(),
+                "CR 611.2a: an ordinary turn-bound rider IS resolution-created"
+            );
+        }
+
+        state.layers_dirty.mark_full();
+        crate::game::layers::evaluate_layers(&mut state);
+
+        let obj = &state.objects[&host];
+        assert_eq!(
+            obj.replacement_definitions
+                .iter_all()
+                .filter(|d| d.event == ReplacementEvent::Untap)
+                .count(),
+            1,
+            "the durable rider must be reseeded from base EXACTLY once, not \
+             reseeded AND carried"
+        );
+        assert_eq!(
+            obj.replacement_definitions
+                .iter_all()
+                .filter(|d| d.event == ReplacementEvent::Moved)
+                .count(),
+            1,
+            "the carried EOT rider survives the CR 613.1 reset"
         );
     }
 

--- a/crates/engine/src/game/effects/create_damage_replacement.rs
+++ b/crates/engine/src/game/effects/create_damage_replacement.rs
@@ -254,8 +254,13 @@ pub fn resolve(
         if shield.valid_card.is_none() {
             shield.valid_card = Some(TargetFilter::SelfRef);
         }
+        // CR 611.2c + CR 613.1: the recipient-hosted shield is stored on its host so
+        // the pipeline can find it, but it is not one of that host's
+        // characteristics, so the CR 613.1 reseed must carry it. CR 702.26b: the
+        // per-arm phasing decision is "keep the gate, vacuous" here — the host IS
+        // the damage recipient, and a phased-out permanent cannot be dealt damage.
         if let Some(obj) = state.objects.get_mut(&host_id) {
-            obj.replacement_definitions.push(shield);
+            obj.install_resolution_replacement(shield);
         }
     } else {
         let is_permanent_on_battlefield = state
@@ -263,17 +268,55 @@ pub fn resolve(
             .get(&ability.source_id)
             .is_some_and(|obj| obj.zone == Zone::Battlefield);
         if is_permanent_on_battlefield {
+            // CR 611.2c + CR 613.1: this arm stays OBJECT-hosted deliberately (see
+            // the registry note in the `else` below), but it is still routed through
+            // the resolution-install authority so a Beacon-of-Destiny-class redirect
+            // shield survives a layer pass. It still dies with its host's zone
+            // change, and CR 702.26b still gates it off while the host is phased
+            // out: for a `SourceObject` recipient that is vacuous
+            // (`redirect_recipient_is_legal` requires a battlefield permanent), and
+            // for `Controller` / `AttachedToSource` recipients it is a PRE-EXISTING
+            // CR 113.7a divergence that cannot be fixed without the registry move
+            // the sentinel-blind `resolve_redirect_recipient` forbids.
             if let Some(obj) = state.objects.get_mut(&ability.source_id) {
-                obj.replacement_definitions.push(shield);
+                obj.install_resolution_replacement(shield);
             }
         } else {
-            // CR 109.4 + CR 614.1a: Anchor the installing controller so a
+            // CR 109.4 + CR 113.8 + CR 614.1a: Anchor the installing controller so a
             // controller-relative `damage_source_filter` (e.g. Desperate Gambit's
             // chosen "source you control" recheck) matches under the sentinel host.
-            if shield.source_controller.is_none() {
-                shield.source_controller = Some(ability.controller);
-            }
-            state.pending_damage_replacements.push(shield);
+            // Delegated to the one floating-install authority so this file and
+            // `prevent_damage.rs` cannot drift.
+            //
+            // `anchor_zones` is EMPTY, and that is structural, not incidental: this
+            // arm is only being refactored onto the authority, it moves NO shield.
+            // Every shield reaching it was already registry-hosted before the
+            // authority existed (including one from a Command-zone source, which the
+            // `Zone::Battlefield`-only fork above also routes here), so anchoring any
+            // of them would be an unmeasured behavior change on a pre-existing
+            // population -- over-matching, the inverse of the under-matching the
+            // anchor exists to fix.
+            //
+            // CR 113.7a: the battlefield arm above deliberately stays object-hosted
+            // and is NOT moved here. `replacement.rs::redirect_damage_event` passes
+            // `rid.source` to `resolve_redirect_recipient`, which has no
+            // `ObjectId(0)` sentinel arm: `DamageRedirectTarget::Controller` would
+            // look up the sentinel in `state.objects` and find nothing,
+            // `SourceObject` would build `TargetRef::Object(ObjectId(0))` and be
+            // rejected by `redirect_recipient_is_legal`, and `AttachedToSource`
+            // resolves `attached_to` live and is not concretizable at install time at
+            // all. That is an `rid.source` (storage-discriminator) failure, which the
+            // `source_object` host anchor does not address -- the anchor supplies the
+            // HOST identity, not the registry-vs-object storage route. The battlefield
+            // arm's layer-fragility is fixed instead by installing through
+            // `GameObject::install_resolution_replacement` (CR 611.2c).
+            crate::game::effects::install_floating_damage_replacement(
+                state,
+                shield,
+                ability.controller,
+                ability.source_id,
+                &[],
+            );
         }
     }
 
@@ -486,6 +529,182 @@ mod tests {
             "second event must NOT be doubled (one-shot consumed)"
         );
         assert_eq!(state.players[1].life, 11);
+    }
+
+    /// CR 611.2c + CR 613.1 + CR 614.9 (issue #8485, matrix row 19): a
+    /// BATTLEFIELD-SOURCED redirection shield still redirects after a layer pass.
+    ///
+    /// This arm is deliberately left OBJECT-hosted — `resolve_redirect_recipient`
+    /// reads `rid.source`, and it has no `ObjectId(0)` sentinel arm, so moving it to
+    /// the floating registry would silently no-op `DamageRedirectTarget::
+    /// {Controller, SourceObject, AttachedToSource}`. But object-hosting made it
+    /// layer-fragile, which is what routing through
+    /// `GameObject::install_resolution_replacement` fixes (CR 611.2c: the shield is
+    /// not one of the source's characteristics, so the CR 613.1 reseed carries it).
+    ///
+    /// The named redirect suites do not cover this arm: `veteran_bodyguard_tap_
+    /// redirect.rs` is a printed static (base-seeded) and `heroic_sacrifice_
+    /// redirect.rs` is instant-sourced (already registry-hosted).
+    ///
+    /// Revert-failing against C2: without the authority the shield is gone after the
+    /// pass and the damage lands on the original recipient.
+    #[test]
+    fn battlefield_sourced_redirect_survives_a_layer_pass() {
+        let mut state = GameState::new_two_player(42);
+        let source = create_creature(&mut state, PlayerId(0), "Redirector");
+        let victim = create_creature(&mut state, PlayerId(1), "Victim");
+
+        let ability = ResolvedAbility::new(
+            Effect::CreateDamageReplacement {
+                redirect_lifetime: RedirectionLifetime::OneOpportunity,
+                source_filter: Some(TargetFilter::SelfRef),
+                combat_scope: None,
+                target_filter: None,
+                modification: None,
+                redirect_to: Some(DamageRedirectTarget::Controller),
+                redirect_amount: None,
+                redirect_object_filter: None,
+                recipient_object_filter: None,
+            },
+            vec![],
+            source,
+            PlayerId(0),
+        );
+        resolve(&mut state, &ability, &mut Vec::new()).unwrap();
+        assert!(
+            state.objects[&source].replacement_definitions[0].is_resolution_installed(),
+            "CR 611.2c: the battlefield arm is object-hosted but resolution-stamped"
+        );
+
+        // CR 613.1: a layer pass between install and use.
+        state.layers_dirty.mark_full();
+        crate::game::layers::evaluate_layers(&mut state);
+        assert_eq!(
+            state.objects[&source].replacement_definitions.len(),
+            1,
+            "the redirect shield must survive the CR 613.1 reset"
+        );
+
+        let ctx = deal_damage::DamageContext::from_source(&state, source).unwrap();
+        deal_damage::apply_damage_to_target(
+            &mut state,
+            &ctx,
+            TargetRef::Object(victim),
+            4,
+            false,
+            &mut Vec::new(),
+        )
+        .unwrap();
+        assert_eq!(
+            state.objects[&victim].damage_marked, 0,
+            "CR 614.9: the damage is still redirected after the pass"
+        );
+        assert_eq!(state.players[0].life, 16);
+
+        // NEGATIVE SIBLING (CR 614.9): once the SOURCE is gone the object-hosted
+        // shield correctly stops applying — this arm is host-bound by design.
+        let mut state2 = GameState::new_two_player(42);
+        let source2 = create_creature(&mut state2, PlayerId(0), "Redirector");
+        let victim2 = create_creature(&mut state2, PlayerId(1), "Victim");
+        let ability2 = ResolvedAbility::new(
+            Effect::CreateDamageReplacement {
+                redirect_lifetime: RedirectionLifetime::OneOpportunity,
+                source_filter: None,
+                combat_scope: None,
+                target_filter: None,
+                modification: None,
+                redirect_to: Some(DamageRedirectTarget::Controller),
+                redirect_amount: None,
+                redirect_object_filter: None,
+                recipient_object_filter: None,
+            },
+            vec![],
+            source2,
+            PlayerId(0),
+        );
+        resolve(&mut state2, &ability2, &mut Vec::new()).unwrap();
+        crate::game::zones::move_to_zone(&mut state2, source2, Zone::Graveyard, &mut Vec::new());
+        let ctx2 = deal_damage::DamageContext::from_source(&state2, victim2).unwrap();
+        deal_damage::apply_damage_to_target(
+            &mut state2,
+            &ctx2,
+            TargetRef::Object(victim2),
+            4,
+            false,
+            &mut Vec::new(),
+        )
+        .unwrap();
+        assert_eq!(
+            state2.players[0].life, 20,
+            "a host-bound redirect does nothing once its host left the battlefield"
+        );
+    }
+
+    /// CR 615.7 + CR 611.2c (issue #8485, matrix row 20): a `Next(n)` redirection
+    /// shield's DEPLETION survives a layer pass. This is the property dual-write
+    /// cannot deliver — two copies plus mutable state means the pristine base twin
+    /// is re-seeded over the depleted live one on every pass.
+    #[test]
+    fn redirect_shield_depletion_survives_a_layer_pass() {
+        let mut state = GameState::new_two_player(42);
+        let source = create_creature(&mut state, PlayerId(0), "Redirector");
+        let victim = create_creature(&mut state, PlayerId(1), "Victim");
+
+        let ability = ResolvedAbility::new(
+            Effect::CreateDamageReplacement {
+                redirect_lifetime: RedirectionLifetime::OneOpportunity,
+                source_filter: Some(TargetFilter::SelfRef),
+                combat_scope: None,
+                target_filter: None,
+                modification: None,
+                redirect_to: Some(DamageRedirectTarget::Controller),
+                redirect_amount: None,
+                redirect_object_filter: None,
+                recipient_object_filter: None,
+            },
+            vec![],
+            source,
+            PlayerId(0),
+        );
+        resolve(&mut state, &ability, &mut Vec::new()).unwrap();
+
+        // Reach-guard: the first event IS redirected.
+        let ctx = deal_damage::DamageContext::from_source(&state, source).unwrap();
+        deal_damage::apply_damage_to_target(
+            &mut state,
+            &ctx,
+            TargetRef::Object(victim),
+            2,
+            false,
+            &mut Vec::new(),
+        )
+        .unwrap();
+        assert_eq!(state.players[0].life, 18);
+        assert!(state.objects[&source].replacement_definitions[0].is_consumed);
+
+        // CR 613.1: the pass must not refill the spent one-shot.
+        state.layers_dirty.mark_full();
+        crate::game::layers::evaluate_layers(&mut state);
+        assert!(
+            state.objects[&source].replacement_definitions[0].is_consumed,
+            "CR 615.3: a layer pass must not un-spend the shield"
+        );
+
+        let ctx = deal_damage::DamageContext::from_source(&state, source).unwrap();
+        deal_damage::apply_damage_to_target(
+            &mut state,
+            &ctx,
+            TargetRef::Object(victim),
+            2,
+            false,
+            &mut Vec::new(),
+        )
+        .unwrap();
+        assert_eq!(
+            state.players[0].life, 18,
+            "the second event is NOT redirected"
+        );
+        assert_eq!(state.objects[&victim].damage_marked, 2);
     }
 
     /// CR 614.9: A redirection one-shot redirects the recipient (here to the

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -2864,8 +2864,19 @@ pub(crate) fn first_object_target(targets: &[TargetRef]) -> Option<ObjectId> {
 /// RESOLUTION of a spell or ability whose scope is its SOURCE rather than a
 /// recipient object.
 ///
-/// THE single authority for that case, shared by `prevent_damage` and
-/// `create_damage_replacement` so the two cannot drift.
+/// The single authority for the SOURCE-SCOPED DAMAGE-SHIELD installs it owns —
+/// `prevent_damage`'s untargeted branch and player-scoped arm, and
+/// `create_damage_replacement`'s non-battlefield arm — so those cannot drift.
+///
+/// Scope of that claim, stated precisely: it is NOT the only writer to
+/// `state.pending_damage_replacements`. `add_target_replacement::resolve` still
+/// pushes raw at its `TargetFilter::None` global arm and its `TargetRef::Player`
+/// arm, and neither latches `source_controller`, so a controller-relative gate on
+/// those definitions falls back to `state.active_player` in the pending scan
+/// rather than to the installer (CR 113.8 / CR 109.5 would prefer the installer).
+/// That is PRE-EXISTING behavior, deliberately left alone by issue #8485 rather
+/// than changed late in that work, and it is recorded in `BACKLOG.md`. Routing
+/// those two arms through this authority is the clean end state.
 ///
 /// CR 113.7a: "Once activated or triggered, an ability exists on the stack
 /// independently of its source. Destruction or removal of the source after that

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -2875,7 +2875,7 @@ pub(crate) fn first_object_target(targets: &[TargetRef]) -> Option<ObjectId> {
 /// those definitions falls back to `state.active_player` in the pending scan
 /// rather than to the installer (CR 113.8 / CR 109.5 would prefer the installer).
 /// That is PRE-EXISTING behavior, deliberately left alone by issue #8485 rather
-/// than changed late in that work, and it is recorded in `BACKLOG.md`. Routing
+/// than changed late in that work, and this comment is its only record. Routing
 /// those two arms through this authority is the clean end state.
 ///
 /// CR 113.7a: "Once activated or triggered, an ability exists on the stack

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -2860,6 +2860,84 @@ pub(crate) fn first_object_target(targets: &[TargetRef]) -> Option<ObjectId> {
     })
 }
 
+/// CR 113.7a + CR 611.2a + CR 615.3: install a damage replacement created by the
+/// RESOLUTION of a spell or ability whose scope is its SOURCE rather than a
+/// recipient object.
+///
+/// THE single authority for that case, shared by `prevent_damage` and
+/// `create_damage_replacement` so the two cannot drift.
+///
+/// CR 113.7a: "Once activated or triggered, an ability exists on the stack
+/// independently of its source. Destruction or removal of the source after that
+/// time won't affect the ability." Hosting such a shield on the SOURCE permanent
+/// (which the pre-#8485 code did whenever the source happened to be a
+/// battlefield object) makes its lifetime an accident of the SOURCE'S ZONE
+/// rather than of the effect's stated duration (CR 611.2a), and subjects it to
+/// the CR 702.26b phased-out gate in `functioning_abilities::active_replacements`
+/// even though the effect is not the source's ability any more.
+///
+/// The floating registry is the engine's home for exactly this: it is not
+/// touched by the CR 613.1 layer reset, is not zone-gated, is mutated in place
+/// by the prevention appliers (all three of which dispatch on the `ObjectId(0)`
+/// sentinel), and is pruned on schedule by all three windows (`turns.rs`:
+/// cleanup, end-of-combat teardown, untap step) -- CR 615.3, "until they're used
+/// up or their duration has expired".
+///
+/// `anchor_zones` is the CALLER'S OWN pre-existing object-hosting zone set --
+/// the zones in which that caller stored the shield on its source before this
+/// authority existed. It is a caller parameter and not a constant because the
+/// two pre-existing forks disagree: `prevent_damage::resolve`'s untargeted
+/// branch tested `Zone::Battlefield` alone while `push_player_scoped_shield`
+/// tested `Zone::Battlefield | Zone::Command`. Handing each caller its own set
+/// is what makes the ANCHORED population exactly the population that caller
+/// newly moves, and leaves every shield that was ALREADY in the registry
+/// carrying `source_object: None` and today's sentinel semantics -- including an
+/// untargeted shield sourced from a Command-zone emblem. A single hardcoded
+/// `Battlefield | Command` test would newly anchor that emblem case and flip
+/// `SourceExclusion::Exclude`, `DamageTargetPlayerScope::SourceChosenPlayer`
+/// and every host-reading `ReplacementCondition` from inert to evaluated.
+/// The SHAPE mirrors the object scan's own `zones_to_scan`
+/// (`replacement.rs`) -- a zone set, checked with `contains`. That is a
+/// shape precedent only: `zones_to_scan` is a hardcoded local with no callers,
+/// so it is not itself an instance of per-caller parameterization. An EMPTY
+/// slice means "anchor nothing", which is correct for a caller that is only
+/// being refactored onto the authority and moves no shield at all.
+pub(crate) fn install_floating_damage_replacement(
+    state: &mut GameState,
+    mut shield: crate::types::ability::ReplacementDefinition,
+    controller: PlayerId,
+    source_id: ObjectId,
+    anchor_zones: &[Zone],
+) {
+    // CR 113.8 + CR 109.5: "The controller of an activated ability on the stack is
+    // the player who activated it"; CR 109.5's "you"/"your" clause says the same
+    // for an activated ability. Latch the installing controller so a
+    // controller-relative filter or condition resolves under the sentinel host,
+    // which per CR 109.4 has no controller of its own.
+    if shield.source_controller.is_none() {
+        shield.source_controller = Some(controller);
+    }
+    // CR 113.7a: anchor the host ONLY for a source that was actually
+    // hosting the shield before this authority existed -- i.e. an object in THIS
+    // CALLER'S `anchor_zones`. The two callers do not agree on that set (see the
+    // doc comment), so it must not be hardcoded here. A shield created by a
+    // resolving instant/sorcery never had a host, and neither did any shield this
+    // caller was ALREADY routing to the registry -- for `prevent_damage::resolve`'s
+    // untargeted branch that includes a Command-zone (emblem) source, which its
+    // `Battlefield`-only fork already sent here. Leaving all of those `None`
+    // reproduces today's sentinel semantics byte-for-byte for the entire
+    // pre-existing registry population.
+    if shield.source_object.is_none()
+        && state
+            .objects
+            .get(&source_id)
+            .is_some_and(|obj| anchor_zones.contains(&obj.zone))
+    {
+        shield.source_object = Some(source_id);
+    }
+    state.pending_damage_replacements.push(shield);
+}
+
 enum OneSidedFightSubject {
     /// The parent chose this object; prepend it to restore the contract.
     Prepend(ObjectId),

--- a/crates/engine/src/game/effects/prevent_damage.rs
+++ b/crates/engine/src/game/effects/prevent_damage.rs
@@ -140,22 +140,35 @@ pub(crate) fn resolve_source_filter(
     }
 }
 
+/// CR 113.7a + CR 611.2a: install a player-scoped prevention shield ("prevent all
+/// damage that would be dealt to target player this turn").
+///
+/// Delegates to the one floating-install authority
+/// (`effects::install_floating_damage_replacement`). This function used to fork on
+/// storage -- object-hosted when the source was an object on the battlefield or in
+/// the command zone, registry-hosted otherwise -- which made the shield's lifetime
+/// an accident of the SOURCE'S zone and of the next CR 613.1 layer pass rather
+/// than of the stated duration. `Zone::Battlefield | Zone::Command` is exactly the
+/// pair this caller used for that fork, so it is passed through as THIS caller's
+/// `anchor_zones`: the population it newly moves is the population it anchors.
+///
+/// Incidental fix: the old registry arm pushed WITHOUT latching
+/// `source_controller`, so a controller-relative gate on a player-scoped shield
+/// resolved against `state.active_player`. The authority latches it
+/// unconditionally (CR 113.8).
 fn push_player_scoped_shield(
     state: &mut GameState,
+    controller: PlayerId,
     source_id: ObjectId,
     shield: ReplacementDefinition,
 ) {
-    let source_is_active_object = state
-        .objects
-        .get(&source_id)
-        .is_some_and(|obj| matches!(obj.zone, Zone::Battlefield | Zone::Command));
-    if source_is_active_object {
-        if let Some(obj) = state.objects.get_mut(&source_id) {
-            obj.replacement_definitions.push(shield);
-        }
-    } else {
-        state.pending_damage_replacements.push(shield);
-    }
+    crate::game::effects::install_floating_damage_replacement(
+        state,
+        shield,
+        controller,
+        source_id,
+        &[Zone::Battlefield, Zone::Command],
+    );
 }
 
 fn player_damage_filter(player: PlayerId) -> DamageTargetFilter {
@@ -259,14 +272,27 @@ fn typed_recipient_valid_card_filter(target: &TargetFilter) -> Option<TargetFilt
     }
 }
 
-/// CR 615: Prevent damage — creates a prevention shield on the source object.
+/// CR 615 + CR 611.2a: Prevent damage — creates a prevention shield.
 ///
-/// The shield is stored as a `ReplacementDefinition` with `ShieldKind::Prevention`
-/// on the source object's `replacement_definitions`. The `damage_done_applier`
-/// in `replacement.rs` consumes these shields when matching `ProposedEvent::Damage`.
+/// The shield is a `ReplacementDefinition` with `ShieldKind::Prevention` (or
+/// `PreventionOneShot`), and it lands in ONE of two stores, never both:
 ///
-/// Follows the same lifecycle as regeneration shields:
-/// 1. Created here → 2. Matched/applied in replacement pipeline → 3. Cleaned up at end of turn
+/// * RECIPIENT-scoped ("prevent the next N damage that would be dealt to target
+///   creature") -> the TARGET object's live `replacement_definitions`, installed
+///   through `GameObject::install_resolution_replacement` so the CR 613.1 layer
+///   reset carries it (CR 611.2c: a prevention effect is not a characteristic).
+///   It correctly dies when its host changes zones (CR 400.7).
+/// * SOURCE-scoped ("prevent all combat damage that would be dealt by that
+///   creature", Circle of Protection, Mercenaries) and PLAYER-scoped ->
+///   `state.pending_damage_replacements`, through the one authority
+///   `effects::install_floating_damage_replacement`. CR 113.7a: once activated,
+///   the ability -- and the continuous effect it created -- exists independently
+///   of its source, so the shield must not ride on the source permanent.
+///
+/// `damage_done_applier` in `replacement.rs` consumes shields from either store
+/// when matching `ProposedEvent::Damage`. Lifetime is CR 615.3 -- "until they're
+/// used up or their duration has expired" -- enforced by the three `turns.rs`
+/// prunes (cleanup, end-of-combat teardown, untap step), which key on `expiry`.
 pub fn resolve(
     state: &mut GameState,
     ability: &ResolvedAbility,
@@ -611,7 +637,13 @@ pub fn resolve(
                         object_shield.valid_card = Some(TargetFilter::SelfRef);
                     }
                     if let Some(obj) = state.objects.get_mut(obj_id) {
-                        obj.replacement_definitions.push(object_shield);
+                        // CR 611.2c + CR 613.1: install through the one
+                        // resolution-install authority so the CR 613.1 layer reseed
+                        // CARRIES this shield instead of wiping it. A prevention
+                        // effect is not an object characteristic (CR 611.2c), so a
+                        // layer pass has no authority to end it; a zone change
+                        // (CR 400.7) and the `expiry` prunes still do.
+                        obj.install_resolution_replacement(object_shield);
                     }
                 }
                 TargetRef::Player(player) => {
@@ -620,34 +652,47 @@ pub fn resolve(
                     let player_shield = shield
                         .clone()
                         .damage_target_filter(player_damage_filter(*player));
-                    push_player_scoped_shield(state, ability.source_id, player_shield);
+                    push_player_scoped_shield(
+                        state,
+                        ability.controller,
+                        ability.source_id,
+                        player_shield,
+                    );
                 }
             }
         }
     } else {
-        // CR 615.3: Untargeted prevention — attach to source if it's a permanent on the
-        // battlefield. Instants/sorceries on the Stack will be moved to graveyard/exile
-        // after resolution, so their shields must go to the global registry instead.
-        // find_applicable_replacements only scans Battlefield/Command zones for
-        // object-attached shields.
-        let is_permanent_on_battlefield = state
-            .objects
-            .get(&ability.source_id)
-            .is_some_and(|obj| obj.zone == Zone::Battlefield);
-        if is_permanent_on_battlefield {
-            if let Some(obj) = state.objects.get_mut(&ability.source_id) {
-                obj.replacement_definitions.push(shield);
-            }
-        } else {
-            // Source is on the Stack (instant/sorcery mid-resolution) or already left —
-            // store in game-state-level registry so it persists until end of turn.
-            // CR 109.4 + CR 614.1a: Anchor the installing controller so a
-            // controller-relative `damage_source_filter` matches under the sentinel host.
-            if shield.source_controller.is_none() {
-                shield.source_controller = Some(ability.controller);
-            }
-            state.pending_damage_replacements.push(shield);
-        }
+        // CR 113.7a + CR 611.2a + CR 615.3: Untargeted (SOURCE-scoped) prevention.
+        // This branch used to fork on storage -- object-hosted when
+        // `ability.source_id` was a permanent on the battlefield, registry-hosted
+        // otherwise. That made the shield a characteristic of its source: the
+        // CR 613.1 layer reset in `layers::seed_live_characteristics_from_base`
+        // wiped it on the next pass, and the source leaving the battlefield ended an
+        // effect that CR 113.7a says exists independently of it (issue #8485).
+        // Every such shield now goes to the floating registry through the one
+        // authority. `Zone::Battlefield` -- the exact predicate this branch used for
+        // the old storage fork -- is passed as THIS caller's `anchor_zones`, so the
+        // ANCHORED population is exactly the population this branch newly moves. An
+        // untargeted shield sourced from a Command-zone object (an emblem) was
+        // ALREADY registry-hosted here, so it stays unanchored and byte-identical to
+        // its pre-#8485 behavior.
+        //
+        // CR 113.7a: a host-relative reference in the shield survives the move
+        // because the authority latches the host IDENTITY on `source_object`, not
+        // because the filter is rewritten. Both shapes this branch can produce are
+        // covered: a `SelfRef` in `damage_source_filter` (the Mercenaries shape,
+        // arriving through `resolve_source_filter`'s `_ => filter.clone()` fallback)
+        // and a `SelfRef` in `valid_card` (the Gideon shape, through
+        // `typed_recipient_valid_card_filter`'s `filter @ TargetFilter::SelfRef`
+        // arm) are both resolved by the pending scan against that anchor, evaluating
+        // the identical AST under an identical `FilterContext` to the object scan.
+        crate::game::effects::install_floating_damage_replacement(
+            state,
+            shield,
+            ability.controller,
+            ability.source_id,
+            &[Zone::Battlefield],
+        );
     }
 
     events.push(GameEvent::EffectResolved {
@@ -734,8 +779,13 @@ mod tests {
         )
     }
 
+    /// CR 113.7a + CR 611.2a (issue #8485): an UNTARGETED (source-scoped)
+    /// prevention shield goes to the floating registry, not onto the source
+    /// permanent. Repointed from `prevent_all_creates_shield_on_source` and
+    /// STRENGTHENED with the two install-time anchors — the storage location
+    /// changed, no behavioral assertion was weakened.
     #[test]
-    fn prevent_all_creates_shield_on_source() {
+    fn prevent_all_creates_a_floating_shield_anchored_to_its_source() {
         let mut state = GameState::new_two_player(42);
         let source = create_object(
             &mut state,
@@ -754,19 +804,31 @@ mod tests {
         let mut events = Vec::new();
         resolve(&mut state, &ability, &mut events).unwrap();
 
-        let obj = state.objects.get(&source).unwrap();
-        assert_eq!(obj.replacement_definitions.len(), 1);
+        assert!(
+            state
+                .objects
+                .get(&source)
+                .unwrap()
+                .replacement_definitions
+                .is_empty(),
+            "CR 113.7a: the shield must not ride on its source permanent"
+        );
+        assert_eq!(state.pending_damage_replacements.len(), 1);
+        let shield = &state.pending_damage_replacements[0];
         assert!(matches!(
-            obj.replacement_definitions[0].shield_kind,
+            shield.shield_kind,
             ShieldKind::Prevention {
                 amount: PreventionAmount::All
             }
         ));
-        assert_eq!(
-            obj.replacement_definitions[0].event,
-            ReplacementEvent::DamageDone
-        );
-        assert!(!obj.replacement_definitions[0].is_consumed);
+        assert_eq!(shield.event, ReplacementEvent::DamageDone);
+        assert!(!shield.is_consumed);
+        // CR 113.8: the installing controller is latched so a controller-relative
+        // gate resolves under the sentinel host.
+        assert_eq!(shield.source_controller, Some(PlayerId(0)));
+        // CR 113.7a: the host identity this branch used to store the shield on is
+        // carried on the definition instead.
+        assert_eq!(shield.source_object, Some(source));
     }
 
     /// CR 511.2 + CR 615 (issue #2924, Bug B): a `prevention_duration` of
@@ -820,11 +882,16 @@ mod tests {
             let mut events = Vec::new();
             resolve(&mut state, &ability, &mut events).unwrap();
 
-            let obj = state.objects.get(&source).unwrap();
-            assert_eq!(obj.replacement_definitions.len(), 1);
+            // CR 113.7a (issue #8485): an untargeted shield from a battlefield
+            // source now lives in the floating registry, anchored to that source.
+            assert_eq!(state.pending_damage_replacements.len(), 1);
             assert_eq!(
-                obj.replacement_definitions[0].expiry, expected_expiry,
+                state.pending_damage_replacements[0].expiry, expected_expiry,
                 "wrong shield expiry for prevention_duration {duration:?}"
+            );
+            assert_eq!(
+                state.pending_damage_replacements[0].source_object,
+                Some(source)
             );
         }
     }
@@ -859,17 +926,21 @@ mod tests {
         let mut events = Vec::new();
         resolve(&mut state, &ability, &mut events).unwrap();
 
-        let obj = state.objects.get(&source).unwrap();
-        assert_eq!(obj.replacement_definitions.len(), 1);
+        // CR 113.7a (issue #8485): untargeted => floating registry, anchored.
+        assert_eq!(state.pending_damage_replacements.len(), 1);
         assert!(
             matches!(
-                obj.replacement_definitions[0].shield_kind,
+                state.pending_damage_replacements[0].shield_kind,
                 ShieldKind::Prevention {
                     amount: PreventionAmount::Next(4)
                 }
             ),
             "dynamic Fixed(4) should resolve to a Next(4) shield, got {:?}",
-            obj.replacement_definitions[0].shield_kind
+            state.pending_damage_replacements[0].shield_kind
+        );
+        assert_eq!(
+            state.pending_damage_replacements[0].source_object,
+            Some(source)
         );
     }
 
@@ -1127,18 +1198,19 @@ mod tests {
             crate::types::actions::GameAction::ChooseDamageSource { source: red },
         )
         .expect("submit damage source choice");
-        // CR 615.3: the source (Circle of Protection) is a battlefield permanent,
-        // so the untargeted shield hosts on the source object, not the pending
-        // registry. Reach-guard: prove the shield was actually installed.
+        // CR 113.7a (issue #8485): the untargeted shield lives in the floating
+        // registry even though the source (Circle of Protection) is a battlefield
+        // permanent — the effect exists independently of its source. Reach-guard:
+        // prove the shield was actually installed, and that it carries the host
+        // anchor so its host-relative gates still resolve.
         assert_eq!(
-            state
-                .objects
-                .get(&cop)
-                .unwrap()
-                .replacement_definitions
-                .len(),
+            state.pending_damage_replacements.len(),
             1,
             "shield must exist before the recheck"
+        );
+        assert_eq!(
+            state.pending_damage_replacements[0].source_object,
+            Some(cop)
         );
 
         // CR 609.7b: chosen source becomes colorless before it deals damage.
@@ -1150,7 +1222,7 @@ mod tests {
         );
         // CR 609.7b: a shield that never matched must not be consumed.
         assert!(
-            !state.objects.get(&cop).unwrap().replacement_definitions[0].is_consumed,
+            !state.pending_damage_replacements[0].is_consumed,
             "a shield that never matched must not be consumed (CR 609.7b)"
         );
     }
@@ -1268,13 +1340,17 @@ mod tests {
         let mut events = Vec::new();
         resolve(&mut state, &ability, &mut events).unwrap();
 
-        let obj = state.objects.get(&source).unwrap();
+        // CR 113.7a (issue #8485): untargeted => floating registry, anchored.
         assert!(matches!(
-            obj.replacement_definitions[0].shield_kind,
+            state.pending_damage_replacements[0].shield_kind,
             ShieldKind::Prevention {
                 amount: PreventionAmount::Next(3)
             }
         ));
+        assert_eq!(
+            state.pending_damage_replacements[0].source_object,
+            Some(source)
+        );
     }
 
     /// CR 611.2a: a stated prevention window this seam cannot enforce must FAIL
@@ -1325,6 +1401,13 @@ mod tests {
             "CR 611.2a: the refused window must not be shortened to the \
              end-of-turn fallback"
         );
+        // Issue #8485: the untargeted branch now routes to the floating registry,
+        // so the object-store negative alone would be VACUOUS. Both stores must be
+        // empty for the refusal to mean anything.
+        assert!(
+            state.pending_damage_replacements.is_empty(),
+            "CR 611.2a: the refused window must not install a floating shield either"
+        );
 
         // Effect-level carrier, `GateControlled` class: the control wording earns
         // its gate only on the bare untap rider
@@ -1360,6 +1443,10 @@ mod tests {
             state.objects[&source].replacement_definitions.is_empty(),
             "CR 611.2a: the refused window must not install an ungated shield"
         );
+        assert!(
+            state.pending_damage_replacements.is_empty(),
+            "CR 611.2a: nor an ungated FLOATING shield (issue #8485)"
+        );
     }
 
     #[test]
@@ -1382,10 +1469,14 @@ mod tests {
         let mut events = Vec::new();
         resolve(&mut state, &ability, &mut events).unwrap();
 
-        let obj = state.objects.get(&source).unwrap();
+        // CR 113.7a (issue #8485): untargeted => floating registry, anchored.
         assert_eq!(
-            obj.replacement_definitions[0].combat_scope,
+            state.pending_damage_replacements[0].combat_scope,
             Some(CombatDamageScope::CombatOnly)
+        );
+        assert_eq!(
+            state.pending_damage_replacements[0].source_object,
+            Some(source)
         );
     }
 
@@ -1623,20 +1714,29 @@ mod tests {
         let mut events = Vec::new();
         resolve(&mut state, &ability, &mut events).unwrap();
 
-        // The shield rides on the source permanent, object-scoped — never in the
-        // global pending registry, which is the un-constrained Fog placement.
+        // CR 113.7a (issue #8485): the shield is source-scoped, so it lives in the
+        // floating registry — but it stays OBJECT-scoped, because the host identity
+        // travels with it on `source_object` and `valid_card: SelfRef` is evaluated
+        // against that anchor rather than being rewritten. Repointed from the
+        // pre-#8485 object-store assertion and strengthened with the anchor check;
+        // the un-constrained global Fog placement (no `valid_card` at all) is still
+        // excluded, now by the `valid_card` assertion below.
         assert!(
-            state.pending_damage_replacements.is_empty(),
-            "a SelfRef recipient is object-scoped, not a global Fog: {:?}",
-            state.pending_damage_replacements
+            state
+                .objects
+                .get(&gideon)
+                .unwrap()
+                .replacement_definitions
+                .is_empty(),
+            "CR 113.7a: the shield must not ride on its source permanent"
         );
-        let shield = state
-            .objects
-            .get(&gideon)
-            .unwrap()
-            .replacement_definitions
-            .last()
-            .expect("the shield hosts on the source");
+        assert_eq!(state.pending_damage_replacements.len(), 1);
+        let shield = &state.pending_damage_replacements[0];
+        assert_eq!(
+            shield.source_object,
+            Some(gideon),
+            "the SelfRef recipient filter resolves against this anchor"
+        );
         assert_eq!(shield.valid_card, Some(TargetFilter::SelfRef));
         assert_eq!(
             shield.damage_target_filter, None,
@@ -1875,11 +1975,13 @@ mod tests {
         let mut events = Vec::new();
         resolve(&mut state, &ability, &mut events).unwrap();
 
-        let shield = &state
-            .objects
-            .get(&pack_leader)
-            .unwrap()
-            .replacement_definitions[0];
+        // CR 113.7a (issue #8485): untargeted => floating registry, anchored.
+        assert_eq!(state.pending_damage_replacements.len(), 1);
+        assert_eq!(
+            state.pending_damage_replacements[0].source_object,
+            Some(pack_leader)
+        );
+        let shield = &state.pending_damage_replacements[0];
         assert_eq!(
             shield.valid_card,
             Some(TargetFilter::Typed(
@@ -2807,7 +2909,8 @@ mod tests {
             .sub_ability(put_counter_sub(source, SubAbilityLink::ContinuationStep));
             let mut events = Vec::new();
             resolve(&mut state, &ability, &mut events).unwrap();
-            let shield = &state.objects.get(&source).unwrap().replacement_definitions[0];
+            // CR 113.7a (issue #8485): untargeted => floating registry.
+            let shield = &state.pending_damage_replacements[0];
             assert!(
                 shield.runtime_execute.is_some(),
                 "a ContinuationStep rider must install as runtime_execute"
@@ -2833,11 +2936,852 @@ mod tests {
             .sub_ability(put_counter_sub(source, SubAbilityLink::SequentialSibling));
             let mut events = Vec::new();
             resolve(&mut state, &ability, &mut events).unwrap();
-            let shield = &state.objects.get(&source).unwrap().replacement_definitions[0];
+            // CR 113.7a (issue #8485): untargeted => floating registry.
+            let shield = &state.pending_damage_replacements[0];
             assert!(
                 shield.runtime_execute.is_none(),
                 "a SequentialSibling sub must NOT install as runtime_execute"
             );
         }
+    }
+
+    // ---- Issue #8485: CR 113.7a source-independence + the host-identity anchor ----
+
+    /// Install an untargeted (source-scoped) prevention shield from `source`.
+    fn install_untargeted_shield(
+        state: &mut GameState,
+        source: ObjectId,
+        controller: PlayerId,
+        target: TargetFilter,
+        damage_source_filter: Option<TargetFilter>,
+        amount: PreventionAmount,
+    ) {
+        let ability = ResolvedAbility::new(
+            Effect::PreventDamage {
+                amount,
+                amount_dynamic: None,
+                target,
+                scope: PreventionScope::AllDamage,
+                damage_source_filter,
+                prevention_duration: None,
+            },
+            vec![],
+            source,
+            controller,
+        );
+        resolve(state, &ability, &mut Vec::new()).expect("prevention resolves");
+    }
+
+    /// Deal `amount` noncombat damage from `source` to `target`, returning the
+    /// amount that actually landed. Drives the real replacement pipeline.
+    fn damage_landed(
+        state: &mut GameState,
+        source: ObjectId,
+        target: TargetRef,
+        amount: u32,
+    ) -> u32 {
+        let ctx = deal_damage::DamageContext::from_source(state, source).expect("damage context");
+        let mut events = Vec::new();
+        match deal_damage::apply_damage_to_target(state, &ctx, target, amount, false, &mut events)
+            .expect("damage resolves")
+        {
+            deal_damage::DamageResult::Applied(n) => n,
+            deal_damage::DamageResult::NeedsChoice => {
+                panic!("unexpected CR 616.1 replacement-choice park")
+            }
+        }
+    }
+
+    /// CR 113.7a (issue #8485, BL1): a HOST-RELATIVE damage-source filter must keep
+    /// matching after the shield is routed to the floating registry.
+    ///
+    /// Mercenaries — "{3}: The next time this creature would deal damage to you
+    /// this turn, prevent that damage." — lowers to `damage_source_filter:
+    /// Some(TargetFilter::SelfRef)` and takes the untargeted branch. Under the bare
+    /// `ObjectId(0)` sentinel, `filter.rs`'s `object_matches_trigger_source` would
+    /// compare the damage source against `ObjectId(0)` and never match, silently
+    /// deleting the shield. The `source_object` anchor supplies the host identity
+    /// the sentinel cannot, WITHOUT rewriting the filter — so the pending scan
+    /// evaluates the identical AST under an identical `FilterContext` to the object
+    /// scan.
+    ///
+    /// Revert-failing against A2(i)'s anchor threading: drop `source_host` from the
+    /// `damage_source_filter` context and leg (ii) fails.
+    #[test]
+    fn mercenaries_shaped_selfref_source_shield_still_matches_after_routing() {
+        let mut state = GameState::new_two_player(42);
+        let mercenaries = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Mercenaries".to_string(),
+            Zone::Battlefield,
+        );
+        let twin = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Mercenaries".to_string(),
+            Zone::Battlefield,
+        );
+
+        install_untargeted_shield(
+            &mut state,
+            mercenaries,
+            PlayerId(0),
+            TargetFilter::Any,
+            Some(TargetFilter::SelfRef),
+            PreventionAmount::All,
+        );
+
+        // (i) Reach-guard: exactly one registry entry, carrying the host anchor.
+        assert_eq!(state.pending_damage_replacements.len(), 1);
+        assert_eq!(
+            state.pending_damage_replacements[0].source_object,
+            Some(mercenaries),
+            "CR 113.7a: the host identity must travel with the shield"
+        );
+
+        // (ii) Damage dealt BY that permanent is prevented.
+        assert_eq!(
+            damage_landed(&mut state, mercenaries, TargetRef::Player(PlayerId(0)), 3),
+            0,
+            "\"this creature\" as the damage source must still resolve to the anchor"
+        );
+
+        // (iii) HOSTILE: a second, identical permanent's damage is NOT prevented.
+        // This is what separates the anchor from a blanket shield: the filter is
+        // evaluated, not ignored.
+        assert_eq!(
+            damage_landed(&mut state, twin, TargetRef::Player(PlayerId(0)), 3),
+            3,
+            "a different Mercenaries' damage must not be prevented by this shield"
+        );
+    }
+
+    /// CR 109.1 (issue #8485, BL1 second instance): the "you and OTHER permanents
+    /// you control" exclusion is HOST-RELATIVE and must survive routing.
+    ///
+    /// `untargeted_damage_filter` lowers
+    /// `TargetFilter::ControllerAndControlledPermanents { source_scope: Exclude }`
+    /// into `DamageTargetFilter::PlayerOrPermanentsControlledBy { source_scope:
+    /// Exclude }`, whose permanent leg is `*oid != repl_source`
+    /// (`replacement.rs`). Under the sentinel that comparison is inert — the shield
+    /// would start protecting its OWN host, the exact inverse of the printed "other"
+    /// article. Revert-failing against A2(i)'s `matches_damage_target_filter` anchor.
+    #[test]
+    fn other_permanents_exclusion_survives_routing() {
+        let mut state = GameState::new_two_player(42);
+        let wanderer = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "The Wanderer".to_string(),
+            Zone::Battlefield,
+        );
+        let ally = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(0),
+            "Ally".to_string(),
+            Zone::Battlefield,
+        );
+        let attacker = create_object(
+            &mut state,
+            CardId(3),
+            PlayerId(1),
+            "Attacker".to_string(),
+            Zone::Battlefield,
+        );
+
+        install_untargeted_shield(
+            &mut state,
+            wanderer,
+            PlayerId(0),
+            TargetFilter::ControllerAndControlledPermanents {
+                permanent_type: None,
+                source_scope: crate::types::ability::SourceExclusion::Exclude,
+            },
+            None,
+            PreventionAmount::All,
+        );
+        assert_eq!(state.pending_damage_replacements.len(), 1);
+        assert_eq!(
+            state.pending_damage_replacements[0].source_object,
+            Some(wanderer)
+        );
+
+        // Reach-guard: another permanent that player controls IS protected.
+        assert_eq!(
+            damage_landed(&mut state, attacker, TargetRef::Object(ally), 3),
+            0,
+            "the shield must protect other permanents its controller controls"
+        );
+        // CR 109.1: the HOST itself is excluded by the "other" article.
+        assert_eq!(
+            damage_landed(&mut state, attacker, TargetRef::Object(wanderer), 3),
+            3,
+            "CR 109.1: \"OTHER permanents you control\" must not cover the source"
+        );
+    }
+
+    /// CR 109.1 + CR 614.1a (issue #8485, migration hazard; settles U3): the pending
+    /// scan's `valid_card` gate now delegates to `replacement_valid_card_matches` —
+    /// the same authority the per-object scan uses — so the two agree for every
+    /// `ProposedEvent::Damage` shape, including the player-target case where they
+    /// previously diverged.
+    ///
+    /// A "prevent all damage that would be dealt to creatures this turn" shield
+    /// carries `valid_card: Some(Typed(creature))` and `damage_target_filter: None`.
+    /// Before the consolidation the pending scan SKIPPED the gate for a player
+    /// recipient, so moving such a shield to the registry would newly have made it
+    /// prevent damage dealt to players. This also corrects the pre-existing
+    /// instant-sourced (Blinding Fog class) case.
+    #[test]
+    fn pending_valid_card_gate_matches_the_object_path() {
+        let mut state = GameState::new_two_player(42);
+        let fog = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Blinding Fog".to_string(),
+            Zone::Battlefield,
+        );
+        let bear = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(0),
+            "Bear".to_string(),
+            Zone::Battlefield,
+        );
+        state
+            .objects
+            .get_mut(&bear)
+            .unwrap()
+            .card_types
+            .core_types
+            .push(CoreType::Creature);
+        let attacker = create_object(
+            &mut state,
+            CardId(3),
+            PlayerId(1),
+            "Attacker".to_string(),
+            Zone::Battlefield,
+        );
+
+        install_untargeted_shield(
+            &mut state,
+            fog,
+            PlayerId(0),
+            TargetFilter::Typed(TypedFilter::creature()),
+            None,
+            PreventionAmount::All,
+        );
+        let shield = &state.pending_damage_replacements[0];
+        assert_eq!(
+            shield.valid_card,
+            Some(TargetFilter::Typed(TypedFilter::creature()))
+        );
+        assert_eq!(shield.damage_target_filter, None);
+
+        // Positive reach-guard: object damage matching the filter IS prevented.
+        assert_eq!(
+            damage_landed(&mut state, attacker, TargetRef::Object(bear), 3),
+            0
+        );
+        // CR 109.1: a player is not an object, so player damage is NOT prevented.
+        assert_eq!(
+            damage_landed(&mut state, attacker, TargetRef::Player(PlayerId(0)), 3),
+            3,
+            "CR 109.1: a card-shaped recipient filter must not cover a player"
+        );
+    }
+
+    /// CR 113.7a (issue #8485, MG-A; settles U7): the `source_object` anchor is
+    /// latched ONLY over each caller's OWN pre-existing object-hosting zone set, so
+    /// it is inert for every shield that was already registry-hosted before it
+    /// existed. Four legs.
+    ///
+    /// Legs (iii) and (iv) are the multi-authority pair: the SAME Command-zone
+    /// source anchors through `push_player_scoped_shield` (whose `anchor_zones` is
+    /// `[Battlefield, Command]`, the pair its old storage fork tested) but does NOT
+    /// anchor through `resolve`'s untargeted branch (whose `anchor_zones` is
+    /// `[Battlefield]` alone, the predicate ITS old fork tested). Revert-failing
+    /// against A3(b)'s per-caller slice: a single hardcoded `Battlefield | Command`
+    /// test would flip leg (iii) to `Some`, newly activating `SourceExclusion::
+    /// Exclude` and `DamageTargetPlayerScope::SourceChosenPlayer` on a population
+    /// that is already registry-hosted today — over-matching, the exact inverse of
+    /// the under-matching the anchor exists to fix.
+    #[test]
+    fn instant_sourced_shield_carries_no_source_object_anchor() {
+        // (i) A shield installed from a STACK source (instant mid-resolution).
+        let mut state = GameState::new_two_player(42);
+        let spell = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Fog".to_string(),
+            Zone::Stack,
+        );
+        install_untargeted_shield(
+            &mut state,
+            spell,
+            PlayerId(0),
+            TargetFilter::Any,
+            None,
+            PreventionAmount::All,
+        );
+        assert_eq!(state.pending_damage_replacements.len(), 1);
+        assert_eq!(
+            state.pending_damage_replacements[0].source_object, None,
+            "a shield created by a resolving instant never had a host to anchor"
+        );
+        // CR 113.8: the controller is latched regardless.
+        assert_eq!(
+            state.pending_damage_replacements[0].source_controller,
+            Some(PlayerId(0))
+        );
+
+        // (ii) Paired positive reach-guard: a BATTLEFIELD source does anchor, so
+        // leg (i) is not passing merely because the anchor path never fires.
+        let mut state = GameState::new_two_player(42);
+        let permanent = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(0),
+            "Circle of Protection".to_string(),
+            Zone::Battlefield,
+        );
+        install_untargeted_shield(
+            &mut state,
+            permanent,
+            PlayerId(0),
+            TargetFilter::Any,
+            None,
+            PreventionAmount::All,
+        );
+        assert_eq!(
+            state.pending_damage_replacements[0].source_object,
+            Some(permanent)
+        );
+
+        // (iii) HOSTILE (MG-A): a COMMAND-zone source (an emblem) routed through
+        // `resolve`'s untargeted branch. That branch's old storage fork tested
+        // `Zone::Battlefield` ALONE, so a Command-zone source was ALREADY going to
+        // the registry unanchored — and must stay that way.
+        let mut state = GameState::new_two_player(42);
+        let emblem = create_object(
+            &mut state,
+            CardId(3),
+            PlayerId(0),
+            "Emblem".to_string(),
+            Zone::Command,
+        );
+        install_untargeted_shield(
+            &mut state,
+            emblem,
+            PlayerId(0),
+            TargetFilter::Any,
+            None,
+            PreventionAmount::All,
+        );
+        assert_eq!(state.pending_damage_replacements.len(), 1);
+        assert_eq!(
+            state.pending_damage_replacements[0].source_object, None,
+            "an emblem-sourced untargeted shield was already registry-hosted, so \
+             anchoring it would be an unmeasured behavior change"
+        );
+
+        // (iv) MULTI-AUTHORITY: the SAME Command-zone source, routed instead
+        // through `push_player_scoped_shield` (a PLAYER-targeted prevention), DOES
+        // anchor — because that caller genuinely hosted on Battlefield | Command.
+        let mut state = GameState::new_two_player(42);
+        let emblem = create_object(
+            &mut state,
+            CardId(4),
+            PlayerId(0),
+            "Emblem".to_string(),
+            Zone::Command,
+        );
+        let ability = ResolvedAbility::new(
+            Effect::PreventDamage {
+                amount: PreventionAmount::All,
+                amount_dynamic: None,
+                target: TargetFilter::Player,
+                scope: PreventionScope::AllDamage,
+                damage_source_filter: None,
+                prevention_duration: None,
+            },
+            vec![TargetRef::Player(PlayerId(0))],
+            emblem,
+            PlayerId(0),
+        );
+        resolve(&mut state, &ability, &mut Vec::new()).expect("prevention resolves");
+        assert_eq!(state.pending_damage_replacements.len(), 1);
+        assert_eq!(
+            state.pending_damage_replacements[0].source_object,
+            Some(emblem),
+            "`push_player_scoped_shield`'s own zone set includes Command"
+        );
+        // Incidental fix pinned: the old registry arm of `push_player_scoped_shield`
+        // never latched `source_controller` (CR 113.8); the authority always does.
+        assert_eq!(
+            state.pending_damage_replacements[0].source_controller,
+            Some(PlayerId(0))
+        );
+    }
+
+    /// CR 702.26b + CR 113.7a (issue #8485, M6): a source-scoped shield survives its
+    /// SOURCE phasing out. CR 702.26b makes a phased-out PERMANENT nonexistent; it
+    /// says nothing about a continuous effect that already exists, and CR 113.7a
+    /// says the effect is independent of its source once the ability resolved. A
+    /// Circle of Protection whose controller phases it out mid-turn must not lose
+    /// the shield it already created.
+    ///
+    /// This is a DELIBERATE behavior change: object-hosted definitions are filtered
+    /// through `functioning_abilities::object_functions`, which returns false for a
+    /// phased-out permanent; the floating registry has no such gate.
+    #[test]
+    fn floating_shield_survives_its_source_phasing_out() {
+        let mut state = GameState::new_two_player(42);
+        let cop = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Circle of Protection".to_string(),
+            Zone::Battlefield,
+        );
+        let attacker = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(1),
+            "Attacker".to_string(),
+            Zone::Battlefield,
+        );
+        install_untargeted_shield(
+            &mut state,
+            cop,
+            PlayerId(0),
+            TargetFilter::Any,
+            None,
+            PreventionAmount::All,
+        );
+
+        // Positive reach-guard: the shield applies BEFORE the phase-out.
+        assert_eq!(
+            damage_landed(&mut state, attacker, TargetRef::Player(PlayerId(0)), 2),
+            0
+        );
+
+        state.objects.get_mut(&cop).unwrap().phase_status =
+            crate::game::game_object::PhaseStatus::PhasedOut {
+                cause: crate::game::game_object::PhaseOutCause::Directly,
+            };
+        assert!(state.objects[&cop].is_phased_out());
+
+        assert_eq!(
+            damage_landed(&mut state, attacker, TargetRef::Player(PlayerId(0)), 2),
+            0,
+            "CR 113.7a: the effect exists independently of its phased-out source"
+        );
+    }
+
+    /// CR 616.1 (issue #8485; settles U2): two applicable prevention shields on one
+    /// damage event — one object-hosted, one in the floating registry — prevent the
+    /// damage exactly ONCE, with no panic and no double-consume.
+    ///
+    /// OBSERVED VERDICT (this is the U2 measurement the plan asked to record, and it
+    /// contradicts the guess this test was first written with): the engine PARKS.
+    /// `apply_damage_to_target` returns `DamageResult::NeedsChoice` and
+    /// `state.waiting_for` becomes `WaitingFor::ReplacementChoice`, because CR 616.1
+    /// gives the AFFECTED player the choice of which applicable replacement to apply
+    /// first and `replacement_ordering_is_material` finds the order material for two
+    /// prevention shields on one damage event. It does NOT auto-resolve.
+    ///
+    /// That matters for Unit A specifically: the pending scan runs AFTER the
+    /// per-object walk in `find_applicable_replacements`, so moving a shield from
+    /// the object store to the registry changes the ORDER the two candidates are
+    /// offered in — and `PendingReplacement.candidates` parks those raw
+    /// `ReplacementId`s across a layer flush, which is exactly why Unit B's carried
+    /// entries are settled to the TAIL rather than inserted ahead of derived grants.
+    ///
+    /// The choice is submitted through the real production path
+    /// (`GameAction::ChooseReplacement` via `apply_as_current`), not by poking the
+    /// pipeline, so this covers the `WaitingFor` route rather than a helper.
+    #[test]
+    fn two_shields_on_one_damage_event_prevent_it_exactly_once() {
+        let mut state = GameState::new_two_player(42);
+        let host = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Shielded Creature".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let obj = state.objects.get_mut(&host).unwrap();
+            obj.card_types.core_types.push(CoreType::Creature);
+            obj.power = Some(2);
+            obj.toughness = Some(2);
+        }
+        let source = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(0),
+            "Shield Source".to_string(),
+            Zone::Battlefield,
+        );
+        let attacker = create_object(
+            &mut state,
+            CardId(3),
+            PlayerId(1),
+            "Attacker".to_string(),
+            Zone::Battlefield,
+        );
+
+        // Shield 1: object-hosted on the damage recipient (the targeted arm).
+        // Both shields are `Next(1)` against a 1-damage event: a `Prevention { All }`
+        // shield mutates nothing when it applies (it stays live for the rest of the
+        // turn), so it could not make "exactly once" observable at all. `Next(1)`
+        // depletes, and 1 damage is fully absorbed by the first shield to apply, so
+        // the CR 616.1 loop ends before the second becomes applicable again.
+        let targeted = ResolvedAbility::new(
+            Effect::PreventDamage {
+                amount: PreventionAmount::Next(1),
+                amount_dynamic: None,
+                target: TargetFilter::Any,
+                scope: PreventionScope::AllDamage,
+                damage_source_filter: None,
+                prevention_duration: None,
+            },
+            vec![TargetRef::Object(host)],
+            source,
+            PlayerId(0),
+        );
+        resolve(&mut state, &targeted, &mut Vec::new()).expect("targeted shield resolves");
+        // Shield 2: source-scoped, in the floating registry (the untargeted arm).
+        install_untargeted_shield(
+            &mut state,
+            source,
+            PlayerId(0),
+            TargetFilter::Any,
+            None,
+            PreventionAmount::Next(1),
+        );
+
+        // Reach-guard: both stores really hold one shield each, so the CR 616.1
+        // competition below is not vacuous.
+        assert_eq!(state.objects[&host].replacement_definitions.len(), 1);
+        assert_eq!(state.pending_damage_replacements.len(), 1);
+        let object_before = format!("{:?}", state.objects[&host].replacement_definitions.first());
+        let registry_before = format!("{:?}", state.pending_damage_replacements.first());
+
+        let ctx = deal_damage::DamageContext::from_source(&state, attacker).expect("context");
+        let result = deal_damage::apply_damage_to_target(
+            &mut state,
+            &ctx,
+            TargetRef::Object(host),
+            1,
+            false,
+            &mut Vec::new(),
+        )
+        .expect("damage resolves");
+        assert!(
+            matches!(result, deal_damage::DamageResult::NeedsChoice),
+            "U2 observation: the engine PARKS a CR 616.1 replacement choice here"
+        );
+        let WaitingFor::ReplacementChoice {
+            player,
+            candidate_count,
+            ..
+        } = state.waiting_for.clone()
+        else {
+            panic!(
+                "expected a ReplacementChoice park, got {:?}",
+                state.waiting_for
+            );
+        };
+        assert_eq!(
+            player,
+            PlayerId(0),
+            "CR 616.1: the AFFECTED object's controller chooses"
+        );
+        assert_eq!(candidate_count, 2, "both shields are offered");
+
+        // Submit the choice through the real action path.
+        state.priority_player = player;
+        crate::game::engine::apply_as_current(
+            &mut state,
+            crate::types::actions::GameAction::ChooseReplacement { index: 0 },
+        )
+        .expect("submit the CR 616.1 replacement choice");
+
+        assert_eq!(
+            state.objects[&host].damage_marked, 0,
+            "the damage is prevented"
+        );
+        // CR 614.5: exactly ONE of the two shields absorbs the event — compared by
+        // whole-definition Debug so the assertion holds whether the applier records
+        // the use as `is_consumed` or as a decremented amount.
+        let object_changed =
+            format!("{:?}", state.objects[&host].replacement_definitions.first()) != object_before;
+        let registry_changed =
+            format!("{:?}", state.pending_damage_replacements.first()) != registry_before;
+        assert!(
+            object_changed != registry_changed,
+            "CR 614.5: exactly one shield may absorb one damage event \
+             (object_changed={object_changed}, registry_changed={registry_changed})"
+        );
+    }
+
+    /// CR 616.1 + CR 113.7a (issue #8485, R1): the CR 616.1 replacement-choice
+    /// PROMPT must name the permanent that created a registry-hosted shield.
+    ///
+    /// This is a regression THIS change would otherwise have introduced. Before
+    /// #8485 a Maze of Ith / Circle of Protection / Mercenaries shield was
+    /// object-hosted, so `ReplacementCandidateSummary` read `name_of(rid.source)`
+    /// and got the permanent's name. Unit A moves those shields into
+    /// `state.pending_damage_replacements`, whose `rid.source` is the `ObjectId(0)`
+    /// storage sentinel — which per CR 109.4 has no entry in `state.objects`, so the
+    /// name went blank and the description fell through to the bare "Replacement
+    /// effect" placeholder. That lands exactly where this change also makes CR 616.1
+    /// prompts newly appear (see
+    /// `two_shields_on_one_damage_event_prevent_it_exactly_once`), so a player could
+    /// be asked to choose between two indistinguishable options.
+    ///
+    /// `replacement_choice_display_source` / `replacement_choice_definition` in
+    /// `replacement.rs` resolve the DISPLAY anchor through the shield's CR 113.7a
+    /// `source_object`. `ReplacementId::source` is untouched as a storage
+    /// discriminator — `handle_replacement_choice` still resolves the raw `rid`.
+    ///
+    /// Revert-failing: revert either helper and the registry candidate's
+    /// `source_id` is `ObjectId(0)` with an empty `source_name`.
+    #[test]
+    fn replacement_choice_prompt_names_the_anchored_source_of_a_registry_shield() {
+        /// Build the two-competing-shields park and return the parked candidates.
+        /// `shield_source_zone` decides whether the registry shield is anchored:
+        /// `Battlefield` anchors it (issue #8485's moved population), `Stack` does
+        /// not (a resolving instant never had a host).
+        fn park_with_two_shields(
+            shield_source_zone: Zone,
+        ) -> (
+            GameState,
+            ObjectId,
+            ObjectId,
+            Vec<crate::types::game_state::ReplacementCandidateSummary>,
+        ) {
+            let mut state = GameState::new_two_player(42);
+            let host = create_object(
+                &mut state,
+                CardId(1),
+                PlayerId(0),
+                "Shielded Creature".to_string(),
+                Zone::Battlefield,
+            );
+            {
+                let obj = state.objects.get_mut(&host).unwrap();
+                obj.card_types.core_types.push(CoreType::Creature);
+                obj.power = Some(2);
+                obj.toughness = Some(2);
+            }
+            let shield_source = create_object(
+                &mut state,
+                CardId(2),
+                PlayerId(0),
+                "Circle of Protection".to_string(),
+                shield_source_zone,
+            );
+            let attacker = create_object(
+                &mut state,
+                CardId(3),
+                PlayerId(1),
+                "Attacker".to_string(),
+                Zone::Battlefield,
+            );
+
+            // Object-hosted shield on the recipient (the targeted arm).
+            let targeted = ResolvedAbility::new(
+                Effect::PreventDamage {
+                    amount: PreventionAmount::Next(1),
+                    amount_dynamic: None,
+                    target: TargetFilter::Any,
+                    scope: PreventionScope::AllDamage,
+                    damage_source_filter: None,
+                    prevention_duration: None,
+                },
+                vec![TargetRef::Object(host)],
+                shield_source,
+                PlayerId(0),
+            );
+            resolve(&mut state, &targeted, &mut Vec::new()).expect("targeted shield resolves");
+            // Registry-hosted shield (the untargeted arm).
+            install_untargeted_shield(
+                &mut state,
+                shield_source,
+                PlayerId(0),
+                TargetFilter::Any,
+                None,
+                PreventionAmount::Next(1),
+            );
+            assert_eq!(state.pending_damage_replacements.len(), 1);
+
+            let ctx = deal_damage::DamageContext::from_source(&state, attacker).expect("context");
+            let result = deal_damage::apply_damage_to_target(
+                &mut state,
+                &ctx,
+                TargetRef::Object(host),
+                1,
+                false,
+                &mut Vec::new(),
+            )
+            .expect("damage resolves");
+            assert!(
+                matches!(result, deal_damage::DamageResult::NeedsChoice),
+                "reach-guard: two applicable shields must park a CR 616.1 choice"
+            );
+            let WaitingFor::ReplacementChoice { candidates, .. } = state.waiting_for.clone() else {
+                panic!(
+                    "expected a ReplacementChoice park, got {:?}",
+                    state.waiting_for
+                );
+            };
+            assert_eq!(candidates.len(), 2, "both shields are offered");
+            (state, host, shield_source, candidates)
+        }
+
+        // POSITIVE: a battlefield source anchors, so the prompt names it.
+        let (state, host, cop, candidates) = park_with_two_shields(Zone::Battlefield);
+        assert_eq!(
+            state.pending_damage_replacements[0].source_object,
+            Some(cop),
+            "reach-guard: this is the anchored (moved) population"
+        );
+        let registry_option = candidates
+            .iter()
+            .find(|c| c.source_id == cop)
+            .unwrap_or_else(|| {
+                panic!(
+                    "CR 616.1: the registry shield's option must name its host, got {candidates:?}"
+                )
+            });
+        assert_eq!(
+            registry_option.source_name, "Circle of Protection",
+            "CR 113.7a: the shield's host identity travels with it and names the option"
+        );
+        // The label site now reads the REGISTRY entry, so the option describes
+        // itself instead of falling through to the bare placeholder.
+        assert_eq!(
+            Some(registry_option.description.clone()),
+            state.pending_damage_replacements[0].description.clone(),
+            "the option's description must come from the registry entry itself"
+        );
+        // SIBLING: the object-hosted option is unaffected and still names its host.
+        let object_option = candidates
+            .iter()
+            .find(|c| c.source_id == host)
+            .expect("the object-hosted shield's option still names its host");
+        assert_eq!(object_option.source_name, "Shielded Creature");
+
+        // NEGATIVE SIBLING: a STACK-sourced shield has no host to anchor, so it
+        // degrades to today's behavior — the sentinel and an empty name — rather
+        // than panicking or naming some unrelated object.
+        let (state, host, _spell, candidates) = park_with_two_shields(Zone::Stack);
+        assert_eq!(
+            state.pending_damage_replacements[0].source_object, None,
+            "an instant-sourced shield carries no anchor"
+        );
+        let unanchored = candidates
+            .iter()
+            .find(|c| c.source_id == ObjectId(0))
+            .unwrap_or_else(|| {
+                panic!("the unanchored option keeps the sentinel, got {candidates:?}")
+            });
+        assert_eq!(
+            unanchored.source_name, "",
+            "no anchor means no name — it must not borrow another object's"
+        );
+        assert!(
+            candidates.iter().filter(|c| c.source_id == host).count() == 1,
+            "the unanchored option must not be mislabelled as the object-hosted one"
+        );
+    }
+
+    /// CR 113.8 + CR 109.5 + CR 611.2a (issue #8485, MG-B): a controller-relative
+    /// gate on a MOVED shield follows the INSTALLER, not the source permanent's live
+    /// controller.
+    ///
+    /// This is the second identity axis Unit A changes. The object scan computes
+    /// `replacement_source_player(obj)` — the host's LIVE controller, re-read every
+    /// pass — and never reads `source_controller`; the pending scan uses
+    /// `source_controller.unwrap_or(active_player)`, which the install authority now
+    /// always latches. CR 113.8: "The controller of an activated ability on the
+    /// stack is the player who activated it." CR 109.5: for an activated ability,
+    /// "you" is the player who activated the ability. CR 611.2a: the continuous
+    /// effect lasts as stated by the ability that created it, so its "you" is fixed
+    /// at resolution and does not follow the source permanent to a new controller.
+    ///
+    /// HOSTILE FIXTURE: the control change is the only input that separates the two
+    /// readings, and `state.active_player` is set to the NON-installer so the
+    /// `unwrap_or(active_player)` fallback is also discriminated.
+    /// Revert-failing against A3(a): without the latch, `source_controller` is
+    /// `None` and the gate drifts to whoever is active.
+    #[test]
+    fn controller_relative_gate_follows_the_installer_not_the_live_host_controller() {
+        let mut state = GameState::new_two_player(42);
+        // The NON-installer is active, so `unwrap_or(state.active_player)` would
+        // answer P1 if the latch were missing.
+        state.active_player = PlayerId(1);
+        let source = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Comeuppance".to_string(),
+            Zone::Battlefield,
+        );
+        let attacker = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(1),
+            "Attacker".to_string(),
+            Zone::Battlefield,
+        );
+
+        install_untargeted_shield(
+            &mut state,
+            source,
+            PlayerId(0),
+            TargetFilter::ControllerAndControlledPermanents {
+                permanent_type: None,
+                source_scope: crate::types::ability::SourceExclusion::Include,
+            },
+            None,
+            PreventionAmount::All,
+        );
+        // Reach-guard, and the pin that this IS the moved population.
+        let shield = &state.pending_damage_replacements[0];
+        assert_eq!(shield.source_controller, Some(PlayerId(0)));
+        assert_eq!(shield.source_object, Some(source));
+        assert!(matches!(
+            shield.damage_target_filter,
+            Some(DamageTargetFilter::PlayerOrPermanentsControlledBy {
+                player: DamageTargetPlayerScope::Controller,
+                ..
+            })
+        ));
+
+        // CR 611.2c: change control of the SOURCE permanent (Threaten / Ray of
+        // Command) inside the shield's window.
+        state.objects.get_mut(&source).unwrap().controller = PlayerId(1);
+
+        assert_eq!(
+            damage_landed(&mut state, attacker, TargetRef::Player(PlayerId(0)), 3),
+            0,
+            "CR 113.8: the shield still protects the player who activated the ability"
+        );
+        assert_eq!(
+            damage_landed(&mut state, attacker, TargetRef::Player(PlayerId(1)), 3),
+            3,
+            "the source's NEW controller does not inherit the shield"
+        );
     }
 }

--- a/crates/engine/src/game/effects/regenerate.rs
+++ b/crates/engine/src/game/effects/regenerate.rs
@@ -77,7 +77,18 @@ pub fn resolve(
             .regeneration_shield();
 
         if let Some(obj) = state.objects.get_mut(&obj_id) {
-            obj.replacement_definitions.push(shield);
+            // CR 701.19a: "If the effect of a resolving spell or ability regenerates
+            // a permanent, it creates a replacement effect that protects the
+            // permanent the next time it would be destroyed THIS TURN." The shield's
+            // window is the turn, not the next layer pass — so it installs through
+            // the resolution-install authority, which the CR 613.1 reseed carries
+            // (CR 611.2c: it is not one of the permanent's characteristics).
+            //
+            // This is also why the shield must exist in exactly ONE store: the
+            // `destroy_applier` marks it `is_consumed` in place, and a second copy
+            // in base would be re-seeded over the consumed one on the next pass,
+            // producing infinite regeneration.
+            obj.install_resolution_replacement(shield);
         }
     }
 
@@ -96,6 +107,109 @@ mod tests {
     use crate::game::zones::create_object;
     use crate::types::identifiers::{CardId, ObjectId};
     use crate::types::player::PlayerId;
+
+    /// CR 701.19a + CR 611.2c + CR 613.1 (issue #8485): a regeneration shield
+    /// survives a layer pass WITH its consumed state, so the permanent regenerates
+    /// EXACTLY ONCE.
+    ///
+    /// This is the anti-resurrection witness. It discriminates against the rejected
+    /// dual-write design: if the shield lived in BOTH `base_replacement_definitions`
+    /// and the live store, the CR 613.1 reseed would copy the pristine base twin
+    /// over the consumed live one and the creature would regenerate forever.
+    /// CR 701.19a: "it creates a replacement effect that protects the permanent the
+    /// next time it would be destroyed THIS TURN" — the next time, once.
+    ///
+    /// Revert-failing on two seams at once: revert C3 (the install authority) and
+    /// the shield is wiped by the first `evaluate_layers`, so the FIRST destroy
+    /// kills the creature; adopt dual-write and the SECOND destroy does not.
+    #[test]
+    fn regeneration_shield_survives_a_layer_pass_and_regenerates_exactly_once() {
+        let mut state = GameState::new_two_player(42);
+        let bear = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Bear".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let obj = state.objects.get_mut(&bear).unwrap();
+            obj.card_types
+                .core_types
+                .push(crate::types::card_type::CoreType::Creature);
+            obj.base_card_types = obj.card_types.clone();
+            obj.power = Some(2);
+            obj.toughness = Some(2);
+            obj.base_power = Some(2);
+            obj.base_toughness = Some(2);
+            obj.base_characteristics_initialized = true;
+        }
+
+        let ability = ResolvedAbility::new(
+            Effect::Regenerate {
+                target: TargetFilter::SelfRef,
+            },
+            vec![],
+            bear,
+            PlayerId(0),
+        );
+        resolve(&mut state, &ability, &mut Vec::new()).unwrap();
+        assert!(
+            state.objects[&bear].replacement_definitions[0].is_resolution_installed(),
+            "CR 611.2c: the shield is stamped as resolution-created"
+        );
+
+        // CR 613.1: a layer pass between the regeneration and the destruction.
+        state.layers_dirty.mark_full();
+        crate::game::layers::evaluate_layers(&mut state);
+        assert_eq!(
+            state.objects[&bear].replacement_definitions.len(),
+            1,
+            "the shield must survive the reset"
+        );
+
+        // First destroy: survived (positive reach-guard), shield consumed.
+        let mut events = Vec::new();
+        crate::game::effects::destroy::destroy_single_object(
+            &mut state,
+            bear,
+            bear,
+            false,
+            &mut events,
+        );
+        assert_eq!(
+            state.objects[&bear].zone,
+            Zone::Battlefield,
+            "CR 701.19a: the first destruction is replaced by regeneration"
+        );
+        assert!(
+            state.objects[&bear].replacement_definitions[0].is_consumed,
+            "CR 615.3: the shield is used up"
+        );
+
+        // Second layer pass — the anti-resurrection step.
+        state.layers_dirty.mark_full();
+        crate::game::layers::evaluate_layers(&mut state);
+        assert!(
+            state.objects[&bear].replacement_definitions[0].is_consumed,
+            "a layer pass must not resurrect a spent regeneration shield"
+        );
+
+        // Second destroy: the creature dies.
+        let mut events = Vec::new();
+        crate::game::effects::destroy::destroy_single_object(
+            &mut state,
+            bear,
+            bear,
+            false,
+            &mut events,
+        );
+        assert_eq!(
+            state.objects[&bear].zone,
+            Zone::Graveyard,
+            "CR 701.19a: the shield protects the permanent the NEXT time, once"
+        );
+    }
 
     #[test]
     fn regenerate_creates_shield_on_source() {

--- a/crates/engine/src/game/game_object.rs
+++ b/crates/engine/src/game/game_object.rs
@@ -1688,10 +1688,6 @@ impl GameObject {
     /// it is also what makes the carry-over idempotent under mid-pass re-entry
     /// (see `reseed_replacements_carrying_resolution_effects`).
     pub(crate) fn install_resolution_replacement(&mut self, mut def: ReplacementDefinition) {
-        debug_assert!(
-            !self.base_replacement_definitions.contains(&def),
-            "a resolution-installed replacement must not also live in base"
-        );
         // CR 611.2a: a `Resolution`-origin def is carried across every CR 613.1
         // reset, so its ONLY removal paths are an expiry prune (`turns.rs`, all
         // three of which key on `expiry` alone) and a zone change. A def with no
@@ -1707,6 +1703,15 @@ impl GameObject {
             self.replacement_definitions.push(def);
             return;
         }
+        // Asserted AFTER the fail-closed return, not before it: the invariant is
+        // about defs that actually get STAMPED `Resolution`, and an unbounded def
+        // never is. Checking it earlier would abort debug and test builds for a
+        // legitimate unstated-duration rider that merely happens to equal a printed
+        // base def — a def that, being live-only and unstamped, cannot double-apply.
+        debug_assert!(
+            !self.base_replacement_definitions.contains(&def),
+            "a resolution-installed replacement must not also live in base"
+        );
         def.origin = crate::types::ability::ReplacementOrigin::Resolution;
         self.replacement_definitions.push(def);
     }

--- a/crates/engine/src/game/game_object.rs
+++ b/crates/engine/src/game/game_object.rs
@@ -1672,6 +1672,45 @@ impl GameObject {
             .collect();
     }
 
+    /// CR 611.2a + CR 611.2c + CR 613.1: install a replacement effect created by the
+    /// RESOLUTION of a spell or ability onto this object as its HOST.
+    ///
+    /// THE single authority for resolution-time object installs. Callers must never
+    /// push onto `replacement_definitions` or `base_replacement_definitions`
+    /// directly: a raw live push is reset away at the next layer pass (CR 613.1,
+    /// `layers::seed_live_characteristics_from_base`), and a base push would put a
+    /// second, unaddressable copy behind the pipeline's `ReplacementId` index and
+    /// resurrect the def's runtime state — CR 615.3 "used up", CR 615.7 depletion,
+    /// CR 701.19a regeneration consumption — on the next reseed.
+    ///
+    /// INVARIANT: a `Resolution`-origin def is never present in
+    /// `base_replacement_definitions`. Violating it double-applies the effect, and
+    /// it is also what makes the carry-over idempotent under mid-pass re-entry
+    /// (see `reseed_replacements_carrying_resolution_effects`).
+    pub(crate) fn install_resolution_replacement(&mut self, mut def: ReplacementDefinition) {
+        debug_assert!(
+            !self.base_replacement_definitions.contains(&def),
+            "a resolution-installed replacement must not also live in base"
+        );
+        // CR 611.2a: a `Resolution`-origin def is carried across every CR 613.1
+        // reset, so its ONLY removal paths are an expiry prune (`turns.rs`, all
+        // three of which key on `expiry` alone) and a zone change. A def with no
+        // expiry has neither — carrying it would make it immortal. Fail CLOSED:
+        // install it live-only, exactly as this call site behaved before the
+        // authority existed, so it is still reset away at the next pass. The one
+        // caller that can reach this arm is `add_target_replacement`'s
+        // unstated-duration NON-shield rider (`with_resolution_shield_expiry` is
+        // gated on `shield_kind.is_shield()` precisely so those keep `None`);
+        // `prevent_damage`, `create_damage_replacement` and `regenerate` all stamp
+        // an expiry unconditionally.
+        if def.expiry.is_none() {
+            self.replacement_definitions.push(def);
+            return;
+        }
+        def.origin = crate::types::ability::ReplacementOrigin::Resolution;
+        self.replacement_definitions.push(def);
+    }
+
     /// Installs a new intentional base/face/cleave trigger set and then
     /// materializes its ordered printed slots. Allocation occurs before the
     /// live entries become observable.
@@ -2265,8 +2304,26 @@ impl GameObject {
         self.materialize_test_fixture_trigger_base();
         if self.base_replacement_definitions.is_empty() && !self.replacement_definitions.is_empty()
         {
-            self.base_replacement_definitions =
-                Arc::new(self.replacement_definitions.iter_all().cloned().collect());
+            // CR 611.2c: a resolution-created continuous effect is NOT a printed
+            // characteristic, so it must never be back-filled into the base store.
+            // Doing so would put it in base AND in the carried set, double-applying
+            // it and resurrecting its consumed/depleted runtime state at the next
+            // CR 613.1 reseed. This function is the ONLY production path in the tree
+            // that can copy the live store into base; the filter is what makes
+            // `reseed_replacements_carrying_resolution_effects`'s idempotence
+            // invariant ("no baseline ever contains a `Resolution` member")
+            // unconditional rather than true only in practice. Reachable only on a
+            // fixture whose base was never initialized (the function is gated on
+            // `base_characteristics_initialized`).
+            let carried: Vec<ReplacementDefinition> = self
+                .replacement_definitions
+                .iter_all()
+                .filter(|d| !d.is_resolution_installed())
+                .cloned()
+                .collect();
+            if !carried.is_empty() {
+                self.base_replacement_definitions = Arc::new(carried);
+            }
         }
         if self.base_static_definitions.is_empty() && !self.static_definitions.is_empty() {
             self.base_static_definitions =
@@ -3264,6 +3321,87 @@ pub(crate) fn source_chosen_player(state: &GameState, source_id: ObjectId) -> Op
                 })
             })
         })
+}
+
+/// CR 611.2c + CR 613.1: rebuild a live replacement store from a baseline while
+/// CARRYING FORWARD every replacement created by the resolution of a spell or
+/// ability.
+///
+/// CR 613.1 governs an object's CHARACTERISTICS. CR 611.2c settles that a
+/// prevention shield is not one — "An effect that reads 'Prevent all damage
+/// creatures would deal this turn' doesn't modify any object's characteristics,
+/// so it's modifying the rules of the game." A shield is merely stored on an
+/// object so the pipeline can find it, and CR 611.2a gives it the lifetime the
+/// ability stated, not "until the next layer pass". CR 615.3 ends it when it is
+/// used up or its duration expires.
+///
+/// Carried entries keep their runtime state — CR 615.3 consumption, CR 615.7
+/// depletion, CR 701.19a regeneration — because they are the same, single copy
+/// the appliers mutate.
+///
+/// TWO baselines, ONE authority. Within a single layer pass an object's live
+/// store can be wholesale-rewritten up to three times:
+///   1. the Step-1 top-of-pass reset (`layers::reset_recipient_to_base` ->
+///      `seed_live_characteristics_from_base`), baseline `base_replacement_definitions`;
+///   2. the CR 613.1a Layer-1a copy application (`layers.rs` `CopyValues` arm ->
+///      `printed_cards::apply_copiable_values`), baseline `CopiableValues::replacement_definitions`;
+///   3. the CR 613.2b Layer-1b face-down reseed (`layers.rs`, which calls
+///      `seed_live_characteristics_from_base` DIRECTLY, not via
+///      `reset_recipient_to_base`), baseline `base_replacement_definitions` again.
+///
+/// A copy effect has no authority to remove a resolution-created shield: CR 613.1a
+/// applies effects that modify COPIABLE VALUES, and CR 707.2 defines those as the
+/// values derived from the object's printed text, closing "Other effects ...,
+/// status, counters, and stickers are not copied."
+///
+/// IDEMPOTENT under that re-entry: `reseed(reseed(live, X), Y) == reseed(live, Y)`
+/// for any baselines X, Y, because the carried set is exactly the
+/// `Resolution`-origin members of `live` in order, and NO baseline ever contains
+/// a `Resolution`-origin member. THREE legs make that unconditional:
+///   1. `GameObject::install_resolution_replacement`'s `debug_assert!` pins that a
+///      `Resolution` def is never also in `base_replacement_definitions` at
+///      install time.
+///   2. `GameObject::sync_missing_base_characteristics` is the ONLY production path
+///      anywhere in the tree that can copy the LIVE store INTO base, and it filters
+///      `Resolution` defs out.
+///   3. EVERY other production write to `base_replacement_definitions` sources its
+///      content from somewhere a `Resolution` def cannot be — a parsed / printed /
+///      face / snapshot source, or a RETAIN over what is already there, or a
+///      `#[cfg(test)]` fixture. Regenerate that audit with:
+///      `grep -rn "base_replacement_definitions" crates/engine/src | grep -E "=|make_mut"`.
+///      (The `printed_cards.rs` write copies `CopiableValues::replacement_definitions`,
+///      which `copiable_replacement_definitions` derives from base — so it inherits
+///      the invariant rather than threatening it.)
+///
+/// The carried set is therefore invariant across all three rewrites, for every
+/// baseline the two callers can supply. That is why this function takes the
+/// baseline as a PARAMETER rather than reading `obj.base_replacement_definitions`
+/// itself.
+///
+/// Carried entries are appended right after the baseline so the in-pass
+/// consumers (the CR 613.1f / CR 305.7 retains, and the derived-grant dedups)
+/// see them; `layers::settle_resolution_replacements_to_tail` moves them behind
+/// the per-pass derived grants at the end of the pass.
+///
+/// Zero-alloc fast path: with no carried entry this is the pre-existing refcount
+/// bump. Mirrors `printed_cards::copiable_replacement_definitions`.
+pub(crate) fn reseed_replacements_carrying_resolution_effects(
+    live: &Definitions<ReplacementDefinition>,
+    baseline: &Arc<Vec<ReplacementDefinition>>,
+) -> Definitions<ReplacementDefinition> {
+    if !live
+        .iter_all()
+        .any(ReplacementDefinition::is_resolution_installed)
+    {
+        return Arc::clone(baseline).into();
+    }
+    let mut rebuilt: Vec<ReplacementDefinition> = baseline.as_ref().clone();
+    rebuilt.extend(
+        live.iter_all()
+            .filter(|d| d.is_resolution_installed())
+            .cloned(),
+    );
+    rebuilt.into()
 }
 
 #[cfg(test)]
@@ -4325,6 +4463,159 @@ mod tests {
         assert_eq!(canonical["prepared_copy_source"], serde_json::json!(77));
         let restored: GameObject = serde_json::from_value(canonical).unwrap();
         assert_eq!(restored.prepared_copy_source, Some(ObjectId(77)));
+    }
+
+    // ---- Issue #8485: the resolution-install and carry-over authorities ----
+
+    fn eot_shield() -> ReplacementDefinition {
+        ReplacementDefinition::new(crate::types::replacements::ReplacementEvent::DamageDone)
+            .prevention_shield(crate::types::ability::PreventionAmount::All)
+            .expiry(crate::types::ability::RestrictionExpiry::EndOfTurn)
+    }
+
+    /// CR 611.2a + CR 611.2c: the install authority stamps `Resolution` and leaves
+    /// the base store untouched. The base half is the invariant that makes the
+    /// carry-over idempotent — a def in base AND in the carried set applies twice.
+    #[test]
+    fn install_resolution_replacement_stamps_origin_and_leaves_base_untouched() {
+        let mut obj = GameObject::new(
+            ObjectId(1),
+            CardId(1),
+            PlayerId(0),
+            "Host".to_string(),
+            Zone::Battlefield,
+        );
+        obj.install_resolution_replacement(eot_shield());
+        assert_eq!(obj.replacement_definitions.len(), 1);
+        assert!(obj.replacement_definitions[0].is_resolution_installed());
+        assert!(
+            obj.base_replacement_definitions.is_empty(),
+            "CR 611.2c: a resolution shield is not a printed characteristic"
+        );
+    }
+
+    /// CR 611.2a (issue #8485, round-1 BLOCKER 4): a def with NO expiry is refused
+    /// the `Resolution` stamp and installed live-only — exactly today's behavior,
+    /// layer-fragile but never immortal. All three `turns.rs` prunes key on `expiry`
+    /// alone, so carrying an unbounded def across every reset would make it
+    /// permanent.
+    ///
+    /// The reachable caller is `add_target_replacement`'s unstated-duration NON-shield
+    /// rider: `with_resolution_shield_expiry` is gated on `shield_kind.is_shield()`
+    /// precisely so those keep `None`.
+    #[test]
+    fn resolution_install_refuses_an_unbounded_def() {
+        let unbounded =
+            ReplacementDefinition::new(crate::types::replacements::ReplacementEvent::GainLife);
+        assert!(unbounded.expiry.is_none());
+        let mut obj = GameObject::new(
+            ObjectId(1),
+            CardId(1),
+            PlayerId(0),
+            "Host".to_string(),
+            Zone::Battlefield,
+        );
+        obj.install_resolution_replacement(unbounded);
+        assert!(
+            !obj.replacement_definitions[0].is_resolution_installed(),
+            "an unbounded def must NOT be carried across layer passes"
+        );
+
+        // PAIRED POSITIVE REACH-GUARD: the same def WITH an expiry is stamped.
+        let bounded =
+            ReplacementDefinition::new(crate::types::replacements::ReplacementEvent::GainLife)
+                .expiry(crate::types::ability::RestrictionExpiry::EndOfTurn);
+        let mut obj2 = GameObject::new(
+            ObjectId(2),
+            CardId(1),
+            PlayerId(0),
+            "Host".to_string(),
+            Zone::Battlefield,
+        );
+        obj2.install_resolution_replacement(bounded);
+        assert!(obj2.replacement_definitions[0].is_resolution_installed());
+    }
+
+    /// The MG2 idempotence contract as an executable assertion, not prose:
+    /// `reseed(reseed(live, X), Y) == reseed(live, Y)` for any baselines X, Y.
+    /// This is what makes the carry-over safe under the up-to-three wholesale live
+    /// rewrites a single layer pass performs (Step-1 reset, Layer-1a copy
+    /// application, Layer-1b face-down reseed).
+    #[test]
+    fn reseed_carrying_resolution_effects_is_idempotent_across_baselines() {
+        let mut carried = eot_shield();
+        carried.origin = crate::types::ability::ReplacementOrigin::Resolution;
+        carried.is_consumed = true;
+
+        let base_x: Arc<Vec<ReplacementDefinition>> = Arc::new(vec![ReplacementDefinition::new(
+            crate::types::replacements::ReplacementEvent::GainLife,
+        )]);
+        let base_y: Arc<Vec<ReplacementDefinition>> = Arc::new(vec![
+            ReplacementDefinition::new(crate::types::replacements::ReplacementEvent::Draw),
+            ReplacementDefinition::new(crate::types::replacements::ReplacementEvent::DamageDone),
+        ]);
+
+        let live: Definitions<ReplacementDefinition> = vec![
+            ReplacementDefinition::new(crate::types::replacements::ReplacementEvent::GainLife),
+            carried.clone(),
+        ]
+        .into();
+
+        let once = reseed_replacements_carrying_resolution_effects(&live, &base_y);
+        let twice = reseed_replacements_carrying_resolution_effects(
+            &reseed_replacements_carrying_resolution_effects(&live, &base_x),
+            &base_y,
+        );
+        assert_eq!(
+            once.as_slice(),
+            twice.as_slice(),
+            "reseed(reseed(live, X), Y) must equal reseed(live, Y)"
+        );
+        assert!(once
+            .iter_all()
+            .any(|d| d.is_resolution_installed() && d.is_consumed));
+
+        // Zero-alloc fast path: no carried entry means the baseline `Arc` itself.
+        let plain: Definitions<ReplacementDefinition> = vec![ReplacementDefinition::new(
+            crate::types::replacements::ReplacementEvent::GainLife,
+        )]
+        .into();
+        let reseeded = reseed_replacements_carrying_resolution_effects(&plain, &base_y);
+        assert_eq!(reseeded.as_slice(), base_y.as_slice());
+    }
+
+    /// CR 611.2c: the base back-fill on an uninitialized fixture must never capture
+    /// a resolution shield — that is what keeps the idempotence invariant ("no
+    /// baseline ever contains a `Resolution` member") unconditional.
+    #[test]
+    fn base_backfill_never_captures_a_resolution_shield() {
+        let mut obj = GameObject::new(
+            ObjectId(1),
+            CardId(1),
+            PlayerId(0),
+            "Host".to_string(),
+            Zone::Battlefield,
+        );
+        obj.base_characteristics_initialized = false;
+        obj.install_resolution_replacement(eot_shield());
+        obj.sync_missing_base_characteristics();
+        assert!(
+            obj.base_replacement_definitions.is_empty(),
+            "a Resolution def must not be back-filled into base"
+        );
+
+        // PAIRED POSITIVE REACH-GUARD: a Characteristic def IS still back-filled.
+        let mut obj2 = GameObject::new(
+            ObjectId(2),
+            CardId(1),
+            PlayerId(0),
+            "Host".to_string(),
+            Zone::Battlefield,
+        );
+        obj2.base_characteristics_initialized = false;
+        obj2.replacement_definitions.push(eot_shield());
+        obj2.sync_missing_base_characteristics();
+        assert_eq!(obj2.base_replacement_definitions.len(), 1);
     }
 
     #[test]

--- a/crates/engine/src/game/game_object.rs
+++ b/crates/engine/src/game/game_object.rs
@@ -3426,9 +3426,9 @@ pub(crate) fn source_chosen_player(state: &GameState, source_id: ObjectId) -> Op
 /// `printed_cards::apply_back_face_to_object` (transform / specialize),
 /// `flip.rs` (CR 710.1b), and `morph.rs` (turn face down, CR 708.2a). Those three
 /// are shield-LOSS, not duplication, and are a known limitation rather than a
-/// correctness hazard; CR 611.2a argues the shield should survive them, which is
-/// recorded in `BACKLOG.md`. Do not restate the old "removed ONLY by an expiry
-/// prune or a zone change" claim — it is false.
+/// correctness hazard; CR 611.2a argues the shield should survive them, and this
+/// comment is that limitation's only record. Do not restate the old "removed ONLY
+/// by an expiry prune or a zone change" claim — it is false.
 ///
 /// The carried set is therefore invariant across all three IN-PASS rewrites, for
 /// every baseline the two callers can supply. That is why this function takes the

--- a/crates/engine/src/game/game_object.rs
+++ b/crates/engine/src/game/game_object.rs
@@ -1689,9 +1689,13 @@ impl GameObject {
     /// (see `reseed_replacements_carrying_resolution_effects`).
     pub(crate) fn install_resolution_replacement(&mut self, mut def: ReplacementDefinition) {
         // CR 611.2a: a `Resolution`-origin def is carried across every CR 613.1
-        // reset, so its ONLY removal paths are an expiry prune (`turns.rs`, all
-        // three of which key on `expiry` alone) and a zone change. A def with no
-        // expiry has neither — carrying it would make it immortal. Fail CLOSED:
+        // reset, so its SCHEDULED removal paths are an expiry prune (`turns.rs`, all
+        // three of which key on `expiry` alone) and a zone change. (Three face
+        // rewrites — transform/specialize, flip, morph — also drop it in place; see
+        // `reseed_replacements_carrying_resolution_effects`. Those are unscheduled
+        // shield-loss and cannot be relied on to end anything.) A def with no expiry
+        // has no scheduled end at all — carrying it would make it immortal. Fail
+        // CLOSED:
         // install it live-only, exactly as this call site behaved before the
         // authority existed, so it is still reset away at the next pass. The one
         // caller that can reach this arm is `add_target_replacement`'s
@@ -1703,14 +1707,31 @@ impl GameObject {
             self.replacement_definitions.push(def);
             return;
         }
-        // Asserted AFTER the fail-closed return, not before it: the invariant is
-        // about defs that actually get STAMPED `Resolution`, and an unbounded def
-        // never is. Checking it earlier would abort debug and test builds for a
-        // legitimate unstated-duration rider that merely happens to equal a printed
-        // base def — a def that, being live-only and unstamped, cannot double-apply.
+        // Asserts the ACTUAL precondition of the carry-over: base holds no
+        // `Resolution`-origin member at all. That is what
+        // `reseed_replacements_carrying_resolution_effects` needs to stay
+        // idempotent, and violating it causes unbounded per-pass duplication.
+        //
+        // Deliberately NOT `base.contains(&def)`. That older form compared the
+        // incoming def — necessarily still `Characteristic` at this point, since the
+        // stamp is applied below — against base by full structural equality, so it
+        // fired on a legitimate shape: a turn-bound rider installed through this arm
+        // onto an object that already carries a structurally identical rider written
+        // to base by `add_target_replacement`'s `install_to_base` trio (two Auras or
+        // two triggers granting the same rider). That is legal and harmless, and it
+        // would have aborted debug and test builds.
+        //
+        // Placed after the fail-closed return because an unbounded def is never
+        // stamped and so cannot break the invariant either way. This form would also
+        // have caught the transform round-trip that seeded base with a `Resolution`
+        // def (issue #8485 round 5) on the next install onto that object.
         debug_assert!(
-            !self.base_replacement_definitions.contains(&def),
-            "a resolution-installed replacement must not also live in base"
+            !self
+                .base_replacement_definitions
+                .iter()
+                .any(|d| d.is_resolution_installed()),
+            "base must never hold a `Resolution`-origin replacement: the CR 613.1 \
+             carry-over would then re-add it every pass, duplicating the effect"
         );
         def.origin = crate::types::ability::ReplacementOrigin::Resolution;
         self.replacement_definitions.push(def);
@@ -3333,16 +3354,24 @@ pub(crate) fn source_chosen_player(state: &GameState, source_id: ObjectId) -> Op
 /// ability.
 ///
 /// CR 613.1 governs an object's CHARACTERISTICS. CR 611.2c settles that a
-/// prevention shield is not one — "An effect that reads 'Prevent all damage
-/// creatures would deal this turn' doesn't modify any object's characteristics,
-/// so it's modifying the rules of the game." A shield is merely stored on an
+/// prevention shield is not one — CR 611.2c's EXAMPLE block says so outright:
+/// "An effect that reads 'Prevent all damage creatures would deal this turn'
+/// doesn't modify any object's characteristics, so it's modifying the rules of
+/// the game." (That sentence is the Example, not the rule text proper; the rule
+/// itself is the surrounding CR 611.2c paragraph on continuous effects from
+/// resolution.) A shield is merely stored on an
 /// object so the pipeline can find it, and CR 611.2a gives it the lifetime the
 /// ability stated, not "until the next layer pass". CR 615.3 ends it when it is
 /// used up or its duration expires.
 ///
 /// Carried entries keep their runtime state — CR 615.3 consumption, CR 615.7
-/// depletion, CR 701.19a regeneration — because they are the same, single copy
-/// the appliers mutate.
+/// depletion, CR 701.19a regeneration — because the carried VALUE is copied
+/// forward verbatim, `is_consumed` and depleted amount included. (The entries are
+/// `.cloned()` into the rebuilt vector below, so this is value preservation, not
+/// object identity; nothing holds a borrow across the rebuild. The single-copy
+/// property that matters is the STORE-level one: a resolution def lives in the
+/// live store only, never also in base, so no pristine twin can be re-seeded over
+/// a mutated one.)
 ///
 /// TWO baselines, ONE authority. Within a single layer pass an object's live
 /// store can be wholesale-rewritten up to three times:
@@ -3369,17 +3398,40 @@ pub(crate) fn source_chosen_player(state: &GameState, source_id: ObjectId) -> Op
 ///   2. `GameObject::sync_missing_base_characteristics` is the ONLY production path
 ///      anywhere in the tree that can copy the LIVE store INTO base, and it filters
 ///      `Resolution` defs out.
-///   3. EVERY other production write to `base_replacement_definitions` sources its
-///      content from somewhere a `Resolution` def cannot be — a parsed / printed /
-///      face / snapshot source, or a RETAIN over what is already there, or a
-///      `#[cfg(test)]` fixture. Regenerate that audit with:
-///      `grep -rn "base_replacement_definitions" crates/engine/src | grep -E "=|make_mut"`.
-///      (The `printed_cards.rs` write copies `CopiableValues::replacement_definitions`,
+///   3. `printed_cards::apply_back_face_to_object` writes a `BackFaceData` snapshot
+///      to base. That snapshot comes from `printed_cards::snapshot_object_face`,
+///      which copies the LIVE store — so it MUST filter `Resolution` defs out, and
+///      does. This leg was previously (and wrongly) written as "a parsed / printed /
+///      face / snapshot source" being safe by construction; it is not, and a
+///      transform round-trip (`transform.rs` stashes the live face and restores it,
+///      also reachable via `turn_face_up.rs`, `morph.rs`, `zones.rs`, `casting.rs`,
+///      `specialize.rs`) put a `Resolution` def into base and made this function
+///      compute `base ++ live_resolution` on EVERY pass — unbounded per-pass
+///      duplication of the shield. Pinned by
+///      `printed_cards::tests::transform_round_trip_does_not_duplicate_a_resolution_shield`.
+///   4. EVERY other production write to `base_replacement_definitions` sources its
+///      content from a parsed / printed source, or is a RETAIN over what is already
+///      there, or is a `#[cfg(test)]` fixture. Regenerate that audit with:
+///      `grep -rn "base_replacement_definitions" crates/engine/src | grep -E "=|make_mut"`
+///      and check each hit against the live store, NOT just against the parser.
+///      (The `printed_cards.rs` copy write takes `CopiableValues::replacement_definitions`,
 ///      which `copiable_replacement_definitions` derives from base — so it inherits
 ///      the invariant rather than threatening it.)
 ///
-/// The carried set is therefore invariant across all three rewrites, for every
-/// baseline the two callers can supply. That is why this function takes the
+/// REMOVAL PATHS, stated accurately. The expiry prunes (`turns.rs`: cleanup,
+/// end-of-combat teardown, untap step) and a zone change
+/// (`revert_layered_characteristics_to_base`, CR 400.7) are the SCHEDULED ends. They
+/// are not the only ones: three in-place face rewrites also drop a carried shield,
+/// because each wholesale-assigns the live store from a face snapshot —
+/// `printed_cards::apply_back_face_to_object` (transform / specialize),
+/// `flip.rs` (CR 710.1b), and `morph.rs` (turn face down, CR 708.2a). Those three
+/// are shield-LOSS, not duplication, and are a known limitation rather than a
+/// correctness hazard; CR 611.2a argues the shield should survive them, which is
+/// recorded in `BACKLOG.md`. Do not restate the old "removed ONLY by an expiry
+/// prune or a zone change" claim — it is false.
+///
+/// The carried set is therefore invariant across all three IN-PASS rewrites, for
+/// every baseline the two callers can supply. That is why this function takes the
 /// baseline as a PARAMETER rather than reading `obj.base_replacement_definitions`
 /// itself.
 ///

--- a/crates/engine/src/game/layers.rs
+++ b/crates/engine/src/game/layers.rs
@@ -2415,7 +2415,18 @@ fn seed_live_characteristics_from_base(obj: &mut crate::game::game_object::GameO
     // trigger copy-on-write via `Arc::make_mut`.
     obj.abilities = Arc::clone(&obj.base_abilities);
     obj.materialize_base_trigger_definitions();
-    obj.replacement_definitions = Arc::clone(&obj.base_replacement_definitions).into();
+    // CR 611.2c + CR 613.1: reseed the printed baseline, carrying resolution-created
+    // continuous effects across the reset. See
+    // `game_object::reseed_replacements_carrying_resolution_effects`. This single
+    // edit covers ALL THREE call sites of `seed_live_characteristics_from_base`:
+    // both `reset_recipient_to_base` reach paths (the full-board pass and the
+    // incremental flush) and the CR 613.2b Layer-1b face-down reseed, which calls
+    // this function directly rather than through `reset_recipient_to_base`.
+    obj.replacement_definitions =
+        crate::game::game_object::reseed_replacements_carrying_resolution_effects(
+            &obj.replacement_definitions,
+            &obj.base_replacement_definitions,
+        );
     obj.static_definitions = Arc::clone(&obj.base_static_definitions).into();
     obj.color = obj.base_color.clone();
     // Reset the display-identity pointer to its baseline; the Copy layer
@@ -3004,6 +3015,15 @@ pub fn evaluate_layers(state: &mut GameState) {
     // off. Production always rebuilds at the top (above) and never reaches here.
     if !rebuild_static_index_at_top() {
         crate::types::game_state::StaticSourceIndex::rebuild_from_state(state);
+    }
+
+    // CR 616.1 + CR 613.1: settle carried resolution-created replacements behind
+    // this pass's derived grants, so the `base ++ derived` prefix stays
+    // index-stable for `PendingReplacement.candidates` / `AppliedReplacementKey`.
+    for &id in &bf_ids {
+        if let Some(obj) = state.objects.get_mut(&id) {
+            settle_resolution_replacements_to_tail(obj);
+        }
     }
 
     // Step 5: Clear dirty flag. A full evaluation satisfies any pending request
@@ -4118,6 +4138,53 @@ pub fn flush_layers(state: &mut GameState) {
                 super::public_state::mark_public_state_all_dirty(state);
             }
         }
+    }
+}
+
+/// CR 616.1 + CR 613.1: put carried resolution-created replacements BEHIND the
+/// per-pass derived grants, reproducing the pre-#8485 live layout
+/// (`base ++ derived ++ runtime`) exactly.
+///
+/// `PendingReplacement.candidates` (`types/game_state.rs`) parks raw
+/// `ReplacementId { source, index }` values on `GameState` across a CR 616.1
+/// `WaitingFor::ReplacementChoice` prompt, and `engine::finish_action_boundary`
+/// -> `public_state::finalize_rules_state` -> `flush_layers` runs a layer pass
+/// in between; `ProposedEvent`'s `applied: HashSet<AppliedReplacementKey>` is
+/// keyed on the same `(source, index)` pair across the same park. Any placement
+/// that inserted carried entries AHEAD of the derived grants would shift every
+/// derived slot and mis-resolve both. Appending at the tail leaves the
+/// `base ++ derived` prefix index-stable, which is the layout the park already
+/// depends on today.
+///
+/// Idempotent and allocation-free unless the object holds a carried entry that
+/// is not already part of a contiguous tail — i.e. only when the host also
+/// received a per-pass derived grant this pass.
+fn settle_resolution_replacements_to_tail(obj: &mut crate::game::game_object::GameObject) {
+    let Some(first) = obj
+        .replacement_definitions
+        .iter_all()
+        .position(|d| d.is_resolution_installed())
+    else {
+        return;
+    };
+    if obj
+        .replacement_definitions
+        .iter_all()
+        .skip(first)
+        .all(|d| d.is_resolution_installed())
+    {
+        return;
+    }
+    let carried: Vec<crate::types::ability::ReplacementDefinition> = obj
+        .replacement_definitions
+        .iter_all()
+        .filter(|d| d.is_resolution_installed())
+        .cloned()
+        .collect();
+    obj.replacement_definitions
+        .retain(|d| !d.is_resolution_installed());
+    for def in carried {
+        obj.replacement_definitions.push(def);
     }
 }
 
@@ -5719,6 +5786,17 @@ fn apply_layers_incremental(state: &mut GameState, prepared: PreparedIncremental
     // CR 603.6a + CR 611.2e: Rebuild the TriggerIndex so the next event scan
     // sees the entered objects' (and any granted) trigger sets.
     crate::types::game_state::TriggerIndex::rebuild_from_battlefield(state);
+
+    // CR 616.1 + CR 613.1: same tail settle as the full pass (see
+    // `settle_resolution_replacements_to_tail`). `evaluate_layers` and
+    // `apply_layers_incremental` are the only two pass tails; the calls live
+    // inside them rather than in `flush_layers` because production also calls
+    // `evaluate_layers` directly from many sites.
+    for &id in &recipient_ids {
+        if let Some(obj) = state.objects.get_mut(&id) {
+            settle_resolution_replacements_to_tail(obj);
+        }
+    }
 
     // Test-only buggy end-of-pass static-index placement (see `evaluate_layers`).
     if !rebuild_static_index_at_top() {
@@ -8555,7 +8633,13 @@ fn apply_continuous_effect_filtered(
             ContinuousModification::RemoveAllAbilities => {
                 Arc::make_mut(&mut obj.abilities).clear();
                 obj.trigger_definitions.clear();
-                obj.replacement_definitions.clear();
+                // CR 613.1f + CR 611.2c: Layer 6 removes the object's ABILITIES.
+                // A replacement created by the resolution of a spell or ability is
+                // not one of the object's abilities — and per CR 611.2c not one of
+                // its characteristics at all — so Humility does not end a
+                // prevention/regeneration shield already resolved onto this object.
+                obj.replacement_definitions
+                    .retain(|d| d.is_resolution_installed());
                 obj.static_definitions.clear();
                 obj.keywords.clear();
                 abilities_suppressed.insert(id);
@@ -9063,7 +9147,13 @@ fn set_land_subtype_replacing(obj: &mut crate::game::game_object::GameObject, su
     obj.card_types.subtypes.push(subtype);
     Arc::make_mut(&mut obj.abilities).clear();
     obj.trigger_definitions.clear();
-    obj.replacement_definitions.clear();
+    // CR 305.7: "It loses all abilities generated from its rules text... Note that
+    // this doesn't remove any abilities that were granted to the land by other
+    // effects." A resolution-created replacement is neither: CR 611.2c says it is
+    // not a characteristic of the object at all, so a Blood Moon-class subtype set
+    // must not end a shield already resolved onto this land.
+    obj.replacement_definitions
+        .retain(|d| d.is_resolution_installed());
     obj.static_definitions.clear();
     obj.keywords.clear();
 }
@@ -9453,6 +9543,387 @@ mod tests {
         obj.base_toughness = Some(toughness);
         obj.timestamp = ts;
         id
+    }
+
+    // ---- Issue #8485: CR 611.2c / CR 613.1 resolution-shield durability ----
+
+    /// Build a resolution-created prevention shield with runtime state already
+    /// mutated: consumed once and depleted to `Next(1)`.
+    fn spent_resolution_shield() -> crate::types::ability::ReplacementDefinition {
+        let mut def =
+            crate::types::ability::ReplacementDefinition::new(ReplacementEvent::DamageDone)
+                .prevention_shield(crate::types::ability::PreventionAmount::Next(1))
+                .expiry(crate::types::ability::RestrictionExpiry::EndOfTurn);
+        def.is_consumed = true;
+        def
+    }
+
+    fn printed_base_shield() -> crate::types::ability::ReplacementDefinition {
+        crate::types::ability::ReplacementDefinition::new(ReplacementEvent::DamageDone)
+            .prevention_shield(crate::types::ability::PreventionAmount::All)
+    }
+
+    /// CR 611.2c + CR 613.1 (issue #8485): a `Resolution`-origin definition survives
+    /// the layer reset WITH its runtime state.
+    ///
+    /// CR 613.1 determines the values of an object's CHARACTERISTICS. CR 611.2c
+    /// settles that a prevention effect is not one — "An effect that reads 'Prevent
+    /// all damage creatures would deal this turn' doesn't modify any object's
+    /// characteristics, so it's modifying the rules of the game." So the CR 613.1
+    /// reseed must CARRY it, and carry the same single copy the appliers mutate
+    /// (CR 615.3 "used up", CR 615.7 depletion), never a pristine re-seeded twin.
+    ///
+    /// Revert-failing: undo the `seed_live_characteristics_from_base` carry-over and
+    /// the carried def is gone entirely.
+    #[test]
+    fn resolution_origin_replacement_survives_the_layer_reset_with_its_runtime_state() {
+        let mut state = setup();
+        let host = make_creature(&mut state, "Shield Host", 2, 2, PlayerId(0));
+        {
+            let obj = state.objects.get_mut(&host).unwrap();
+            obj.base_replacement_definitions = Arc::new(vec![printed_base_shield()]);
+            obj.replacement_definitions = vec![printed_base_shield()].into();
+            obj.base_characteristics_initialized = true;
+            obj.install_resolution_replacement(spent_resolution_shield());
+        }
+        assert_eq!(state.objects[&host].replacement_definitions.len(), 2);
+
+        state.layers_dirty.mark_full();
+        evaluate_layers(&mut state);
+
+        let live = &state.objects[&host].replacement_definitions;
+        assert_eq!(
+            live.len(),
+            2,
+            "printed def reseeded, resolution def carried"
+        );
+        assert_eq!(
+            live[0],
+            printed_base_shield(),
+            "the printed def came from base"
+        );
+        let carried = &live[1];
+        assert!(carried.is_resolution_installed());
+        assert!(
+            carried.is_consumed,
+            "CR 615.3: the carried shield keeps its consumed state"
+        );
+        assert!(
+            matches!(
+                carried.shield_kind,
+                crate::types::ability::ShieldKind::Prevention {
+                    amount: crate::types::ability::PreventionAmount::Next(1)
+                }
+            ),
+            "CR 615.7: the carried shield keeps its depleted amount"
+        );
+    }
+
+    /// NEGATIVE SIBLING: the carry-over keys on the typed `origin` field, not on
+    /// "anything that happens to be in the live store". A `Characteristic`-origin
+    /// def pushed live-only is still reset away, exactly as before #8485.
+    #[test]
+    fn characteristic_origin_live_only_replacement_is_still_reset_away() {
+        let mut state = setup();
+        let host = make_creature(&mut state, "Host", 2, 2, PlayerId(0));
+        {
+            let obj = state.objects.get_mut(&host).unwrap();
+            obj.base_characteristics_initialized = true;
+            obj.replacement_definitions.push(printed_base_shield());
+        }
+        state.layers_dirty.mark_full();
+        evaluate_layers(&mut state);
+        assert!(
+            state.objects[&host].replacement_definitions.is_empty(),
+            "a live-only Characteristic def must still be reset away"
+        );
+    }
+
+    /// NEGATIVE SIBLING: a base-only def is reseeded exactly once — the carry-over
+    /// must not duplicate it.
+    #[test]
+    fn base_only_replacement_is_not_duplicated_by_the_carry_over() {
+        let mut state = setup();
+        let host = make_creature(&mut state, "Host", 2, 2, PlayerId(0));
+        {
+            let obj = state.objects.get_mut(&host).unwrap();
+            obj.base_replacement_definitions = Arc::new(vec![printed_base_shield()]);
+            obj.replacement_definitions = vec![printed_base_shield()].into();
+            obj.base_characteristics_initialized = true;
+        }
+        state.layers_dirty.mark_full();
+        evaluate_layers(&mut state);
+        assert_eq!(state.objects[&host].replacement_definitions.len(), 1);
+    }
+
+    /// CR 613.1a + CR 707.2 + CR 611.2c (issue #8485, MG2; settles U8): a Layer-1a
+    /// COPY effect must not destroy a carried resolution shield.
+    ///
+    /// CR 707.2 defines copiable values as "the values derived from the text printed
+    /// on the object" and closes "Other effects ..., status, counters, and stickers
+    /// are not copied." A shield created by a resolving spell or ability is not a
+    /// characteristic at all (CR 611.2c), so a Clone / Vesuvan / Mirrorweave /
+    /// Copy-Enchantment recipient keeps it.
+    ///
+    /// Driven through `evaluate_layers` with a real `ContinuousModification::
+    /// CopyValues`, NOT by calling `apply_copiable_values` directly — the point is
+    /// that the production path is closed. Revert-failing against B4.
+    #[test]
+    fn copy_effect_does_not_destroy_a_carried_resolution_shield() {
+        let mut state = setup();
+        let player = PlayerId(0);
+        let donor = make_creature(&mut state, "Donor", 7, 7, player);
+        let donor_values =
+            crate::game::printed_cards::intrinsic_copiable_values(&state.objects[&donor]);
+        let recipient = make_creature(&mut state, "Recipient", 1, 1, player);
+        {
+            let obj = state.objects.get_mut(&recipient).unwrap();
+            obj.base_characteristics_initialized = true;
+            obj.install_resolution_replacement(spent_resolution_shield());
+        }
+        state.add_transient_continuous_effect(
+            recipient,
+            player,
+            Duration::Permanent,
+            TargetFilter::SpecificObject { id: recipient },
+            vec![ContinuousModification::CopyValues {
+                values: Box::new(donor_values),
+                display_source: crate::game::game_object::DisplaySource::Card,
+                printed_ref: None,
+                token_image_ref: None,
+            }],
+            None,
+        );
+
+        state.layers_dirty.mark_full();
+        evaluate_layers(&mut state);
+
+        // Positive reach-guard: layer 1a really ran.
+        let obj = &state.objects[&recipient];
+        assert_eq!(obj.name, "Donor", "reach-guard: the copy effect applied");
+        assert_eq!(obj.power, Some(7));
+        assert_eq!(obj.toughness, Some(7));
+        // CR 611.2c: and the carried shield is still there, runtime state intact.
+        let carried = obj
+            .replacement_definitions
+            .iter_all()
+            .find(|d| d.is_resolution_installed())
+            .expect("CR 707.2: a copy effect may not remove a resolution shield");
+        assert!(carried.is_consumed);
+    }
+
+    /// CR 613.2b (issue #8485): the Layer-1b face-down reseed is the THIRD
+    /// `seed_live_characteristics_from_base` call site — it does not go through
+    /// `reset_recipient_to_base`. Exercise it rather than merely naming it.
+    #[test]
+    fn face_down_reseed_does_not_drop_a_carried_shield() {
+        let mut state = setup();
+        let player = PlayerId(0);
+        let fd = make_face_down(&mut state, player, FaceDownProfile::vanilla_2_2(), "Hidden");
+        state
+            .objects
+            .get_mut(&fd)
+            .unwrap()
+            .install_resolution_replacement(spent_resolution_shield());
+
+        state.layers_dirty.mark_full();
+        evaluate_layers(&mut state);
+
+        // Reach-guard: the face-down profile really was re-seeded this pass.
+        assert_eq!(state.objects[&fd].power, state.objects[&fd].base_power);
+        assert!(
+            state.objects[&fd]
+                .replacement_definitions
+                .iter_all()
+                .any(|d| d.is_resolution_installed()),
+            "the CR 613.2b Layer-1b reseed must carry the shield too"
+        );
+
+        // FACE-UP SIBLING: identical behavior, so the assertion is not an artifact
+        // of the face-down path.
+        let up = make_creature(&mut state, "Face Up", 2, 2, player);
+        state
+            .objects
+            .get_mut(&up)
+            .unwrap()
+            .install_resolution_replacement(spent_resolution_shield());
+        state.layers_dirty.mark_full();
+        evaluate_layers(&mut state);
+        assert!(state.objects[&up]
+            .replacement_definitions
+            .iter_all()
+            .any(|d| d.is_resolution_installed()));
+    }
+
+    /// CR 616.1 (issue #8485; settles U4): carried resolution defs sort BEHIND the
+    /// per-pass derived grants, reproducing the pre-#8485 `base ++ derived` prefix
+    /// exactly so `PendingReplacement.candidates` and `AppliedReplacementKey` — both
+    /// keyed on `(source, index)` and both parked across a CR 616.1
+    /// `ReplacementChoice` prompt that runs a layer flush — stay index-stable.
+    ///
+    /// Revert-failing against `settle_resolution_replacements_to_tail`: without it
+    /// the carried def sits at index `len(base)`, shifting the derived grant.
+    #[test]
+    fn carried_resolution_defs_sort_after_derived_grants() {
+        let mut state = setup();
+        let host = make_creature(&mut state, "Host", 2, 2, PlayerId(0));
+        let granted = crate::types::ability::ReplacementDefinition::new(ReplacementEvent::GainLife);
+        {
+            let obj = state.objects.get_mut(&host).unwrap();
+            obj.base_replacement_definitions = Arc::new(vec![printed_base_shield()]);
+            obj.replacement_definitions = vec![printed_base_shield()].into();
+            obj.base_characteristics_initialized = true;
+            obj.install_resolution_replacement(spent_resolution_shield());
+        }
+        let grantor = create_object(
+            &mut state,
+            CardId(9),
+            PlayerId(0),
+            "Grantor".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let obj = state.objects.get_mut(&grantor).unwrap();
+            obj.card_types.core_types.push(CoreType::Enchantment);
+            obj.base_card_types = obj.card_types.clone();
+            obj.static_definitions.push(
+                StaticDefinition::continuous()
+                    .affected(TargetFilter::SpecificObject { id: host })
+                    .modifications(vec![ContinuousModification::GrantReplacement {
+                        replacement: Box::new(granted.clone()),
+                    }]),
+            );
+            obj.base_static_definitions = obj.static_definitions.as_slice().to_vec().into();
+        }
+
+        state.layers_dirty.mark_full();
+        evaluate_layers(&mut state);
+
+        let live = &state.objects[&host].replacement_definitions;
+        assert_eq!(live.len(), 3, "base ++ derived ++ carried");
+        assert_eq!(live[0], printed_base_shield(), "index 0: printed base");
+        assert_eq!(live[1], granted, "index 1: the per-pass derived grant");
+        assert!(
+            live[2].is_resolution_installed(),
+            "index 2: the carried resolution shield sorts to the tail"
+        );
+    }
+
+    /// M9 HOSTILE FIXTURE: `origin` participates in `PartialEq`, and that is what
+    /// keeps the two structural-equality dedups in this file honest — a carried
+    /// resolution def must never SUPPRESS a per-pass derived grant. The accepted
+    /// dual consequence is that the structurally-identical-but-for-`origin` pair
+    /// leaves TWO entries.
+    ///
+    /// Synthetic by construction: in practice `expiry` already discriminates (a
+    /// resolution shield carries `Some(..)`, a derived grant `None`), so this shape
+    /// does not arise from any card. It pins the coupling anyway.
+    #[test]
+    fn carried_resolution_def_does_not_suppress_an_identical_derived_grant() {
+        let mut state = setup();
+        let host = make_creature(&mut state, "Host", 2, 2, PlayerId(0));
+        // A def that IS structurally identical to the derived grant except for
+        // `origin` — so it must carry an expiry (the authority's fail-closed arm
+        // would otherwise refuse to stamp it) and the grant must carry the same one.
+        let granted = crate::types::ability::ReplacementDefinition::new(ReplacementEvent::GainLife)
+            .expiry(crate::types::ability::RestrictionExpiry::EndOfTurn);
+        {
+            let obj = state.objects.get_mut(&host).unwrap();
+            obj.base_characteristics_initialized = true;
+            obj.install_resolution_replacement(granted.clone());
+        }
+        let grantor = create_object(
+            &mut state,
+            CardId(9),
+            PlayerId(0),
+            "Grantor".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let obj = state.objects.get_mut(&grantor).unwrap();
+            obj.card_types.core_types.push(CoreType::Enchantment);
+            obj.base_card_types = obj.card_types.clone();
+            obj.static_definitions.push(
+                StaticDefinition::continuous()
+                    .affected(TargetFilter::SpecificObject { id: host })
+                    .modifications(vec![ContinuousModification::GrantReplacement {
+                        replacement: Box::new(granted.clone()),
+                    }]),
+            );
+            obj.base_static_definitions = obj.static_definitions.as_slice().to_vec().into();
+        }
+
+        state.layers_dirty.mark_full();
+        evaluate_layers(&mut state);
+
+        let live = &state.objects[&host].replacement_definitions;
+        assert_eq!(
+            live.len(),
+            2,
+            "the carried def must not suppress the derived grant"
+        );
+        assert!(
+            live.iter_all()
+                .any(|d| !d.is_resolution_installed() && *d == granted),
+            "the derived grant is still installed"
+        );
+        assert!(
+            live.iter_all().any(|d| d.is_resolution_installed()),
+            "and the carried resolution def is still present"
+        );
+    }
+
+    /// CR 613.1f + CR 611.2c (issue #8485): Humility-class `RemoveAllAbilities`
+    /// removes the object's ABILITIES; it does not end a continuous effect that
+    /// already resolved onto it. Paired positive reach-guard: the printed def
+    /// existed before the pass and IS removed.
+    #[test]
+    fn humility_does_not_end_a_resolution_created_shield() {
+        let mut state = setup();
+        let host = make_creature(&mut state, "Host", 2, 2, PlayerId(0));
+        {
+            let obj = state.objects.get_mut(&host).unwrap();
+            obj.base_replacement_definitions = Arc::new(vec![printed_base_shield()]);
+            obj.replacement_definitions = vec![printed_base_shield()].into();
+            obj.base_characteristics_initialized = true;
+            obj.install_resolution_replacement(spent_resolution_shield());
+        }
+        // Reach-guard: the printed def is present before the pass.
+        assert!(state.objects[&host]
+            .replacement_definitions
+            .iter_all()
+            .any(|d| !d.is_resolution_installed()));
+
+        let humility = create_object(
+            &mut state,
+            CardId(9),
+            PlayerId(0),
+            "Humility".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let obj = state.objects.get_mut(&humility).unwrap();
+            obj.card_types.core_types.push(CoreType::Enchantment);
+            obj.base_card_types = obj.card_types.clone();
+            obj.static_definitions.push(
+                StaticDefinition::continuous()
+                    .affected(TargetFilter::SpecificObject { id: host })
+                    .modifications(vec![ContinuousModification::RemoveAllAbilities]),
+            );
+            obj.base_static_definitions = obj.static_definitions.as_slice().to_vec().into();
+        }
+
+        state.layers_dirty.mark_full();
+        evaluate_layers(&mut state);
+
+        let live = &state.objects[&host].replacement_definitions;
+        assert_eq!(
+            live.len(),
+            1,
+            "the printed def is removed, the shield stays"
+        );
+        assert!(live[0].is_resolution_installed());
+        assert!(live[0].is_consumed, "runtime state survives Humility too");
     }
 
     fn add_unspent_blue_mana(state: &mut GameState, player: PlayerId, count: usize) {

--- a/crates/engine/src/game/layers.rs
+++ b/crates/engine/src/game/layers.rs
@@ -9873,6 +9873,99 @@ mod tests {
         );
     }
 
+    /// CR 305.7 + CR 611.2c (issue #8485): Blood Moon-class `SetBasicLandType`
+    /// removes the land's rules-text abilities; it does not end a continuous effect
+    /// that already resolved onto it.
+    ///
+    /// The CR 305.7 sibling of `humility_does_not_end_a_resolution_created_shield`.
+    /// `set_land_subtype_replacing` got the same
+    /// `.retain(|d| d.is_resolution_installed())` as the CR 613.1f
+    /// `RemoveAllAbilities` arm, but only the latter had a fixture — and this is the
+    /// path that hosts `add_target_replacement` riders on LANDS, so a regression
+    /// here would be silent. CR 305.7: "It loses all abilities generated from its
+    /// rules text... Note that this doesn't remove any abilities that were granted
+    /// to the land by other effects." A resolution-created replacement is neither:
+    /// CR 611.2c says it is not a characteristic of the object at all.
+    #[test]
+    fn blood_moon_does_not_end_a_resolution_created_shield() {
+        let mut state = setup();
+        let land = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Nonbasic Land".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let obj = state.objects.get_mut(&land).unwrap();
+            obj.card_types.core_types.push(CoreType::Land);
+            obj.card_types.subtypes.push("Desert".to_string());
+            obj.base_card_types = obj.card_types.clone();
+            obj.base_replacement_definitions = Arc::new(vec![printed_base_shield()]);
+            obj.replacement_definitions = vec![printed_base_shield()].into();
+            obj.base_characteristics_initialized = true;
+            obj.install_resolution_replacement(spent_resolution_shield());
+        }
+        // Reach-guard: the printed def is present before the pass, so its removal
+        // below is an observed change rather than a vacuous absence.
+        assert!(state.objects[&land]
+            .replacement_definitions
+            .iter_all()
+            .any(|d| !d.is_resolution_installed()));
+
+        let blood_moon = create_object(
+            &mut state,
+            CardId(9),
+            PlayerId(0),
+            "Blood Moon".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let obj = state.objects.get_mut(&blood_moon).unwrap();
+            obj.card_types.core_types.push(CoreType::Enchantment);
+            obj.base_card_types = obj.card_types.clone();
+            obj.static_definitions.push(
+                StaticDefinition::continuous()
+                    .affected(TargetFilter::SpecificObject { id: land })
+                    .modifications(vec![ContinuousModification::SetBasicLandType {
+                        land_type: crate::types::ability::BasicLandType::Mountain,
+                    }]),
+            );
+            obj.base_static_definitions = obj.static_definitions.as_slice().to_vec().into();
+        }
+
+        state.layers_dirty.mark_full();
+        evaluate_layers(&mut state);
+
+        // Positive reach-guard: the subtype set really applied this pass.
+        assert!(
+            state.objects[&land]
+                .card_types
+                .subtypes
+                .contains(&"Mountain".to_string()),
+            "reach-guard: CR 305.7 subtype replacement must have run"
+        );
+        assert!(
+            !state.objects[&land]
+                .card_types
+                .subtypes
+                .contains(&"Desert".to_string()),
+            "CR 205.3i: the old land subtype is replaced"
+        );
+
+        let live = &state.objects[&land].replacement_definitions;
+        assert_eq!(
+            live.len(),
+            1,
+            "the printed rules-text def is removed, the resolution shield stays"
+        );
+        assert!(live[0].is_resolution_installed());
+        assert!(
+            live[0].is_consumed,
+            "CR 615.3: the carried shield keeps its runtime state through Blood Moon"
+        );
+    }
+
     /// CR 613.1f + CR 611.2c (issue #8485): Humility-class `RemoveAllAbilities`
     /// removes the object's ABILITIES; it does not end a continuous effect that
     /// already resolved onto it. Paired positive reach-guard: the printed def

--- a/crates/engine/src/game/printed_cards.rs
+++ b/crates/engine/src/game/printed_cards.rs
@@ -741,7 +741,22 @@ pub fn apply_copiable_values(
             )
         })
         .collect();
-    obj.replacement_definitions = Arc::clone(&values.replacement_definitions).into();
+    // CR 613.1a + CR 707.2 + CR 611.2c: a copy effect applies COPIABLE VALUES —
+    // "the values derived from the text printed on the object" (CR 707.2), which
+    // closes "Other effects ..., status, counters, and stickers are not copied."
+    // A replacement created by the resolution of a spell or ability is not a
+    // characteristic at all (CR 611.2c), so a Clone / Vesuvan / Mirrorweave /
+    // Copy-Enchantment recipient must keep the shields it already carries. Without
+    // this, the Layer-1a assignment here would destroy them MID-PASS, before the
+    // tail settle and before the CR 613.2b Layer-1b reseed (which rebuilds the
+    // carried set by reading `live` and so cannot recover them).
+    // `copiable_replacement_definitions` already encodes the producer half of this
+    // invariant; this is its recipient half.
+    obj.replacement_definitions =
+        crate::game::game_object::reseed_replacements_carrying_resolution_effects(
+            &obj.replacement_definitions,
+            &values.replacement_definitions,
+        );
     obj.static_definitions = Arc::clone(&values.static_definitions).into();
     // CR 709.5b + CR 707.2: carry the copied Room half data. Layer-derived —
     // the Step-1 seed clears it, so it expires with this copy effect.

--- a/crates/engine/src/game/printed_cards.rs
+++ b/crates/engine/src/game/printed_cards.rs
@@ -857,7 +857,36 @@ pub fn snapshot_object_face(obj: &GameObject) -> BackFaceData {
             .iter_all()
             .map(|entry| entry.definition.clone())
             .collect(),
-        replacement_definitions: obj.replacement_definitions.clone(),
+        // CR 611.2c + CR 613.1 (issue #8485): a face snapshot captures the FACE's
+        // characteristics. A replacement created by the resolution of a spell or
+        // ability is not one of them, so it must not ride out with the face.
+        //
+        // This filter is load-bearing for correctness, not tidiness.
+        // `apply_back_face_to_object` writes this vector to BOTH the live store and
+        // `base_replacement_definitions`. A `Resolution`-origin def reaching base
+        // breaks the precondition that
+        // `game_object::reseed_replacements_carrying_resolution_effects` relies on
+        // ("no baseline ever contains a `Resolution` member"): the carry-over would
+        // then compute `base ++ live_resolution` on EVERY layer pass, growing the
+        // shield count by one per pass without bound — a Maze of Ith / regeneration /
+        // Fog shield would prevent N damage events instead of one. Reachable on any
+        // transform round-trip, which stashes the live face and restores it.
+        //
+        // Same guard `copiable_replacement_definitions` (producer side) and
+        // `GameObject::sync_missing_base_characteristics` (back-fill side) already
+        // apply. Filtering HERE rather than at the base write also stops the live
+        // write from restoring a stale, possibly already-consumed shield.
+        //
+        // Consequence, deliberate and documented: a transform DROPS a carried
+        // resolution shield rather than duplicating it. See the removal-paths note
+        // on `reseed_replacements_carrying_resolution_effects`.
+        replacement_definitions: obj
+            .replacement_definitions
+            .iter_all()
+            .filter(|d| !d.is_resolution_installed())
+            .cloned()
+            .collect::<Vec<_>>()
+            .into(),
         // Snapshot: deref the Arc to satisfy `Definitions::from(Vec<T>)`.
         static_definitions: (*obj.base_static_definitions).clone().into(),
         color: obj.color.clone(),
@@ -1718,6 +1747,110 @@ pub fn derive_colors_from_mana_cost(mana_cost: &ManaCost) -> Vec<ManaColor> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// CR 611.2c + CR 613.1 (issue #8485, round-5 HIGH-1): a transform ROUND TRIP
+    /// must not seed `base_replacement_definitions` with a resolution-created
+    /// shield, and must not multiply it once per layer pass.
+    ///
+    /// The bug this pins: `snapshot_object_face` copied the LIVE store verbatim and
+    /// `apply_back_face_to_object` writes that snapshot to live AND base. A
+    /// `Resolution`-origin def in base falsifies the precondition
+    /// `game_object::reseed_replacements_carrying_resolution_effects` depends on, so
+    /// the carry-over computed `base ++ live_resolution` on EVERY pass and the shield
+    /// count grew without bound — a Maze of Ith / regeneration / Fog shield would
+    /// prevent N damage events instead of one. No existing test covered a transform
+    /// round-trip over a live resolution shield, which is how it survived review.
+    ///
+    /// Revert-failing on two independent assertions: un-filter
+    /// `snapshot_object_face` and (a) base holds a `Resolution` def and (b) the
+    /// per-object resolution count GROWS between the two `evaluate_layers` passes.
+    #[test]
+    fn transform_round_trip_does_not_duplicate_a_resolution_shield() {
+        fn printed_def() -> ReplacementDefinition {
+            ReplacementDefinition::new(ReplacementEvent::DamageDone)
+                .prevention_shield(crate::types::ability::PreventionAmount::All)
+        }
+        fn resolution_shield() -> ReplacementDefinition {
+            ReplacementDefinition::new(ReplacementEvent::DamageDone)
+                .prevention_shield(crate::types::ability::PreventionAmount::All)
+                .expiry(crate::types::ability::RestrictionExpiry::EndOfTurn)
+        }
+        fn resolution_count(state: &GameState, id: ObjectId) -> usize {
+            state.objects[&id]
+                .replacement_definitions
+                .iter_all()
+                .filter(|d| d.is_resolution_installed())
+                .count()
+        }
+
+        let mut state = GameState::new_two_player(42);
+        let id = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Front Face".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let obj = state.objects.get_mut(&id).unwrap();
+            obj.card_types.core_types.push(CoreType::Creature);
+            obj.base_card_types = obj.card_types.clone();
+            obj.power = Some(2);
+            obj.toughness = Some(2);
+            obj.base_power = Some(2);
+            obj.base_toughness = Some(2);
+            obj.base_characteristics_initialized = true;
+            obj.base_replacement_definitions = Arc::new(vec![printed_def()]);
+            obj.replacement_definitions = vec![printed_def()].into();
+            obj.install_resolution_replacement(resolution_shield());
+            let mut back = snapshot_object_face(obj);
+            back.name = "Back Face".to_string();
+            obj.back_face = Some(back);
+        }
+        // Positive reach-guard: the shield really is live before the transform, so
+        // the post-transform assertions are not vacuously satisfied by there being
+        // nothing to duplicate.
+        assert_eq!(resolution_count(&state, id), 1);
+
+        swap_object_faces(state.objects.get_mut(&id).unwrap());
+        assert_eq!(
+            state.objects[&id].name, "Back Face",
+            "reach-guard: the transform must actually have happened"
+        );
+        swap_object_faces(state.objects.get_mut(&id).unwrap());
+        assert_eq!(
+            state.objects[&id].name, "Front Face",
+            "reach-guard: the return transform must actually have happened"
+        );
+
+        // The invariant the whole carry-over rests on.
+        assert!(
+            !state.objects[&id]
+                .base_replacement_definitions
+                .iter()
+                .any(|d| d.is_resolution_installed()),
+            "a transform round-trip must not seed base with a `Resolution` def: \
+             base = {:?}",
+            state.objects[&id].base_replacement_definitions
+        );
+
+        state.layers_dirty.mark_full();
+        crate::game::layers::evaluate_layers(&mut state);
+        let after_first = resolution_count(&state, id);
+        state.layers_dirty.mark_full();
+        crate::game::layers::evaluate_layers(&mut state);
+        let after_second = resolution_count(&state, id);
+        assert_eq!(
+            after_first, after_second,
+            "the resolution-shield count must not grow per layer pass \
+             (pass 1: {after_first}, pass 2: {after_second})"
+        );
+        assert!(
+            after_second <= 1,
+            "at most one copy of the shield may survive, got {after_second}"
+        );
+    }
+
     use crate::database::CardDatabase;
     use crate::game::deck_loading::create_object_from_card_face;
     use crate::game::deck_loading::DeckEntry;

--- a/crates/engine/src/game/replacement.rs
+++ b/crates/engine/src/game/replacement.rs
@@ -968,10 +968,18 @@ pub fn replacement_choice_waiting_for(player: PlayerId, state: &GameState) -> Wa
                     // lookup stays aligned.
                     p.candidates
                         .iter()
-                        .map(|rid| ReplacementCandidateSummary {
-                            source_id: rid.source,
-                            source_name: name_of(rid.source),
-                            description: replacement_choice_label_for_rid(state, *rid),
+                        .map(|rid| {
+                            // CR 616.1 + CR 113.7a (issue #8485): label the option
+                            // with the shield's HOST, not with the `ObjectId(0)`
+                            // storage sentinel, which has no name. Display only —
+                            // `rid` itself is unchanged and is what
+                            // `handle_replacement_choice` resolves.
+                            let display = replacement_choice_display_source(state, *rid);
+                            ReplacementCandidateSummary {
+                                source_id: display,
+                                source_name: name_of(display),
+                                description: replacement_choice_label_for_rid(state, *rid),
+                            }
                         })
                         .collect()
                 };
@@ -1267,6 +1275,63 @@ fn replacement_choice_label(repl: &ReplacementDefinition) -> String {
     }
 }
 
+/// CR 616.1 (issue #8485): sentinel-aware definition lookup for the CR 616.1
+/// replacement-choice PROMPT. **Display only.**
+///
+/// Mirrors the `rid.source == ObjectId(0)` dispatch that every runtime shield
+/// reader in this file already performs (`shield_kind_for_rid`,
+/// `consume_prevention_shield`, `update_redirection_shield`, ...): the sentinel
+/// selects `state.pending_damage_replacements`, anything else selects that
+/// object's own `replacement_definitions`. `rid.index` indexes whichever store
+/// `rid.source` selected — that pairing is NOT changed here or anywhere else.
+///
+/// `replacement_definition_for_id` (the rules-side authority, which also runs the
+/// CR 121.2 draw-scope `debug_assert!`) deliberately keeps its object-only lookup;
+/// this is a separate, narrower question asked only while building a
+/// `WaitingFor::ReplacementChoice` payload.
+fn replacement_choice_definition(
+    state: &GameState,
+    rid: ReplacementId,
+) -> Option<&ReplacementDefinition> {
+    if rid.source == ObjectId(0) {
+        state.pending_damage_replacements.get(rid.index)
+    } else {
+        state
+            .objects
+            .get(&rid.source)
+            .and_then(|obj| obj.replacement_definitions.get(rid.index))
+    }
+}
+
+/// CR 616.1 + CR 113.7a (issue #8485): the object a CR 616.1 replacement-choice
+/// option should be LABELLED with. **Display only — this is presentation, not
+/// rules.**
+///
+/// `ReplacementId::source` remains the STORAGE discriminator everywhere else in
+/// this file: it routes ~14 consumers to `state.pending_damage_replacements` (the
+/// `ObjectId(0)` sentinel) rather than to `state.objects`, and it is never used as
+/// a display anchor again after this function.
+///
+/// Why this is needed: `find_applicable_replacements` can offer a registry-hosted
+/// shield as a CR 616.1 candidate, and a registry entry's `rid.source` IS the
+/// sentinel, which has no entry in `state.objects` (CR 109.4). The prompt therefore
+/// rendered an empty source name. Issue #8485 moves every SOURCE-scoped resolution
+/// shield (Maze of Ith, Circle of Protection, Mercenaries) into that registry, so a
+/// prompt that used to name the permanent would have gone blank — and CR 616.1 asks
+/// the affected player to CHOOSE among applicable effects, which they can only do if
+/// the options are distinguishable.
+///
+/// CR 113.7a: `source_object` is the host identity the shield carries precisely
+/// because the sentinel host cannot supply it, so it is the correct display anchor.
+/// A shield created by a resolving instant never had a host, keeps
+/// `source_object: None`, and falls back to `rid.source` — reproducing today's
+/// behavior (empty name) exactly, rather than naming some unrelated object.
+fn replacement_choice_display_source(state: &GameState, rid: ReplacementId) -> ObjectId {
+    replacement_choice_definition(state, rid)
+        .and_then(|def| def.source_object)
+        .unwrap_or(rid.source)
+}
+
 fn replacement_choice_label_for_rid(state: &GameState, rid: ReplacementId) -> String {
     if is_compleated_replacement(rid) {
         return "Compleated: enter with fewer loyalty counters".to_string();
@@ -1300,10 +1365,12 @@ fn replacement_choice_label_for_rid(state: &GameState, rid: ReplacementId) -> St
         Some(ShieldCounterReplacementKind::Damage) => {
             "Prevent damage with shield counter".to_string()
         }
-        None => state
-            .objects
-            .get(&rid.source)
-            .and_then(|obj| obj.replacement_definitions.get(rid.index))
+        // CR 616.1 (issue #8485): read the definition through the sentinel-aware
+        // lookup so a REGISTRY-hosted shield describes itself instead of falling
+        // through to the bare "Replacement effect" placeholder. The object-only
+        // lookup this replaces returned `None` for every `rid.source ==
+        // ObjectId(0)` candidate. Display only.
+        None => replacement_choice_definition(state, rid)
             .map(replacement_choice_label)
             .unwrap_or_else(|| "Replacement effect".to_string()),
     }
@@ -7433,6 +7500,12 @@ pub fn find_applicable_replacements(
             }
 
             if let Some(handler) = registry.get(&repl_def.event) {
+                // CR 113.7a: the shield's HOST identity. `ReplacementId.source` stays the
+                // `ObjectId(0)` storage discriminator; this is the object the shield's
+                // host-relative filters, exclusions and conditions refer to. Parity rule:
+                // every argument position that `object_replacement_candidate_applies` fills
+                // with `obj.id`, this scan fills with `source_host`.
+                let source_host = repl_def.source_object.unwrap_or(ObjectId(0));
                 if let ProposedEvent::Damage { .. } = event {
                     // CR 615.3: Check combat scope, target filters, and source filters.
                     // CR 614.1a: Damage source filter — matches the damage *source* object
@@ -7450,9 +7523,9 @@ pub fn find_applicable_replacements(
                             // resolves; otherwise fall back to the bare source context.
                             let ctx = match repl_def.source_controller {
                                 Some(pid) => {
-                                    FilterContext::from_source_with_controller(ObjectId(0), pid)
+                                    FilterContext::from_source_with_controller(source_host, pid)
                                 }
-                                None => FilterContext::from_source(state, ObjectId(0)),
+                                None => FilterContext::from_source(state, source_host),
                             };
                             if !matches_target_filter(state, *source_id, sf, &ctx) {
                                 continue;
@@ -7482,7 +7555,7 @@ pub fn find_applicable_replacements(
                                 tf,
                                 target,
                                 source_controller,
-                                ObjectId(0),
+                                source_host,
                                 state,
                             ) {
                                 continue;
@@ -7503,24 +7576,25 @@ pub fn find_applicable_replacements(
                     // this pending-registry path never needed to read it —
                     // silently turning a scoped shield into a blanket one for
                     // the FIRST instant/sorcery-sourced population recipient.
-                    // Player-target damage events are unaffected: a card-shaped
-                    // filter has no player to check against (mirrors why
-                    // `damage_target_filter` above is the player-side gate).
+                    //
+                    // CR 109.1 + CR 614.1a: `valid_card` is an OBJECT recipient filter, and a
+                    // player is not an object. The object scan already refuses a player-target
+                    // damage event here (`replacement_valid_card_matches` falls through to
+                    // `event.affected_object_id()`, which is `None` for
+                    // `Damage { target: TargetRef::Player(_) }`). This scan used to SKIP the gate
+                    // in that case, so a registry shield scoped to "creatures" also prevented
+                    // damage dealt to players. Delegating to the one authority removes the
+                    // divergence in both directions and inherits its Connive / ChangeZone /
+                    // TokenEntry handling.
                     if let Some(ref vc) = repl_def.valid_card {
-                        if let ProposedEvent::Damage {
-                            target: TargetRef::Object(obj_id),
-                            ..
-                        } = event
-                        {
-                            let ctx = match repl_def.source_controller {
-                                Some(pid) => {
-                                    FilterContext::from_source_with_controller(ObjectId(0), pid)
-                                }
-                                None => FilterContext::from_source(state, ObjectId(0)),
-                            };
-                            if !matches_target_filter(state, *obj_id, vc, &ctx) {
-                                continue;
+                        let ctx = match repl_def.source_controller {
+                            Some(pid) => {
+                                FilterContext::from_source_with_controller(source_host, pid)
                             }
+                            None => FilterContext::from_source(state, source_host),
+                        };
+                        if !replacement_valid_card_matches(repl_def, event, state, vc, &ctx) {
+                            continue;
                         }
                     }
                     if is_damage_prevention_replacement(state, &rid, &repl_def.event)
@@ -7532,7 +7606,7 @@ pub fn find_applicable_replacements(
                         if !evaluate_replacement_condition(
                             cond,
                             source_controller,
-                            ObjectId(0),
+                            source_host,
                             state,
                             event.affected_object_id(),
                             event,
@@ -7600,7 +7674,7 @@ pub fn find_applicable_replacements(
                     if !apply_state_level_gates(
                         repl_def,
                         event,
-                        ObjectId(0),
+                        source_host,
                         source_controller,
                         state,
                     ) {
@@ -7609,7 +7683,7 @@ pub fn find_applicable_replacements(
                 }
                 // Verify the handler matcher still matches (DamageDone for damage
                 // entries, ChangeZone for zone-redirect entries).
-                if (handler.matcher)(event, ObjectId(0), state) {
+                if (handler.matcher)(event, source_host, state) {
                     candidates.push(rid);
                 }
             }
@@ -20520,41 +20594,79 @@ mod tests {
         );
     }
 
+    /// CR 109.1 + CR 614.1a (issue #8485): a card-shaped `valid_card` recipient
+    /// filter must REFUSE a player-target damage event on the global store, exactly
+    /// as it already did on the per-object store.
+    ///
+    /// STRENGTHENED, not relaxed. This test previously asserted the opposite —
+    /// that the pending scan skipped the `valid_card` gate entirely whenever the
+    /// damage recipient was a player, so a shield reading "prevent all damage that
+    /// would be dealt to CREATURES this turn" (Blinding Fog class: `valid_card:
+    /// Some(Typed(creature))` with `damage_target_filter: None`) also prevented
+    /// damage dealt to players. CR 109.1 enumerates what an object is — "an ability
+    /// on the stack, a card, a copy of a card, a token, a spell, a permanent, or an
+    /// emblem" — and a player is not one of them, so a card-shaped recipient filter
+    /// cannot match a player; CR 614.1a scopes the filter to the damage RECIPIENT.
+    /// The object scan has always refused this (`replacement_valid_card_matches`
+    /// falls through to `event.affected_object_id()`, which is `None` for
+    /// `Damage { target: TargetRef::Player(_) }`, then `.unwrap_or(false)`); the
+    /// pending scan now delegates to that same authority, so the two agree.
+    ///
+    /// This mattered because Unit A of #8485 moves every source-scoped shield from
+    /// a battlefield permanent onto the pending store: without the consolidation, a
+    /// "damage to creatures" shield would have newly started preventing damage to
+    /// players the moment it moved.
     #[test]
-    fn global_store_damage_path_ignores_valid_card_filter_for_player_targets() {
-        // A card-shaped `valid_card` recipient filter has no player to check
-        // against, so it must remain a no-op for a PLAYER-target damage
-        // event — the generalized scan must still prevent damage dealt to a
-        // player even though the shield's `valid_card` is creature-shaped.
-        // CR 608.2c + CR 615.1a (issue #6682): `valid_card` IS now enforced
-        // on this path for OBJECT-target damage events (see
-        // `find_applicable_replacements`'s dedicated `valid_card` gate,
-        // covered by `game::effects::prevent_damage::tests`'s tracked-set
-        // recipient tests) — this test pins the complementary player-target
-        // case, where the gate correctly does not apply.
+    fn global_store_valid_card_gate_refuses_a_player_target_damage_event() {
         let registry = build_replacement_registry();
         let mut state = GameState::new_two_player(42);
-        // Global prevention shield carrying a typed recipient valid_card filter
-        // that the damage target will NOT match.
+        // A creature that the OBJECT-target reach-guard below can match, so the
+        // negative half is not vacuously satisfied by the shield being inert.
+        let mut creature = GameObject::new(
+            ObjectId(51),
+            CardId(3),
+            PlayerId(1),
+            "Bear".to_string(),
+            Zone::Battlefield,
+        );
+        creature.card_types.core_types = vec![CoreType::Creature];
+        state.objects.insert(ObjectId(51), creature);
+        // Global prevention shield carrying a typed recipient valid_card filter.
         let shield = ReplacementDefinition::new(ReplacementEvent::DamageDone)
             .prevention_shield(PreventionAmount::Next(2))
             .valid_card(TargetFilter::Typed(TypedFilter::creature()));
         state.pending_damage_replacements.push(shield);
-        let event = ProposedEvent::Damage {
+
+        // Positive reach-guard: the shield IS a candidate for a matching OBJECT
+        // recipient, proving the gate is reached and the shield is otherwise live.
+        let object_event = ProposedEvent::Damage {
+            source_id: ObjectId(50),
+            target: TargetRef::Object(ObjectId(51)),
+            amount: 3,
+            is_combat: false,
+            applied: HashSet::new(),
+        };
+        assert_eq!(
+            find_applicable_replacements(&state, &object_event, &registry),
+            vec![ReplacementId {
+                source: ObjectId(0),
+                index: 0
+            }],
+            "reach-guard: a creature-shaped valid_card must still match a creature"
+        );
+
+        // CR 109.1: the player-target event is refused.
+        let player_event = ProposedEvent::Damage {
             source_id: ObjectId(50),
             target: TargetRef::Player(PlayerId(1)),
             amount: 3,
             is_combat: false,
             applied: HashSet::new(),
         };
-        let candidates = find_applicable_replacements(&state, &event, &registry);
-        assert_eq!(
-            candidates,
-            vec![ReplacementId {
-                source: ObjectId(0),
-                index: 0
-            }],
-            "damage prevention shield must remain a candidate despite a non-matching valid_card recipient filter"
+        assert!(
+            find_applicable_replacements(&state, &player_event, &registry).is_empty(),
+            "CR 109.1: a player is not an object, so a card-shaped recipient filter \
+             must not match a player-target damage event"
         );
     }
 

--- a/crates/engine/src/game/replacement.rs
+++ b/crates/engine/src/game/replacement.rs
@@ -7577,7 +7577,7 @@ pub fn find_applicable_replacements(
                     // silently turning a scoped shield into a blanket one for
                     // the FIRST instant/sorcery-sourced population recipient.
                     //
-                    // CR 109.1 + CR 614.1a: `valid_card` is an OBJECT recipient filter, and a
+                    // CR 109.1: `valid_card` is an OBJECT recipient filter, and a
                     // player is not an object. The object scan already refuses a player-target
                     // damage event here (`replacement_valid_card_matches` falls through to
                     // `event.affected_object_id()`, which is `None` for
@@ -20594,7 +20594,7 @@ mod tests {
         );
     }
 
-    /// CR 109.1 + CR 614.1a (issue #8485): a card-shaped `valid_card` recipient
+    /// CR 109.1 (issue #8485): a card-shaped `valid_card` recipient
     /// filter must REFUSE a player-target damage event on the global store, exactly
     /// as it already did on the per-object store.
     ///
@@ -20606,7 +20606,7 @@ mod tests {
     /// damage dealt to players. CR 109.1 enumerates what an object is — "an ability
     /// on the stack, a card, a copy of a card, a token, a spell, a permanent, or an
     /// emblem" — and a player is not one of them, so a card-shaped recipient filter
-    /// cannot match a player; CR 614.1a scopes the filter to the damage RECIPIENT.
+    /// cannot match a player.
     /// The object scan has always refused this (`replacement_valid_card_matches`
     /// falls through to `event.affected_object_id()`, which is `None` for
     /// `Damage { target: TargetRef::Player(_) }`, then `.unwrap_or(false)`); the

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -27182,6 +27182,39 @@ pub enum PostReplacementContinuation {
     Resolved(Box<ResolvedAbility>),
 }
 
+/// CR 611.2c vs CR 613.1: where a `ReplacementDefinition` on an object came from.
+///
+/// CR 613.1 determines the values of an object's CHARACTERISTICS, starting from
+/// the printed card — so the layer engine reseeds `replacement_definitions` from
+/// `base_replacement_definitions` every pass. CR 611.2c settles that a prevention
+/// shield is not one of those characteristics; its example says so outright:
+/// "An effect that reads 'Prevent all damage creatures would deal this turn'
+/// doesn't modify any object's characteristics, so it's modifying the rules of
+/// the game."
+///
+/// A continuous effect created by the RESOLUTION of a spell or ability (CR 611.2a)
+/// is merely STORED on a host object so the replacement pipeline can find it. It
+/// lasts as long as the ability stated (CR 611.2a) and ends when it is used up or
+/// its duration expires (CR 615.3) — not at the next layer pass.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub enum ReplacementOrigin {
+    /// A printed/copiable characteristic (CR 613.1), or a per-pass static
+    /// derivation. Reset away and re-derived by every layer pass.
+    #[default]
+    Characteristic,
+    /// A continuous effect created by resolution (CR 611.2a). Survives the
+    /// CR 613.1 reset; removed only by an expiry prune or a zone change.
+    Resolution,
+}
+
+impl ReplacementOrigin {
+    /// `skip_serializing_if` predicate: the default origin emits no key, so every
+    /// pre-existing serialized `ReplacementDefinition` is byte-identical.
+    pub fn is_characteristic(&self) -> bool {
+        matches!(self, ReplacementOrigin::Characteristic)
+    }
+}
+
 /// Replacement effect definition with typed fields. Zero params HashMap.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ReplacementDefinition {
@@ -27366,6 +27399,83 @@ pub struct ReplacementDefinition {
     /// as before (every object-attached replacement; unchanged).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub source_controller: Option<crate::types::player::PlayerId>,
+    /// CR 113.7a + CR 109.1: Installing SOURCE anchor for global pending damage
+    /// replacements whose filters, conditions, or exclusions are HOST-RELATIVE.
+    ///
+    /// The object half of `source_controller` (directly above), added for the same
+    /// reason and by the same mechanism. Global replacements live in
+    /// `pending_damage_replacements` under the sentinel `ObjectId(0)`, which has no
+    /// entry in `state.objects`, so every host-relative reference silently
+    /// mis-resolves there: `TargetFilter::SelfRef` in `damage_source_filter`
+    /// (Mercenaries, "the next time THIS CREATURE would deal damage to you"),
+    /// `SourceExclusion::Exclude` in `DamageTargetFilter::PlayerOrPermanentsControlledBy`
+    /// ("you and OTHER permanents you control"), `DamageTargetPlayerScope::SourceChosenPlayer`,
+    /// and every `ReplacementCondition` that reads its source object.
+    ///
+    /// CR 113.7a: "Once activated or triggered, an ability exists on the stack
+    /// independently of its source. Destruction or removal of the source after that
+    /// time won't affect the ability. ... if the source is no longer in the zone
+    /// it's expected to be in at that time, its last known information is used."
+    /// The effect is independent of its source but still REFERS to it, so the
+    /// reference must be carried rather than dropped.
+    ///
+    /// NOT last-known information, despite the clause the quote above ends on.
+    /// This field carries an ID, not a snapshot of the object's characteristics:
+    /// once the anchored object is gone, `state.objects.get(anchor)` is `None`, so
+    /// IDENTITY comparisons keep working on the id alone (`TargetFilter::SelfRef`
+    /// -> `object_matches_trigger_source`; `SourceExclusion::Exclude`'s
+    /// `*oid != repl_source`) while PROPERTY-READING filters and conditions fail
+    /// CLOSED. The CR 113.7a quote is cited here for its source-independence half;
+    /// implementing LKI itself is out of scope and is not claimed.
+    ///
+    /// Set at install time by `effects::install_floating_damage_replacement`, and
+    /// ONLY when the source is an object in the zone set that caller passed as
+    /// `anchor_zones` -- which is exactly the zone set THAT CALLER used to decide
+    /// object-hosting before the authority existed: `Zone::Battlefield` for
+    /// `prevent_damage::resolve`'s untargeted branch, `Zone::Battlefield |
+    /// Zone::Command` for `push_player_scoped_shield`, and EMPTY for
+    /// `create_damage_replacement`'s already-registry arm. A shield created by a
+    /// resolving instant never had a host, so it has no host identity to anchor and
+    /// keeps `None`; so does an untargeted shield from a Command-zone emblem, which
+    /// that branch already routed to the registry before this field existed.
+    /// `None` therefore reproduces the pre-anchor sentinel behavior exactly, for
+    /// every replacement that existed before this field.
+    ///
+    /// Consumed by the pending scan in `game::replacement::find_applicable_replacements`,
+    /// which fills with `source_object.unwrap_or(ObjectId(0))` every argument
+    /// position that `object_replacement_candidate_applies` fills with `obj.id`.
+    /// `ReplacementId::source` is NOT this field: it stays `ObjectId(0)`, because it
+    /// is the STORAGE discriminator that routes ~14 downstream consumers to the
+    /// registry rather than to `state.objects`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_object: Option<ObjectId>,
+    /// CR 611.2a + CR 611.2c + CR 613.1: provenance of this definition — a printed
+    /// characteristic (or per-pass derived grant) versus a continuous effect
+    /// created by the resolution of a spell or ability. See [`ReplacementOrigin`].
+    ///
+    /// Stamped ONLY by `GameObject::install_resolution_replacement`, which is the
+    /// single authority for resolution-time object installs; every parser/printed
+    /// construction leaves the `Characteristic` default. Read by
+    /// `game_object::reseed_replacements_carrying_resolution_effects` (the CR 613.1
+    /// carry-over) and `layers::settle_resolution_replacements_to_tail`.
+    ///
+    /// `origin` participates in the derived `PartialEq`, and that is LOAD-BEARING.
+    /// `layers.rs` dedups both per-pass derivation sites by whole-definition
+    /// structural equality over the LIVE set (the Riot as-enters derivation and the
+    /// `ContinuousModification::GrantReplacement` arm, both
+    /// `replacement_definitions.iter_all().any(|r| r == &replacement)`). Without
+    /// `origin` in that comparison, a CARRIED resolution shield could compare equal
+    /// to a per-pass derived grant and SUPPRESS it — the grant would silently stop
+    /// being installed while its static was still active. The dual consequence is
+    /// accepted deliberately: in the structurally-identical-but-for-`origin` case
+    /// the dedup necessarily leaves TWO entries. In practice `expiry` already
+    /// discriminates (a resolution shield carries `Some(..)`, a derived grant
+    /// `None`), so that case is synthetic; the hostile fixture
+    /// `carried_resolution_def_does_not_suppress_an_identical_derived_grant`
+    /// (`layers.rs`) pins it anyway. `source_object` (directly above) joins
+    /// `PartialEq` on exactly the same terms.
+    #[serde(default, skip_serializing_if = "ReplacementOrigin::is_characteristic")]
+    pub origin: ReplacementOrigin,
     /// CR 614.1a: For `AddCounter` replacements, whether `valid_player` scopes by
     /// the counter *recipient* (default — prevention/affected-controller doublers)
     /// or by the *actor* putting the counters (Vorinclex/Halving Season, per the
@@ -27471,6 +27581,8 @@ impl ReplacementDefinition {
             counter_match: None,
             enters_under: None,
             source_controller: None,
+            source_object: None,
+            origin: ReplacementOrigin::Characteristic,
             counter_replacement_subject: CounterReplacementSubject::Recipient,
         }
     }
@@ -27573,6 +27685,14 @@ impl ReplacementDefinition {
             self.stamp_default_turn_expiry();
         }
         self
+    }
+
+    /// CR 611.2a + CR 611.2c: was this definition created by the RESOLUTION of a
+    /// spell or ability (rather than being a printed characteristic or a per-pass
+    /// derived grant)? Such a definition is carried across the CR 613.1 layer
+    /// reset by `game_object::reseed_replacements_carrying_resolution_effects`.
+    pub fn is_resolution_installed(&self) -> bool {
+        self.origin == ReplacementOrigin::Resolution
     }
 
     pub fn combat_scope(mut self, scope: CombatDamageScope) -> Self {
@@ -30213,6 +30333,43 @@ mod tests {
     use super::*;
     use crate::types::mana::ZoneSpendPolarity;
     use crate::types::zones::Zone;
+
+    /// Issue #8485: `origin` and `source_object` are additive and wire-compatible.
+    ///
+    /// Both carry `#[serde(default, skip_serializing_if = ..)]`, so a plain printed
+    /// definition emits NEITHER key (every existing serialized state, including
+    /// `card-data.json`, stays byte-identical) and an old payload carrying neither
+    /// loads as `Characteristic` / `None`.
+    #[test]
+    fn replacement_origin_and_source_object_are_wire_compatible() {
+        let plain =
+            ReplacementDefinition::new(crate::types::replacements::ReplacementEvent::DamageDone);
+        let json = serde_json::to_string(&plain).expect("serializes");
+        assert!(
+            !json.contains("origin"),
+            "a Characteristic def must emit no `origin` key: {json}"
+        );
+        assert!(
+            !json.contains("source_object"),
+            "an unanchored def must emit no `source_object` key: {json}"
+        );
+
+        // An old payload with neither key loads as Characteristic / None.
+        let loaded: ReplacementDefinition = serde_json::from_str(&json).expect("deserializes");
+        assert_eq!(loaded.origin, ReplacementOrigin::Characteristic);
+        assert_eq!(loaded.source_object, None);
+        assert!(!loaded.is_resolution_installed());
+
+        // A Resolution def with an anchor round-trips faithfully.
+        let mut stamped = plain.clone();
+        stamped.origin = ReplacementOrigin::Resolution;
+        stamped.source_object = Some(ObjectId(42));
+        let round_tripped: ReplacementDefinition =
+            serde_json::from_str(&serde_json::to_string(&stamped).expect("serializes"))
+                .expect("deserializes");
+        assert_eq!(round_tripped, stamped);
+        assert!(round_tripped.is_resolution_installed());
+    }
 
     #[test]
     fn attach_target_bindings_keep_spell_context_construction_and_wire_shape_stable() {

--- a/crates/engine/tests/integration/issue_8485_maze_of_ith_defender.rs
+++ b/crates/engine/tests/integration/issue_8485_maze_of_ith_defender.rs
@@ -214,9 +214,18 @@ fn run_mazed_combat_with_maze_removal(
     // have been performed. Without this, a future change that stopped raising
     // `AssignCombatDamage` would silently return those fixtures to the vacuous state
     // this guard was added to fix.
+    //
+    // Counted PER ATTACKER, not over the whole combat: CR 510.1c raises the
+    // division for a single attacker blocked by two or more creatures, so a combat
+    // with two attackers blocked by one creature EACH needs no division at all
+    // (`issue_8485_maze_prevents_both_directions_against_opposing_attacker`). A
+    // whole-combat `blockers.len() > 1` would demand a division that correctly never
+    // happens and fail that fixture. `blockers` is `(blocker, attacker)` pairs.
+    //
     // Looked up defensively: a panic on a missing object here would mask the
     // assertion rather than report it.
-    let needs_division = blockers.len() > 1
+    let blockers_on_mazed = blockers.iter().filter(|(_, atk)| *atk == attacker).count();
+    let needs_division = blockers_on_mazed > 1
         || runner
             .state()
             .objects
@@ -224,9 +233,9 @@ fn run_mazed_combat_with_maze_removal(
             .is_some_and(|o| o.has_keyword(&engine::types::keywords::Keyword::Trample));
     assert!(
         !needs_division || divided_damage,
-        "this fixture blocks with {} creature(s) and/or has trample, so a CR 510.1c \
-         damage division was required — but `AssignCombatDamage` never fired",
-        blockers.len()
+        "the Mazed attacker is blocked by {blockers_on_mazed} creature(s) and/or has \
+         trample, so a CR 510.1c damage division was required — but \
+         `AssignCombatDamage` never fired"
     );
 }
 

--- a/crates/engine/tests/integration/issue_8485_maze_of_ith_defender.rs
+++ b/crates/engine/tests/integration/issue_8485_maze_of_ith_defender.rs
@@ -1,0 +1,771 @@
+//! Reproduction probe for issue #8485 (Maze of Ith still not preventing combat
+//! damage in real games). The pre-existing #1094 regression only exercises the
+//! SAME-controller orientation (P0 owns both the Maze and the attacker) with a
+//! plain attacker. These drive the real-play orientation — the DEFENDING player
+//! Mazes the ATTACKING player's creature — across the combat shapes a real game
+//! actually produces (unblocked, blocked, first strike, trample, multi-block,
+//! planeswalker attack, and activation after blockers are declared).
+
+use super::rules::{GameScenario, Phase, P0, P1};
+use engine::game::combat::AttackTarget;
+use engine::types::actions::GameAction;
+use engine::types::game_state::WaitingFor;
+use engine::types::identifiers::ObjectId;
+
+const MAZE_OF_ITH: &str = "{T}: Untap target attacking creature. Prevent all combat damage that would be dealt to and dealt by that creature this turn.";
+
+/// When the Maze is activated relative to the declare-blockers step.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum MazeTiming {
+    /// First P0 priority window in the declare-attackers step.
+    BeforeBlockers,
+    /// First P0 priority window after blockers are declared.
+    AfterBlockers,
+}
+
+/// Drive P1's combat against P0, activating `maze` on `attacker` at the first
+/// P0 priority window in the requested step. Runs until combat damage is done.
+fn run_mazed_combat(
+    runner: &mut engine::game::scenario::GameRunner,
+    maze: ObjectId,
+    attacker: ObjectId,
+    attacks: &[(ObjectId, AttackTarget)],
+    blockers: &[(ObjectId, ObjectId)],
+    timing: MazeTiming,
+) {
+    run_mazed_combat_with_maze_removal(
+        runner, maze, attacker, attacks, blockers, timing, false, false,
+    )
+}
+
+/// As [`run_mazed_combat`], but optionally destroys the Maze right after its
+/// ability resolves. CR 113.7a: "Once activated or triggered, an ability exists
+/// on the stack independently of its source. Destruction or removal of the
+/// source after that time won't affect the ability." So removing the Maze must
+/// not lift the shield its resolved ability created.
+#[allow(clippy::too_many_arguments)]
+fn run_mazed_combat_with_maze_removal(
+    runner: &mut engine::game::scenario::GameRunner,
+    maze: ObjectId,
+    attacker: ObjectId,
+    attacks: &[(ObjectId, AttackTarget)],
+    blockers: &[(ObjectId, ObjectId)],
+    timing: MazeTiming,
+    remove_maze_after_activation: bool,
+    relayer_after_activation: bool,
+) {
+    let mut mazed = false;
+    let mut blocked = false;
+    runner
+        .declare_attackers(attacks)
+        .expect("P1 must be able to declare its attack");
+    for _ in 0..400 {
+        if matches!(
+            runner.state().phase,
+            Phase::EndCombat | Phase::PostCombatMain
+        ) {
+            break;
+        }
+        match runner.state().waiting_for.clone() {
+            WaitingFor::DeclareAttackers { .. } => {
+                if runner.declare_attackers(&[]).is_err() {
+                    break;
+                }
+            }
+            WaitingFor::DeclareBlockers { .. } => {
+                let b = if blocked { &[][..] } else { blockers };
+                blocked = true;
+                if runner.declare_blockers(b).is_err() {
+                    break;
+                }
+            }
+            WaitingFor::OrderTriggers { .. } => {
+                if runner
+                    .act(GameAction::OrderTriggers { order: vec![0] })
+                    .is_err()
+                {
+                    break;
+                }
+            }
+            WaitingFor::Priority { player, .. }
+                if player == P0 && !mazed && (timing == MazeTiming::BeforeBlockers || blocked) =>
+            {
+                mazed = true;
+                runner.activate(maze, 0).target_object(attacker).resolve();
+                // CR 701.26b reach-guard: the untap is observable, proving the
+                // ability actually resolved before any damage assertion below.
+                assert!(
+                    !runner.state().objects[&attacker].tapped,
+                    "Maze of Ith must untap the opposing attacker"
+                );
+                if relayer_after_activation {
+                    engine::game::layers::evaluate_layers(runner.state_mut());
+                }
+                if remove_maze_after_activation {
+                    let mut events = Vec::new();
+                    engine::game::zones::move_to_zone(
+                        runner.state_mut(),
+                        maze,
+                        engine::types::zones::Zone::Graveyard,
+                        &mut events,
+                    );
+                }
+            }
+            WaitingFor::Priority { .. } => {
+                if runner.act(GameAction::PassPriority).is_err() {
+                    break;
+                }
+            }
+            _ => break,
+        }
+    }
+    assert!(mazed, "Maze of Ith must have been activated");
+}
+
+fn damage_marked(runner: &engine::game::scenario::GameRunner, obj: ObjectId) -> u32 {
+    runner.state().objects[&obj].damage_marked
+}
+
+/// CR 615 + CR 608.2c: the defending player Mazes ONE of two UNBLOCKED opposing
+/// attackers. The Mazed one deals nothing; the un-Mazed control still connects
+/// for its full power — the hostile fixture proving the life assertion is not
+/// vacuously satisfied by combat never happening.
+#[test]
+fn issue_8485_maze_prevents_only_the_mazed_unblocked_attacker() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let maze = scenario
+        .add_land_from_oracle(P0, "Maze of Ith", MAZE_OF_ITH)
+        .id();
+    let mazed = scenario.add_creature(P1, "Mazed Attacker", 3, 3).id();
+    let control = scenario.add_creature(P1, "Free Attacker", 2, 2).id();
+
+    let mut runner = scenario.build();
+    runner.state_mut().active_player = P1;
+
+    let p0_life_before = runner.life(P0);
+    runner.advance_to_combat();
+    run_mazed_combat(
+        &mut runner,
+        maze,
+        mazed,
+        &[
+            (mazed, AttackTarget::Player(P0)),
+            (control, AttackTarget::Player(P0)),
+        ],
+        &[],
+        MazeTiming::BeforeBlockers,
+    );
+
+    assert_eq!(
+        runner.life(P0),
+        p0_life_before - 2,
+        "only the un-Mazed 2/2 may connect: the Mazed 3/3's combat damage to the \
+         defending Maze controller must be prevented"
+    );
+}
+
+/// CR 615: the Mazed attacker is BLOCKED by the Maze controller's creature.
+/// Both directions are prevented; a second, un-Mazed pair in the same combat
+/// takes normal damage on both sides.
+#[test]
+fn issue_8485_maze_prevents_both_directions_against_opposing_attacker() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let maze = scenario
+        .add_land_from_oracle(P0, "Maze of Ith", MAZE_OF_ITH)
+        .id();
+    let mazed = scenario.add_creature(P1, "Mazed Attacker", 2, 3).id();
+    let mazed_blocker = scenario.add_creature(P0, "Mazed Blocker", 2, 3).id();
+    let free = scenario.add_creature(P1, "Free Attacker", 2, 3).id();
+    let free_blocker = scenario.add_creature(P0, "Free Blocker", 2, 3).id();
+
+    let mut runner = scenario.build();
+    runner.state_mut().active_player = P1;
+
+    runner.advance_to_combat();
+    run_mazed_combat(
+        &mut runner,
+        maze,
+        mazed,
+        &[
+            (mazed, AttackTarget::Player(P0)),
+            (free, AttackTarget::Player(P0)),
+        ],
+        &[(mazed_blocker, mazed), (free_blocker, free)],
+        MazeTiming::BeforeBlockers,
+    );
+
+    assert_eq!(
+        damage_marked(&runner, mazed_blocker),
+        0,
+        "'by' shield: the Mazed attacker deals no combat damage to its blocker"
+    );
+    assert_eq!(
+        damage_marked(&runner, mazed),
+        0,
+        "'to' shield: the Mazed attacker takes no combat damage"
+    );
+    assert_eq!(
+        damage_marked(&runner, free_blocker),
+        2,
+        "hostile fixture: the un-Mazed pair trades normally"
+    );
+    assert_eq!(
+        damage_marked(&runner, free),
+        2,
+        "hostile fixture, reverse leg"
+    );
+}
+
+/// CR 615 + CR 509.1: the Maze is activated AFTER blockers are declared — the
+/// normal way a defender uses it once they see the block assignment.
+#[test]
+fn issue_8485_maze_activated_after_blockers_still_prevents() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let maze = scenario
+        .add_land_from_oracle(P0, "Maze of Ith", MAZE_OF_ITH)
+        .id();
+    let mazed = scenario.add_creature(P1, "Mazed Attacker", 4, 4).id();
+    let blocker = scenario.add_creature(P0, "Chump Blocker", 1, 1).id();
+
+    let mut runner = scenario.build();
+    runner.state_mut().active_player = P1;
+
+    runner.advance_to_combat();
+    run_mazed_combat(
+        &mut runner,
+        maze,
+        mazed,
+        &[(mazed, AttackTarget::Player(P0))],
+        &[(blocker, mazed)],
+        MazeTiming::AfterBlockers,
+    );
+
+    assert_eq!(
+        damage_marked(&runner, mazed),
+        0,
+        "'to' shield installed after blocks still prevents damage to the attacker"
+    );
+    assert_eq!(
+        runner.state().objects[&blocker].zone,
+        engine::types::zones::Zone::Battlefield,
+        "'by' shield installed after blocks must save the 1/1 blocker"
+    );
+}
+
+/// CR 615 + CR 702.19b: a Mazed TRAMPLE attacker blocked by a 1/1 must not push
+/// excess damage through to the defending player — prevention applies to the
+/// whole combat-damage assignment, trample spillover included.
+#[test]
+fn issue_8485_maze_prevents_trample_spillover() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let maze = scenario
+        .add_land_from_oracle(P0, "Maze of Ith", MAZE_OF_ITH)
+        .id();
+    let mazed = {
+        let mut b = scenario.add_creature(P1, "Trampler", 5, 5);
+        b.trample();
+        b.id()
+    };
+    let blocker = scenario.add_creature(P0, "Chump Blocker", 1, 1).id();
+
+    let mut runner = scenario.build();
+    runner.state_mut().active_player = P1;
+
+    let p0_life_before = runner.life(P0);
+    runner.advance_to_combat();
+    run_mazed_combat(
+        &mut runner,
+        maze,
+        mazed,
+        &[(mazed, AttackTarget::Player(P0))],
+        &[(blocker, mazed)],
+        MazeTiming::BeforeBlockers,
+    );
+
+    assert_eq!(
+        runner.life(P0),
+        p0_life_before,
+        "trample spillover from a Mazed attacker must be prevented too"
+    );
+    assert_eq!(
+        damage_marked(&runner, blocker),
+        0,
+        "the blocker takes no damage from the Mazed trampler"
+    );
+}
+
+/// CR 615 + CR 702.7b: a Mazed FIRST STRIKE attacker deals its damage in the
+/// first-strike combat damage step (CR 510.4). The shield must apply there too.
+#[test]
+fn issue_8485_maze_prevents_first_strike_damage() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let maze = scenario
+        .add_land_from_oracle(P0, "Maze of Ith", MAZE_OF_ITH)
+        .id();
+    let mazed = {
+        let mut b = scenario.add_creature(P1, "First Striker", 3, 3);
+        b.first_strike();
+        b.id()
+    };
+
+    let mut runner = scenario.build();
+    runner.state_mut().active_player = P1;
+
+    let p0_life_before = runner.life(P0);
+    runner.advance_to_combat();
+    run_mazed_combat(
+        &mut runner,
+        maze,
+        mazed,
+        &[(mazed, AttackTarget::Player(P0))],
+        &[],
+        MazeTiming::BeforeBlockers,
+    );
+
+    assert_eq!(
+        runner.life(P0),
+        p0_life_before,
+        "first-strike combat damage from a Mazed attacker must be prevented"
+    );
+}
+
+/// CR 615 + CR 508.1: an opposing creature attacking the Maze controller's
+/// PLANESWALKER. The "by" shield is recipient-agnostic, so the planeswalker
+/// must lose no loyalty.
+#[test]
+fn issue_8485_maze_prevents_damage_to_attacked_planeswalker() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let maze = scenario
+        .add_land_from_oracle(P0, "Maze of Ith", MAZE_OF_ITH)
+        .id();
+    let walker = {
+        let mut b = scenario.add_creature(P0, "Loyal Walker", 0, 0);
+        b.as_planeswalker_with_loyalty("Jace", 5);
+        b.id()
+    };
+    let mazed = scenario.add_creature(P1, "Mazed Attacker", 3, 3).id();
+
+    let mut runner = scenario.build();
+    runner.state_mut().active_player = P1;
+
+    runner.advance_to_combat();
+    run_mazed_combat(
+        &mut runner,
+        maze,
+        mazed,
+        &[(mazed, AttackTarget::Planeswalker(walker))],
+        &[],
+        MazeTiming::BeforeBlockers,
+    );
+
+    assert_eq!(
+        runner.state().objects[&walker].loyalty,
+        Some(5),
+        "a Mazed attacker must deal no combat damage to the attacked planeswalker"
+    );
+}
+
+/// CR 615 + CR 509.2: the Mazed attacker is blocked by TWO creatures, so ONE
+/// shield must absorb TWO damage events in the same combat damage step (two
+/// "by" events out, two "to" events in). A shield that is consumed on first
+/// apply would let the second blocker's damage through in each direction.
+#[test]
+fn issue_8485_maze_prevents_every_event_when_multiple_blockers() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let maze = scenario
+        .add_land_from_oracle(P0, "Maze of Ith", MAZE_OF_ITH)
+        .id();
+    let mazed = scenario.add_creature(P1, "Mazed Attacker", 4, 6).id();
+    let blocker_a = scenario.add_creature(P0, "Blocker A", 2, 4).id();
+    let blocker_b = scenario.add_creature(P0, "Blocker B", 2, 4).id();
+
+    let mut runner = scenario.build();
+    runner.state_mut().active_player = P1;
+
+    runner.advance_to_combat();
+    run_mazed_combat(
+        &mut runner,
+        maze,
+        mazed,
+        &[(mazed, AttackTarget::Player(P0))],
+        &[(blocker_a, mazed), (blocker_b, mazed)],
+        MazeTiming::BeforeBlockers,
+    );
+
+    assert_eq!(
+        damage_marked(&runner, blocker_a),
+        0,
+        "'by' shield must prevent the damage assigned to the FIRST blocker"
+    );
+    assert_eq!(
+        damage_marked(&runner, blocker_b),
+        0,
+        "'by' shield must prevent the damage assigned to the SECOND blocker too"
+    );
+    assert_eq!(
+        damage_marked(&runner, mazed),
+        0,
+        "'to' shield must absorb both blockers' damage, not just the first"
+    );
+}
+
+/// CR 615 + CR 702.4b + CR 510.4: a Mazed DOUBLE STRIKE attacker deals combat
+/// damage in TWO separate combat damage steps. The same shield must still be
+/// live in the second step.
+#[test]
+fn issue_8485_maze_prevents_both_double_strike_steps() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let maze = scenario
+        .add_land_from_oracle(P0, "Maze of Ith", MAZE_OF_ITH)
+        .id();
+    let mazed = {
+        let mut b = scenario.add_creature(P1, "Double Striker", 3, 3);
+        b.double_strike();
+        b.id()
+    };
+
+    let mut runner = scenario.build();
+    runner.state_mut().active_player = P1;
+
+    let p0_life_before = runner.life(P0);
+    runner.advance_to_combat();
+    run_mazed_combat(
+        &mut runner,
+        maze,
+        mazed,
+        &[(mazed, AttackTarget::Player(P0))],
+        &[],
+        MazeTiming::BeforeBlockers,
+    );
+
+    assert_eq!(
+        runner.life(P0),
+        p0_life_before,
+        "BOTH the first-strike and regular combat damage steps must be prevented"
+    );
+}
+
+/// CR 615 + CR 806: the same defender-side orientation in a MULTIPLAYER game —
+/// the shape a real Commander table produces.
+#[test]
+fn issue_8485_maze_prevents_in_multiplayer() {
+    let mut scenario = GameScenario::new_n_player(3, 42);
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let maze = scenario
+        .add_land_from_oracle(P0, "Maze of Ith", MAZE_OF_ITH)
+        .id();
+    let mazed = scenario.add_creature(P1, "Mazed Attacker", 3, 3).id();
+
+    let mut runner = scenario.build();
+    runner.state_mut().active_player = P1;
+
+    let p0_life_before = runner.life(P0);
+    runner.advance_to_combat();
+    run_mazed_combat(
+        &mut runner,
+        maze,
+        mazed,
+        &[(mazed, AttackTarget::Player(P0))],
+        &[],
+        MazeTiming::BeforeBlockers,
+    );
+
+    assert_eq!(
+        runner.life(P0),
+        p0_life_before,
+        "multiplayer: the Mazed attacker's combat damage to the Maze controller \
+         must be prevented"
+    );
+}
+
+/// Production parity: a real game does NOT parse Oracle text in process — it
+/// loads pre-parsed `AbilityDefinition`s out of `card-data.json`. Round-trip
+/// the parsed ability through serde JSON (exactly what the export/import
+/// pipeline does) and re-run the prevention, so a field the export drops or
+/// defaults differently cannot hide behind the in-process parse.
+#[test]
+fn issue_8485_maze_prevents_after_card_data_json_round_trip() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let maze = scenario
+        .add_land_from_oracle(P0, "Maze of Ith", MAZE_OF_ITH)
+        .id();
+    let mazed = scenario.add_creature(P1, "Mazed Attacker", 3, 3).id();
+    let control = scenario.add_creature(P1, "Free Attacker", 2, 2).id();
+
+    let mut runner = scenario.build();
+
+    // Serialize → deserialize the parsed abilities, then reinstall them.
+    let round_tripped: Vec<engine::types::ability::AbilityDefinition> = {
+        let parsed = runner.state().objects[&maze].abilities.as_ref().clone();
+        let json = serde_json::to_string(&parsed).expect("abilities must serialize");
+        serde_json::from_str(&json).expect("abilities must deserialize")
+    };
+    {
+        let obj = runner.state_mut().objects.get_mut(&maze).unwrap();
+        obj.abilities = std::sync::Arc::new(round_tripped.clone());
+        obj.base_abilities = std::sync::Arc::new(round_tripped);
+    }
+
+    runner.state_mut().active_player = P1;
+    let p0_life_before = runner.life(P0);
+    runner.advance_to_combat();
+    run_mazed_combat(
+        &mut runner,
+        maze,
+        mazed,
+        &[
+            (mazed, AttackTarget::Player(P0)),
+            (control, AttackTarget::Player(P0)),
+        ],
+        &[],
+        MazeTiming::BeforeBlockers,
+    );
+
+    assert_eq!(
+        runner.life(P0),
+        p0_life_before - 2,
+        "the card-data.json round-tripped ability must still prevent the Mazed \
+         attacker's combat damage (only the un-Mazed 2/2 connects)"
+    );
+}
+
+/// CR 113.7a: "Once activated or triggered, an ability exists on the stack
+/// independently of its source. Destruction or removal of the source after that
+/// time won't affect the ability." Destroying Maze of Ith after its ability has
+/// resolved must NOT lift the shield — an extremely common real game line (the
+/// attacker's controller answers the Maze in response to, or right after, the
+/// activation).
+#[test]
+fn issue_8485_maze_shield_survives_the_maze_leaving_the_battlefield() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let maze = scenario
+        .add_land_from_oracle(P0, "Maze of Ith", MAZE_OF_ITH)
+        .id();
+    let mazed = scenario.add_creature(P1, "Mazed Attacker", 3, 3).id();
+    let control = scenario.add_creature(P1, "Free Attacker", 2, 2).id();
+
+    let mut runner = scenario.build();
+    runner.state_mut().active_player = P1;
+
+    let p0_life_before = runner.life(P0);
+    runner.advance_to_combat();
+    run_mazed_combat_with_maze_removal(
+        &mut runner,
+        maze,
+        mazed,
+        &[
+            (mazed, AttackTarget::Player(P0)),
+            (control, AttackTarget::Player(P0)),
+        ],
+        &[],
+        MazeTiming::BeforeBlockers,
+        true,
+        false,
+    );
+
+    assert_eq!(
+        runner.life(P0),
+        p0_life_before - 2,
+        "CR 113.7a: the prevention shield outlives Maze of Ith itself — only the \
+         un-Mazed 2/2 may connect"
+    );
+}
+
+/// CR 611.2c + CR 613.1: a continuous-effect (layer) re-evaluation between the
+/// Maze's activation and the combat damage step must not wipe the shield it
+/// installed. CR 613.1 determines an object's CHARACTERISTICS; CR 611.2c settles
+/// that a prevention effect is not one of them — "An effect that reads 'Prevent
+/// all damage creatures would deal this turn' doesn't modify any object's
+/// characteristics, so it's modifying the rules of the game."
+/// A layer pass therefore has no authority to end it. Layers are re-evaluated constantly in a real game (every ETB,
+/// every cast, every trigger), so a shield that does not survive a relayer is
+/// effectively never live by the time damage is dealt.
+#[test]
+fn issue_8485_maze_shield_survives_layer_reevaluation() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let maze = scenario
+        .add_land_from_oracle(P0, "Maze of Ith", MAZE_OF_ITH)
+        .id();
+    let mazed = scenario.add_creature(P1, "Mazed Attacker", 3, 3).id();
+    let control = scenario.add_creature(P1, "Free Attacker", 2, 2).id();
+
+    let mut runner = scenario.build();
+    runner.state_mut().active_player = P1;
+
+    let p0_life_before = runner.life(P0);
+    runner.advance_to_combat();
+    run_mazed_combat_with_maze_removal(
+        &mut runner,
+        maze,
+        mazed,
+        &[
+            (mazed, AttackTarget::Player(P0)),
+            (control, AttackTarget::Player(P0)),
+        ],
+        &[],
+        MazeTiming::BeforeBlockers,
+        false,
+        true,
+    );
+
+    assert_eq!(
+        runner.life(P0),
+        p0_life_before - 2,
+        "the prevention shield must survive a layer re-evaluation — only the \
+         un-Mazed 2/2 may connect"
+    );
+}
+
+/// CR 611.2c + CR 613.1 (issue #8485, Unit C): the RECIPIENT-hosted "dealt TO that
+/// creature" half must survive a layer re-evaluation too.
+///
+/// The two `..._survives_...` tests above engage only the source-scoped "dealt BY"
+/// half, because an UNBLOCKED Mazed attacker deals damage but is never dealt any.
+/// Blocking it engages both directions: the blocker deals combat damage TO the
+/// Mazed creature, which only the recipient-hosted shield prevents. That shield is
+/// stored on the attacker so a zone change correctly ends it (CR 400.7), but it is
+/// not one of the attacker's CHARACTERISTICS (CR 611.2c), so the CR 613.1 reseed
+/// must carry it.
+///
+/// Revert-failing against C1: with the raw live push, the forced `evaluate_layers`
+/// between the activation and the combat damage step wipes the "to" shield and the
+/// blocker's damage lands on the Mazed attacker.
+#[test]
+fn issue_8485_maze_to_shield_survives_layer_reevaluation_when_blocked() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let maze = scenario
+        .add_land_from_oracle(P0, "Maze of Ith", MAZE_OF_ITH)
+        .id();
+    let mazed = scenario.add_creature(P1, "Mazed Attacker", 3, 3).id();
+    let blocker = scenario.add_creature(P0, "Blocker", 2, 2).id();
+
+    let mut runner = scenario.build();
+    runner.state_mut().active_player = P1;
+    runner.advance_to_combat();
+    run_mazed_combat_with_maze_removal(
+        &mut runner,
+        maze,
+        mazed,
+        &[(mazed, AttackTarget::Player(P0))],
+        &[(blocker, mazed)],
+        MazeTiming::AfterBlockers,
+        false,
+        true,
+    );
+
+    // CR 615: the "to" half prevents the blocker's damage to the Mazed creature.
+    assert_eq!(
+        damage_marked(&runner, mazed),
+        0,
+        "CR 611.2c + CR 613.1: a layer pass must not wipe the recipient-hosted \\
+         \"dealt to that creature\" shield"
+    );
+    // CR 615: and the "by" half still prevents the Mazed creature's damage, so the
+    // blocker survives — the reach-guard that the block really happened.
+    assert_eq!(
+        damage_marked(&runner, blocker),
+        0,
+        "the source-scoped \"dealt by that creature\" shield still applies"
+    );
+    assert_eq!(
+        runner.state().objects[&blocker].zone,
+        engine::types::zones::Zone::Battlefield,
+        "the blocker must survive"
+    );
+}
+
+/// CR 611.2c + CR 613.1: STORAGE-level pin for the same defect the behavioral
+/// tests above cover. Maze of Ith installs two shields — a SOURCE-scoped "dealt
+/// by that creature" half (CR 113.7a: it must not ride on the Maze, so it lives
+/// in `state.pending_damage_replacements`) and a RECIPIENT-hosted "dealt to that
+/// creature" half (hosted on the attacker, because CR 400.7 says it should die
+/// when that creature changes zones). Neither is an object CHARACTERISTIC
+/// (CR 611.2c), so neither may be destroyed by a CR 613.1 layer pass.
+///
+/// This test asserts the counts directly rather than reporting them, so a
+/// regression that silently drops a store is caught here and not only through a
+/// life-total assertion three combat steps later.
+#[test]
+fn issue_8485_shield_storage_survives_layer_reevaluation() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let maze = scenario
+        .add_land_from_oracle(P0, "Maze of Ith", MAZE_OF_ITH)
+        .id();
+    let mazed = scenario.add_creature(P1, "Mazed Attacker", 3, 3).id();
+
+    let mut runner = scenario.build();
+    runner.state_mut().active_player = P1;
+    runner.advance_to_combat();
+    runner
+        .declare_attackers(&[(mazed, AttackTarget::Player(P0))])
+        .expect("attack");
+    for _ in 0..20 {
+        if matches!(runner.state().waiting_for, WaitingFor::Priority { player, .. } if player == P0)
+        {
+            break;
+        }
+        let _ = runner.act(GameAction::PassPriority);
+    }
+    runner.activate(maze, 0).target_object(mazed).resolve();
+    // CR 701.26b reach-guard: the untap proves the ability actually resolved, so
+    // the shield counts below are not vacuously zero-vs-zero.
+    assert!(
+        !runner.state().objects[&mazed].tapped,
+        "Maze of Ith must untap the opposing attacker"
+    );
+
+    let registry_before = runner.state().pending_damage_replacements.len();
+    let host_live_before = runner.state().objects[&mazed].replacement_definitions.len();
+    assert_eq!(
+        registry_before, 1,
+        "CR 113.7a: the source-scoped \"dealt by that creature\" half must live in \
+         the floating registry, not on the Maze"
+    );
+    assert_eq!(
+        host_live_before, 1,
+        "CR 400.7: the recipient-hosted \"dealt to that creature\" half must live on \
+         the attacker it is scoped to"
+    );
+
+    engine::game::layers::evaluate_layers(runner.state_mut());
+
+    assert_eq!(
+        runner.state().pending_damage_replacements.len(),
+        registry_before,
+        "CR 611.2c + CR 613.1: a layer pass must not touch the floating registry"
+    );
+    assert_eq!(
+        runner.state().objects[&mazed].replacement_definitions.len(),
+        host_live_before,
+        "CR 611.2c + CR 613.1: the CR 613.1 reseed must CARRY the recipient-hosted \
+         resolution shield, not wipe it — a prevention effect is not an object \
+         characteristic"
+    );
+}

--- a/crates/engine/tests/integration/issue_8485_maze_of_ith_defender.rs
+++ b/crates/engine/tests/integration/issue_8485_maze_of_ith_defender.rs
@@ -111,6 +111,53 @@ fn run_mazed_combat_with_maze_removal(
                     );
                 }
             }
+            // CR 510.1c + CR 702.19b: an attacker blocked by MORE THAN ONE creature,
+            // or one with trample, must have its combat damage divided by its
+            // controller before the combat damage step can proceed. Without this arm
+            // the loop fell through to `_ => break` and left combat unfinished — which
+            // is exactly what the terminal reach-guard below now catches, and what
+            // silently hollowed out `..._prevents_trample_spillover` and
+            // `..._prevents_every_event_when_multiple_blockers`.
+            //
+            // The division mirrors the shared driver in `rules.rs`
+            // (`run_combat_with_blocker_divisions`): assign each blocker its lethal
+            // minimum in order, then give the remainder to the defending player as
+            // trample damage (CR 702.19b) or, with no trample, dump it on the last
+            // blocker so the assignment totals the attacker's power (CR 510.1c).
+            WaitingFor::AssignCombatDamage {
+                blockers,
+                total_damage,
+                trample,
+                ..
+            } => {
+                // NOTE: this loop matches on a CLONED `waiting_for`, so these
+                // bindings are owned values, not the references `rules.rs` gets.
+                let mut remaining = total_damage;
+                let mut assignments: Vec<(ObjectId, u32)> = Vec::new();
+                for slot in &blockers {
+                    let assign = remaining.min(slot.lethal_minimum);
+                    assignments.push((slot.blocker_id, assign));
+                    remaining = remaining.saturating_sub(assign);
+                }
+                if trample.is_none() && remaining > 0 {
+                    if let Some(last) = assignments.last_mut() {
+                        last.1 += remaining;
+                        remaining = 0;
+                    }
+                }
+                let trample_damage = if trample.is_some() { remaining } else { 0 };
+                if runner
+                    .act(GameAction::AssignCombatDamage {
+                        mode: engine::types::game_state::CombatDamageAssignmentMode::Normal,
+                        assignments,
+                        trample_damage,
+                        controller_damage: 0,
+                    })
+                    .is_err()
+                {
+                    break;
+                }
+            }
             WaitingFor::Priority { .. } => {
                 if runner.act(GameAction::PassPriority).is_err() {
                     break;
@@ -120,6 +167,28 @@ fn run_mazed_combat_with_maze_removal(
         }
     }
     assert!(mazed, "Maze of Ith must have been activated");
+    // TERMINAL REACH-GUARD. Most assertions in this file are ABSENCES — "the Mazed
+    // creature dealt no damage", "the planeswalker lost no loyalty", "the blocker
+    // took no damage" — and an absence is satisfied for free if combat never
+    // reached the combat damage step at all. This loop has six ways to stop early
+    // that are not "combat finished": the `_ => break` arm on an unrecognized
+    // `WaitingFor`, the four `.is_err()` breaks, and exhausting 400 iterations.
+    // Without this guard a future `WaitingFor` variant, a new trigger shape, or a
+    // CR 616.1 `WaitingFor::ReplacementChoice` park (which issue #8485 makes newly
+    // reachable — see `prevent_damage::tests::
+    // two_shields_on_one_damage_event_prevent_it_exactly_once`) would silently turn
+    // eight of these tests green-for-the-wrong-reason. Only the tests that carry an
+    // un-Mazed control creature are immune on their own.
+    assert!(
+        matches!(
+            runner.state().phase,
+            Phase::EndCombat | Phase::PostCombatMain
+        ),
+        "combat must have run to completion — an absence-only assertion below would \
+         otherwise pass vacuously (stopped in {:?} waiting for {:?})",
+        runner.state().phase,
+        runner.state().waiting_for
+    );
 }
 
 fn damage_marked(runner: &engine::game::scenario::GameRunner, obj: ObjectId) -> u32 {
@@ -389,7 +458,13 @@ fn issue_8485_maze_prevents_every_event_when_multiple_blockers() {
     let maze = scenario
         .add_land_from_oracle(P0, "Maze of Ith", MAZE_OF_ITH)
         .id();
-    let mazed = scenario.add_creature(P1, "Mazed Attacker", 4, 6).id();
+    // CR 510.1c: the attacker's power must be at least the SUM of both blockers'
+    // lethal minimums, or the division cannot legally put damage on the second
+    // blocker at all. At the original 4 power against two 4-toughness blockers the
+    // only legal assignment was 4/0, so the "SECOND blocker" assertion below was
+    // vacuous no matter what the shield did. 8 power forces a genuine 4/4 split, so
+    // both "by" events are really produced and really have to be prevented.
+    let mazed = scenario.add_creature(P1, "Mazed Attacker", 8, 6).id();
     let blocker_a = scenario.add_creature(P0, "Blocker A", 2, 4).id();
     let blocker_b = scenario.add_creature(P0, "Blocker B", 2, 4).id();
 

--- a/crates/engine/tests/integration/issue_8485_maze_of_ith_defender.rs
+++ b/crates/engine/tests/integration/issue_8485_maze_of_ith_defender.rs
@@ -56,10 +56,19 @@ fn run_mazed_combat_with_maze_removal(
 ) {
     let mut mazed = false;
     let mut blocked = false;
+    // Reach latches for the terminal guard below. The phase check alone only proves
+    // combat ENDED, which any change that pulls the attacker out of combat or skips
+    // the damage step also satisfies — leaving every absence-only assertion in this
+    // file green for the wrong reason, i.e. the exact class the guard exists to
+    // close. These latch that the combat damage step was actually entered, and that
+    // the CR 510.1c/702.19b division actually ran for the fixtures that need one.
+    let mut saw_damage_step = false;
+    let mut divided_damage = false;
     runner
         .declare_attackers(attacks)
         .expect("P1 must be able to declare its attack");
     for _ in 0..400 {
+        saw_damage_step |= runner.state().phase == Phase::CombatDamage;
         if matches!(
             runner.state().phase,
             Phase::EndCombat | Phase::PostCombatMain
@@ -157,6 +166,7 @@ fn run_mazed_combat_with_maze_removal(
                 {
                     break;
                 }
+                divided_damage = true;
             }
             WaitingFor::Priority { .. } => {
                 if runner.act(GameAction::PassPriority).is_err() {
@@ -188,6 +198,35 @@ fn run_mazed_combat_with_maze_removal(
          otherwise pass vacuously (stopped in {:?} waiting for {:?})",
         runner.state().phase,
         runner.state().waiting_for
+    );
+    // CR 510.2: reaching EndCombat is necessary but NOT sufficient. A change that
+    // removed the attacker from combat, or skipped the damage step, would satisfy
+    // the phase check while producing no damage event at all — and every
+    // absence-only assertion below would still pass. Require that the combat damage
+    // step was actually entered.
+    assert!(
+        saw_damage_step,
+        "combat reached its end without ever entering the combat damage step — \
+         no damage event was produced, so the absence assertions below prove nothing"
+    );
+    // CR 510.1c + CR 702.19b: for the fixtures that need a division (an attacker
+    // blocked by more than one creature, or a trampler), the division must actually
+    // have been performed. Without this, a future change that stopped raising
+    // `AssignCombatDamage` would silently return those fixtures to the vacuous state
+    // this guard was added to fix.
+    // Looked up defensively: a panic on a missing object here would mask the
+    // assertion rather than report it.
+    let needs_division = blockers.len() > 1
+        || runner
+            .state()
+            .objects
+            .get(&attacker)
+            .is_some_and(|o| o.has_keyword(&engine::types::keywords::Keyword::Trample));
+    assert!(
+        !needs_division || divided_damage,
+        "this fixture blocks with {} creature(s) and/or has trample, so a CR 510.1c \
+         damage division was required — but `AssignCombatDamage` never fired",
+        blockers.len()
     );
 }
 

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -815,6 +815,7 @@ mod issue_828_full_throttle;
 mod issue_8302_liberator_mana_spent_power;
 mod issue_841_selvala_explorer_returned;
 mod issue_847_braids_cabal_minion;
+mod issue_8485_maze_of_ith_defender;
 mod issue_852_torrential_gearhulk;
 mod issue_859_weathered_wayfarer;
 mod issue_860_luminarch_aspirant;

--- a/crates/engine/tests/integration/mercenaries_any_player_activate_prevention_scope.rs
+++ b/crates/engine/tests/integration/mercenaries_any_player_activate_prevention_scope.rs
@@ -97,9 +97,20 @@ fn opponent_activated_shield_scopes_to_activator_not_source_controller() {
 
     // The installed prevention shield must scope its recipient to the ACTIVATOR
     // (P1). Pre-fix, `target: Any` yields `damage_target_filter = None`.
-    let shields: Vec<&DamageTargetFilter> = runner.state().objects[&merc]
-        .replacement_definitions
-        .iter_unchecked()
+    //
+    // STORAGE REPOINTED for issue #8485, not weakened. Mercenaries' clause is
+    // SOURCE-scoped and untargeted, so `prevent_damage::resolve` now routes it to
+    // `state.pending_damage_replacements` through
+    // `effects::install_floating_damage_replacement` instead of hosting it on the
+    // Mercenaries permanent. CR 113.7a: "Once activated or triggered, an ability
+    // exists on the stack independently of its source. Destruction or removal of
+    // the source after that time won't affect the ability." Both behavioral
+    // assertions below are unchanged and still run through the production
+    // replacement pipeline.
+    let shields: Vec<&DamageTargetFilter> = runner
+        .state()
+        .pending_damage_replacements
+        .iter()
         .filter_map(|r| r.damage_target_filter.as_ref())
         .collect();
     assert_eq!(
@@ -113,6 +124,36 @@ fn opponent_activated_shield_scopes_to_activator_not_source_controller() {
             player: DamageTargetPlayerScope::Specific(P1),
         },
         "the shield must scope to the activator (P1), not Mercenaries' controller (P0)"
+    );
+    assert!(
+        runner.state().objects[&merc]
+            .replacement_definitions
+            .as_slice()
+            .is_empty(),
+        "CR 113.7a: the shield must not ride on the Mercenaries permanent"
+    );
+
+    // CR 113.8 + CR 109.5: the install authority latches the ability's CONTROLLER,
+    // and for an activated ability that is "the player who activated the ability"
+    // (CR 109.5) — here P1, even though P0 controls the Mercenaries permanent. This
+    // fixture predates issue #8485 and is not about the latch, which is exactly why
+    // it is worth asserting here: it is an INDEPENDENT confirmation, from a
+    // pre-existing multi-controller setup, that the pending scan's
+    // `source_controller` reading is the activator and not the source permanent's
+    // live controller.
+    assert_eq!(
+        runner.state().pending_damage_replacements[0].source_controller,
+        Some(P1),
+        "CR 113.8 + CR 109.5: the latched controller is the ACTIVATOR (P1), not the \
+         Mercenaries permanent's controller (P0)"
+    );
+    // CR 113.7a: the host identity travels with the shield on `source_object`, so a
+    // host-relative filter (Mercenaries' own "this creature" source reference) can
+    // still resolve under the `ObjectId(0)` sentinel host.
+    assert_eq!(
+        runner.state().pending_damage_replacements[0].source_object,
+        Some(merc),
+        "the shield carries the Mercenaries permanent as its host anchor"
     );
 
     // Behavioral proof through the production replacement pipeline. Feed P0's

--- a/crates/engine/tests/integration/printed_damage_prevention_survives_turn.rs
+++ b/crates/engine/tests/integration/printed_damage_prevention_survives_turn.rs
@@ -530,6 +530,38 @@ fn finish_combat(runner: &mut GameRunner) -> bool {
     false
 }
 
+/// Drive out of the End Combat STEP and into the postcombat main phase.
+///
+/// CR 511.3: "until end of combat" effects expire when the End Combat step ENDS,
+/// after its priority window — not when it begins. `finish_combat` above returns
+/// the moment `state.phase` IS `Phase::EndCombat`, i.e. at the START of that step,
+/// so an `EndOfCombat` shield is still legitimately live at that point. Only after
+/// leaving the step does `turns::complete_end_combat_teardown` run and prune it.
+fn leave_end_combat_step(runner: &mut GameRunner) -> bool {
+    for _ in 0..400 {
+        if matches!(runner.state().phase, Phase::PostCombatMain) {
+            return true;
+        }
+        match runner.state().waiting_for.clone() {
+            WaitingFor::Priority { .. } => {
+                if runner.act(GameAction::PassPriority).is_err() {
+                    break;
+                }
+            }
+            WaitingFor::OrderTriggers { .. } => {
+                if runner
+                    .act(GameAction::OrderTriggers { order: vec![0] })
+                    .is_err()
+                {
+                    break;
+                }
+            }
+            _ => break,
+        }
+    }
+    false
+}
+
 /// **T3b — the production reach-guard for the `EndOfCombat` value.** Sewers of
 /// Estark is the corpus's only card whose prevention window rides on
 /// `prevention_duration: UntilEndOfCombat`, and its "If it's blocking" gate makes
@@ -587,13 +619,46 @@ fn sewers_of_estark_stamps_end_of_combat_on_the_blocking_creature() {
         "the shielded blocker must survive combat damage"
     );
 
-    // Pre-existing behavior: the window ends with the combat phase.
+    // CR 511.3: the window ends when the End Combat STEP ends — and this assertion
+    // is only now able to observe that.
+    //
+    // DO NOT "simplify" this back to asserting emptiness right after
+    // `finish_combat`. `finish_combat` returns at the START of `Phase::EndCombat`,
+    // whereas `turns::complete_end_combat_teardown` runs under
+    // `if leaving == Phase::EndCombat` in `advance_phase` — i.e. when the step ENDS,
+    // after its priority window (CR 511.3). At the earlier point the shield is
+    // legitimately still live.
+    //
+    // Until issue #8485 this assertion passed at the earlier point anyway, for the
+    // WRONG reason: the CR 613.1 layer reset in
+    // `layers::seed_live_characteristics_from_base` re-seeded
+    // `replacement_definitions` from base every pass and silently deleted the
+    // resolution-created shield long before any prune ran. The assertion was
+    // measuring the bug, not the prune. Now that CR 611.2c shields survive the
+    // reset, the EndOfCombat prune is genuinely observable for the first time — so
+    // this test must drive past the step to make the claim real.
+    //
+    // Reach-guard first: the shield is STILL PRESENT at the start of the End Combat
+    // step, which is what makes the emptiness assertion below non-vacuous.
+    assert_eq!(
+        runner.state().objects[&blocker]
+            .replacement_definitions
+            .as_slice()
+            .len(),
+        1,
+        "CR 511.3: the shield is still live at the START of the End Combat step"
+    );
+    assert!(
+        leave_end_combat_step(&mut runner),
+        "the End Combat step must end so its teardown runs"
+    );
     assert!(
         runner.state().objects[&blocker]
             .replacement_definitions
             .as_slice()
             .is_empty(),
-        "CR 511.2: effects that last 'until end of combat' expire at the end of the combat phase"
+        "CR 511.2 + CR 511.3: effects that last 'until end of combat' expire when \
+         the End Combat step ends"
     );
 }
 


### PR DESCRIPTION
## Summary

Fixes #8485. Maze of Ith untapped the attacking creature but never prevented combat damage. The parser was correct and both shields installed correctly — the next continuous-effect pass deleted them.

`prevent_damage::resolve` installed shields onto `obj.replacement_definitions`, the layer-derived **live** set, which `seed_live_characteristics_from_base` reseeds from `base_replacement_definitions` on every pass (CR 613.1). A runtime-installed shield is in neither store, so it was dropped. Measured at the base commit, immediately after the ability resolves and again after one `evaluate_layers`: both shields go `live=1` → `live=0`. Layers re-evaluate constantly in a real game, so the shields were essentially always gone by the combat damage step.

CR 611.2c settles that this is wrong — its Example states that "Prevent all damage creatures would deal this turn" *"doesn't modify any object's characteristics, so it's modifying the rules of the game."* A resolution-created shield is not a characteristic, so CR 613.1 must not reset it away; CR 611.2a gives it the lifetime the ability stated.

**Class-general, not a Maze fix.** The same defect silently broke regeneration (a resolved "regenerate target creature" was wiped identically — previously unreported), the Circle/Rune of Protection cycle, Fog effects from permanents, and the damage-redirection class.

- `ReplacementOrigin { Characteristic, Resolution }` — typed provenance; `GameObject::install_resolution_replacement` is the single install authority for object-hosted resolution replacements, failing closed when a definition carries no enforceable expiry so nothing becomes immortal.
- One carry-over authority reached by every live-store rewrite: the top-of-pass reset, the CR 613.1a Layer-1a copy application, and the CR 613.2b Layer-1b face-down reseed. Idempotent across baselines, so a Clone/Vesuvan recipient keeps its shields.
- Carried definitions settle behind per-pass derived grants, preserving the `base ++ derived` index prefix that `PendingReplacement.candidates` depends on across a CR 616.1 park.
- Host-less shields route to the floating registry (CR 113.7a — the effect is independent of its source), carrying a `source_object` anchor so host-relative filters still resolve under the sentinel host. Without it, Mercenaries and the "other permanents you control" class would silently stop matching.
- The registry `valid_card` gate delegates to the object path's authority, so a card-shaped recipient filter no longer matches player damage (CR 109.1).

### Deliberate behavior changes

1. A source-scoped shield survives its source leaving the battlefield or phasing out (CR 113.7a, CR 702.26b).
2. A registry shield's `valid_card` refuses player-target damage (CR 109.1). Previously the registry path skipped that gate while the object path enforced it.
3. Controller-relative gates on the moved population follow the ability's controller rather than the source permanent's live controller (CR 113.8, CR 109.5, CR 611.2a).
4. **New CR 616.1 replacement-choice prompts appear** where the deleted shield previously left only one candidate. Player-facing.
5. Those prompts now name the permanent that created each shield; registry-hosted candidates previously rendered blank.

### Known limitations, disclosed

- A transform, flip, or turn-face-down **drops** a carried shield rather than preserving it. Not CR 611.2a-correct, but it is the pre-branch behavior (no shield survived a layer pass at all), so it is not a regression. It replaces a worse bug found in review: the face-snapshot path copied the live store into `base`, which made the carry-over duplicate a shield once per layer pass — unbounded.
- `ReplacementId` remains positional, so a candidate parked across a layer flush can shift if that pass derives a different number of grants. Pre-existing; this change broadens the exposure by making runtime shields survivable and therefore parkable.
- `add_target_replacement.rs:555`/`:656` still push raw and never latch `source_controller`. Pre-existing, unchanged here.

## Files changed

- `crates/engine/src/types/ability.rs`
- `crates/engine/src/game/game_object.rs`
- `crates/engine/src/game/layers.rs`
- `crates/engine/src/game/printed_cards.rs`
- `crates/engine/src/game/replacement.rs`
- `crates/engine/src/game/effects/mod.rs`
- `crates/engine/src/game/effects/prevent_damage.rs`
- `crates/engine/src/game/effects/create_damage_replacement.rs`
- `crates/engine/src/game/effects/regenerate.rs`
- `crates/engine/src/game/effects/add_target_replacement.rs`
- `crates/engine/tests/integration/issue_8485_maze_of_ith_defender.rs`
- `crates/engine/tests/integration/main.rs`
- `crates/engine/tests/integration/mercenaries_any_player_activate_prevention_scope.rs`
- `crates/engine/tests/integration/printed_damage_prevention_survives_turn.rs`

## Track

Developer

## LLM

Model: claude-opus-5[1m]
Tier: Frontier
Thinking: high

## Implementation method (required)

Method: /engine-implementer

## CR references

CR 109.1, CR 109.4, CR 109.5, CR 113.7a, CR 113.8, CR 305.7, CR 400.7, CR 510.1c, CR 511.2, CR 511.3, CR 609.7a, CR 611.2a, CR 611.2b, CR 611.2c, CR 613.1, CR 613.1a, CR 613.1f, CR 613.2b, CR 614.1a, CR 614.5, CR 614.9, CR 615.3, CR 615.7, CR 616.1, CR 701.19a, CR 702.19b, CR 702.26b, CR 702.84a, CR 707.2, CR 708.2a, CR 710.1b

## Verification

- [x] Required checks ran clean, or the exact CI-owned alternative is stated below.
- [x] Gate A output below is for the current committed head.
- [x] Final review-impl below is clean for the current committed head.
- [x] Both anchors cite existing analogous code at the same seam.

- `cargo fmt --all --check` — clean
- `./scripts/check-parser-combinators.sh` — Gate A PASS, Gate G PASS (see below)
- `cargo clippy -p phase-engine -p phase-ai --all-targets -- -D warnings` — exit 0
- `cargo test -p phase-engine` (lib) — **20562 passed, 0 failed, 6 ignored**
- `cargo test -p phase-engine` (integration) — **6220 passed, 0 failed, 3 ignored**
- `cargo test -p phase-engine` (other binaries) — 21 / 9 / 0 passed, 0 failed
- `crates/engine/tests/integration/issue_8485_maze_of_ith_defender.rs` in isolation — **14 passed, 0 failed**
- `cargo test -p phase-ai` — 2325 passed, 0 failed (see Validation Failures for run 1)
- CR-annotation diff gate (every `CR` number in the diff grepped against `docs/MagicCompRules.txt`) — zero `UNVERIFIED`

Not run, with reasons:

- `cargo nextest run -p phase-engine` — `nextest` is not installed in this environment (`error: no such command: nextest`); used `cargo test -p phase-engine`, which covers lib + integration + the other test binaries.
- Workspace-wide `cargo clippy --all-targets` — `openssl-sys` cannot build here (no `libssl-dev`/pkg-config). `cargo tree -p phase-engine -i openssl-sys` and `-p phase-ai -i openssl-sys` both report the package is absent from those graphs; it reaches only `phase-server` and `feed-scraper`, neither touched. `cargo build -p openssl-sys` fails standalone with zero workspace source involved. `-p phase-engine -p phase-ai` is therefore the complete relevant scope for this diff, not a convenient subset.
- `./scripts/gen-card-data.sh`, `cargo coverage`, `cargo semantic-audit` — require `data/mtgjson/` and `client/public/card-data.json`, neither present in this checkout. **No parser file is touched** (`git diff --name-only BASE..HEAD -- crates/engine/src/parser/` is empty), so no Oracle text is newly accepted and no card changes support status; see Claimed parse impact.

## Gate A

Gate A PASS head=6e1e9fd823f3401b6bb1dc8149cd14063da5a88c base=6da6dc3bc26619b5e1539fd687d9af923e1c3f8d

## Anchored on

- `crates/engine/src/game/effects/add_target_replacement.rs` (the `install_to_base` branch) — the one pre-existing production additive base-write for a runtime-created replacement, and the durability classification this change generalizes from shape-sniffing to typed provenance.
- `crates/engine/src/game/printed_cards.rs::copiable_replacement_definitions` — already encodes "a runtime-installed definition is not a copiable value" on the producer side; this change completes the same invariant on the recipient side.

## Final review-impl

Final review-impl PASS head=6e1e9fd823f3401b6bb1dc8149cd14063da5a88c

## Claimed parse impact

None. No file under `crates/engine/src/parser/` is modified, no Oracle text is newly accepted, and no card moves between supported and unsupported. This is a runtime-semantics fix for already-supported cards.

## Scope Expansion

The issue names one card; the fix spans the replacement pipeline because the defect is in the shared layer reset, not in Maze of Ith. Every replacement created by a resolving spell or ability and hosted on a battlefield permanent was affected — prevention shields, regeneration shields, and damage redirection. Repairing only the prevention path would have left regeneration silently broken by the same line, so the change follows the class per CLAUDE.md's "build for the class, not the card".

Two consequential widenings, both forced by review findings rather than chosen:

- `game/replacement.rs` entered scope to thread a host-identity anchor into the pending scan. Without it, moving source-scoped shields to the floating registry would have silently disabled Mercenaries (`damage_source_filter: SelfRef`) and the "you and other permanents you control" class.
- `game/printed_cards.rs` entered scope for the Layer-1a copy application, and again for the face-snapshot fix above.

## Validation Failures

One unresolved evidence gap, disclosed rather than rounded up.

The first `cargo test -p phase-ai` run returned **2324 passed, 1 failed**. The failing test's name was lost to a log filter and could not be recovered from that output. Three consecutive re-runs returned **2325 passed, 0 failed**.

Plausible mechanism, unconfirmed: this diff adds per-object, per-layer-pass work on the hot path — `seed_live_characteristics_from_base` now scans for carried definitions instead of a bare `Arc::clone`, and a tail sweep runs over battlefield/recipient objects at the end of both layer arms. `phase-ai` has wall-clock-bounded search tests, and that first run started immediately after a 42-minute integration suite on a contended box; two search tests self-reported running over 60 seconds in it. That combination can flip a time-bounded assertion intermittently.

Corroborating, found after the fact: the harness's low-memory killer was actively reaping processes on this box during that window, with `MemFree` at 1.7 GB against `MemAvailable` at 24.1 GB. Every task it killed was a watcher, never a build. That confirms the box was under enough apparent pressure to be reaping during the failing run, though it does not identify the test.

Affirmative evidence against a real regression: the one deterministic AI-visible behavior change here (the pending-registry `valid_card` gate now refusing player-target damage) would fail every run, not one in four.

This is stated as unconfirmed. Reproducing it needs a `phase-ai` run under the same post-suite contention.

## CI Failures

None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed damage-prevention and redirection effects failing or being duplicated after layer recalculations, transformations, source removal, or copy effects.
  - Corrected Maze of Ith interactions across blocking, first strike, trample, planeswalkers, double strike, and multiplayer combat.
  - Improved replacement-choice displays and host-relative filtering.
  - Corrected card-validity checks so player-target damage is handled appropriately.

- **Reliability**
  - Prevention, regeneration, and redirection shields now retain their consumed state and expiration behavior consistently through relevant game updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->