### PR TITLE
ci: stop persisting the checkout token across ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          # Not persisted: the token is not needed after the fetch, and
+          # leaving it in .git/config exposes it to anything this job runs.
+          persist-credentials: false
           # Full history so the parser-combinator gate can diff against origin/main.
           fetch-depth: 0
 
@@ -155,6 +158,10 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Not persisted: the token is not needed after the fetch, and
+          # leaving it in .git/config exposes it to anything this job runs.
+          persist-credentials: false
 
       - name: Free runner disk for Rust test linking
         # Build the workspace's test binaries once. Keep the Rust caches intact
@@ -244,6 +251,10 @@ jobs:
         shard: [1, 2, 3, 4]
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Not persisted: the token is not needed after the fetch, and
+          # leaving it in .git/config exposes it to anything this job runs.
+          persist-credentials: false
 
       # Some snapshot tests query Cargo metadata at runtime. This makes Cargo
       # available but does not build test binaries; those come from the archive.
@@ -292,6 +303,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          # Not persisted: the token is not needed after the fetch, and
+          # leaving it in .git/config exposes it to anything this job runs.
+          persist-credentials: false
           # Parse-diff reads both parents of GitHub's synthetic PR merge commit.
           fetch-depth: 2
 
@@ -689,6 +703,10 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Not persisted: the token is not needed after the fetch, and
+          # leaving it in .git/config exposes it to anything this job runs.
+          persist-credentials: false
 
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
@@ -738,6 +756,10 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Not persisted: the token is not needed after the fetch, and
+          # leaving it in .git/config exposes it to anything this job runs.
+          persist-credentials: false
 
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
@@ -756,6 +778,10 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Not persisted: the token is not needed after the fetch, and
+          # leaving it in .git/config exposes it to anything this job runs.
+          persist-credentials: false
 
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
@@ -801,6 +827,10 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          # Not persisted: the token is not needed after the fetch, and
+          # leaving it in .git/config exposes it to anything this job runs.
+          persist-credentials: false
 
       - name: Validate Gradle wrapper
         uses: gradle/actions/wrapper-validation@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
@@ -940,6 +970,10 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Not persisted: the token is not needed after the fetch, and
+          # leaving it in .git/config exposes it to anything this job runs.
+          persist-credentials: false
 
       - uses: pnpm/action-setup@v4
         with:
@@ -963,6 +997,10 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Not persisted: the token is not needed after the fetch, and
+          # leaving it in .git/config exposes it to anything this job runs.
+          persist-credentials: false
 
       - uses: pnpm/action-setup@v4
         with:


### PR DESCRIPTION
## Summary

`actions/checkout` persists the job's token into `.git/config` by default. Every job in `ci.yml` then *runs* the pull request's own code — cargo build scripts and proc macros during `clippy`/`build`, pnpm lifecycle scripts, Gradle — so that credential sits on disk, readable by the code under test, for the life of the job.

This sets `persist-credentials: false` on all 10 checkout steps in `ci.yml`, including the SHA-pinned one in `android-debug-apk`.

Split out of [#8602](https://github.com/phase-rs/phase/pull/8602) at reviewer request; that PR now contains only the Windows lint job it was opened for.

## Severity: low, and worth stating plainly

`ci.yml` grants only `contents: read`, and a fork pull request's token is read-only regardless. **This is not a fix for a live exposure.** It removes a credential that nothing in the file needs — defence in depth, not an incident.

The finding was originally raised by an automated reviewer against a single job. It applies uniformly to the file, which is why this covers all of them rather than the one that happened to be flagged.

## No job loses capability

Checked rather than assumed:

- **Nothing here authenticates to git after the initial fetch.** The only remote git operation in the whole file is `card-data-gate`'s `git fetch --no-tags --depth=1 origin "$BASE_SHA"`. This repository is public, so that fetch works unauthenticated.
- **The helper scripts contain no remote git operations** — `parse-diff-base.sh`, `engine-source-hash.sh`, and the four `check-*.sh` gates were each checked. The only other git usage is a local `git diff --exit-code`.
- **`fetch-depth` is preserved** where it was set: `0` for `rust-lint`'s parser-combinator gate, `2` for `card-data-gate`'s parse-diff.

## Verification

Confirmed on the sibling PR before splitting, where this exact change ran in CI:

| job | result |
|---|---|
| Card data (performs the `git fetch`) | **pass, 3m35s** |
| Rust lint (`fetch-depth: 0`) | **pass, 13m28s** |
| all four Rust test shards, Android, frontend, WASM, lobby worker | pass |

The `card-data-gate` logs confirm the unauthenticated fetch actually ran rather than silently skipping:

```
From https://github.com/phase-rs/phase
 * branch  e41cac565c0e86b3b277823fb46d4397d44a46a3 -> FETCH_HEAD
Engine source unchanged vs base (69f53a1f1e658792) — no parse change possible; skipping.
```

Also verified structurally: parsing this revision and `main` and comparing them with the `persist-credentials` keys stripped shows the workflows are otherwise identical. The diff is **38 insertions, 0 deletions** — no existing option was dropped or reordered.

## Not included

This deliberately does **not** SHA-pin the actions in `ci.yml`, which the same scanner also suggests. `scripts/check_action_pins.py` scopes that policy to `release.yml` and `deploy.yml` — the privileged workflows that carry secrets — and `ci.yml` already contains 36 unpinned refs. Changing a couple of them as a side effect would imply a policy the repo does not hold. If maintainers want `ci.yml` pinned, that is a defensible change, but it belongs in its own PR covering all 36 refs plus the checker's `DEFAULT_ENTRIES`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
