### PR TITLE
ci: lint phase-ai test targets on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,6 +164,12 @@ jobs:
     timeout-minutes: 25
     steps:
       - uses: actions/checkout@v4
+        with:
+          # This job compiles pull-request code (build scripts, proc macros)
+          # on the runner. Checkout otherwise leaves the job's token in
+          # .git/config, where that code could read it. Nothing here needs
+          # git authentication after the initial fetch.
+          persist-credentials: false
 
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,6 +149,39 @@ jobs:
           fi
           ./scripts/check-test-card-data-load.sh "$BASE"
 
+  windows-lint:
+    name: Windows lint (phase-ai clippy)
+    runs-on: windows-latest
+    # Scoped to phase-ai on purpose. The defect class this catches is
+    # cfg-gated code that only compiles on one platform, and phase-ai is
+    # where the repo's `#[cfg(unix)]` test paths live (ai_gate's symlink
+    # test, duel_suite's reserved-sink test). A full
+    # `--workspace --all-targets` Windows clippy is NOT viable here:
+    # release.yml's Windows leg documents ~33-34 min warm against a 35-min
+    # ceiling, and cache misses there tripped the timeout and cancelled
+    # releases. A cold scoped run measured ~6 min locally; 25 leaves room
+    # for a cold hosted cache without approaching that failure mode.
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          # Distinct from rust-lint's `rust-debug` key: that cache is built by
+          # a Linux runner and shares nothing with an MSVC target.
+          cache-shared-key: rust-windows-lint
+
+      # `--tests` is the point of this job, not an incidental flag. The Windows
+      # break in #8591 was a `#[cfg(test)]`-only binding, so it is invisible to
+      # any target set that omits test targets -- which is every Windows job
+      # the repo had (release.yml and preview-server.yml build `phase-server`;
+      # shell-release.yml runs `cargo check` on phase-tauri).
+      #
+      # `--locked` matches rust-lint: a Windows-only lockfile rewrite would
+      # otherwise go unnoticed here.
+      - name: Clippy (phase-ai, Windows)
+        run: cargo clippy --locked -p phase-ai --bins --tests -- -D warnings
+
   rust-test-build:
     name: Rust tests (build archive)
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

[#8591](https://github.com/phase-rs/phase/pull/8591) fixed a `#[cfg(test)]`-only binding that broke `cargo clippy` on Windows while every CI check stayed green. This adds the leg that would have caught it.

Nothing in CI could have caught it. `ci.yml` is entirely `ubuntu-latest`, and the three jobs that *do* use a Windows runner are all release-artifact builds:

| workflow | what its Windows job runs | compiles `phase-ai`? | `--tests`? |
|---|---|---|---|
| `release.yml` | `cargo build -p phase-server --bin phase-server` | no | no |
| `preview-server.yml` | `cargo build -p phase-server --bin phase-server` | no | no |
| `shell-release.yml` | `cargo check` on phase-tauri | no | no |

A defect inside `#[cfg(test)] mod tests` is invisible to all of them.

## The gap is not hypothetical

Every lint entry point this repo documents uses `--all-targets`, a **superset** of `--bins --tests`:

- `.cargo/config.toml`: `clippy-strict = "clippy --all-targets -- -D warnings"`
- `Tiltfile:259`: `cargo clippy --all-targets -- -D warnings`
- `ci.yml`'s own `rust-lint` job

So a Windows contributor running documented tooling on unmodified `main` got a hard error on code they did not write.

## Why scoped to `phase-ai`

`phase-ai` is where the repo's `#[cfg(unix)]` paths actually live — `ai_gate`'s symlink test and `duel_suite`'s reserved-sink test (`run.rs:1498`) — so this covers the defect class at a fraction of the cost.

A full `--workspace --all-targets` Windows clippy is deliberately **not** proposed. `release.yml:869-875` documents its Windows leg running ~33-34 min warm against a 35-min ceiling, where cache misses tripped the timeout and cancelled releases. `timeout-minutes: 25` is sized off a measured ~6 min cold scoped run, leaving headroom for a cold hosted cache without approaching that failure mode.

## Verification

Both directions, on Windows, with the exact command this job runs:

| code under test | `cargo clippy --locked -p phase-ai --bins --tests -- -D warnings` |
|---|---|
| pre-#8591 binding restored | **exit 101** — `error: unused variable: link` |
| current `main` | **exit 0**, clean |

A job that cannot fail is decoration, so both controls were run rather than just the passing one.

Also checked: YAML parses (12 jobs); the action-pin gate passes (`93 external refs, all SHA-pinned`). Unpinned `@v4`/`@v1` tags are correct here — `scripts/check_action_pins.py` requires pins only for `release.yml` and `deploy.yml`, and this matches `ci.yml`'s existing style. The cache key is deliberately distinct from `rust-lint`'s `rust-debug`, which is built by a Linux runner and shares nothing with an MSVC target.

## Suggested rollout

I'd suggest **not** making this a required status check immediately. A cold Windows cache is the main timeout risk, and it seems better to observe a few real runs before it can block merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Added Windows-specific lint validation to the continuous integration workflow.
  - Checks platform-specific code and test bindings with strict warning enforcement.
  - Builds are now verified against warnings treated as errors on Windows.

- **Chores**
  - Improved CI credential handling to reduce the risk of access tokens being exposed during automated builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->