### PR TITLE
Add CR 903.5a command-zone netting, and narrow previously-unconditional commander placement

### DIFF
--- a/crates/engine/src/game/deck_loading.rs
+++ b/crates/engine/src/game/deck_loading.rs
@@ -758,6 +758,98 @@ pub fn load_deck_into_state(state: &mut GameState, payload: &DeckPayload) {
             submitted.to_vec()
         }
     };
+    // CR 903.5a: the commander is one of the 100 — a decklist that names it in
+    // both the command zone and the main deck describes ONE physical card, not
+    // two. The validator nets exactly this double-listing out of its deck-size
+    // and singleton checks (`CommandZoneNetting::NetAgainstMainDeck` in
+    // `deck_validation.rs`), so the loader must drop the same copy or it builds
+    // a 101-card game the validator promised was legal. Oathbreaker RC's
+    // signature spell is the second command-zone slot with the same "one
+    // physical card" identity, and it is netted on the same axis rather than as
+    // a special case. This is the rule-enforcement boundary, mirroring
+    // `sideboard_for` above.
+    //
+    // Netting is bounded by occurrence: `min(command_zone_copies,
+    // main_deck_copies)` per card, so a main deck holding more copies than the
+    // command zone claims keeps its remainder (and the validator still reports
+    // the CR 903.5b singleton violation).
+    let net_command_zone = |main: &[DeckEntry], command: &[&[DeckEntry]]| -> Vec<DeckEntry> {
+        let mut netted = main.to_vec();
+        for entry in command.iter().copied().flatten() {
+            let Some(target) = netted
+                .iter_mut()
+                .find(|m| m.card.name.eq_ignore_ascii_case(&entry.card.name))
+            else {
+                continue;
+            };
+            target.count = target.count.saturating_sub(entry.count);
+        }
+        netted.retain(|entry| entry.count > 0);
+        netted
+    };
+    // The netted slots must mirror the command-zone placement loops below
+    // EXACTLY: commanders only when the format's command zone is filled from
+    // the decklist's `commander` slot, signature spells only under
+    // Oathbreaker. Netting a slot that is not placed would
+    // silently delete a library card; placing a slot that is not netted is the
+    // 101-card bug this guards. `place_commanders` is therefore read by BOTH
+    // this closure and the placement loop — the single predicate is what keeps
+    // the two in lockstep.
+    //
+    // CR 903.5a's "the commander is one of the 100" identity exists only where
+    // a command zone does. A constructed payload can still carry a populated
+    // `commander` slot (the deck-builder reuses it the way it reuses the
+    // sideboard as a maybeboard, and `resolve_deck_list` forwards the slot
+    // without gating), and for those formats the card is an ordinary main-deck
+    // copy: `deck_validation.rs` counts it with
+    // `CommandZoneNetting::CountVerbatim` precisely so a command-zone entry
+    // does NOT discount a main-deck copy. Netting it here would start the game
+    // one library card short of the decklist the validator approved.
+    //
+    // NOTE ON SCOPE: placement was UNCONDITIONAL before this change — every
+    // format placed whatever sat in the `commander` slot, and nothing was ever
+    // netted. This introduces both the netting and a deliberate narrowing of
+    // placement to formats whose command zone holds a decklist card. Two
+    // pre-existing tests had to declare `FormatConfig::commander()` to keep
+    // passing; that is the narrowing, made visible.
+    //
+    // The predicate is `command_zone_holds_decklist_commander`, NOT
+    // `uses_commander`. `uses_commander` is `command_zone &&
+    // commander_damage_threshold.is_some()` — it answers "does CR 903.10a
+    // commander damage apply", not "does the command zone hold a decklist
+    // card". Tiny Leaders and Oathbreaker seat a real commander card in the
+    // command zone with no damage threshold, so `uses_commander` is `false`
+    // for both while `deck_validation.rs` nets them with
+    // `CommandZoneNetting::NetAgainstMainDeck`. Narrowing on `uses_commander`
+    // instead WOULD leave a legal Oathbreaker or Tiny Leaders deck's commander
+    // in the library AND unplaced in the command zone, while the validator had
+    // already netted it out of the deck-size check — the two would disagree
+    // about the same card. That is the trap this predicate exists to avoid, not
+    // a bug that shipped. `FormatConfig::command_zone` is not the predicate
+    // either:
+    // Archenemy (CR 904.3 + CR 904.4: the scheme deck lives in the command
+    // zone) and Momir have a command zone that holds no
+    // decklist card at all, so netting on it would delete a library card.
+    //
+    // Called on the RESOLVED config, not the bare `GameFormat`: a Custom
+    // format is answered from its own `CommandZoneMode`. Deriving Custom from
+    // `uses_commander` would reopen exactly that trap for Custom, since
+    // `for_custom_rules` sets `uses_commander` from the declared
+    // commander-damage threshold alone — a custom format shaped like
+    // Oathbreaker (enabled command zone, an eligibility rule, no threshold)
+    // would strand its commander in the library.
+    let place_commanders = state.format_config.command_zone_holds_decklist_commander();
+    let oathbreaker = state.format_config.format == crate::types::format::GameFormat::Oathbreaker;
+    let main_deck_for = |deck: &PlayerDeckPayload| -> Vec<DeckEntry> {
+        let mut command: Vec<&[DeckEntry]> = Vec::new();
+        if place_commanders {
+            command.push(deck.commander.as_slice());
+        }
+        if oathbreaker {
+            command.push(deck.signature_spell.as_slice());
+        }
+        net_command_zone(&deck.main_deck, &command)
+    };
     // CR 702.139a: The Commander-family external companion slot represents one
     // card, even when a transport bypasses name-list validation and supplies a
     // resolved entry with an aggregated count. Keep one normalized copy in the
@@ -786,7 +878,7 @@ pub fn load_deck_into_state(state: &mut GameState, payload: &DeckPayload) {
 
     // Build each Arc<Vec<_>> once and share between registered_X and current_X —
     // they start identical and diverge via Arc::make_mut on first mutation.
-    let p0_main = std::sync::Arc::new(payload.player.main_deck.clone());
+    let p0_main = std::sync::Arc::new(main_deck_for(&payload.player));
     let p0_side = std::sync::Arc::new(sideboard_for(&payload.player.sideboard));
     let p0_cmdr = std::sync::Arc::new(payload.player.commander.clone());
     let p0_companion = std::sync::Arc::new(dedicated_companion_for(&payload.player.companion));
@@ -812,7 +904,7 @@ pub fn load_deck_into_state(state: &mut GameState, payload: &DeckPayload) {
             current_scheme_deck: p0_scheme,
             bracket_tier: payload.player.bracket_tier,
         });
-    let p1_main = std::sync::Arc::new(payload.opponent.main_deck.clone());
+    let p1_main = std::sync::Arc::new(main_deck_for(&payload.opponent));
     let p1_side = std::sync::Arc::new(sideboard_for(&payload.opponent.sideboard));
     let p1_cmdr = std::sync::Arc::new(payload.opponent.commander.clone());
     let p1_companion = std::sync::Arc::new(dedicated_companion_for(&payload.opponent.companion));
@@ -839,7 +931,7 @@ pub fn load_deck_into_state(state: &mut GameState, payload: &DeckPayload) {
         });
     for (i, ai_deck) in payload.ai_decks.iter().enumerate() {
         let player_id = PlayerId((2 + i) as u8);
-        let main = std::sync::Arc::new(ai_deck.main_deck.clone());
+        let main = std::sync::Arc::new(main_deck_for(ai_deck));
         let side = std::sync::Arc::new(sideboard_for(&ai_deck.sideboard));
         let cmdr = std::sync::Arc::new(ai_deck.commander.clone());
         let companion = std::sync::Arc::new(dedicated_companion_for(&ai_deck.companion));
@@ -866,17 +958,31 @@ pub fn load_deck_into_state(state: &mut GameState, payload: &DeckPayload) {
             });
     }
 
-    load_player_library(state, &payload.player.main_deck, PlayerId(0));
-    load_player_library(state, &payload.opponent.main_deck, PlayerId(1));
+    // CR 903.5a: load the command-zone-netted list, not the submitted one, so
+    // the library holds exactly the copies the command zone did not claim. The
+    // registered pools above were built from the same `main_deck_for` output,
+    // so library and pool cannot disagree about the 100.
+    let p0_library = main_deck_for(&payload.player);
+    let p1_library = main_deck_for(&payload.opponent);
+    load_player_library(state, &p0_library, PlayerId(0));
+    load_player_library(state, &p1_library, PlayerId(1));
 
     // Load additional AI decks into PlayerId(2), PlayerId(3), etc.
     for (i, ai_deck) in payload.ai_decks.iter().enumerate() {
         let player_id = PlayerId((2 + i) as u8);
-        load_player_library(state, &ai_deck.main_deck, player_id);
+        let library = main_deck_for(ai_deck);
+        load_player_library(state, &library, player_id);
     }
 
     // CR 903.6 + CR 408.1: Place commanders in the command zone at game start.
-    let commander_decks: Vec<(PlayerId, &[DeckEntry])> =
+    // Gated on the same `place_commanders` predicate `main_deck_for` nets with:
+    // a format whose command zone is not filled from the decklist's
+    // `commander` slot must neither place a command-zone object nor net the
+    // slot out of the library, or a populated-but-inert `commander` slot would
+    // add a 61st card to a constructed game.
+    let commander_decks: Vec<(PlayerId, &[DeckEntry])> = if !place_commanders {
+        Vec::new()
+    } else {
         std::iter::once((PlayerId(0), payload.player.commander.as_slice()))
             .chain(std::iter::once((
                 PlayerId(1),
@@ -889,7 +995,8 @@ pub fn load_deck_into_state(state: &mut GameState, payload: &DeckPayload) {
                     .enumerate()
                     .map(|(i, d)| (PlayerId((2 + i) as u8), d.commander.as_slice())),
             )
-            .collect();
+            .collect()
+    };
     for (owner, entries) in commander_decks {
         for entry in entries {
             for _ in 0..entry.count {
@@ -1644,6 +1751,175 @@ mod tests {
     }
 
     #[test]
+    fn load_deck_nets_a_commander_also_listed_in_the_main_deck() {
+        // CR 903.5a: the commander is one of the 100. A decklist naming it in
+        // both the command zone and the main deck describes ONE physical card,
+        // and the validator nets exactly that double-listing out of its
+        // deck-size and singleton checks. If the loader did not drop the same
+        // copy it would build a 101-card game the validator called legal.
+        let mut state = GameState::new_two_player(42);
+        state.format_config = crate::types::format::FormatConfig::commander();
+        let payload = DeckPayload {
+            player: PlayerDeckPayload {
+                main_deck: vec![
+                    DeckEntry {
+                        card: make_creature_face(),
+                        count: 1,
+                    },
+                    DeckEntry {
+                        card: make_instant_face(),
+                        count: 2,
+                    },
+                ],
+                commander: vec![DeckEntry {
+                    card: make_creature_face(),
+                    count: 1,
+                }],
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        load_deck_into_state(&mut state, &payload);
+
+        let library = state
+            .objects
+            .values()
+            .filter(|o| o.owner == PlayerId(0) && o.zone == Zone::Library)
+            .count();
+        assert_eq!(
+            library, 2,
+            "the commander's main-deck listing is the same physical card as its              command-zone entry, so only the untouched instant playset remains"
+        );
+        assert!(
+            !state.deck_pools[0]
+                .registered_main
+                .iter()
+                .any(|e| e.card.name == "Grizzly Bears"),
+            "the registered pool must agree with the library about the 100"
+        );
+        assert_eq!(
+            state
+                .objects
+                .values()
+                .filter(|o| o.owner == PlayerId(0) && o.zone == Zone::Command)
+                .count(),
+            1,
+            "the card is still in the command zone — netted, not deleted"
+        );
+    }
+
+    #[test]
+    fn load_deck_nets_only_as_many_copies_as_the_command_zone_claims() {
+        // Netting is the CR 903.5a double-listing correction, not a blanket
+        // amnesty: a main deck holding MORE copies than the command zone claims
+        // keeps its remainder, so the copy-limit verdict still has something to
+        // catch.
+        let mut state = GameState::new_two_player(42);
+        state.format_config = crate::types::format::FormatConfig::commander();
+        let payload = DeckPayload {
+            player: PlayerDeckPayload {
+                main_deck: vec![DeckEntry {
+                    card: make_creature_face(),
+                    count: 3,
+                }],
+                commander: vec![DeckEntry {
+                    card: make_creature_face(),
+                    count: 1,
+                }],
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        load_deck_into_state(&mut state, &payload);
+
+        assert_eq!(
+            state
+                .objects
+                .values()
+                .filter(|o| o.owner == PlayerId(0) && o.zone == Zone::Library)
+                .count(),
+            2,
+            "only the one copy the command zone claims is netted away"
+        );
+    }
+
+    #[test]
+    fn load_deck_does_not_net_a_commander_slot_in_a_format_without_a_command_zone() {
+        // CR 903.5a's "the commander is one of the 100" identity exists only
+        // where a format designates a decklist commander for the command zone.
+        // CR 408.1 defines the zone generally (Archenemy schemes live there per
+        // CR 904.4), so the zone's existence is NOT the test — the decklist
+        // commander is. A
+        // constructed payload can still arrive with a populated `commander`
+        // slot — the deck builder reuses the slot and `resolve_deck_list`
+        // forwards it ungated — and for such a format that card is an ordinary
+        // main-deck copy.
+        //
+        // This is the negative twin of
+        // `constructed_copy_limit_does_not_net_out_a_commander_slot_entry` in
+        // `deck_validation.rs`: the validator counts the slot with
+        // `CommandZoneNetting::CountVerbatim`, so the loader must not discount a
+        // main-deck copy against it or the game starts one library card short
+        // of the decklist the validator approved. It also pins the other half of
+        // the mirror — an inert slot must not be placed either, or the same deck
+        // would gain a card in the command zone.
+        let mut state = GameState::new_two_player(42);
+        state.format_config = crate::types::format::FormatConfig::standard();
+        assert!(
+            !state.format_config.uses_commander,
+            "fixture must exercise the no-command-zone arm"
+        );
+        let payload = DeckPayload {
+            player: PlayerDeckPayload {
+                main_deck: vec![
+                    DeckEntry {
+                        card: make_creature_face(),
+                        count: 4,
+                    },
+                    DeckEntry {
+                        card: make_instant_face(),
+                        count: 2,
+                    },
+                ],
+                commander: vec![DeckEntry {
+                    card: make_creature_face(),
+                    count: 1,
+                }],
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        load_deck_into_state(&mut state, &payload);
+
+        assert_eq!(
+            state
+                .objects
+                .values()
+                .filter(|o| o.owner == PlayerId(0) && o.zone == Zone::Library)
+                .count(),
+            6,
+            "with no command zone the slot nets nothing — every submitted              main-deck copy stays in the library"
+        );
+        assert_eq!(
+            state.deck_pools[0]
+                .registered_main
+                .iter()
+                .filter(|e| e.card.name == "Grizzly Bears")
+                .map(|e| e.count)
+                .sum::<u32>(),
+            4,
+            "the registered pool must agree with the library about the playset"
+        );
+        assert!(
+            state.command_zone.is_empty(),
+            "a format with no command zone places nothing there, so the netting              gate and the placement gate stay mirrored"
+        );
+    }
+
+    #[test]
     fn load_deck_ignores_signature_spells_outside_oathbreaker() {
         let mut state = GameState::new_two_player(42);
         let payload = DeckPayload {
@@ -1690,6 +1966,129 @@ mod tests {
                 ["signature_spell"],
             serde_json::json!({}),
             "the wire marker must be non-null so clients recognize the signature spell"
+        );
+    }
+
+    /// CR 903.5a: Oathbreaker's command zone holds a decklist card, so its
+    /// commander must be placed in the command zone AND netted out of the
+    /// library — the two halves of one physical card's identity.
+    ///
+    /// This PR narrows command-zone placement, which was unconditional before
+    /// it, to formats whose zone holds a decklist commander. Oathbreaker is the
+    /// case that makes the narrowing predicate load-bearing rather than
+    /// cosmetic: it declares no commander-damage threshold, so
+    /// `FormatConfig::uses_commander` is `false` for it, and gating on that
+    /// field instead would leave a legal Oathbreaker in the library with no
+    /// command-zone object while `deck_validation` had already netted it out of
+    /// the deck-size check. The `current_main.is_empty()` and
+    /// `library.len() == 0` assertions below are what pin the netting half.
+    #[test]
+    fn load_deck_places_the_oathbreaker_in_the_command_zone() {
+        let mut state = GameState::new_two_player(42);
+        state.format_config = crate::types::format::FormatConfig::oathbreaker();
+        let commander = make_creature_face();
+        let payload = DeckPayload {
+            player: PlayerDeckPayload {
+                main_deck: vec![DeckEntry {
+                    card: commander.clone(),
+                    count: 1,
+                }],
+                commander: vec![DeckEntry {
+                    card: commander.clone(),
+                    count: 1,
+                }],
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        load_deck_into_state(&mut state, &payload);
+
+        assert_eq!(
+            state.command_zone.len(),
+            1,
+            "the Oathbreaker must occupy the command zone"
+        );
+        assert!(state.objects[&state.command_zone[0]].is_commander);
+        // CR 903.5a: netted out of the library, so the same physical card is
+        // not in two zones at once.
+        assert!(
+            state.deck_pools[0].current_main.is_empty(),
+            "the command-zone copy must be netted out of the main deck"
+        );
+        assert_eq!(
+            state.players[0].library.len(),
+            0,
+            "the netted copy must not also be shuffled into the library"
+        );
+    }
+
+    /// Tiny Leaders has the same shape as Oathbreaker: a decklist card in the
+    /// command zone with no commander-damage threshold, so `uses_commander` is
+    /// `false` while `deck_validation` nets with `NetAgainstMainDeck`.
+    #[test]
+    fn load_deck_places_the_tiny_leaders_commander_in_the_command_zone() {
+        let mut state = GameState::new_two_player(42);
+        state.format_config = crate::types::format::FormatConfig::tiny_leaders();
+        let commander = make_creature_face();
+        let payload = DeckPayload {
+            player: PlayerDeckPayload {
+                main_deck: vec![DeckEntry {
+                    card: commander.clone(),
+                    count: 1,
+                }],
+                commander: vec![DeckEntry {
+                    card: commander.clone(),
+                    count: 1,
+                }],
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        load_deck_into_state(&mut state, &payload);
+
+        assert_eq!(state.command_zone.len(), 1);
+        assert!(state.objects[&state.command_zone[0]].is_commander);
+        assert!(state.deck_pools[0].current_main.is_empty());
+    }
+
+    /// Control for the two tests above: Archenemy has `command_zone: true`
+    /// (CR 904.3 + CR 904.4, the scheme deck) but its zone holds no decklist
+    /// card, so a
+    /// populated-but-inert `commander` slot must be neither placed nor netted.
+    /// Widening the predicate to `FormatConfig::command_zone` instead of
+    /// `command_zone_holds_decklist_commander` would delete this library card.
+    #[test]
+    fn load_deck_neither_places_nor_nets_a_commander_slot_without_a_decklist_command_zone() {
+        let mut state = GameState::new_two_player(42);
+        state.format_config = crate::types::format::FormatConfig::archenemy();
+        let card = make_creature_face();
+        let payload = DeckPayload {
+            player: PlayerDeckPayload {
+                main_deck: vec![DeckEntry {
+                    card: card.clone(),
+                    count: 1,
+                }],
+                commander: vec![DeckEntry {
+                    card: card.clone(),
+                    count: 1,
+                }],
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        load_deck_into_state(&mut state, &payload);
+
+        assert!(
+            state.command_zone.is_empty(),
+            "Archenemy's command zone holds schemes, not a decklist commander"
+        );
+        assert_eq!(
+            state.deck_pools[0].current_main.len(),
+            1,
+            "an inert commander slot must not discount a real main-deck card"
         );
     }
 
@@ -1932,6 +2331,11 @@ mod tests {
     #[test]
     fn load_deck_with_commanders_creates_command_zone_objects() {
         let mut state = GameState::new_two_player(42);
+        // CR 903.6: a commander is put into the command zone at the start of
+        // the game. This PR narrows placement from unconditional to
+        // command-zone-holding formats, so this pre-existing test must now
+        // declare one; without it the payload's `commander` slot is inert.
+        state.format_config = crate::types::format::FormatConfig::commander();
         let commander_face = CardFace {
             name: "Kaalia".to_string(),
             card_type: CardType {
@@ -2030,6 +2434,10 @@ mod tests {
         );
 
         let mut state = GameState::new_two_player(42);
+        // CR 903.6: command-zone placement now requires a format whose command
+        // zone holds a decklist commander (narrowed by this PR from
+        // unconditional), so this pre-existing test must declare one.
+        state.format_config = crate::types::format::FormatConfig::commander();
         load_deck_into_state(&mut state, &payload);
 
         assert_eq!(state.command_zone.len(), 1);

--- a/crates/engine/src/game/deck_validation.rs
+++ b/crates/engine/src/game/deck_validation.rs
@@ -611,7 +611,7 @@ fn evaluate_constructed(
     // CR 100.2a + CR 100.4a: The copy limit applies to main + sideboard
     // combined, at the ceiling the request's resolved format config carries.
     let limit = resolved_copy_limit(request, format);
-    let counts = combined_copy_counts(db, request);
+    let counts = combined_copy_counts(db, request, CommandZoneNetting::CountVerbatim);
     let over_limit = copy_limit_violations(db, &counts, limit);
     if !over_limit.is_empty() {
         reasons.push(summarize_cards(&copy_limit_label(limit), &over_limit, 6));
@@ -702,7 +702,7 @@ fn evaluate_planechase(
     }
 
     let limit = resolved_copy_limit(request, GameFormat::Planechase);
-    let counts = combined_copy_counts(db, request);
+    let counts = combined_copy_counts(db, request, CommandZoneNetting::CountVerbatim);
     let over_limit = copy_limit_violations(db, &counts, limit);
     if !over_limit.is_empty() {
         reasons.push(summarize_cards(&copy_limit_label(limit), &over_limit, 6));
@@ -807,7 +807,7 @@ fn evaluate_archenemy(
     }
 
     let limit = resolved_copy_limit(request, GameFormat::Archenemy);
-    let counts = combined_copy_counts(db, request);
+    let counts = combined_copy_counts(db, request, CommandZoneNetting::CountVerbatim);
     let over_limit = copy_limit_violations(db, &counts, limit);
     if !over_limit.is_empty() {
         reasons.push(summarize_cards(&copy_limit_label(limit), &over_limit, 6));
@@ -1171,7 +1171,7 @@ fn evaluate_commander_with_format(
     // same name" — which is exactly what `default_deck_copy_limit()` already
     // reports as `Unlimited`, so the format answers this rather than the
     // caller.
-    let counts = combined_copy_counts(db, request);
+    let counts = combined_copy_counts(db, request, CommandZoneNetting::NetAgainstMainDeck);
     let singleton_violations =
         copy_limit_violations(db, &counts, resolved_copy_limit(request, game_format));
     if !singleton_violations.is_empty() {
@@ -1342,7 +1342,7 @@ fn evaluate_brawl(
     // CR 903.5b (Brawl variant): singleton rule, basic lands exempt,
     // canonicalized to one bucket per physical card (CR 709.2 / CR 712.1) in
     // the shared helper.
-    let counts = combined_copy_counts(db, request);
+    let counts = combined_copy_counts(db, request, CommandZoneNetting::NetAgainstMainDeck);
     let singleton_violations =
         copy_limit_violations(db, &counts, resolved_copy_limit(request, game_format));
     if !singleton_violations.is_empty() {
@@ -1578,7 +1578,7 @@ fn evaluate_tiny_leaders(
         ));
     }
 
-    let counts = combined_copy_counts(db, request);
+    let counts = combined_copy_counts(db, request, CommandZoneNetting::NetAgainstMainDeck);
     let singleton_violations = copy_limit_violations(
         db,
         &counts,
@@ -1916,11 +1916,12 @@ fn evaluate_oathbreaker(
     // Oathbreaker RC: singleton (basic lands exempt, consistent with other
     // singleton command-zone formats). `construction_deck_cards` includes
     // `signature_spell`, so a genuine second copy of a card in both the main
-    // deck and the signature-spell slot is caught here. Counts are keyed by
-    // resolved card identity (CR 709.2 / CR 712.1: one physical card) rather
-    // than by raw spelling, so the two spellings of one multi-face card share
-    // a bucket.
-    let counts = combined_copy_counts(db, request);
+    // deck and the signature-spell slot is caught here; a single physical card
+    // named in both slots under different spellings is netted out first by
+    // `CommandZoneNetting::NetAgainstMainDeck`, which resolves both command-zone
+    // slots by card identity (CR 709.2 / CR 712.1: one physical card) rather
+    // than by raw spelling.
+    let counts = combined_copy_counts(db, request, CommandZoneNetting::NetAgainstMainDeck);
     let singleton_violations = copy_limit_violations(
         db,
         &counts,
@@ -2453,7 +2454,7 @@ fn quick_commander_check(
     // card identity (CR 709.2 / CR 712.1 — one physical card per multi-face
     // card), so re-deriving counts here would make the summary path reach a
     // different singleton verdict than the full path for the same decklist.
-    let counts = combined_copy_counts(db, request);
+    let counts = combined_copy_counts(db, request, CommandZoneNetting::NetAgainstMainDeck);
     for name in construction_deck_cards(request) {
         let resolved = db.lookup_key(name);
         let Some(face) = db.get_face_by_name(&resolved) else {
@@ -3107,14 +3108,105 @@ fn canonical_deck_count_key(db: &CardDatabase, name: &str) -> String {
         .unwrap_or(resolved)
 }
 
+/// Whether the evaluating format has a command zone whose entries are part of
+/// the deck proper.
+///
+/// CR 903.5a makes the commander one of the 100, so a decklist naming a
+/// command-zone card in BOTH its zone slot and the main deck still describes a
+/// single physical card, and the duplicate must be netted out before the copy
+/// limit is applied. Formats with no command zone (constructed, Planechase,
+/// Archenemy) have no such identity: they must count `construction_deck_cards`
+/// verbatim, or netting would silently hide one copy of any card that also
+/// appears in a (rejected, but still populated) commander slot and turn a real
+/// CR 100.2a violation into a pass, from a rule that has no commander concept.
+///
+/// The set of formats whose `evaluate_*`/`quick_*` function passes
+/// `NetAgainstMainDeck` is exactly the set for which
+/// `GameFormat::command_zone_holds_decklist_commander()` returns `true`, and
+/// `game::deck_loading` reads that predicate to decide both what it nets out of
+/// the library and what it places in the command zone. The two must agree: a
+/// format netted here but not placed there starts the game a card short, and
+/// one placed but not netted starts it a card long.
+/// `types::format`'s
+/// `command_zone_holds_decklist_commander_matches_the_validator_netting_set`
+/// locks that agreement — update it when adding a format to either side.
+///
+/// Typed rather than a `bool` so each call site states which rule it is under.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CommandZoneNetting {
+    /// CR 903.5a: net a command-zone card that is also listed in the main deck
+    /// down to the one physical card it is.
+    NetAgainstMainDeck,
+    /// No command zone: count every listed slot verbatim.
+    CountVerbatim,
+}
+
 fn combined_copy_counts(
     db: &CardDatabase,
     request: &DeckCompatibilityRequest,
+    netting: CommandZoneNetting,
 ) -> HashMap<String, u32> {
     let mut counts: HashMap<String, u32> = HashMap::new();
     for name in construction_deck_cards(request) {
         let canonical = canonical_deck_count_key(db, name);
         *counts.entry(canonical).or_insert(0) += 1;
+    }
+    if netting == CommandZoneNetting::CountVerbatim {
+        return counts;
+    }
+    // CR 903.5a: the commander is one of the 100, so a decklist naming it in
+    // both the command zone and the main deck still describes a single physical
+    // card. `construction_deck_cards` chains both slots, so that card was just
+    // counted twice — decrement the duplicate before CR 903.5b sees it, or the
+    // commander is reported as a singleton violation against itself. Comparing
+    // resolved keys (CR 709.2 / CR 712.1: a split or double-faced card is one
+    // physical card) is what makes this fire for a composite-named
+    // commander listed in the 99 by its front name; the same double-listing
+    // is already netted out of the CR 903.5a total by
+    // `commanders_represented_in_main`.
+    //
+    // The Oathbreaker signature spell (Oathbreaker RC) is a second command-zone
+    // slot with the same "one physical card" identity, and
+    // `construction_deck_cards` chains it too — so it is netted on the same
+    // axis rather than as a special case. Without it, a compositely-named
+    // signature spell listed by its front face in the 58 is reported as a
+    // CR 903.5b singleton violation against itself.
+    //
+    // The decrement is bounded by OCCURRENCE, not merely gated on presence:
+    // subtract `min(command_zone_entries, main_deck_occurrences)` per canonical
+    // key. A per-entry `saturating_sub(1)` gated only on "the main deck
+    // contains this card at all" over-credits whenever two command-zone slots
+    // resolve to the same card — partner slots spelled composite and front-face
+    // ("Fire // Ice" + "Fire"), or an Oathbreaker whose commander and signature
+    // spell name one card — netting two copies away against a single main-deck
+    // listing and hiding a genuine CR 903.5b violation. Netting must be the
+    // exact CR 903.5a double-listing correction, never a blanket amnesty.
+    let mut main_deck_occurrences: HashMap<String, u32> = HashMap::new();
+    for name in &request.main_deck {
+        *main_deck_occurrences
+            .entry(canonical_deck_count_key(db, name))
+            .or_insert(0) += 1;
+    }
+    let mut command_zone_entries: HashMap<String, u32> = HashMap::new();
+    for entry in request
+        .commander
+        .iter()
+        .chain(request.signature_spell.iter())
+    {
+        *command_zone_entries
+            .entry(canonical_deck_count_key(db, entry))
+            .or_insert(0) += 1;
+    }
+    for (canonical, command_copies) in command_zone_entries {
+        let netted = command_copies.min(
+            main_deck_occurrences
+                .get(&canonical)
+                .copied()
+                .unwrap_or_default(),
+        );
+        if let Some(count) = counts.get_mut(&canonical) {
+            *count = count.saturating_sub(netted);
+        }
     }
     counts
 }
@@ -4879,7 +4971,7 @@ mod tests {
             default_deck_copy_limit: None,
         };
 
-        let counts = combined_copy_counts(&db, &request);
+        let counts = combined_copy_counts(&db, &request, CommandZoneNetting::NetAgainstMainDeck);
         assert_eq!(counts.get("nazgûl"), Some(&10));
         assert!(!copy_limit_violations(&db, &counts, DeckCopyLimit::UpTo(1)).is_empty());
     }
@@ -8399,6 +8491,168 @@ mod tests {
         CardDatabase::from_json_str(&Value::Object(cards).to_string()).unwrap()
     }
 
+    /// The headline regression, driven end-to-end through
+    /// `evaluate_deck_compatibility` rather than through a hand-written closure,
+    /// so it actually executes the production comparison sites.
+    ///
+    /// A commander listed in the command zone by its composite name and in the
+    /// 99 by its front name is ONE card (CR 903.5a: the deck is 100 cards
+    /// *including* its commander; CR 709.2 / CR 712.1: a split or double-faced
+    /// card is a single physical card, whichever of its faces a decklist names
+    /// it by). Comparing raw spellings made all three CR 903.5 checks
+    /// misfire at once: the deck counted 101 cards, the commander was reported
+    /// as a 2-copy CR 903.5b singleton violation against itself, and it escaped
+    /// the CR 903.5c command-zone skip.
+    #[test]
+    fn commander_listed_by_composite_and_front_name_is_one_card() {
+        let db = dfc_commander_db();
+        let composite = "Tovolar, Dire Overlord // Tovolar, the Midnight Scourge";
+
+        let mut main = vec!["Tovolar, Dire Overlord".to_string()];
+        main.extend(expand("Mountain", 99));
+        assert_eq!(main.len(), 100, "the commander is one of the 100");
+
+        for summary_only in [false, true] {
+            let request = DeckCompatibilityRequest {
+                main_deck: main.clone(),
+                commander: vec![composite.to_string()],
+                selected_format: Some(GameFormat::Commander),
+                summary_only,
+                player_count: default_player_count(),
+                ..Default::default()
+            };
+
+            let result = evaluate_deck_compatibility(&db, &request);
+            assert_eq!(
+                result.selected_format_compatible,
+                Some(true),
+                "summary_only={summary_only}: deck must be legal, got: {:?}",
+                result.selected_format_reasons
+            );
+            assert!(
+                result.selected_format_reasons.is_empty(),
+                "summary_only={summary_only}: {:?}",
+                result.selected_format_reasons
+            );
+        }
+    }
+
+    /// Regression: the Oathbreaker RC deck-size check is the fourth
+    /// command-zone format, and it must resolve card identity (CR 709.2 /
+    /// CR 712.1: one physical card per multi-face card) like
+    /// the other three. Listing the Oathbreaker in the command zone by its
+    /// composite name and in the 59 by its front face describes ONE physical
+    /// card; a raw-spelling compare counted it twice and rejected a legal
+    /// 60-card deck as 61.
+    #[test]
+    fn oathbreaker_listed_by_composite_and_front_name_is_one_card() {
+        let db = dfc_oathbreaker_db();
+
+        // 58 Mountain + 1 Ob Front + 1 Sig Front = 60 physical cards.
+        let mut main = vec!["Ob Front".to_string(), "Sig Front".to_string()];
+        main.extend(expand("Mountain", 58));
+        assert_eq!(main.len(), 60);
+
+        // Both verdict paths: the summary twin delegates to the same
+        // `evaluate_oathbreaker`, so they must agree for the same decklist.
+        for summary_only in [false, true] {
+            let request = DeckCompatibilityRequest {
+                main_deck: main.clone(),
+                commander: vec!["Ob Front // Ob Back".to_string()],
+                signature_spell: vec!["Sig Front // Sig Back".to_string()],
+                selected_format: Some(GameFormat::Oathbreaker),
+                summary_only,
+                player_count: default_player_count(),
+                ..Default::default()
+            };
+
+            let result = evaluate_deck_compatibility(&db, &request);
+            assert_eq!(
+                result.selected_format_compatible,
+                Some(true),
+                "summary_only={summary_only}: reasons: {:?}",
+                result.selected_format_reasons
+            );
+            assert!(
+                result.selected_format_reasons.is_empty(),
+                "summary_only={summary_only}: {:?}",
+                result.selected_format_reasons
+            );
+        }
+    }
+
+    /// Regression: the signature spell is a command-zone slot with the same
+    /// "one physical card" identity as the Oathbreaker, so a composite/front
+    /// spelling split across the two slots must not be reported as a CR 903.5b
+    /// singleton violation against itself. Netting only the commander left this
+    /// live even after the deck-size check was fixed.
+    #[test]
+    fn signature_spell_listed_under_two_spellings_is_not_its_own_singleton_violation() {
+        let db = dfc_oathbreaker_db();
+
+        let mut main = vec!["Ob Front".to_string(), "Sig Front".to_string()];
+        main.extend(expand("Mountain", 58));
+
+        let request = DeckCompatibilityRequest {
+            main_deck: main,
+            commander: vec!["Ob Front".to_string()],
+            signature_spell: vec!["Sig Front // Sig Back".to_string()],
+            selected_format: Some(GameFormat::Oathbreaker),
+            player_count: default_player_count(),
+            ..Default::default()
+        };
+
+        let counts = combined_copy_counts(&db, &request, CommandZoneNetting::NetAgainstMainDeck);
+        assert_eq!(
+            counts.get("sig front"),
+            Some(&1),
+            "one physical signature spell counts once: {counts:?}"
+        );
+
+        let result = evaluate_deck_compatibility(&db, &request);
+        assert!(
+            !result
+                .selected_format_reasons
+                .iter()
+                .any(|reason| reason.contains("Singleton violations")),
+            "{:?}",
+            result.selected_format_reasons
+        );
+    }
+
+    /// CR 903.5a netting corrects a DOUBLE-listing; it is not a blanket amnesty.
+    /// When two command-zone slots resolve to the same card — here an
+    /// Oathbreaker whose commander and signature spell are two spellings of one
+    /// card — a per-entry `saturating_sub(1)` gated only on "the main deck
+    /// contains this card at all" decrements twice against a single main-deck
+    /// listing, netting a real 2-copy CR 903.5b violation down to 1 and hiding
+    /// it. Bounding the decrement by main-deck occurrence is what keeps the
+    /// violation visible.
+    #[test]
+    fn netting_never_credits_more_copies_than_the_main_deck_actually_lists() {
+        let db = dfc_oathbreaker_db();
+
+        let mut main = vec!["Ob Front".to_string(), "Ob Front".to_string()];
+        main.extend(expand("Mountain", 58));
+
+        let request = DeckCompatibilityRequest {
+            main_deck: main,
+            // Both command-zone slots resolve to the SAME card.
+            commander: vec!["Ob Front".to_string()],
+            signature_spell: vec!["Ob Front // Ob Back".to_string()],
+            selected_format: Some(GameFormat::Oathbreaker),
+            player_count: default_player_count(),
+            ..Default::default()
+        };
+
+        let counts = combined_copy_counts(&db, &request, CommandZoneNetting::NetAgainstMainDeck);
+        assert_eq!(
+            counts.get("ob front"),
+            Some(&2),
+            "three listings minus the one copy the main deck actually double-lists              leaves a genuine 2-copy singleton violation: {counts:?}"
+        );
+    }
+
     /// The signature-spell exemption must not become a blanket amnesty either:
     /// a genuine SECOND copy of the signature spell in the 58 is still a
     /// singleton violation. Guards the copy-count bucketing against
@@ -8430,6 +8684,46 @@ mod tests {
                 .iter()
                 .any(|reason| reason.contains("Singleton violations")),
             "two real copies must still trip the singleton rule: {:?}",
+            result.selected_format_reasons
+        );
+    }
+
+    /// Regression: CR 903.5a netting belongs to command-zone formats only.
+    /// Constructed has no commander concept, so a populated commander slot must
+    /// not silently discount one main-deck copy and hide a real CR 100.2a
+    /// violation. `CommandZoneNetting::CountVerbatim` is what keeps the two
+    /// rules apart.
+    #[test]
+    fn constructed_copy_limit_does_not_net_out_a_commander_slot_entry() {
+        let mut cards = Map::new();
+        insert_planechase_card(&mut cards, "Fire", &[], &["Instant"]);
+        insert_planechase_card(&mut cards, "Plains", &["Basic"], &["Land"]);
+        let db = CardDatabase::from_json_str(&Value::Object(cards).to_string()).unwrap();
+
+        let mut main = expand("Fire", 5);
+        main.extend(expand("Plains", 55));
+        let request = DeckCompatibilityRequest {
+            main_deck: main,
+            commander: vec!["Fire".to_string()],
+            selected_format: Some(GameFormat::Standard),
+            player_count: default_player_count(),
+            ..Default::default()
+        };
+
+        let counts = combined_copy_counts(&db, &request, CommandZoneNetting::CountVerbatim);
+        assert_eq!(
+            counts.get("fire"),
+            Some(&6),
+            "constructed counts every listed slot verbatim: {counts:?}"
+        );
+
+        let result = evaluate_deck_compatibility(&db, &request);
+        assert!(
+            result
+                .selected_format_reasons
+                .iter()
+                .any(|reason| reason.contains("Fire")),
+            "five main-deck copies must still trip CR 100.2a: {:?}",
             result.selected_format_reasons
         );
     }

--- a/crates/engine/src/types/format.rs
+++ b/crates/engine/src/types/format.rs
@@ -847,6 +847,95 @@ impl GameFormat {
         }
     }
 
+    /// Whether this format's command zone is filled from the decklist's
+    /// `commander` slot — i.e. the zone holds a card that is part of the deck
+    /// proper and is therefore netted against the main deck.
+    ///
+    /// This is deliberately NOT `uses_commander`, and NOT
+    /// `FormatConfig::command_zone`. The three predicates answer different
+    /// questions and their answers genuinely differ:
+    ///
+    /// - `uses_commander` is `command_zone && commander_damage_threshold`, so
+    ///   it means "CR 903.10a commander damage applies". Tiny Leaders and
+    ///   Oathbreaker put a real card in the command zone but declare no
+    ///   damage threshold, so they answer `false` there while answering
+    ///   `true` here.
+    /// - `command_zone` is true for Archenemy (CR 904.3 + CR 904.4: the
+    ///   supplementary scheme deck, which remains in the command zone) and
+    ///   Momir (its emblem), whose zones hold no decklist card at all, so
+    ///   they answer `true` there while answering `false` here.
+    ///
+    /// The netting invariant is format-neutral: wherever a format designates a
+    /// decklist card for the command zone, that card is COUNTED IN that
+    /// format's deck, so a decklist naming it in both the command zone and the
+    /// main deck describes ONE physical card, not two. Only the deck size
+    /// differs per format, which is why this predicate cannot be phrased in
+    /// terms of any single count:
+    ///
+    /// - CR 903.5a — Commander: exactly 100 cards, INCLUDING its commander.
+    /// - CR 903.12d — Brawl: exactly 60 cards, including its commander
+    ///   (CR 903.12a makes Brawl a Commander variant, so CR 903.5's identity
+    ///   carries over with this size modification).
+    /// - CR 903.13f — Commander Draft: at least 60 with no maximum, otherwise
+    ///   following CR 903.5 deck construction.
+    /// - Tiny Leaders and Oathbreaker appear NOWHERE in the Comprehensive
+    ///   Rules — both are community/WPN formats, so their command-zone
+    ///   identity comes from their own rules documents (Oathbreaker RC: 60
+    ///   cards including the Oathbreaker and signature spell), not from
+    ///   CR 903. Do not annotate them with a CR number.
+    ///
+    /// `deck_validation`'s `CommandZoneNetting::NetAgainstMainDeck` call sites
+    /// are exactly the formats that answer `true` here, and `deck_loading`
+    /// reads this same predicate for both netting and command-zone placement —
+    /// a format that netted without placing would start the game a card short,
+    /// and one that placed without netting would start it a card long.
+    ///
+    /// Returns `Err` for `GameFormat::Custom` for the same reason
+    /// `uses_commander` does: a bare `GameFormat` carries no
+    /// `CustomFormatRules` to answer from, and `false` would be silently
+    /// wrong rather than a safe default.
+    pub fn command_zone_holds_decklist_commander(self) -> Result<bool, FormatConfigError> {
+        match self {
+            GameFormat::Commander
+            | GameFormat::DuelCommander
+            | GameFormat::PauperCommander
+            | GameFormat::Brawl
+            | GameFormat::HistoricBrawl
+            | GameFormat::CommanderDraft
+            // Tiny Leaders and Oathbreaker seat a decklist card in the command
+            // zone without a commander-damage threshold, which is precisely the
+            // case `uses_commander` cannot express.
+            | GameFormat::TinyLeaders
+            | GameFormat::Oathbreaker => Ok(true),
+            // Archenemy's scheme deck (CR 904.3: the supplementary deck;
+            // CR 904.4: its cards remain in the command zone) and Momir's
+            // emblem occupy a
+            // command zone that holds no decklist card, so there is nothing to
+            // net and nothing to place from the `commander` slot.
+            GameFormat::Archenemy
+            | GameFormat::Momir
+            | GameFormat::Standard
+            | GameFormat::Limited
+            | GameFormat::Pioneer
+            | GameFormat::Modern
+            | GameFormat::Premodern
+            | GameFormat::Legacy
+            | GameFormat::Vintage
+            | GameFormat::Historic
+            | GameFormat::Timeless
+            | GameFormat::Pauper
+            | GameFormat::FreeForAll
+            | GameFormat::TwoHeadedGiant
+            | GameFormat::Planechase => Ok(false),
+            GameFormat::Custom(id) => Err(FormatConfigError(format!(
+                "command_zone_holds_decklist_commander cannot resolve ad-hoc Custom format {} — \
+                 a bare GameFormat carries no CustomFormatRules; decide from the resolved \
+                 FormatConfig (its command_zone and uses_commander fields) instead",
+                id.0
+            ))),
+        }
+    }
+
     /// Whether this format's deck is fixed by the format rules and supplied
     /// automatically by the engine — the player never builds or selects one.
     /// True only for Momir's Madness, whose deck is the fixed 60-card snow-basic
@@ -1679,6 +1768,44 @@ impl FormatConfig {
         }
     }
 
+    /// Whether this RESOLVED config's command zone is filled from the
+    /// decklist's `commander` slot — the netting/placement axis described on
+    /// [`GameFormat::command_zone_holds_decklist_commander`].
+    ///
+    /// This is the method consumers should call. The bare `GameFormat`
+    /// predicate cannot answer for `GameFormat::Custom`, because a bare format
+    /// carries no `CustomFormatRules`; this one resolves Custom from the rules
+    /// the config was actually built with.
+    ///
+    /// Custom is answered from `CommandZoneMode`, NOT from `uses_commander`.
+    /// `for_custom_rules` derives `uses_commander` from the declared
+    /// `commander_damage_threshold` alone, so a custom format shaped like
+    /// Oathbreaker or Tiny Leaders — `CommandZoneMode::Enabled` with a
+    /// `CommanderEligibilityRule` and NO damage threshold — has
+    /// `uses_commander: false` while still designating a decklist commander.
+    /// Falling back to `uses_commander` would strand that commander in the
+    /// library exactly the way the built-in formats did before this predicate
+    /// existed. Every `CommandZoneMode::Enabled` carries an
+    /// `eligibility_rule`, so an enabled custom command zone always designates
+    /// a decklist commander; `Disabled` never does.
+    pub fn command_zone_holds_decklist_commander(&self) -> bool {
+        match self.format {
+            GameFormat::Custom(_) => match self.custom_rules.as_deref() {
+                Some(rules) => matches!(
+                    rules.structural.command_zone_mode,
+                    CommandZoneMode::Enabled { .. }
+                ),
+                // A Custom config with no attached rules cannot be resolved;
+                // `command_zone` is the closest structural fact it still
+                // carries, and it is what `for_custom_rules` would have set.
+                None => self.command_zone,
+            },
+            format => format
+                .command_zone_holds_decklist_commander()
+                .expect("non-Custom formats always resolve"),
+        }
+    }
+
     /// Return a copy of this config with the sandbox capability enabled.
     /// Pure data transform; the resulting config is otherwise identical and
     /// keeps the same `GameFormat`, deck/seat/life rules, etc. Idempotent.
@@ -2294,6 +2421,248 @@ mod tests {
             FormatConfig::for_format(GameFormat::Premodern).unwrap(),
             FormatConfig::premodern()
         );
+    }
+
+    /// `command_zone_holds_decklist_commander` is a strictly weaker condition
+    /// than `uses_commander` (commander damage implies a decklist commander,
+    /// never the reverse) and strictly stronger than `command_zone` (a zone
+    /// can hold schemes or an emblem instead). Pinning both directions is what
+    /// keeps a future variant from being added to only one of the three.
+    #[test]
+    fn command_zone_holds_decklist_commander_sits_between_uses_commander_and_command_zone() {
+        for meta in GameFormat::registry() {
+            let holds = meta.format.command_zone_holds_decklist_commander().unwrap();
+            let config = &meta.default_config;
+
+            if config.uses_commander {
+                assert!(
+                    holds,
+                    "{:?}: commander damage (CR 903.10a) requires a decklist commander",
+                    meta.format
+                );
+            }
+            if holds {
+                assert!(
+                    config.command_zone,
+                    "{:?}: a decklist commander needs a command zone to sit in",
+                    meta.format
+                );
+            }
+        }
+    }
+
+    /// CR 903.5a: the formats that place a commander from the decklist are
+    /// exactly the formats that net that copy out of the main deck. This is the
+    /// list `game::deck_loading` gates BOTH netting and command-zone placement
+    /// on, and the list `game::deck_validation` passes
+    /// `CommandZoneNetting::NetAgainstMainDeck` for. Spelled out literally so
+    /// adding a variant to one side without the other fails here rather than
+    /// silently starting a game one card short or one card long.
+    /// A custom format shaped like Oathbreaker or Tiny Leaders — an enabled
+    /// command zone with an eligibility rule but NO commander-damage threshold
+    /// — still designates a decklist commander. `for_custom_rules` derives
+    /// `uses_commander` from the threshold alone, so reading that field would
+    /// answer `false` here and strand the commander in the library, which is
+    /// the same class of bug this predicate exists to prevent for the built-in
+    /// formats. Resolve Custom from `CommandZoneMode` instead.
+    #[test]
+    fn custom_command_zone_without_a_damage_threshold_still_holds_a_decklist_commander() {
+        use crate::types::custom_format::{
+            CommanderEligibilityRule, CustomFormatId, CustomFormatRules, LegacyRuleSet,
+            LegalityRules, StructuralRules,
+        };
+
+        let build = |command_zone_mode| {
+            let rules = CustomFormatRules {
+                id: CustomFormatId(4242),
+                structural: StructuralRules {
+                    starting_life: 20,
+                    min_players: 2,
+                    max_players: 4,
+                    deck_size: DeckSizeRule::Exactly(60),
+                    singleton: true,
+                    command_zone_mode,
+                    range_of_influence: None,
+                    team_based: false,
+                    sideboard_policy: SideboardPolicy::Forbidden,
+                    default_deck_copy_limit: DeckCopyLimit::UpTo(1),
+                },
+                legality: LegalityRules {
+                    legal_sets: None,
+                    banned: Vec::new(),
+                    restricted: Vec::new(),
+                    legacy: LegacyRuleSet::default(),
+                },
+            };
+            FormatConfig::for_custom_rules(&rules)
+        };
+
+        let oathbreaker_shaped = build(CommandZoneMode::Enabled {
+            commander_damage_threshold: None,
+            eligibility_rule: CommanderEligibilityRule::OathbreakerSignatureSpell,
+        });
+        // PREMISE: this is genuinely the threshold-less shape, so the assertion
+        // below is about the predicate rather than a trivially true case.
+        assert!(!oathbreaker_shaped.uses_commander);
+        assert!(oathbreaker_shaped.command_zone);
+        assert!(
+            oathbreaker_shaped.command_zone_holds_decklist_commander(),
+            "an enabled custom command zone designates a decklist commander              regardless of the commander-damage threshold"
+        );
+
+        // Control: a threshold-bearing custom command zone answers the same,
+        // so the predicate is not merely inverting `uses_commander`.
+        let commander_shaped = build(CommandZoneMode::Enabled {
+            commander_damage_threshold: Some(21),
+            eligibility_rule: CommanderEligibilityRule::Standard,
+        });
+        assert!(commander_shaped.uses_commander);
+        assert!(commander_shaped.command_zone_holds_decklist_commander());
+
+        // Control: a disabled custom command zone holds nothing, so nothing may
+        // be netted or placed.
+        let no_zone = build(CommandZoneMode::Disabled);
+        assert!(!no_zone.command_zone);
+        assert!(!no_zone.command_zone_holds_decklist_commander());
+    }
+
+    /// CR 903.5a: the formats that place a commander from the decklist are
+    /// exactly the formats that net that copy out of the main deck.
+    /// `game::deck_loading` gates BOTH netting and command-zone placement on
+    /// this predicate, and `game::deck_validation` passes
+    /// `CommandZoneNetting::NetAgainstMainDeck` for the same set. A format
+    /// netted there but not placed here starts the game a card short; one
+    /// placed but not netted starts it a card long.
+    ///
+    /// This SCANS `deck_validation.rs` rather than asserting a hardcoded list.
+    /// A hardcoded array cannot fail when a call site changes — flipping
+    /// `evaluate_tiny_leaders` to `CountVerbatim` would leave a list-based
+    /// test green while the loader and validator silently disagreed, which is
+    /// exactly the defect this predicate exists to prevent. Scanning the
+    /// source is the same technique `phase-ai`'s `score_contract_lint` uses to
+    /// pin a cross-file contract.
+    #[test]
+    fn command_zone_holds_decklist_commander_matches_the_validator_netting_set() {
+        let source = std::fs::read_to_string(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/src/game/deck_validation.rs"
+        ))
+        .expect("deck_validation.rs must be readable");
+
+        // Production code only: `#[cfg(test)]` fixtures call
+        // `combined_copy_counts` too, and those calls sit after the last
+        // `evaluate_*` function, so including them would attribute a netting
+        // mode to whatever helper happened to be declared last.
+        const TEST_MODULE_MARKER: &str = "\n#[cfg(test)]\n";
+        let production = source
+            .split_once(TEST_MODULE_MARKER)
+            .map_or(source.as_str(), |(before, _)| before);
+
+        // Map each `evaluate_*`/`quick_*` function to the netting mode its
+        // `combined_copy_counts` call passes, by walking the file and
+        // remembering the most recent `fn` header.
+        let mut current_fn: Option<&str> = None;
+        let mut netted: Vec<&str> = Vec::new();
+        let mut verbatim: Vec<&str> = Vec::new();
+        for line in production.lines() {
+            // Accept any visibility/qualifier prefix: `pub fn evaluate_…` and
+            // `pub(crate) fn …` are real headers in this file, and a bare
+            // `strip_prefix("fn ")` would skip them, silently attributing
+            // their call sites to whichever function was declared before.
+            if let Some(header) = line
+                .split_once("fn ")
+                .filter(|(before, _)| {
+                    before.is_empty()
+                        || before.split_whitespace().all(|w| {
+                            matches!(w, "pub" | "async" | "const" | "unsafe" | "extern")
+                                || w.starts_with("pub(")
+                        })
+                })
+                .map(|(_, rest)| rest)
+            {
+                current_fn = header.split('(').next();
+            }
+            let Some(name) = current_fn else { continue };
+            if line.contains("CommandZoneNetting::NetAgainstMainDeck")
+                && line.contains("combined_copy_counts(")
+            {
+                netted.push(name);
+            } else if line.contains("CommandZoneNetting::CountVerbatim")
+                && line.contains("combined_copy_counts(")
+            {
+                verbatim.push(name);
+            }
+        }
+
+        // PREMISE: the scan actually found call sites. Without this the whole
+        // test passes vacuously if the call shape is ever reformatted.
+        assert!(
+            netted.len() >= 5,
+            "expected to find the NetAgainstMainDeck call sites, found {netted:?} — \
+             has `combined_copy_counts` been reformatted? Update the scan."
+        );
+        assert!(
+            verbatim.len() >= 3,
+            "expected to find the CountVerbatim call sites, found {verbatim:?}"
+        );
+
+        // Every format whose validator nets must answer `true` here.
+        for fn_name in &netted {
+            let formats = formats_evaluated_by(fn_name);
+            assert!(
+                !formats.is_empty(),
+                "{fn_name} nets against the main deck but maps to no GameFormat — \
+                 add it to `formats_evaluated_by` so this invariant keeps covering it"
+            );
+            for format in formats {
+                assert!(
+                    format.command_zone_holds_decklist_commander().unwrap(),
+                    "{fn_name} passes NetAgainstMainDeck for {format:?}, so \
+                     command_zone_holds_decklist_commander must be true — otherwise \
+                     deck_loading leaves that commander in the library while the \
+                     validator has already netted it out"
+                );
+            }
+        }
+
+        // And every format counted verbatim must answer `false`, or netting
+        // would delete a library card from a format with no decklist commander.
+        for fn_name in &verbatim {
+            for format in formats_evaluated_by(fn_name) {
+                assert!(
+                    !format.command_zone_holds_decklist_commander().unwrap(),
+                    "{fn_name} counts {format:?} verbatim, so \
+                     command_zone_holds_decklist_commander must be false"
+                );
+            }
+        }
+    }
+
+    /// The `GameFormat`s each `deck_validation` entry point evaluates. Kept
+    /// beside the scan above so a new validator function fails loudly (empty
+    /// mapping) rather than being silently skipped.
+    fn formats_evaluated_by(fn_name: &str) -> Vec<GameFormat> {
+        match fn_name {
+            "evaluate_commander_with_format" | "quick_commander_check" => vec![
+                GameFormat::Commander,
+                GameFormat::DuelCommander,
+                GameFormat::PauperCommander,
+                GameFormat::CommanderDraft,
+            ],
+            "evaluate_brawl" => vec![GameFormat::Brawl, GameFormat::HistoricBrawl],
+            "evaluate_tiny_leaders" => vec![GameFormat::TinyLeaders],
+            "evaluate_oathbreaker" => vec![GameFormat::Oathbreaker],
+            "evaluate_archenemy" => vec![GameFormat::Archenemy],
+            "evaluate_planechase" => vec![GameFormat::Planechase],
+            "evaluate_constructed" => vec![
+                GameFormat::Standard,
+                GameFormat::Modern,
+                GameFormat::Legacy,
+                GameFormat::Vintage,
+                GameFormat::Pauper,
+            ],
+            _ => Vec::new(),
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Two changes, and the second is the one a reviewer of the title would not expect:

1. **Adds CR 903.5a command-zone netting** to deck loading and validation — a decklist naming its commander in both the command zone and the main deck describes ONE physical card, so the loader must drop the copy the validator already netted out.
2. **Narrows command-zone placement, which was previously unconditional.** On `main`, `load_deck_into_state` places whatever sits in the `commander` slot for **every** format — `git grep place_commanders origin/main -- crates/engine/` returns nothing, and `deck_loading.rs:861-882` is an unconditional `commander_decks` chain. This PR introduces that gate and restricts placement to formats whose command zone holds a decklist card.

> ### ⚠️ Stacked on #8551 — merge that first
>
> Built on #8551's composite-name-resolution commit, not on `main`. GitHub shows the base as `main` only because a cross-fork PR cannot take a fork branch as its base, so **the diff here includes #8551's commit too**. The command-zone half is the second commit alone. Once #8551 merges this collapses on its own, no rebase needed.

## The narrowing, stated plainly

This is a behavior change beyond "add netting", and it is deliberate. Without the gate, netting alone would silently delete a library card from any format that carries a populated-but-inert `commander` slot — the deck builder reuses that slot the way it reuses the sideboard as a maybeboard, and `resolve_deck_list` forwards it without gating.

**The proof of the narrowing is in the test diff:** two pre-existing tests had to gain `state.format_config = FormatConfig::commander();` to keep passing, because their payloads previously relied on unconditional placement —

- `load_deck_with_commanders_creates_command_zone_objects`
- `resolve_combined_face_commander_name_creates_command_zone_object`

(An earlier revision of this body said three, counting `load_deck_drops_sideboard_for_commander_format`. That one already declared the format at the base for its CR 903.5e sideboard assertion, so it is not evidence of the narrowing — corrected.)

Safe on every production path — `match_flow.rs:468`, `server-core/src/session.rs:975`, `engine-wasm/src/lib.rs:1479`, `replay.rs:106` all supply a real `FormatConfig` — and it retires the hazard documented at `server-core/src/draft_session.rs:756-761`.

## The predicate, and why a third one was needed

Gating is `GameFormat::command_zone_holds_decklist_commander` — deliberately **not** `uses_commander` and **not** `command_zone`:

| | means | Tiny Leaders / Oathbreaker | Archenemy / Momir |
|---|---|---|---|
| `uses_commander` | CR 903.10a commander damage applies | **false** (no damage threshold) | false |
| `command_zone` | the format has a command zone | true | **true** (schemes / emblem — no decklist card) |
| `command_zone_holds_decklist_commander` | the zone is filled from the decklist | **true** | **false** |

Narrowing on `uses_commander` would leave a legal Oathbreaker or Tiny Leaders commander in the library *and* unplaced, while the validator had already netted it out — the loader and validator disagreeing about one physical card. Narrowing on `command_zone` would net a populated-but-inert slot out of an Archenemy or Momir library, deleting a card. Neither is a bug that shipped; both are the trap this predicate exists to avoid.

`FormatConfig::command_zone_holds_decklist_commander` resolves Custom formats from their own `CommandZoneMode` rather than `uses_commander`, which `for_custom_rules` derives from the damage threshold alone.

## CR annotations

Every CR number in this diff was re-verified line-by-line against `docs/MagicCompRules.txt` after review caught two wrong groups:

- **`CR 904.2` → `CR 904.3` + `CR 904.4`** at 4 sites. 904.2 is Archenemy's *team setup*; the scheme deck is 904.3 and its command-zone residence is 904.4. This also brings the PR in line with the 18 existing `904.3`/`904.4` citations on `main`.
- **`CR 903.1` → `CR 903.6`** at 3 sites. 903.1 defines the Commander variant and says nothing about the command zone; CR 408.1 defines the zone generally (Archenemy schemes live there per 904.4), so "the zone exists only for Commander" was simply false. CR 903.6 is the rule that actually authorizes placement, matching `main`'s own `// CR 903.6 + CR 408.1`.

The netting invariant itself is format-neutral — wherever a format designates a decklist card for the command zone, that card is counted in that format's deck — and only the size differs: CR 903.5a (Commander, 100), CR 903.12d (Brawl, 60), CR 903.13f (Commander Draft, 60+ no maximum). Tiny Leaders and Oathbreaker appear **zero** times in the Comprehensive Rules — community/WPN formats — so they deliberately carry no CR annotation.

## Tests

- `load_deck_places_the_oathbreaker_in_the_command_zone` / `..._tiny_leaders_...` — placed in the zone AND netted out of pool and library
- `load_deck_neither_places_nor_nets_a_commander_slot_without_a_decklist_command_zone` — Archenemy control; **fails if the predicate is widened to `command_zone`**
- `custom_command_zone_without_a_damage_threshold_still_holds_a_decklist_commander` — with an explicit premise assertion that `uses_commander` really is `false` there
- `command_zone_holds_decklist_commander_matches_the_validator_netting_set` — **scans `deck_validation.rs`** for production `combined_copy_counts` call sites and buckets them by netting mode, rather than asserting a hardcoded list. Flipping `evaluate_tiny_leaders` to `CountVerbatim` now fails this test; with the previous array-based version it passed. Guarded against vacuity by minimum-call-site-count assertions and a hard failure if a netting function maps to no `GameFormat`.
- four validation tests covering command-zone double-listing (these assert *netting*, so they live here rather than in #8551)

**Mutation-checked.** Reverting the predicate to `uses_commander` fails both the Oathbreaker and Tiny Leaders tests while the Archenemy control still passes.

## Verification

- `cargo fmt --all` — clean
- `cargo clippy -p phase-engine --lib --tests -- -D warnings` — **exit 0**
- `cargo test -p phase-engine --lib` over `types::format`, `deck_loading`, `deck_validation`, `card_db` — **226 passed, 0 failed**
- Test-set diffed by name against the pre-split branch to confirm **zero tests lost** in the split

## Context

Split out of #8551 at @matthewevans's request — he was right that this is a separate mechanic (it was in that PR's original commit, not added by the review round), and my earlier claim that the split could not compile was wrong: I had tested the wrong direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved card-name matching across capitalization, aliases, alternate spellings, and composite card faces.
  - Corrected Commander and Oathbreaker deck validation to account for commander and signature-spell copies already included in the main deck.
  - Applied bounded copy counting so only the appropriate number of duplicates is netted.
  - Corrected commander placement for formats whose command zones do not contain decklist commanders.
  - Preserved verbatim card counting for Constructed, Planechase, and Archenemy formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->