### PR TITLE
fix(ai): project as the authorized submitter under a controlled turn

### DIFF
--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -1212,7 +1212,15 @@ pub fn apply_verified_ai_priority_pass_with_rejection(
     })
 }
 
-pub(crate) fn apply_interaction_for_simulation(
+/// Simulation counterpart of [`apply_interaction`]: `authenticated_actor` is
+/// the trusted submitting connection and `semantic_owner` is the player whose
+/// decision slot the action names, which differ when another player controls
+/// that player's decisions. Runs in `DeferredDisplay` mode, so it skips the
+/// board-global mana-availability sweep for throwaway states no client
+/// renders. Simulation callers with no such split want
+/// [`apply_for_simulation`], the collapsed form that forwards one actor into
+/// both slots.
+pub fn apply_interaction_for_simulation(
     state: &mut GameState,
     authenticated_actor: PlayerId,
     semantic_owner: PlayerId,

--- a/crates/phase-ai/src/projection.rs
+++ b/crates/phase-ai/src/projection.rs
@@ -16,8 +16,9 @@ use engine::ai_support::{
     PaymentContinuationBatchStatus, PaymentContinuationState,
 };
 use engine::game::combat::AttackTarget;
-use engine::game::engine::{apply_for_simulation, EngineError};
+use engine::game::engine::{apply_interaction_for_simulation, EngineError};
 use engine::game::priority;
+use engine::game::turn_control;
 use engine::types::game_state::{ManaChoice, ManaChoicePrompt};
 use engine::types::{
     CoreType, GameAction, GameState, ObjectId, PayCostKind, Phase, PlayerId, WaitingFor,
@@ -205,7 +206,7 @@ pub fn project_to(
             });
         }
 
-        let (actor, action, is_policy_choice, witnessed_successor) =
+        let (seat, action, is_policy_choice, witnessed_successor) =
             resolve_choice(&state, ai_player, target_opponent)?;
         if is_policy_choice {
             choice_count += 1;
@@ -214,7 +215,16 @@ pub fn project_to(
         if let Some(successor) = witnessed_successor {
             state = successor;
         } else {
-            apply_for_simulation(&mut state, actor, action).map_err(BailReason::EngineRejected)?;
+            // CR 723.5: while controlling another player, the controller makes
+            // that player's choices, so the seat holding the decision and the
+            // player authorized to submit it are different players. Dispatch as
+            // the submitter, but keep the seat as the decision owner: CR 723.3
+            // leaves the seat's objects its own, and `semantic_owner` is what
+            // the reducer keys them to. Same split
+            // `auto_play::run_ai_actions_with_limit` applies to live play.
+            let submitter = turn_control::authorized_submitter_for_player(&state, seat);
+            apply_interaction_for_simulation(&mut state, submitter, seat, action)
+                .map_err(BailReason::EngineRejected)?;
         }
 
         if matches!(state.waiting_for, WaitingFor::GameOver { .. }) {
@@ -330,8 +340,13 @@ fn capture_snapshots(
 }
 
 /// Pick a legal action for the currently-waiting player based on projection
-/// policy. Returns `(actor, action, is_policy_choice)` where `is_policy_choice`
-/// flags non-trivial policy decisions that increment `choice_count`.
+/// policy. Returns `(seat, action, is_policy_choice, witnessed_successor)`.
+/// `seat` is the semantic decision owner and NOT the authorized submitter —
+/// under CR 723.5 turn control they differ, and this function's attacker-policy
+/// branch compares it against `target_opponent` in its seat role. The caller
+/// derives the submitter at its dispatch. `is_policy_choice` flags non-trivial
+/// policy decisions that increment `choice_count`; `witnessed_successor` is a
+/// pre-applied payment-continuation state that bypasses that dispatch.
 fn resolve_choice(
     state: &GameState,
     ai_player: PlayerId,
@@ -735,7 +750,7 @@ pub fn threat_velocity(
 /// horizon*, so `project_to` short-circuits at the `Confidence::Exact` branch
 /// above and never enters its loop. The states built here are deliberately the
 /// opposite class: they are NOT at a horizon on entry, so the loop runs real
-/// `apply_for_simulation` dispatches and returns
+/// `apply_interaction_for_simulation` dispatches and returns
 /// `Confidence::Approximated { choice_count >= 1 }` — the witness that the loop
 /// ran rather than the short-circuit.
 ///

--- a/crates/phase-ai/tests/projection_turn_control_submitter.rs
+++ b/crates/phase-ai/tests/projection_turn_control_submitter.rs
@@ -1,0 +1,218 @@
+//! AI projection dispatched the decision *seat* as the authenticated actor, so
+//! every projection under a CR 723 player-control effect bailed with
+//! `EngineRejected(WrongPlayer)`.
+//!
+//! CR 723.5: while controlling another player, the controller makes all that
+//! player's choices — so the seat holding a decision and the player authorized
+//! to submit it are different players. `project_to` forwarded its one `actor`
+//! into both the authenticated-actor and semantic-owner slots of the action
+//! boundary, and `check_actor_authorization` refused the seat. CR 723.3 keeps
+//! the seat's objects its own, so the seat must stay the semantic owner rather
+//! than be remapped. CR 723.9 (self-control) must remain a no-op.
+
+use engine::game::public_state::sync_waiting_for;
+use engine::game::turn_control::authorized_submitter_for_player;
+use engine::types::game_state::GameState;
+use engine::types::phase::Phase;
+use engine::types::player::PlayerId;
+use engine::util::Deadline;
+use phase_ai::projection::{project_to, ProjectionHorizon};
+use phase_ai::saved_state::load_saved_game_state;
+use std::io::Read;
+
+/// The 2p capture's active player, and the seat put under control below.
+const SEAT: PlayerId = PlayerId(1);
+/// The other seat in the 2p capture, used as the turn controller.
+const CONTROLLER: PlayerId = PlayerId(0);
+
+fn gunzip_fixture(gz: &[u8]) -> String {
+    let mut json = String::new();
+    flate2::read::GzDecoder::new(gz)
+        .read_to_string(&mut json)
+        .expect("fixture .json.gz must inflate to UTF-8 JSON");
+    json
+}
+
+/// Turn-4 two-player capture, already committed and loaded by
+/// `manapayment_finalize_from_floating_pool.rs`.
+fn load_2p_capture() -> GameState {
+    let raw = gunzip_fixture(include_bytes!(
+        "../fixtures/scenarios/galvanic-blast-manapayment-turn4.json.gz"
+    ));
+    load_saved_game_state(&raw).expect("the turn-4 capture deserializes and restores")
+}
+
+/// Turn-25 four-player capture, already committed and loaded by `scenarios.rs`.
+fn load_4p_capture() -> GameState {
+    let raw = gunzip_fixture(include_bytes!(
+        "../fixtures/scenarios/invisible-woman-cosmic-crucible-mana.json.gz"
+    ));
+    load_saved_game_state(&raw).expect("the turn-25 capture deserializes and restores")
+}
+
+/// Install turn control the way the engine's CR 723 regression tests do.
+///
+/// The `priority_player`/`turn_decision_controller` pairing is load-bearing,
+/// not cosmetic: the reducer's `lands_tapped_for_mana` insert keys on
+/// `state.priority_player`, so a stale one books a traversal's mana taps to a
+/// different player than live play would. `sync_waiting_for` is the only public
+/// re-synchronizer — it passes the dump's own window straight back in and
+/// re-derives `priority_player` through `sync_priority_player_from_waiting_for`.
+fn with_turn_control(base: &GameState, controller: PlayerId) -> GameState {
+    let mut state = base.clone();
+    state.turn_decision_controller = Some(controller);
+    let waiting_for = state.waiting_for.clone();
+    sync_waiting_for(&mut state, &waiting_for);
+    state
+}
+
+/// Non-vacuity guard. `effective_authority_for_player` redirects a seat only
+/// when it is the active player (individual-seat topology) — a capture whose
+/// active player drifted, or a controller equal to the seat, would silently
+/// take the uncontrolled path and pass for free.
+fn assert_control_is_discriminating(state: &GameState, seat: PlayerId, controller: PlayerId) {
+    assert_ne!(
+        controller, seat,
+        "a controller equal to the seat is CR 723.9 self-control, not the redirecting case"
+    );
+    assert_eq!(
+        state.active_player, seat,
+        "the capture's active player must be the seat under control, or the \
+         redirect never fires"
+    );
+    assert!(
+        !state.format_config.topology().has_shared_team_turns(),
+        "these captures are individual-seat topology; under shared team turns \
+         the redirect gate is team membership and this guard would be the wrong one"
+    );
+}
+
+/// The horizon assertions shared by the controlled and uncontrolled legs.
+fn assert_projected_past_the_turn_boundary(base: &GameState, controlled: &GameState, label: &str) {
+    let projection = project_to(
+        controlled,
+        CONTROLLER,
+        SEAT,
+        ProjectionHorizon::OpponentBeginCombat,
+        Deadline::none(),
+    )
+    .unwrap_or_else(|bail| panic!("{label}: projection bailed with {bail:?}"));
+
+    // The discriminating assertion: the capture starts in the seat's own
+    // EndCombat, so reaching its next BeginCombat requires crossing a turn
+    // boundary, which requires real dispatches the boundary accepted.
+    assert!(
+        projection.state.turn_number > base.turn_number,
+        "{label}: projection did not advance past turn {} (ended at {})",
+        base.turn_number,
+        projection.state.turn_number
+    );
+    // Shape pins, entailed by the projection returning Ok at all — they restate
+    // conjuncts of `reached_horizon`, and discriminate nothing on their own.
+    assert_eq!(
+        projection.state.active_player, SEAT,
+        "{label}: horizon seat"
+    );
+    assert_eq!(
+        projection.state.phase,
+        Phase::BeginCombat,
+        "{label}: horizon phase"
+    );
+}
+
+/// Row 1. Under turn control the projection must complete and advance. Reverting
+/// the `project_to` dispatch to `apply_for_simulation(&mut state, seat, action)`
+/// reds this at `EngineRejected(WrongPlayer)`.
+#[test]
+fn projection_advances_under_turn_control() {
+    let base = load_2p_capture();
+    let controlled = with_turn_control(&base, CONTROLLER);
+    assert_control_is_discriminating(&controlled, SEAT, CONTROLLER);
+    assert_eq!(
+        authorized_submitter_for_player(&controlled, SEAT),
+        CONTROLLER,
+        "the seat's decisions are submittable only by the controller, or there \
+         is no split for this row to exercise"
+    );
+
+    assert_projected_past_the_turn_boundary(&base, &controlled, "controlled");
+}
+
+/// Paired positive reach-guard for row 1: the same capture with no turn control
+/// must reach the same horizon under the same assertions. Without it an
+/// unprojectable fixture would red for the wrong reason, and go green on any
+/// change that made `project_to` return early.
+#[test]
+fn projection_reaches_the_same_horizon_without_turn_control() {
+    let base = load_2p_capture();
+    assert!(
+        base.turn_decision_controller.is_none(),
+        "the capture must carry no turn control, or this is not the OFF leg"
+    );
+    assert_eq!(
+        authorized_submitter_for_player(&base, SEAT),
+        SEAT,
+        "with no controller the seat submits for itself"
+    );
+
+    assert_projected_past_the_turn_boundary(&base, &base, "uncontrolled");
+}
+
+/// Row 2. The mapping must be conditional, not a blanket redirect: on a real
+/// four-player board only the controlled seat resolves to the controller. The
+/// bystander is the admitted-member hunt — a seat the class must refuse.
+#[test]
+fn the_submitter_mapping_redirects_only_the_controlled_seat() {
+    let base = load_4p_capture();
+    let seat = base.active_player;
+    let controller = PlayerId(0);
+    let bystander = PlayerId(1);
+    let controlled = with_turn_control(&base, controller);
+    assert_control_is_discriminating(&controlled, seat, controller);
+    assert_ne!(
+        bystander, seat,
+        "the bystander must not be the controlled seat"
+    );
+    assert_ne!(
+        bystander, controller,
+        "the bystander must not be the controller"
+    );
+
+    assert_eq!(
+        authorized_submitter_for_player(&controlled, seat),
+        controller,
+        "CR 723.5: the controlled seat's decisions go to the controller"
+    );
+    assert_eq!(
+        authorized_submitter_for_player(&controlled, bystander),
+        bystander,
+        "CR 723.5 scopes control to the controlled player, so an uncontrolled \
+         bystander still submits for itself"
+    );
+    assert_eq!(
+        authorized_submitter_for_player(&controlled, controller),
+        controller,
+        "the controller submits for itself"
+    );
+}
+
+/// Row 3. CR 723.9: an effect may give a player control of themselves, and then
+/// that player makes their own decisions — the split must collapse back to a
+/// no-op rather than reject.
+#[test]
+fn self_control_leaves_the_seat_as_its_own_submitter() {
+    let base = load_2p_capture();
+    let controlled = with_turn_control(&base, SEAT);
+    assert_eq!(
+        controlled.turn_decision_controller,
+        Some(SEAT),
+        "self-control must actually be installed"
+    );
+    assert_eq!(
+        authorized_submitter_for_player(&controlled, SEAT),
+        SEAT,
+        "CR 723.9: a player controlling themselves submits their own decisions"
+    );
+
+    assert_projected_past_the_turn_boundary(&base, &controlled, "self-controlled");
+}


### PR DESCRIPTION
## Summary

AI projection simulated every decision as the *seat* that held it. `apply_for_simulation` forwards
its one `actor` into both the authenticated-actor and semantic-owner slots of the action boundary,
so wherever those two differ `check_actor_authorization` refused the seat and the whole projection
bailed with `WrongPlayer`. Combat evaluation swallows that bail, so it ran with no projection at all.

This dispatches through `apply_interaction_for_simulation` — which already existed for callers that
must keep the two slots apart — authenticating the submitter while leaving the seat as the semantic
owner.

## Files changed

- `crates/engine/src/game/engine.rs` — `apply_interaction_for_simulation` becomes `pub`, plus the
  doc it lacked. No behavior change; only visibility.
- `crates/phase-ai/src/projection.rs` — the `project_to` dispatch derives the submitter and passes
  both roles; the destructured binding is renamed `actor` → `seat`; `resolve_choice`'s doc (stale —
  it described a three-element tuple that has four) now states the seat is *not* the submitter.
- `crates/phase-ai/tests/projection_turn_control_submitter.rs` — new. Three rows plus a paired
  control-OFF reach-guard, on two already-committed real captures. Zero fixture bytes added.

## Track

Developer

## LLM

Model: claude-opus-5
Tier: Frontier
Thinking: high

## Implementation method (required)

Method: /engine-implementer

## CR references

Three added, each verified against `docs/MagicCompRules.txt` with its **subject** checked against
the claim beside it, not merely its existence:

- `CR 723.5` — "While controlling another player, a player makes all choices and decisions the
  controlled player is allowed to make." The subject of the split: who submits.
- `CR 723.3` — "Only control of the player changes. All objects are controlled by their normal
  controllers." Why the seat stays `semantic_owner` rather than being remapped.
- `CR 723.9` — "An effect may give a player control of themselves." The self-control row, which
  must collapse to a no-op rather than reject.

## Verification

- [x] Required checks ran clean, or the exact CI-owned alternative is stated below.
- [x] Gate A output below is for the current committed head.
- [x] Final review-impl below is clean for the current committed head — see the note there; the
      review's verdict on the code was clean, and the two commits' worth of delta since it are the
      two prose repairs it asked for.
- [x] Both anchors cite existing analogous code at the same seam.

Run in a clean detached worktree at the committed head, never against the working tree:

- `cargo fmt --all -- --check` — clean
- `./scripts/check-parser-combinators.sh` — Gate A PASS, Gate G PASS
- `./scripts/check-cr-citation-anchors.sh` — PASS, 3561 files walked, 67800 citing lines, 0 matched
- `cargo clippy --workspace --all-targets -- -D warnings` — clean (exit 0)
- `cargo nextest run --workspace` — **30958 passed, 47 skipped, 0 failed**

No parser file is in scope, so no parse-diff evidence applies.

### `cargo ai-gate` — paired, BASE-run vs branch-run

Not compared against the committed `crates/phase-ai/baselines/suite-baseline.json`: `compare.rs`
states that baseline's card-data hash matches no card data on any current checkout, and its
`git_sha` is not a valid object in this repository. It is runnable but is not a sound reference for
an identity claim. The gate is therefore a paired run at the same seeds, both legs resolving
**identical** card data via an explicit `--data-root`:

- BASE leg at the merge-base, `--baseline` passed explicitly and **its verdict discarded** — only
  its report artifact is wanted. (Omitting `--baseline` silently defaults to the committed one, and
  an unreadable path exits before the suite runs, so neither shortcut works.)
- Branch leg at this head, gated against that fresh report. **This is the gate.**

Result: `compare: 0 FAIL, 0 WARN, 3 PASS, 0 NEW, 0 REMOVED` — all three matchups at +0.0 delta.

Stronger than the matchup verdict, and the claim actually being made: with wall-clock fields
stripped, the two reports' outcome-bearing content is **byte-identical** (4337 bytes each), so every
per-seed winner and turn count matches across all 30 games. Verified with controls in both
directions — the stripper demonstrably retained the outcome fields, and a perturbed `avg_turns` is
caught by the same comparison. `base_seed`, `difficulty` and `games_per_matchup` are equal on both
legs. Only `*_duration_ms` and `unix_timestamp_secs` differ.

The baseline is **not** refreshed, and nothing here asks for a tolerance.

## Gate A

Gate A PASS head=53ec966d85a4e6d720f0e99a5aca0d119e9afc6e base=d6d28370c09242182488cac72e16e5a84941885f

No file under `crates/engine/src/parser/` is in scope, so this PASS is reported for what it is: the
gate ran over its usual population and this change put nothing into it.

## Anchored on

- `crates/phase-ai/src/auto_play.rs` — `eligible_ai_decision` already resolves
  `turn_control::authorized_submitter_for_player` to an actor while keeping the semantic owner
  separate, and dispatches `apply_interaction(state, actor, semantic_owner, action)`. Its own
  comment states the rule: "The decision owner and authenticated AI actor are intentionally
  separate: control effects can make one player submit another player's pending choice." This change
  applies that existing in-crate pattern to the one dispatch that lacked it.
- `crates/engine/src/game/engine.rs` — `apply_interaction`'s doc is the engine's statement of the
  contract ("`authenticated_actor` is the trusted submitting connection; `semantic_owner` is the
  player whose decision slot the opaque interaction capability names. They differ when another
  player controls that player's decisions"), and `apply_interaction_for_simulation` is its
  `DeferredDisplay` counterpart, already used by `ai_support/{filter,prospective_mana,targeted_exchange}.rs`.

## Final review-impl

Final review-impl PASS head=99943024eda78c918e4709fcbbbd664ee5914fc2

The tip is `53ec966d8`. The review's verdict on the code was clean — "right seam, right building
block, correct CR grounding, and the test discriminates" — with two findings, **both prose, neither
in the production expression**, and both repaired at the tip:

1. The commit message asserted the change is a no-op "on a state with no turn control". That is the
   wrong population, and the review is right: `authorized_submitter_for_player` consults
   `search_decision_authority` *before* `effective_authority_for_player`, and the search-control
   latch (`StaticMode::ControlPlayersDuringOwnLibrarySearch` — Opposition Agent, which CR 723.2
   names as a player-control card) never reads `turn_decision_controller`. The message now scopes
   the equivalence to *wherever the submitter resolves to the seat* and names the search-control
   case for what it is — a second member of the same class this fix repairs, not an exception.
2. One assert message cited `CR 723.3` for "an uncontrolled bystander still submits for itself".
   723.3 is about object control, not submission. It now cites 723.5's scope.

The delta from the reviewed head is exactly those two repairs: one file
(`tests/projection_turn_control_submitter.rs`, +2/−1) plus the commit message. The message was
amended rather than corrected in a later commit because a squash-merge carries every commit body
onto `main` verbatim.

## Known coverage boundary

This ships covering one member of the class it fixes, and says so rather than implying the class is
closed:

- **Covered:** a seat redirected by scheduled turn control (`turn_decision_controller`).
- **Not covered by a test here:** a seat redirected by the search-control latch while
  `turn_decision_controller` is `None`. The fix repairs it identically — it is the same dispatch —
  but reaching it needs a library search in progress under the latch plus an
  `active_search_decision_controls` record, which is fixture construction rather than a field flip
  on an existing capture. Its test rides the follow-up below.
- **Untouched by this change:** projection's witness branch reaches the reducer through
  `apply_as_current_for_simulation`, which derives a submitter-correct actor and then collapses
  `semantic_owner` onto it. This PR's fixture does enter at a payment carrier that takes that route,
  so the shipped test certifies that projection *completes and advances* and asserts nothing about
  the projected state's mana-tap bookkeeping. The two claims do not overlap. That conflation is a
  separate, sized follow-up: the edit is small but it changes the reducer's player argument under
  turn control at every `apply_as_current*` call site, and four committed CR 723 regression tests
  need re-deriving against CR 723.5a rather than preserving.

## Claimed parse impact

None. No parser code is touched.

## Scope Expansion

None. Three files, one behavior.

## Validation Failures

None.

## CI Failures

None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded simulation support for actions submitted by one player on behalf of another, improving turn-control scenarios.
  * AI projections now distinguish the decision owner from the authorized submitter when resolving actions.

* **Bug Fixes**
  * Fixed projection handling across turn boundaries when turn control is enabled.
  * Preserved correct submitter behavior for controlled seats, bystanders, and self-controlled players.

* **Tests**
  * Added coverage for turn-control projection advancement and submitter mapping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->