### PR TITLE
refactor(parser): rename the folding type-phrase reader

### DIFF
--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -8773,7 +8773,7 @@ fn parse_equip_target_filter(cost_text: &str) -> Option<TargetFilter> {
         ));
     }
 
-    let (filter, rest) = super::oracle_target::parse_type_phrase(descriptor);
+    let (filter, rest) = super::oracle_target::parse_type_phrase_folding(descriptor);
     if !rest.trim().is_empty() {
         return None;
     }

--- a/crates/engine/src/parser/oracle_casting.rs
+++ b/crates/engine/src/parser/oracle_casting.rs
@@ -1759,7 +1759,7 @@ Trample";
 
     /// Issue #3677: Flare of Denial — "sacrifice a nontoken blue creature" must
     /// keep BOTH the `NonToken` negation and the `blue creature` type/color
-    /// filter. Before the fix to `parse_type_phrase`'s color-prefix scan (which
+    /// filter. Before the fix to `parse_type_phrase_folding`'s color-prefix scan (which
     /// only ran before the `non-` negation loop), the color and creature type
     /// were silently dropped, leaving a filter that matched any nontoken
     /// permanent — including a land — as a valid alternative-cost payment.

--- a/crates/engine/src/parser/oracle_condition.rs
+++ b/crates/engine/src/parser/oracle_condition.rs
@@ -10,7 +10,7 @@ use nom::Parser;
 
 use super::oracle_nom::condition as nom_condition;
 use super::oracle_nom::primitives as nom_primitives;
-use super::oracle_target::parse_type_phrase;
+use super::oracle_target::parse_type_phrase_folding;
 use crate::types::ability::{
     Comparator, FilterProp, ParsedCondition, QuantityExpr, QuantityRef, StaticCondition,
     TargetFilter, TypedFilter,
@@ -748,10 +748,10 @@ fn parse_color_word(text: &str) -> Option<ManaColor> {
 
 /// CR 601.3d + CR 608.2c: Parse `"it targets a <type_phrase>"` (or `"it targets <type_phrase>"`)
 /// into a `ParsedCondition::SpellTargetsFilter` whose filter is derived from
-/// `parse_type_phrase`. The pronoun `it` refers to the spell being cast — this
+/// `parse_type_phrase_folding`. The pronoun `it` refers to the spell being cast — this
 /// condition gates target-dependent casting permissions ("you may cast this spell
 /// as though it had flash if it targets a commander" — Timely Ward). The trailing
-/// remainder returned by `parse_type_phrase` must be empty for the parse to
+/// remainder returned by `parse_type_phrase_folding` must be empty for the parse to
 /// succeed; otherwise we'd silently truncate qualifying clauses that the filter
 /// layer hasn't absorbed.
 pub(crate) fn parse_spell_targets_filter(text: &str) -> Option<ParsedCondition> {
@@ -764,7 +764,7 @@ pub(crate) fn parse_spell_targets_filter(text: &str) -> Option<ParsedCondition> 
     .ok()?
     .0;
     // CR 903.3: Bare "commander" / "commanders" without a possessive or
-    // controller suffix is not lifted by `parse_type_phrase` (which expects
+    // controller suffix is not lifted by `parse_type_phrase_folding` (which expects
     // type words) or by the possessive arms of `parse_target` (which require
     // "your" / "their" / a trailing controller-suffix). Recognize it here
     // explicitly so "it targets a commander" maps to the `IsCommander`
@@ -783,7 +783,7 @@ pub(crate) fn parse_spell_targets_filter(text: &str) -> Option<ParsedCondition> 
         }
     }
     // CR 115.1: "it targets a permanent or player" — proliferate-style pool
-    // (Shiko and Narset, Unified Flurry gate). Matched before `parse_type_phrase`
+    // (Shiko and Narset, Unified Flurry gate). Matched before `parse_type_phrase_folding`
     // so the "or player" half is not dropped.
     if rest.trim() == "permanent or player" {
         return Some(ParsedCondition::SpellTargetsFilter {
@@ -803,11 +803,11 @@ pub(crate) fn parse_spell_targets_filter(text: &str) -> Option<ParsedCondition> 
     )))
     .parse(rest)
     .ok()?;
-    let (filter, remainder) = parse_type_phrase(rest);
+    let (filter, remainder) = parse_type_phrase_folding(rest);
     if !remainder.trim().is_empty() {
         return None;
     }
-    // `parse_type_phrase` falls back to `TargetFilter::Any` when no type word
+    // `parse_type_phrase_folding` falls back to `TargetFilter::Any` when no type word
     // matched. A bare "it targets a frob" must not silently widen the gate to
     // "any target"; refuse the parse instead so the casting permission is not
     // emitted (strictly safe — the spell stays sorcery-speed until the

--- a/crates/engine/src/parser/oracle_cost.rs
+++ b/crates/engine/src/parser/oracle_cost.rs
@@ -14,7 +14,7 @@ use super::oracle_nom::primitives::{scan_contains, split_once_on};
 use super::oracle_nom::quantity as nom_quantity;
 use super::oracle_nom::target::parse_cost_self_reference;
 use super::oracle_static::parse_dynamic_x_clause;
-use super::oracle_target::{distribute_shared_properties, parse_target, parse_type_phrase};
+use super::oracle_target::{distribute_shared_properties, parse_target, parse_type_phrase_folding};
 use super::oracle_util::parse_count_expr;
 use super::oracle_util::parse_creature_subtype;
 use super::oracle_util::parse_mana_symbols;
@@ -335,7 +335,7 @@ fn fixup_bare_noun_continuations(costs: &mut [AbilityCost]) {
                 // `count: 1` + `parse_target` path dropped both. Scope the recovery
                 // to explicit counts >= 2 so single-object continuations keep their
                 // previous parse unchanged (this fix moves no parser surface outside
-                // the explicit-multi-count class). `parse_type_phrase` (the exile
+                // the explicit-multi-count class). `parse_type_phrase_folding` (the exile
                 // arm's own consumption-aware primitive) must consume the whole
                 // object phrase into a concrete filter, so an unsupported rider
                 // stays an honest `Unimplemented` rather than a false-green cost.
@@ -343,7 +343,7 @@ fn fixup_bare_noun_continuations(costs: &mut [AbilityCost]) {
                     let filter_text = strip_count_article_prefix(rest.trim())
                         .trim_end_matches('.')
                         .trim();
-                    let (filter, remainder) = parse_type_phrase(filter_text);
+                    let (filter, remainder) = parse_type_phrase_folding(filter_text);
                     if remainder.trim().is_empty() && !matches!(filter, TargetFilter::Any) {
                         costs[i] = match verb {
                             PrecedingVerb::Sacrifice => {
@@ -472,7 +472,7 @@ fn parse_behold_cost(lower: &str) -> Option<AbilityCost> {
     )))
     .parse(filter_text.trim())
     .ok()?;
-    let (filter, remainder) = parse_type_phrase(filter_text);
+    let (filter, remainder) = parse_type_phrase_folding(filter_text);
     if !remainder.trim().is_empty() || matches!(filter, TargetFilter::Any) {
         return None;
     }
@@ -538,8 +538,8 @@ fn parse_choose_or_reveal_behold_cost(lower: &str) -> Option<AbilityCost> {
     .parse(after_article)
     .ok()?;
 
-    let (choose_filter, choose_rem) = parse_type_phrase(choose_type_text.trim());
-    let (reveal_filter, reveal_rem) = parse_type_phrase(reveal_type_text.trim());
+    let (choose_filter, choose_rem) = parse_type_phrase_folding(choose_type_text.trim());
+    let (reveal_filter, reveal_rem) = parse_type_phrase_folding(reveal_type_text.trim());
     if !choose_rem.trim().is_empty()
         || !reveal_rem.trim().is_empty()
         || matches!(choose_filter, TargetFilter::Any)
@@ -953,7 +953,7 @@ pub fn parse_single_cost(text: &str) -> AbilityCost {
         }
         // CR 107.3a + CR 118.8: "Exile X card(s) from your graveyard" — variable
         // count announced during casting (Harvest Pyre). Ordered before the typed
-        // `parse_type_phrase` arm, which cannot represent a bare zone with no filter.
+        // `parse_type_phrase_folding` arm, which cannot represent a bare zone with no filter.
         if let Some(((), rest_after_x)) =
             nom_on_lower(rest, &rest_lower, |i| value((), tag("x ")).parse(i))
         {
@@ -1004,7 +1004,7 @@ pub fn parse_single_cost(text: &str) -> AbilityCost {
             .map(|(_, remaining)| remaining)
             .unwrap_or(rest);
         let filter_text = strip_count_article_prefix(filter_start);
-        let (filter, remainder) = parse_type_phrase(filter_text);
+        let (filter, remainder) = parse_type_phrase_folding(filter_text);
         if remainder.trim().is_empty() {
             let zone = extract_filter_zone(&filter);
             return AbilityCost::Exile {
@@ -1100,7 +1100,7 @@ pub fn parse_single_cost(text: &str) -> AbilityCost {
             // The numeric branch does NOT consume "other" ("tap two other
             // untapped artifacts you control"): the `untapped ` tag fails on
             // the "other " lead, so the phrase reaches `parse_target` intact
-            // and `parse_type_phrase` supplies `FilterProp::Another` itself.
+            // and `parse_type_phrase_folding` supplies `FilterProp::Another` itself.
             // Nothing to re-apply here.
             (n, r, CountWord::Plain)
         } else {
@@ -1187,7 +1187,7 @@ pub fn parse_single_cost(text: &str) -> AbilityCost {
         let (i, _) = tag("unattach ").parse(i)?;
         value((), alt((tag("an "), tag("a ")))).parse(i)
     }) {
-        let (filter, remainder) = parse_type_phrase(after_article);
+        let (filter, remainder) = parse_type_phrase_folding(after_article);
         let rem_lower = remainder.to_lowercase();
         if let Some(((), tail)) = nom_on_lower(remainder, &rem_lower, |i| {
             value((), preceded(tag(" from "), parse_cost_self_reference)).parse(i)
@@ -1484,7 +1484,7 @@ pub(crate) fn try_parse_cost_reduction(text: &str) -> Option<CostReduction> {
     })?;
 
     // Try parse_for_each_clause first (handles counters, player counts, hand size, etc.),
-    // then fall back to parse_type_phrase for standard object count patterns.
+    // then fall back to parse_type_phrase_folding for standard object count patterns.
     if let Ok((_, qty)) = nom_quantity::parse_for_each_clause_ref_complete(after_less) {
         return Some(CostReduction {
             mode,
@@ -1495,7 +1495,7 @@ pub(crate) fn try_parse_cost_reduction(text: &str) -> Option<CostReduction> {
     }
 
     // Parse the condition as a type phrase
-    let (filter, remainder) = parse_type_phrase(after_less);
+    let (filter, remainder) = parse_type_phrase_folding(after_less);
     if !remainder.trim().is_empty() {
         return None;
     }
@@ -1814,7 +1814,7 @@ fn try_parse_return_to_hand_cost(rest_lower: &str) -> Option<AbilityCost> {
     let filter = if rem.trim().is_empty() {
         filter
     } else {
-        let (filter, _) = parse_type_phrase(filter_text);
+        let (filter, _) = parse_type_phrase_folding(filter_text);
         filter
     };
     let filter = match filter {
@@ -2075,7 +2075,7 @@ mod tests {
     #[test]
     fn cost_explicit_count_continuation_with_unmodeled_rider_stays_unimplemented() {
         // Terminal explicit-count guard: a "<N>=2 …" continuation whose object
-        // phrase carries an unmodeled rider that `parse_type_phrase` cannot fully
+        // phrase carries an unmodeled rider that `parse_type_phrase_folding` cannot fully
         // consume ("… that were dealt damage this turn") must stay honest
         // `Unimplemented` — it must NOT fall through to the count-1 fallback,
         // which would emit a broad supported cost that drops both the rider and
@@ -2400,7 +2400,7 @@ mod tests {
     ///
     /// The "two other untapped" row was already green before this fix: the
     /// numeric branch never consumes "other", so the phrase reaches
-    /// `parse_type_phrase` intact and it supplies the property. That row pins
+    /// `parse_type_phrase_folding` intact and it supplies the property. That row pins
     /// the path; it is not evidence for the fix.
     #[test]
     fn tap_cost_another_carries_the_source_exclusion() {
@@ -2498,7 +2498,7 @@ mod tests {
         // CR 701.3d + CR 608.2k: Captain America's Throw cost. The recipient
         // "from Captain America, First Avenger" is normalized to "from ~"
         // upstream by `normalize_card_name_refs`.
-        let (expected_filter, remainder) = super::parse_type_phrase("Equipment from ~");
+        let (expected_filter, remainder) = super::parse_type_phrase_folding("Equipment from ~");
         assert_eq!(remainder, " from ~");
         assert_eq!(
             parse_oracle_cost("Unattach an Equipment from ~"),
@@ -3409,7 +3409,7 @@ mod tests {
             } => {
                 assert_eq!(count, 1);
                 assert_eq!(filter.get_subtype(), Some("Forest"));
-                // "you control" must be captured — parse_type_phrase delegates to
+                // "you control" must be captured — parse_type_phrase_folding delegates to
                 // parse_controller_suffix which handles this suffix.
                 assert_eq!(filter.controller, Some(ControllerRef::You));
             }

--- a/crates/engine/src/parser/oracle_effect/conditions.rs
+++ b/crates/engine/src/parser/oracle_effect/conditions.rs
@@ -20,7 +20,7 @@ use super::super::oracle_nom::condition::{
 use super::super::oracle_nom::primitives as nom_primitives;
 use super::super::oracle_nom::quantity as nom_quantity;
 use super::super::oracle_quantity::{canonicalize_quantity_ref, parse_cda_quantity};
-use super::super::oracle_target::{parse_target, parse_type_phrase, parse_zone_word};
+use super::super::oracle_target::{parse_target, parse_type_phrase_folding, parse_zone_word};
 use super::super::oracle_util::{parse_comparison_suffix, parse_subtype, TextPair};
 use super::sequence::parse_dig_from_among;
 use super::{parse_effect_chain, scan_contains_phrase, ParseContext};
@@ -188,10 +188,10 @@ fn comma_inside_if_creature_subtype_list(lower: &str, comma_idx: usize) -> bool 
     // CR 205.3m + CR 608.2c: target-anaphoric "that creature is a Mutant, Ninja,
     // or Turtle" (Turtle Van). The subtype-list commas separate disjuncts, not
     // the condition from the effect body. Compose the same subject + tense +
-    // article + `parse_type_phrase` span used by
+    // article + `parse_type_phrase_folding` span used by
     // `parse_target_type_membership_condition` and test whether the comma falls
     // inside the matched span. The trailing predicate has no " card" anchor, so
-    // the span ends where `parse_type_phrase` stops consuming type words.
+    // the span ends where `parse_type_phrase_folding` stops consuming type words.
     target_anaphoric_subtype_span(lower, after_prefix)
         .is_some_and(|(start, end)| (start..end).contains(&comma_idx))
 }
@@ -205,7 +205,8 @@ fn target_anaphoric_subtype_span(lower: &str, after_prefix: &str) -> Option<(usi
     let (after_subject, _) = parse_target_demonstrative_subject(after_prefix).ok()?;
     let (after_tense, _) = parse_target_anaphoric_tense_polarity(after_subject).ok()?;
     let (after_article, _) = opt(nom_primitives::parse_article).parse(after_tense).ok()?;
-    let (filter, remainder) = crate::parser::oracle_target::parse_type_phrase(after_article);
+    let (filter, remainder) =
+        crate::parser::oracle_target::parse_type_phrase_folding(after_article);
     if remainder.len() == after_article.len() || matches!(filter, TargetFilter::Any) {
         return None;
     }
@@ -889,7 +890,7 @@ pub(super) fn strip_if_you_do_conditional(text: &str) -> (Option<AbilityConditio
     // The combinator covers past + present tense, single-word imperatives
     // (destroyed/exiled/sacrificed/returned/discarded/milled/countered) AND
     // the multi-word "put onto the battlefield" verb, with subtype filters
-    // (Aura/Equipment/...) via `parse_type_phrase`. Replaces the prior
+    // (Aura/Equipment/...) via `parse_type_phrase_folding`. Replaces the prior
     // hand-rolled past-tense / single-word / top-level-type-only matcher.
     if let Ok((rest, _)) =
         alt((tag::<_, _, OracleError<'_>>("if "), tag("when "))).parse(lower.as_str())
@@ -1467,12 +1468,12 @@ fn parse_its_a_card_type_gate_body<'a>(
     let type_word = type_str.rsplit(' ').next().unwrap_or(type_str);
     let capitalized = format!("{}{}", &type_word[..1].to_uppercase(), &type_word[1..]);
     // CR 608.2c: "permanent" is not a CoreType (it spans CR 110.1's permanent card
-    // types). Build the condition via the existing parse_type_phrase building block —
+    // types). Build the condition via the existing parse_type_phrase_folding building block —
     // "permanent card" → TargetFilter::Typed(TypeFilter::Permanent) — and gate on it
     // with TargetMatchesFilter (the same condition variant the sibling MV arms use).
     if type_word == "permanent" {
         let (mut filter, leftover) =
-            crate::parser::oracle_target::parse_type_phrase("permanent card");
+            crate::parser::oracle_target::parse_type_phrase_folding("permanent card");
         if !matches!(filter, TargetFilter::Any) && leftover.trim().is_empty() {
             let (after_type, chosen_type) = if let Ok((rest_after_chosen, _)) =
                 tag::<_, _, OracleError<'_>>(" of the chosen type").parse(after_type)
@@ -1548,7 +1549,7 @@ pub(super) fn try_parse_moved_card_subtype_attach_followup(
     let (_, (subtype_phrase, body)) = nom_primitives::split_once_on(after_gate, ", ").ok()?;
     // Require a pure subtype gate (Equipment/Aura/Fortification, ...): the type
     // phrase must consume fully and reference at least one CR 205.3 subtype.
-    let (filter, leftover) = parse_type_phrase(subtype_phrase);
+    let (filter, leftover) = parse_type_phrase_folding(subtype_phrase);
     if !leftover.trim().is_empty() {
         return None;
     }
@@ -1779,7 +1780,7 @@ fn parse_target_demonstrative_subject(
 ///   - tense: present (`is`/`'s`) → current state, past (`was`) → LKI (CR 400.7)
 ///   - polarity: positive (`is`/`was`) vs. negative (`isn't`/`wasn't`/…)
 ///
-/// The predicate tail is parsed by the shared `parse_type_phrase` building block,
+/// The predicate tail is parsed by the shared `parse_type_phrase_folding` building block,
 /// so the full comma + "or" subtype-disjunction grammar (CR 205.3m) is covered:
 /// "a Mutant, Ninja, or Turtle" lowers to `Or[Subtype(Mutant), Subtype(Ninja),
 /// Subtype(Turtle)]`. Emits `TargetMatchesFilter` (wrapped in `Not` when negated)
@@ -1793,8 +1794,8 @@ fn parse_target_type_membership_condition(
     // ("is a Goblin"); a leading core type with no article ("is artifact") is not
     // real Oracle wording, so the article guard stays inside the combinator.
     let (rest, _) = opt(nom_primitives::parse_article).parse(rest)?;
-    let (filter, remainder) = crate::parser::oracle_target::parse_type_phrase(rest);
-    // Reject when no type word was consumed (parse_type_phrase echoes its input
+    let (filter, remainder) = crate::parser::oracle_target::parse_type_phrase_folding(rest);
+    // Reject when no type word was consumed (parse_type_phrase_folding echoes its input
     // unchanged on failure) so the alt backtracks to the color / quantity arms.
     if remainder.len() == rest.len() || matches!(filter, TargetFilter::Any) {
         return Err(nom::Err::Error(nom::error::Error::new(
@@ -2076,11 +2077,11 @@ fn parse_target_attacked_this_turn_condition_text(text: &str) -> Option<AbilityC
 ///   (ii) anaphor — "it" / "that creature" → `creature()` (the sibling
 ///       attacked-this-turn form's default subject).
 /// The returned filter has NO `EnteredThisTurn` property yet — the caller
-/// appends it after matching the verb. `parse_type_phrase` returns a suffix
+/// appends it after matching the verb. `parse_type_phrase_folding` returns a suffix
 /// slice of `input`, so its remainder is a valid nom continuation.
 fn parse_entered_this_turn_subject(input: &str) -> OracleResult<'_, TargetFilter> {
     if let Ok((rest, _)) = tag::<_, _, OracleError<'_>>("the ").parse(input) {
-        let (filter, remainder) = parse_type_phrase(rest);
+        let (filter, remainder) = parse_type_phrase_folding(rest);
         if matches!(filter, TargetFilter::Typed(_)) && remainder.len() < rest.len() {
             return Ok((remainder, filter));
         }
@@ -2444,7 +2445,7 @@ pub(super) fn strip_property_conditional(
     ] {
         if let Some((before, after)) = tp.rsplit_around(pattern) {
             let type_text = after.lower.trim_end_matches('.').trim();
-            let (filter, leftover) = parse_type_phrase(type_text);
+            let (filter, leftover) = parse_type_phrase_folding(type_text);
             if !matches!(filter, TargetFilter::Any) && leftover.trim().is_empty() {
                 return (
                     Some(AbilityCondition::TargetMatchesFilter {
@@ -3806,7 +3807,7 @@ fn parse_controller_controlled_as_cast_condition(
     input: &str,
 ) -> OracleResult<'_, AbilityCondition> {
     let (rest, _) = tag("you controlled ").parse(input)?;
-    let (filter, remainder) = parse_type_phrase(rest);
+    let (filter, remainder) = parse_type_phrase_folding(rest);
     if matches!(filter, TargetFilter::Any) {
         return Err(nom::Err::Error(OracleError::new(
             input,
@@ -4494,7 +4495,7 @@ fn parse_control_count_as_ability_condition(text: &str) -> Option<AbilityConditi
     let (type_rest, _) = tag::<_, _, OracleError<'_>>("fewer ").parse(rest).ok()?;
     let pos = type_rest.find(" than ")?;
     let type_text = &type_rest[..pos];
-    let (mut filter, leftover) = parse_type_phrase(type_text);
+    let (mut filter, leftover) = parse_type_phrase_folding(type_text);
     if filter == TargetFilter::Any || !leftover.trim().is_empty() {
         return None;
     }
@@ -5236,7 +5237,7 @@ fn parse_attacked_with_filter_condition(text: &str) -> Option<AbilityCondition> 
         );
     }
     // Type / subtype phrase ("a Wolf or Werewolf", etc.).
-    let (filter, rest) = parse_type_phrase(noun);
+    let (filter, rest) = parse_type_phrase_folding(noun);
     if rest.trim().is_empty() && !matches!(filter, TargetFilter::Any) {
         return make(Some(filter), 1);
     }
@@ -5936,13 +5937,14 @@ pub(super) fn try_nom_condition_as_ability_condition(
             value(false, tag("it was an ")),
         ));
         if let Ok((rest, negated_lki)) = lki_prefix.parse(lower.as_str()) {
-            // Strip trailing " card" / " card." before delegating to parse_type_phrase.
+            // Strip trailing " card" / " card." before delegating to parse_type_phrase_folding.
             let type_text = rest
                 .trim_end_matches('.')
                 .trim()
                 .trim_end_matches(" card")
                 .trim();
-            let (filter, leftover) = crate::parser::oracle_target::parse_type_phrase(type_text);
+            let (filter, leftover) =
+                crate::parser::oracle_target::parse_type_phrase_folding(type_text);
             if !matches!(filter, TargetFilter::Any) && leftover.trim().is_empty() {
                 return Some(maybe_negate(
                     AbilityCondition::TargetMatchesFilter {
@@ -6025,11 +6027,11 @@ pub(super) fn try_nom_condition_as_ability_condition(
     if let Some(rest) = rest_after_prefix {
         let rest = rest.trim_end_matches(" card").trim();
         // CR 608.2c: "permanent" is not a CoreType — gate on it via the existing
-        // parse_type_phrase building block + TargetMatchesFilter, keeping this handler
+        // parse_type_phrase_folding building block + TargetMatchesFilter, keeping this handler
         // in lockstep with strip_card_type_conditional's "permanent" arm.
         if rest == "permanent" {
             let (filter, leftover) =
-                crate::parser::oracle_target::parse_type_phrase("permanent card");
+                crate::parser::oracle_target::parse_type_phrase_folding("permanent card");
             if !matches!(filter, TargetFilter::Any) && leftover.trim().is_empty() {
                 return Some(maybe_negate(
                     AbilityCondition::TargetMatchesFilter {
@@ -6103,18 +6105,18 @@ pub(super) fn try_nom_condition_as_ability_condition(
         }
         // CR 608.2c + CR 205.3a: "it's a [subtype]" (Goblin, Aura, Equipment, ...).
         // The CoreType match above only covers card types; subtypes route through
-        // the parse_type_phrase building block + TargetMatchesFilter, exactly like
+        // the parse_type_phrase_folding building block + TargetMatchesFilter, exactly like
         // the "permanent" arm. Subtype disjunctions ("Goblin or Orc") are handled by
-        // parse_type_phrase's Or support; an unparseable remainder leaves non-empty
+        // parse_type_phrase_folding's Or support; an unparseable remainder leaves non-empty
         // leftover and falls through to parse_inner_condition.
         //
-        // The `references_subtype` gate is load-bearing: parse_type_phrase also
+        // The `references_subtype` gate is load-bearing: parse_type_phrase_folding also
         // consumes CoreType phrases the explicit `match` above already owns
         // (e.g. "creature card of the chosen type" → Creature + IsChosenCreatureType
         // with empty leftover). Those belong to RevealedHasCardType, not the
         // present-target TargetMatchesFilter, so this arm fires only when the parsed
         // filter genuinely references a CR 205.3 subtype.
-        let (filter, leftover) = crate::parser::oracle_target::parse_type_phrase(rest);
+        let (filter, leftover) = crate::parser::oracle_target::parse_type_phrase_folding(rest);
         if let TargetFilter::Typed(typed) = &filter {
             if leftover.trim().is_empty()
                 && typed
@@ -6381,7 +6383,7 @@ fn parse_the_token_is_type_condition(lower: &str) -> Option<AbilityCondition> {
     let (rest, _) = tag::<_, _, OracleError<'_>>("the token is ")
         .parse(lower)
         .ok()?;
-    let (filter, remainder) = parse_type_phrase(rest);
+    let (filter, remainder) = parse_type_phrase_folding(rest);
     if !matches!(filter, TargetFilter::Typed(_)) || !remainder.trim().is_empty() {
         return None;
     }
@@ -7127,7 +7129,7 @@ fn parse_entered_or_cast_from_zone_ability_condition(lower: &str) -> Option<Abil
 /// copula form (`is/isn't [a/an] <type>`) carries a type phrase; the keyword
 /// form (`has/doesn't have <keyword>`) carries a keyword name.
 enum ZoneChangeObjectPredicate<'a> {
-    /// Remaining text is a type phrase (parsed via `parse_type_phrase`).
+    /// Remaining text is a type phrase (parsed via `parse_type_phrase_folding`).
     Type(&'a str),
     /// Remaining text is a keyword name (parsed via `Keyword::from_str`).
     Keyword(&'a str),
@@ -7141,7 +7143,7 @@ fn zone_change_object_predicate_filter(
 ) -> Option<TargetFilter> {
     match predicate {
         ZoneChangeObjectPredicate::Type(type_text) => {
-            let (filter, leftover) = parse_type_phrase(type_text);
+            let (filter, leftover) = parse_type_phrase_folding(type_text);
             if matches!(filter, TargetFilter::Any) || !leftover.trim().is_empty() {
                 return None;
             }
@@ -9776,7 +9778,7 @@ mod tests {
 
     /// CR 205.3m + CR 608.2c: "that creature is a Mutant, Ninja, or Turtle"
     /// (Turtle Van) → `TargetMatchesFilter` over an `Or` of the three subtypes.
-    /// The comma + "or" disjunction is parsed via the shared `parse_type_phrase`
+    /// The comma + "or" disjunction is parsed via the shared `parse_type_phrase_folding`
     /// building block, so the condition covers the whole class of multi-subtype
     /// target-anaphoric gates, not just this card.
     #[test]
@@ -10155,7 +10157,7 @@ mod tests {
     }
 
     /// CR 608.2c: "permanent" is not a CoreType — strip_card_type_conditional must
-    /// still gate on it via TargetMatchesFilter (parse_type_phrase building block).
+    /// still gate on it via TargetMatchesFilter (parse_type_phrase_folding building block).
     /// Covers Primal Surge's "If it's a permanent card, you may put it onto the
     /// battlefield."
     #[test]
@@ -10224,7 +10226,7 @@ mod tests {
     }
 
     /// CR 608.2c + CR 205.3a: "If it's a [subtype]" gates the parent target on a
-    /// subtype via parse_type_phrase + TargetMatchesFilter. Pre-fix this dropped to
+    /// subtype via parse_type_phrase_folding + TargetMatchesFilter. Pre-fix this dropped to
     /// `None` (only CoreType words matched), which silently dropped the else-branch.
     #[test]
     fn if_its_a_subtype_parses_condition() {
@@ -10505,7 +10507,7 @@ mod tests {
         );
     }
 
-    /// CR 608.2c: Regression guard for the subtype fall-through. parse_type_phrase
+    /// CR 608.2c: Regression guard for the subtype fall-through. parse_type_phrase_folding
     /// fully consumes "creature card of the chosen type" (CoreType + chosen-type
     /// property, empty leftover), but that phrase belongs to RevealedHasCardType
     /// (produced by strip_card_type_conditional in the chain path), not the

--- a/crates/engine/src/parser/oracle_effect/counter.rs
+++ b/crates/engine/src/parser/oracle_effect/counter.rs
@@ -18,7 +18,8 @@ use super::super::oracle_nom::bridge::nom_on_lower;
 use super::super::oracle_nom::primitives as nom_primitives;
 use super::super::oracle_nom::quantity as nom_quantity;
 use super::super::oracle_target::{
-    parse_target, parse_target_with_ctx, parse_type_phrase, parse_type_phrase_with_ctx,
+    parse_target, parse_target_with_ctx, parse_type_phrase_folding,
+    parse_type_phrase_folding_with_ctx,
 };
 use super::super::oracle_util::{parse_count_expr, parse_number};
 use super::lower::parse_for_each_multiplier_prefix;
@@ -1153,7 +1154,7 @@ pub(crate) fn normalize_counter_type(raw: &str) -> CounterType {
 
 /// CR 115.1d + CR 122.1: Strip the distribution prefix "each of any number of "
 /// from a remove-counter "from <objects>" clause. Returns the remainder for
-/// `parse_type_phrase` when the prefix was present (Garnet class — player
+/// `parse_type_phrase_folding` when the prefix was present (Garnet class — player
 /// chooses any number of matching permanents, not a "target" phrase).
 fn strip_remove_counter_each_of_any_number(input: &str) -> Option<&str> {
     let after_each_of = nom_on_lower(input, input, |i| value((), opt(tag("each of "))).parse(i))
@@ -1177,7 +1178,7 @@ fn strip_remove_counter_each_of_fixed_number(input: &str) -> Option<&str> {
 /// effect. The optional "each of any number of" prefix denotes a variable-count
 /// non-target distribution — strip it and parse the remainder as a type phrase
 /// instead of routing through `parse_target` (whose bare "each " arm would leave
-/// "of any number of …" for `parse_type_phrase` and collapse to `Any`).
+/// "of any number of …" for `parse_type_phrase_folding` and collapse to `Any`).
 fn resolve_remove_counter_from_target(text: &str, ctx: &mut ParseContext) -> TargetFilter {
     if is_self_ref(text) {
         return TargetFilter::SelfRef;
@@ -1189,7 +1190,7 @@ fn resolve_remove_counter_from_target(text: &str, ctx: &mut ParseContext) -> Tar
     if let Some(filter_text) = strip_remove_counter_each_of_any_number(text)
         .or_else(|| strip_remove_counter_each_of_fixed_number(text))
     {
-        let (t, _rem) = parse_type_phrase_with_ctx(filter_text, ctx);
+        let (t, _rem) = parse_type_phrase_folding_with_ctx(filter_text, ctx);
         #[cfg(debug_assertions)]
         assert_no_compound_remainder(_rem, filter_text);
         return t;
@@ -1790,7 +1791,7 @@ pub(super) fn try_parse_multiply_pt_effect(lower: &str, ctx: &mut ParseContext) 
     let ((), filter_text) = nom_on_lower(after_mode, after_mode, |i| {
         value((), alt((tag("each "), tag("all ")))).parse(i)
     })?;
-    let (target, _) = parse_type_phrase(filter_text);
+    let (target, _) = parse_type_phrase_folding(filter_text);
     Some(Effect::DoublePTAll {
         mode,
         target,

--- a/crates/engine/src/parser/oracle_effect/imperative.rs
+++ b/crates/engine/src/parser/oracle_effect/imperative.rs
@@ -58,9 +58,9 @@ use crate::types::zones::Zone;
 use super::super::oracle_target::{
     match_mass_union_separator, parse_anaphoric_target_ref, parse_definite_parent_reference,
     parse_event_context_ref, parse_fight_target, parse_mass_type_union, parse_target,
-    parse_target_with_ctx, parse_target_with_syntax, parse_type_phrase, parse_type_phrase_with_ctx,
-    parse_word_bounded, resolve_pronoun_target, resolve_singular_exiled_card_target,
-    starts_with_type_word, TargetSyntax,
+    parse_target_with_ctx, parse_target_with_syntax, parse_type_phrase_folding,
+    parse_type_phrase_folding_with_ctx, parse_word_bounded, resolve_pronoun_target,
+    resolve_singular_exiled_card_target, starts_with_type_word, TargetSyntax,
 };
 use super::super::oracle_util::{
     contains_possessive, contains_self_or_object_pronoun, merge_or_filters, parse_count_expr,
@@ -109,7 +109,7 @@ pub(crate) fn try_parse_activated_ability_cost_reduction_effect(
         return None;
     }
     // "artifact tokens you control" → Typed[Artifact, You, FilterProp::Token].
-    let (source_filter, _after) = parse_type_phrase_with_ctx(subject, ctx);
+    let (source_filter, _after) = parse_type_phrase_folding_with_ctx(subject, ctx);
     // CR 601.2f + CR 118.7: identical shape to Training Grounds' printed static
     // (dispatch.rs). `keyword: "activated"` matches every activated ability;
     // `exemption`/`activator`/`minimum_mana`/`dynamic_count` carry no clause on
@@ -1534,7 +1534,7 @@ fn parse_discard_unless_filter<'a>(
 /// Dokuchi Silencer ("you may discard a creature card") preserves the same
 /// filter data as cost-form discards like "Discard a creature card:".
 pub(crate) fn parse_discard_card_filter(tail: &str) -> Option<TargetFilter> {
-    let (filter, remainder) = parse_type_phrase(tail);
+    let (filter, remainder) = parse_type_phrase_folding(tail);
     let is_bare_card = matches!(
         &filter,
         TargetFilter::Typed(TypedFilter {
@@ -1652,7 +1652,7 @@ pub(super) fn parse_one_or_more_sacrifice(
     let target_text = strip_sacrifice_count_suffix(&strip_sacrifice_choice_marker(
         strip_article(filter_text.trim_start()).trim_end_matches('.'),
     ));
-    let (mut target, remainder) = parse_type_phrase(target_text.trim());
+    let (mut target, remainder) = parse_type_phrase_folding(target_text.trim());
     if !remainder.trim().is_empty() || matches!(target, TargetFilter::Any) {
         return None;
     }
@@ -2243,7 +2243,7 @@ pub(super) fn parse_targeted_action_ast(
         // sibling `try_parse_verb_and_target` handler in `mod.rs`, which stamps
         // the same `InZone`/`Owned` constraints (e.g. Dance of the Manse's
         // graveyard-scoped "artifact and/or non-Aura enchantment cards"). Only
-        // stamp when `parse_type_phrase` did not already capture the origin zone
+        // stamp when `parse_type_phrase_folding` did not already capture the origin zone
         // itself ("... creature card from your graveyard" parses the zone + owner
         // inline) — re-stamping an already-zoned filter would double-scope it.
         let target = if target.extract_in_zone().is_none() {
@@ -3030,7 +3030,7 @@ pub(super) fn try_parse_multi_zone_player_exile(
             // owner-possessive + 2-zone-union structure parsed below is the rest of
             // the discriminator (CR 108.2 — cards in a player's zones).
             let (after_head, head) = take_until::<_, _, OracleError<'_>>(" from ").parse(input)?;
-            let (tf, head_rem) = parse_type_phrase(head);
+            let (tf, head_rem) = parse_type_phrase_folding(head);
             let TargetFilter::Typed(tf) = tf else {
                 return Err(oracle_err(head));
             };
@@ -3224,7 +3224,7 @@ fn try_parse_heterogeneous_chosen_exile(input: &str, ctx: &ParseContext) -> Opti
     )
     .parse(input)
     .ok()?;
-    let (mut hand_filter, hand_rem) = parse_type_phrase(hand_head.trim());
+    let (mut hand_filter, hand_rem) = parse_type_phrase_folding(hand_head.trim());
     if !hand_rem.trim().is_empty() || !matches!(hand_filter, TargetFilter::Typed(_)) {
         return None;
     }
@@ -4067,7 +4067,7 @@ fn parse_hand_reveal_target_and_card_filter(
             return (target, TargetFilter::Any);
         }
         let singular = format!("{} card", descriptor.trim());
-        let (filter, rem) = parse_type_phrase(&singular);
+        let (filter, rem) = parse_type_phrase_folding(&singular);
         if rem.trim().is_empty() && matches!(filter, TargetFilter::Typed(_)) {
             return (target, filter);
         }
@@ -4097,7 +4097,7 @@ fn parse_hand_reveal_target_and_card_filter(
         .map(|(_, target)| target)
         .unwrap_or(TargetFilter::Any);
     let singular = format!("{} card", descriptor.trim());
-    let (filter, rem) = parse_type_phrase(&singular);
+    let (filter, rem) = parse_type_phrase_folding(&singular);
     if rem.trim().is_empty() && matches!(filter, TargetFilter::Typed(_)) {
         (target, filter)
     } else {
@@ -4304,7 +4304,7 @@ fn try_parse_choose_and_verb_it_edict(rest_lower: &str) -> Option<ChooseImperati
     // Validate the captured phrase is a real object type with no leftover text —
     // keeps the recognizer precise so it never hijacks unrelated "choose a …"
     // bodies whose type phrase is junk or carries a trailing predicate.
-    let (filter, filter_rem) = parse_type_phrase(type_text);
+    let (filter, filter_rem) = parse_type_phrase_folding(type_text);
     if !filter_rem.trim().is_empty() || matches!(filter, TargetFilter::Any) {
         return None;
     }
@@ -6145,7 +6145,7 @@ pub(super) fn parse_utility_imperative_ast(
         let (input, attachment) = terminated(take_until(" from "), tag(" from ")).parse(input)?;
         Ok((input, attachment.to_string()))
     }) {
-        let (attachment, attachment_rem) = parse_type_phrase(attachment_text.trim());
+        let (attachment, attachment_rem) = parse_type_phrase_folding(attachment_text.trim());
         let (target, target_rem) = parse_target_with_ctx(target_text, ctx);
         if attachment_rem.trim().is_empty() && target_rem.trim().is_empty() {
             return Some(UtilityImperativeAst::UnattachAll { attachment, target });
@@ -9498,7 +9498,7 @@ pub(super) fn parse_exile_ast(
     )
         .parse(rest_lower)
     {
-        let (mut target, rem) = parse_type_phrase(filter_text.trim());
+        let (mut target, rem) = parse_type_phrase_folding(filter_text.trim());
         // `after_hand` is the parser remainder AFTER "from your hand": empty/"."
         // (no-tail case) or " with a number of … counters on it equal to …".
         let enter_with_counters = super::parse_with_counters_suffix(after_hand);
@@ -9537,7 +9537,7 @@ pub(super) fn parse_exile_ast(
     )
         .parse(rest_lower)
     {
-        let (target, rem) = parse_type_phrase(filter_text.trim());
+        let (target, rem) = parse_type_phrase_folding(filter_text.trim());
         let tail_clean = after_among.trim().trim_start_matches('.').trim(); // allow-noncombinator: punctuation cleanup after typed terminator
         if rem.trim().is_empty() && !matches!(target, TargetFilter::Any) && tail_clean.is_empty() {
             return Some(ZoneCounterImperativeAst::Exile {
@@ -10449,14 +10449,14 @@ fn parse_behold_effect_ast(text: &str, lower: &str) -> Option<ImperativeFamilyAs
         .parse(rest_lower)
         .ok()?;
     // Map the consumed lowercase byte span back onto the original-case text so
-    // `parse_type_phrase` sees the properly-cased subtype (e.g. "Dragon").
+    // `parse_type_phrase_folding` sees the properly-cased subtype (e.g. "Dragon").
     let consumed = lower.len() - rest_lower.len();
     let rest_orig = text.get(consumed..)?;
     // CR 701.4a: bound the quality at sentence/reminder-text punctuation.
     let (_, filter_text) = take_till::<_, _, E<'_>>(|c| c == '.' || c == '(')
         .parse(rest_orig)
         .ok()?;
-    let (filter, remainder) = parse_type_phrase(filter_text.trim());
+    let (filter, remainder) = parse_type_phrase_folding(filter_text.trim());
     if !remainder.trim().is_empty() || matches!(filter, TargetFilter::Any) {
         return None;
     }

--- a/crates/engine/src/parser/oracle_effect/lower.rs
+++ b/crates/engine/src/parser/oracle_effect/lower.rs
@@ -22,8 +22,8 @@ use super::super::oracle_quantity::{
     parse_player_attribute_attr_clause, parse_quantity_ref,
 };
 use super::super::oracle_target::{
-    parse_target, parse_target_with_ctx, parse_that_clause_suffix, parse_type_phrase,
-    parse_type_phrase_with_ctx,
+    parse_target, parse_target_with_ctx, parse_that_clause_suffix, parse_type_phrase_folding,
+    parse_type_phrase_folding_with_ctx,
 };
 use super::super::oracle_util::{parse_comparator_prefix, parse_count_expr, strip_after, TextPair};
 use crate::parser::oracle_ir::ast::*;
@@ -5473,7 +5473,7 @@ pub(super) fn strip_each_scope_who_didnt_verb_filter_this_way_subject(
         let (i, _) = alt((tag("didn't "), tag("did not "))).parse(i)?;
         let (i, _) = tag("discard ").parse(i)?;
         let (i, _) = alt((tag("a "), tag("an "))).parse(i)?;
-        let (filter, after_filter) = parse_type_phrase(i);
+        let (filter, after_filter) = parse_type_phrase_folding(i);
         if matches!(filter, TargetFilter::Any) {
             return Err(oracle_err(i));
         }
@@ -5665,7 +5665,7 @@ pub(super) fn rebind_subject_only_body_recipient(effect: &mut Effect) {
 ///   runtime by `player_control_count_compares`.
 ///
 /// The object sub-phrase ("an Elf", "a creature with power 4 or greater")
-/// delegates to the shared `parse_type_phrase_with_ctx` combinator — no bespoke
+/// delegates to the shared `parse_type_phrase_folding_with_ctx` combinator — no bespoke
 /// string matching. This is the DRY core shared by the "each opponent who
 /// controls …" subject path (`strip_controls_permanent_clause`) and the "the
 /// number of opponents who control …" quantity path (`oracle_quantity.rs`).
@@ -5689,7 +5689,7 @@ pub(crate) fn parse_controls_permanent_object<'a>(
         if let Some((type_text, comparative_remainder)) =
             split_once_on_lower(after_verb, &after_verb_lower, " than you")
         {
-            let (bare_filter, _) = parse_type_phrase_with_ctx(type_text, ctx);
+            let (bare_filter, _) = parse_type_phrase_folding_with_ctx(type_text, ctx);
             if matches!(bare_filter, TargetFilter::Any) {
                 return None;
             }
@@ -5729,7 +5729,7 @@ pub(crate) fn parse_controls_permanent_object<'a>(
         let (i, _) = alt((tag("controls the most "), tag("control the most "))).parse(i)?;
         Ok((i, ()))
     }) {
-        let (filter, remainder) = parse_type_phrase_with_ctx(after_verb, ctx);
+        let (filter, remainder) = parse_type_phrase_folding_with_ctx(after_verb, ctx);
         // Honest-red guard: reject Any / content-empty filters so a type phrase
         // that fails to parse stays Unimplemented rather than building a bogus
         // extremum. Both `filter` sides stay BARE (controller-less): the resolvers
@@ -5792,7 +5792,7 @@ pub(crate) fn parse_controls_permanent_object<'a>(
         .parse(i)
     })?;
     // The object sub-phrase is consumed by the shared type-phrase combinator.
-    let (filter, remainder) = parse_type_phrase_with_ctx(after_verb, ctx);
+    let (filter, remainder) = parse_type_phrase_folding_with_ctx(after_verb, ctx);
     if matches!(filter, TargetFilter::Any) {
         return None;
     }
@@ -7102,7 +7102,7 @@ pub(super) fn extract_double_counter_multi_target(text: &str) -> Option<MultiTar
 
 /// CR 115.1d + CR 122.1: Recover `MultiTargetSpec` for "remove … from each of
 /// any number of <type>". The imperative parser strips the distribution prefix
-/// so `parse_type_phrase` sees a bare filter; rebuild the spec from the
+/// so `parse_type_phrase_folding` sees a bare filter; rebuild the spec from the
 /// original text (parallel to `extract_switch_pt_multi_target`).
 pub(super) fn extract_remove_counter_multi_target(text: &str) -> Option<MultiTargetSpec> {
     let lower = text.to_lowercase();

--- a/crates/engine/src/parser/oracle_effect/mana.rs
+++ b/crates/engine/src/parser/oracle_effect/mana.rs
@@ -25,7 +25,7 @@ use super::super::oracle_keyword::parse_granted_keyword_fragment;
 use super::super::oracle_quantity::{
     parse_cda_quantity, parse_cda_quantity_with_context, parse_event_context_quantity,
 };
-use super::super::oracle_target::parse_type_phrase;
+use super::super::oracle_target::parse_type_phrase_folding;
 use super::super::oracle_util::{parse_mana_production, parse_number, TextPair};
 use crate::parser::oracle_ir::context::ParseContext;
 use crate::types::ability::TargetFilter;
@@ -65,7 +65,7 @@ fn try_parse_any_color_among_permanents_filter(
     let prefix_len = trimmed_lower.len() - rest.len();
     let trimmed_original = after_color.trim().trim_end_matches('.').trim();
     let type_text = trimmed_original.get(prefix_len..)?.trim();
-    let (filter, remainder) = parse_type_phrase(type_text);
+    let (filter, remainder) = parse_type_phrase_folding(type_text);
     if !remainder.trim().is_empty() || matches!(filter, TargetFilter::Any) {
         return None;
     }
@@ -91,7 +91,7 @@ fn try_parse_for_each_color_mana(text: &str, lower: &str) -> Option<Effect> {
     // CR 702.167c + CR 105.1: "For each color among the exiled cards used to craft
     // this creature, add one mana of that color" (Sunbird Effigy) — the iteration
     // source is the craft-material linked-exile pool, not a battlefield type
-    // phrase. Tried first so the craft noun phrase wins over `parse_type_phrase`.
+    // phrase. Tried first so the craft noun phrase wins over `parse_type_phrase_folding`.
     if let Ok((craft_rest, filter)) =
         crate::parser::oracle_nom::quantity::parse_craft_materials_filter(type_text_lower.trim())
     {
@@ -105,11 +105,11 @@ fn try_parse_for_each_color_mana(text: &str, lower: &str) -> Option<Effect> {
             });
         }
     }
-    // Recover original-cased slice for parse_type_phrase.
+    // Recover original-cased slice for parse_type_phrase_folding.
     let offset = lower_trimmed.len() - rest.len();
     let original_trimmed = text.trim_end_matches('.').trim();
     let type_text = &original_trimmed[offset..offset + type_text_lower.len()];
-    let (filter, remainder) = parse_type_phrase(type_text);
+    let (filter, remainder) = parse_type_phrase_folding(type_text);
     if !remainder.trim().is_empty() || matches!(filter, TargetFilter::Any) {
         return None;
     }
@@ -1399,7 +1399,7 @@ fn scan_mana_production_type(
                     nom_rest,
                 ),
                 |type_text: &str| {
-                    let (filter, remainder) = parse_type_phrase(type_text.trim());
+                    let (filter, remainder) = parse_type_phrase_folding(type_text.trim());
                     if !remainder.trim().is_empty() || matches!(filter, TargetFilter::Any) {
                         return None;
                     }
@@ -2694,7 +2694,7 @@ pub(crate) fn parse_mana_spend_trigger(lower: &str) -> Option<ManaSpellGrant> {
 /// CR 106.6 spend restriction was never the right type — see
 /// [`ManaSpellGrant::TriggerOnSpend`].
 ///
-/// The type/color phrase is DELEGATED to `oracle_target::parse_type_phrase`, the
+/// The type/color phrase is DELEGATED to `oracle_target::parse_type_phrase_folding`, the
 /// engine's single authority for phrases like "red instant or sorcery". One call
 /// therefore covers the whole type × color class ("an instant or sorcery spell",
 /// "a red instant or sorcery spell", "a Dragon creature spell") instead of the
@@ -2772,7 +2772,7 @@ fn parse_spend_trigger_filter(filter: &str) -> Option<TargetFilter> {
     if !post.is_empty() || pre.is_empty() {
         return None;
     }
-    let (parsed, remainder) = parse_type_phrase(pre);
+    let (parsed, remainder) = parse_type_phrase_folding(pre);
     if !remainder.trim().is_empty() || matches!(parsed, TargetFilter::Any) {
         return None;
     }

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -95,8 +95,8 @@ use super::oracle_quantity::{
 use super::oracle_target::{
     parse_definite_parent_reference, parse_event_context_ref, parse_fight_target, parse_target,
     parse_target_with_ctx, parse_target_with_disjunctive_restriction, parse_target_with_syntax,
-    parse_type_phrase, parse_type_phrase_with_ctx, resolve_singular_exiled_card_target,
-    TargetSyntax,
+    parse_type_phrase_folding, parse_type_phrase_folding_with_ctx,
+    resolve_singular_exiled_card_target, TargetSyntax,
 };
 use super::oracle_util::{
     contains_possessive, has_unconsumed_conditional, parse_count_expr, parse_creature_subtype,
@@ -1607,7 +1607,7 @@ fn parse_dealt_damage_this_way_dies_trigger(
     let (rest, _) = eof::<_, OracleError<'_>>.parse(rest).ok()?;
     debug_assert!(rest.is_empty());
 
-    let (valid_card, rem) = parse_type_phrase(subject);
+    let (valid_card, rem) = parse_type_phrase_folding(subject);
     if !rem.trim().is_empty() || matches!(valid_card, TargetFilter::Any) {
         ctx.push_diagnostic(OracleDiagnostic::TargetFallback {
             context: "unrecognized delayed damage subject".into(),
@@ -1879,7 +1879,7 @@ fn try_parse_whenever_this_turn(tp: TextPair) -> Option<ParsedEffectClause> {
 /// into a combined `TargetFilter`.
 ///
 /// The payload must contain the word "spell". Text before " spell" is parsed as a type
-/// phrase (`parse_type_phrase`); text after " spell" is parsed by
+/// phrase (`parse_type_phrase_folding`); text after " spell" is parsed by
 /// `oracle_trigger::parse_post_spell_modifier` (CR 107.3 + CR 202.1 — "with {X} in its
 /// mana cost"). When both shapes contribute a filter, the result is an `And` composition.
 ///
@@ -1908,7 +1908,7 @@ fn extract_when_next_spell_filter(payload: &str) -> Option<TargetFilter> {
     let type_filter = if pre.is_empty() {
         None
     } else {
-        let (filter, remainder) = super::oracle_target::parse_type_phrase(pre);
+        let (filter, remainder) = super::oracle_target::parse_type_phrase_folding(pre);
         if !remainder.trim().is_empty() {
             return None;
         }
@@ -2115,7 +2115,7 @@ fn try_parse_lose_control_delayed_trigger(
         .ok()?
     {
         (rest, Some(_)) => {
-            let (host, host_rest) = parse_type_phrase(rest);
+            let (host, host_rest) = parse_type_phrase_folding(rest);
             let (rest, _) = tag::<_, _, OracleError<'_>>(", ").parse(host_rest).ok()?;
             (rest, host)
         }
@@ -2504,10 +2504,10 @@ fn parse_reflexive_excess_damage_trigger(before_lower: &str) -> Option<TriggerDe
     let (rest, _) = tag::<_, _, OracleError<'_>>("excess damage is dealt to ")
         .parse(rest)
         .ok()?;
-    // Strip an optional leading "the " that `parse_type_phrase` does not fold.
+    // Strip an optional leading "the " that `parse_type_phrase_folding` does not fold.
     let (rest, _) = opt(tag::<_, _, OracleError<'_>>("the ")).parse(rest).ok()?;
 
-    let (subject, tail) = parse_type_phrase(rest);
+    let (subject, tail) = parse_type_phrase_folding(rest);
     if !tail.trim().is_empty() {
         return None;
     }
@@ -4155,7 +4155,7 @@ fn try_parse_grant_next_spell_ability(tp: TextPair) -> Option<ParsedEffectClause
     //
     // `filter_text` is the `take_until("spell")` capture — the spell-type
     // filter slice ("creature ", "instant or sorcery ", "noncreature ", …)
-    // fed to parse_type_phrase below. Preserving it is REQUIRED: dropping it
+    // fed to parse_type_phrase_folding below. Preserving it is REQUIRED: dropping it
     // regresses filtered next-spell grants to no filter. `scope` is the parsed
     // subject (you = Controller, they/that player = Target). `pair` keeps BOTH
     // the `take_until` slice and the `parse_next_spell_subject` output — unlike
@@ -4174,7 +4174,7 @@ fn try_parse_grant_next_spell_ability(tp: TextPair) -> Option<ParsedEffectClause
     let type_prefix = if filter_text.is_empty() {
         None
     } else {
-        let (filter, _) = parse_type_phrase(filter_text);
+        let (filter, _) = parse_type_phrase_folding(filter_text);
         if matches!(filter, TargetFilter::Any) {
             None
         } else {
@@ -4819,7 +4819,7 @@ fn try_parse_cant_cast_spells_effect(tp: TextPair<'_>) -> Option<ParsedEffectCla
     let spell_filter = match spell_filter_text {
         None => None,
         Some(text) => {
-            let (filter, rem) = parse_type_phrase(text.trim());
+            let (filter, rem) = parse_type_phrase_folding(text.trim());
             if !rem.trim().is_empty() || matches!(filter, TargetFilter::Any) {
                 return None;
             }
@@ -4909,7 +4909,7 @@ fn parse_passive_cant_be_played_land_filter(before_played: &str) -> Option<Targe
     let type_text = strip_required_suffix(before_played, " lands")
         .or_else(|| strip_required_suffix(before_played, " land"))?;
 
-    let (filter, remainder) = parse_type_phrase(type_text);
+    let (filter, remainder) = parse_type_phrase_folding(type_text);
     if !remainder.trim().is_empty() {
         return None;
     }
@@ -6751,7 +6751,7 @@ fn try_parse_choose_one_of_inline(
     // truncates the type phrase — "you may cast an instant" / "sorcery spell
     // ..." — and silently drops the cast-from-exile grant. `before_lower` and
     // `after_lower` are contiguous slices of `tp.lower` around the separator,
-    // so running the shared `parse_type_phrase` combinator from the last word
+    // so running the shared `parse_type_phrase_folding` combinator from the last word
     // of the left half scans straight across the " or " into the right half. If
     // it yields a multi-type `AnyOf`, the coordinator is part of the type list
     // and this is not a clause boundary. Reusing the filter combinator covers
@@ -7540,7 +7540,7 @@ fn try_parse_for_each_category_put_counter(tp: TextPair<'_>) -> Option<ParsedEff
     let (rest, _) = nom_primitives::parse_article.parse(rest).ok()?;
     let (rest, counter_type) = nom_primitives::parse_counter_type_typed(rest).ok()?;
     let (rest, _) = tag::<_, _, E>(" counter on ").parse(rest).ok()?;
-    let (target, rest) = parse_type_phrase(rest);
+    let (target, rest) = parse_type_phrase_folding(rest);
     if matches!(target, TargetFilter::Any) {
         return None;
     }
@@ -8388,7 +8388,7 @@ fn parse_controls_count_threshold<'a>(
     })
     .ok_or_else(|| oracle_err(input))?;
     let count = i32::try_from(count).map_err(|_| oracle_err(input))?;
-    let (filter, rest) = parse_type_phrase_with_ctx(after_verb, ctx);
+    let (filter, rest) = parse_type_phrase_folding_with_ctx(after_verb, ctx);
     // Honest-red guard, mirroring the sibling arms in
     // `parse_controls_permanent_object`: an unparsed type phrase must fail the
     // clause rather than produce a filter that matches everything.
@@ -13138,7 +13138,7 @@ fn try_parse_reveal_until_shares_creature_type(filter_text: &str) -> Option<Targ
         subject: Some(TargetFilter::AttachedTo),
         ..Default::default()
     };
-    let (filter, rem) = parse_type_phrase_with_ctx(filter_text, &mut ctx);
+    let (filter, rem) = parse_type_phrase_folding_with_ctx(filter_text, &mut ctx);
     if !rem.trim().is_empty() {
         return None;
     }
@@ -13534,7 +13534,7 @@ fn try_parse_cast_from_tracked_exile_grant(tp: TextPair<'_>) -> Option<ParsedEff
                 let (i, _) = alt((tag("an "), tag("a "), tag("one "))).parse(i)?;
                 // CR 601.2a: the printed type-phrase ("instant or sorcery", a bare
                 // "spell") restricts WHICH exiled cards this single-use grant
-                // authorizes. `parse_type_phrase` maps a bare "spell" → `Card`; a
+                // authorizes. `parse_type_phrase_folding` maps a bare "spell" → `Card`; a
                 // typed phrase ("instant or sorcery") → the `AnyOf` type filter.
                 let (i, filter) = super::oracle_nom::target::parse_type_phrase.parse(i)?;
                 // A typed phrase ("instant or sorcery") is followed by the " spell"
@@ -14826,7 +14826,7 @@ fn balance_clause_effect(verb: EqualizeVerb, filter: TargetFilter) -> Effect {
 /// Force a type-phrase filter's controller clause to "you control" so the
 /// `player_scope` driver scopes it to the iterating player. Balance's "lands
 /// they control" has the "they control" consumed by an outer `tag()`, so the
-/// inner `parse_type_phrase` sees only the bare type word.
+/// inner `parse_type_phrase_folding` sees only the bare type word.
 fn balance_filter_you_control(filter: TargetFilter) -> TargetFilter {
     match filter {
         TargetFilter::Typed(tf) => TargetFilter::Typed(TypedFilter {
@@ -14864,7 +14864,7 @@ fn balance_filter_scoped_player(filter: &TargetFilter) -> TargetFilter {
 /// Arm B — Balance's first sentence: "each player chooses a number of
 /// [type-phrase] they control equal to [min-quantity], then
 /// sacrifices/discards the rest". The verb branch determines the clause type;
-/// the `[type-phrase]` is consumed by the nom-typed `parse_type_phrase`.
+/// the `[type-phrase]` is consumed by the nom-typed `parse_type_phrase_folding`.
 fn parse_balance_arm_b(input: &str) -> OracleResult<'_, (EqualizeVerb, TargetFilter)> {
     let (input, _) = tag("each player chooses a number of ").parse(input)?;
     let (input, filter) = super::oracle_nom::target::parse_type_phrase(input)?;
@@ -17623,7 +17623,7 @@ fn try_parse_verb_and_target<'a>(
 
     // Exile: infer origin zone from the primary target clause the target parser
     // consumed (see the `infer_origin_zone` call below) — NOT the bare remainder
-    // (parse_zone_suffix inside parse_type_phrase strips zone phrases off it) and
+    // (parse_zone_suffix inside parse_type_phrase_folding strips zone phrases off it) and
     // NOT the full post-verb text (a trailing compound conjunct would leak).
     if let Some((_, rest)) = nom_on_lower(text, lower, |i| {
         value((), alt((tag("exile all "), tag("exile each ")))).parse(i)
@@ -24582,10 +24582,10 @@ fn parse_cast_quantifier_prefix(input: &str) -> OracleResult<'_, ()> {
 /// ```
 ///
 /// **Acceptance boundary.** Returns `Some` only when it consumed something
-/// `parse_type_phrase` demonstrably cannot: at least two legs (so a connector
+/// `parse_type_phrase_folding` demonstrably cannot: at least two legs (so a connector
 /// was consumed) OR a leading quantifier. A single leg with no quantifier is
 /// still rejected, exactly as before, so "a creature spell", "an artifact
-/// spell", and "an Aura spell" keep falling through to `parse_type_phrase`
+/// spell", and "an Aura spell" keep falling through to `parse_type_phrase_folding`
 /// byte-for-byte. That predicate, together with the mandatory head noun and the
 /// `separated_list1` (which yields zero legs when the clause opens on the head
 /// noun — "cast a spell from among them"), is the anti-swallow guard that keeps
@@ -24632,7 +24632,7 @@ fn parse_cast_type_list(rest: &str) -> Option<TargetFilter> {
 
     match legs.as_slice() {
         // CR 601.3: one leg with no quantifier is ordinary type-phrase
-        // territory — `parse_type_phrase` already handles it and can carry
+        // territory — `parse_type_phrase_folding` already handles it and can carry
         // controller/property legs this helper never builds. Reject, exactly as
         // before this helper was composed.
         [_single] if quantifier.is_none() => None,
@@ -24684,7 +24684,7 @@ fn cast_gate_names_a_card_type(filter: &TargetFilter) -> bool {
 /// Composes the two existing subject parsers in the same order the
 /// `has_from_among_cards_exiled_with_self` branch already uses:
 /// `parse_cast_type_list` first (it owns the multi-leg / quantified / subtype
-/// grammar `parse_type_phrase` does not), then `parse_type_phrase`.
+/// grammar `parse_type_phrase_folding` does not), then `parse_type_phrase_folding`.
 ///
 /// Returns `None` when the clause names no card type — "cast a spell from among
 /// them" (Aetherworks Marvel, Svella, Apex of Power) grants an unrestricted
@@ -24695,13 +24695,12 @@ fn cast_gate_names_a_card_type(filter: &TargetFilter) -> bool {
 /// colors", Perception Bobblehead's mana-value bound) also yield `None` so this
 /// helper never invents a type gate the Oracle text did not state.
 fn parse_cast_type_gate(rest: &str) -> Option<TargetFilter> {
-    let gate =
-        parse_cast_type_list(rest).or_else(|| {
-            match super::oracle_target::parse_type_phrase(rest).0 {
-                typed @ TargetFilter::Typed(_) => Some(typed),
-                _ => None,
-            }
-        })?;
+    let gate = parse_cast_type_list(rest).or_else(|| {
+        match super::oracle_target::parse_type_phrase_folding(rest).0 {
+            typed @ TargetFilter::Typed(_) => Some(typed),
+            _ => None,
+        }
+    })?;
     cast_gate_names_a_card_type(&gate).then_some(gate)
 }
 
@@ -25218,7 +25217,7 @@ fn ensure_exile_zone_on_cast_target(filter: &mut TargetFilter) {
 /// * `None` — anchor or "exiled this way" suffix not present.
 ///
 /// Composition mirrors `has_from_among_cards_exiled_with_self` (anchor
-/// strip) and `parse_cast_type_list` / `parse_type_phrase` (typed
+/// strip) and `parse_cast_type_list` / `parse_type_phrase_folding` (typed
 /// leg extraction).
 fn parse_from_among_exiled_this_way(rest: &str) -> Option<TargetFilter> {
     type E<'a> = OracleError<'a>;
@@ -25247,10 +25246,10 @@ fn parse_from_among_exiled_this_way(rest: &str) -> Option<TargetFilter> {
     // empty once the head noun is guarded out, so they stay bare.
     //
     // Then the post-article probe ("instant or sorcery cards"), then
-    // `parse_type_phrase` ("nonland cards", "creature cards").
+    // `parse_type_phrase_folding` ("nonland cards", "creature cards").
     let mut typed_filter = parse_cast_type_list(before_anchor)
         .or_else(|| parse_cast_type_list(after_article))
-        .unwrap_or_else(|| super::oracle_target::parse_type_phrase(after_article).0);
+        .unwrap_or_else(|| super::oracle_target::parse_type_phrase_folding(after_article).0);
 
     // "the cards exiled this way" lifts a bare `Typed(Card)` leaf with no
     // further constraint — that's the structural "cards" anchor, not a
@@ -25413,7 +25412,7 @@ fn try_parse_cast_as_though_flash_permission(tp: TextPair<'_>) -> Option<ParsedE
         TargetFilter::Any
     } else {
         let phrase = format!("{type_text_orig} spells");
-        parse_type_phrase(&phrase).0
+        parse_type_phrase_folding(&phrase).0
     };
     if let TargetFilter::Typed(ref mut tf) = spell_filter {
         if tf.controller.is_none() {
@@ -25714,7 +25713,7 @@ fn parse_owned_plus_lesser_exiled_subject(i: &str) -> OracleResult<'_, ()> {
 /// 1. Anaphoric — "cast it", "cast that spell", "cast those cards" — target is
 ///    `ParentTarget` (refers to the cards exiled / chosen by a prior effect).
 /// 2. Constrained — "cast a [type-phrase] [from <zone>] [with mana value <bound>]
-///    without paying its mana cost" — target is built from `parse_type_phrase` +
+///    without paying its mana cost" — target is built from `parse_type_phrase_folding` +
 ///    origin-zone inference. CR 118.9 + CR 601.2a + CR 120.3.
 /// 3. Bare — fallback `TargetFilter::Any`.
 fn try_parse_cast_effect(lower: &str, ctx: &ParseContext) -> Option<Effect> {
@@ -26174,11 +26173,11 @@ fn try_parse_cast_effect(lower: &str, ctx: &ParseContext) -> Option<Effect> {
     // finds it documented rather than discovers it.
     if has_from_among_cards_exiled_with_self(rest) {
         // First try the composed type-list form ("an instant or sorcery
-        // spell ...") since `parse_type_phrase` doesn't handle connectors
-        // between bare core-type words. Then fall back to `parse_type_phrase`
+        // spell ...") since `parse_type_phrase_folding` doesn't handle connectors
+        // between bare core-type words. Then fall back to `parse_type_phrase_folding`
         // for single-type forms.
         let mut typed_filter = parse_cast_type_list(rest)
-            .unwrap_or_else(|| super::oracle_target::parse_type_phrase(rest).0);
+            .unwrap_or_else(|| super::oracle_target::parse_type_phrase_folding(rest).0);
         let target = match typed_filter {
             TargetFilter::Typed(_) | TargetFilter::Or { .. } => {
                 // CR 406.1: source-linked exiled cards live in the Exile zone.
@@ -26270,15 +26269,15 @@ fn try_parse_cast_effect(lower: &str, ctx: &ParseContext) -> Option<Effect> {
     // Branch 2: constrained-filter form (Buster Sword, FIN equipment cycle).
     // CR 118.9 + CR 601.2a: "cast a <filter> spell [from <zone>] [with mana
     // value <bound>] without paying its mana cost" — extract the constraint
-    // by composing `parse_type_phrase` (handles "a [type-phrase]") with
+    // by composing `parse_type_phrase_folding` (handles "a [type-phrase]") with
     // origin-zone inference and a `with mana value` suffix scan over the
-    // remainder. The suffix scan is necessary because `parse_type_phrase`'s
+    // remainder. The suffix scan is necessary because `parse_type_phrase_folding`'s
     // own internal `parse_mana_value_suffix` call runs before `parse_zone_suffix`,
     // so for inputs of the form "spell from your hand with mana value ..."
     // the mana-value clause is past the type-phrase pos when reached.
     let cast_target_rest = strip_cast_target_prefix(rest);
     let mut filter = parse_cast_type_list(rest)
-        .unwrap_or_else(|| super::oracle_target::parse_type_phrase(cast_target_rest).0);
+        .unwrap_or_else(|| super::oracle_target::parse_type_phrase_folding(cast_target_rest).0);
     if cast_filter_has_typed_leaf(&filter) {
         apply_cast_target_suffixes(&mut filter, rest);
         let alt_ability_cost = parse_alt_ability_cost_rider(lower);
@@ -28099,7 +28098,7 @@ fn refine_damage_target_remainder(target: TargetFilter, remainder: &str) -> (Tar
     }
     // "or <target>" — expand target to union: "creature or planeswalker",
     // "creature or blocking creature", "~ or enchanted creature", etc.
-    // Uses parse_target (not parse_type_phrase) to handle special patterns
+    // Uses parse_target (not parse_type_phrase_folding) to handle special patterns
     // like "enchanted creature" that aren't plain type phrases.
     if let Ok((after_or, _)) = tag::<_, _, OracleError<'_>>("or ").parse(trimmed) {
         let (additional, type_rem) = parse_target(after_or);
@@ -28241,7 +28240,7 @@ fn parse_choose_filter(lower: &str, ctx: &mut ParseContext) -> TargetFilter {
 
     // Try full type phrase parsing first — handles compound patterns like
     // "green or white creature", "nonland permanent", "spirit or arcane"
-    let (phrase_filter, phrase_rem) = parse_type_phrase(cleaned);
+    let (phrase_filter, phrase_rem) = parse_type_phrase_folding(cleaned);
     if !matches!(phrase_filter, TargetFilter::Any) && phrase_rem.trim().is_empty() {
         return phrase_filter;
     }
@@ -31780,7 +31779,7 @@ pub(crate) fn parse_each_player_copy_chosen_ir(
     ))
     .parse(i)
     .ok()?;
-    let (choose_filter, noun_rest) = parse_type_phrase(noun);
+    let (choose_filter, noun_rest) = parse_type_phrase_folding(noun);
     if !noun_rest.trim().is_empty() {
         return None;
     }
@@ -32572,11 +32571,11 @@ fn parse_exile_pile_shuffle_cloak_ir(
         return None;
     }
 
-    // Parse the filter phrase in its original case — `parse_type_phrase` folds
+    // Parse the filter phrase in its original case — `parse_type_phrase_folding` folds
     // "you control" into `ControllerRef::You` and "with disguise" into
     // `FilterProp::HasKeywordKind { Disguise }`. Require a full, non-`None` parse
     // so a partial match falls through to the generic pipeline.
-    let (filter, filter_rem) = parse_type_phrase(filter_tp.original.trim());
+    let (filter, filter_rem) = parse_type_phrase_folding(filter_tp.original.trim());
     if matches!(filter, TargetFilter::None) || !filter_rem.trim().is_empty() {
         return None;
     }
@@ -39207,7 +39206,7 @@ fn try_parse_change_targets(lower: &str) -> Option<Effect> {
     // Strip "with a single target" qualifier before parsing the type.
     let has_single_target = scan_contains_phrase(spell_phrase, "with a single target");
     // CR 115.9c: "that targets only [X]" is handled by parse_that_clause_suffix via
-    // parse_type_phrase, producing FilterProp::TargetsOnly — no manual stripping needed.
+    // parse_type_phrase_folding, producing FilterProp::TargetsOnly — no manual stripping needed.
     let spell_phrase_clean = spell_phrase.replace(" with a single target", "");
     let spell_phrase_clean = spell_phrase_clean.trim();
 

--- a/crates/engine/src/parser/oracle_effect/search.rs
+++ b/crates/engine/src/parser/oracle_effect/search.rs
@@ -14,7 +14,7 @@ use super::super::oracle_nom::quantity as nom_quantity;
 use super::super::oracle_quantity;
 use super::super::oracle_target::{
     distribute_properties_to_or, parse_mana_value_suffix, parse_shared_quality_clause,
-    parse_target, parse_type_phrase, parse_zone_word,
+    parse_target, parse_type_phrase_folding, parse_zone_word,
 };
 use super::super::oracle_util::{
     contains_possessive, infer_core_type_for_subtype, split_around, strip_after,
@@ -799,7 +799,7 @@ pub(crate) fn parse_search_filter(text: &str, ctx: &mut ParseContext) -> TargetF
         return filter;
     }
 
-    let (parsed_filter, remainder) = parse_type_phrase(type_text);
+    let (parsed_filter, remainder) = parse_type_phrase_folding(type_text);
     if search_filter_has_meaningful_content(&parsed_filter) {
         let mut suffix = SearchSuffixConstraints::default();
         let linked_reference = last_shared_quality_reference_in_filter(&parsed_filter);
@@ -1579,7 +1579,7 @@ fn parse_search_specialized_type_word(type_word: &str, ctx: &mut ParseContext) -
         return TargetFilter::Typed(TypedFilter::default().subtype(capitalize(type_word)));
     }
 
-    let (filter, _) = parse_type_phrase(type_word);
+    let (filter, _) = parse_type_phrase_folding(type_word);
     if !matches!(filter, TargetFilter::Any) {
         return filter;
     }
@@ -1812,7 +1812,7 @@ fn parse_search_type_negation_suffix(
         tag("that are not "),
     ))
     .parse(input)?;
-    let (filter, rest) = parse_type_phrase(rest);
+    let (filter, rest) = parse_type_phrase_folding(rest);
     let Some(negated_type) = single_search_type_filter(filter) else {
         return Err(nom::Err::Error(OracleError::new(
             input,
@@ -1889,7 +1889,7 @@ pub(crate) fn parse_search_name_reference_suffix(
         ));
     }
 
-    let (reference, rest) = parse_type_phrase(rest);
+    let (reference, rest) = parse_type_phrase_folding(rest);
     if !search_filter_has_meaningful_content(&reference) {
         return Err(nom::Err::Error(OracleError::new(
             input,
@@ -2275,8 +2275,8 @@ fn parse_search_filter_suffixes(
     while !remaining.is_empty() {
         remaining = remaining.trim_start();
 
-        // Consume redundant "card(s)" re-declaration left by parse_type_phrase.
-        // parse_type_phrase extracts only the type word (e.g. "creature"), so the
+        // Consume redundant "card(s)" re-declaration left by parse_type_phrase_folding.
+        // parse_type_phrase_folding extracts only the type word (e.g. "creature"), so the
         // literal " card" / " cards" token remains and carries no filter meaning.
         if let Ok((rest, _)) = tag::<_, _, OracleError<'_>>("cards").parse(remaining) {
             remaining = rest.trim_start();
@@ -2622,7 +2622,7 @@ fn parse_search_enchant_keyword_suffix(
     let (target, remainder) = {
         let (target, remainder) = parse_target(target_text.trim());
         if matches!(target, TargetFilter::Any) {
-            parse_type_phrase(target_text.trim())
+            parse_type_phrase_folding(target_text.trim())
         } else {
             (target, remainder)
         }
@@ -3230,7 +3230,7 @@ mod tests {
     fn action_chain_continuation_does_not_warn() {
         // Regression: filter parser must not emit "search-filter-suffix unmatched"
         // for legitimate action-chain continuations. The filter is already
-        // extracted by parse_type_phrase; what follows the filter clause
+        // extracted by parse_type_phrase_folding; what follows the filter clause
         // (", put it onto the battlefield, then shuffle") is handled by the
         // downstream sequence parser — not a filter-suffix gap.
         for text in [

--- a/crates/engine/src/parser/oracle_effect/sequence.rs
+++ b/crates/engine/src/parser/oracle_effect/sequence.rs
@@ -12,7 +12,7 @@ use super::super::oracle_nom::enters_under::{
 };
 use super::super::oracle_nom::primitives as nom_primitives;
 use super::super::oracle_nom::primitives::parse_keyword_name;
-use super::super::oracle_target::{parse_target, parse_target_with_ctx, parse_type_phrase};
+use super::super::oracle_target::{parse_target, parse_target_with_ctx, parse_type_phrase_folding};
 use super::super::oracle_util::{contains_possessive, parse_count_expr, parse_ordinal, TextPair};
 use super::{apply_where_x_to_filter, strip_trailing_where_x};
 use crate::parser::oracle_ir::ast::*;
@@ -7230,11 +7230,11 @@ fn parse_change_zone_enters_tapped_attacking(
     if !recognized {
         return None;
     }
-    // N-D: materialize TargetFilter::Typed via parse_type_phrase on the type
+    // N-D: materialize TargetFilter::Typed via parse_type_phrase_folding on the type
     // tail — RevealedHasCardType carries no TargetFilter, so reuse the canonical
     // materializer rather than reconstructing from the recognized condition.
     let type_tail = strip_moved_object_subject(condition_clause)?;
-    let (filter, leftover) = crate::parser::oracle_target::parse_type_phrase(type_tail);
+    let (filter, leftover) = crate::parser::oracle_target::parse_type_phrase_folding(type_tail);
     if matches!(filter, TargetFilter::Any | TargetFilter::None) || !leftover.trim().is_empty() {
         return None;
     }
@@ -7249,7 +7249,7 @@ fn parse_change_zone_enters_tapped_attacking(
 /// (Summoner's Grimoire). Shared with the `Condition_If` swallow detector so the
 /// represented clause can be located and stripped text-scoped, reusing the same
 /// leading-condition combinators (`strip_moved_object_subject` +
-/// `parse_type_phrase`) that `parse_change_zone_enters_tapped_attacking` uses —
+/// `parse_type_phrase_folding`) that `parse_change_zone_enters_tapped_attacking` uses —
 /// not a verbatim Oracle-string match.
 pub(crate) fn is_moved_object_enters_modifier_clause(sentence: &str) -> bool {
     let lower = sentence.to_lowercase();
@@ -7265,7 +7265,7 @@ pub(crate) fn is_moved_object_enters_modifier_clause(sentence: &str) -> bool {
     let Some(type_tail) = strip_moved_object_subject(after_if) else {
         return false;
     };
-    let (filter, _leftover) = crate::parser::oracle_target::parse_type_phrase(type_tail);
+    let (filter, _leftover) = crate::parser::oracle_target::parse_type_phrase_folding(type_tail);
     !matches!(filter, TargetFilter::Any | TargetFilter::None)
 }
 
@@ -8837,7 +8837,7 @@ pub(super) fn try_parse_repeat_process_for_keywords(text: &str) -> Option<Vec<Ke
 /// class ("do the same for <type>"), not Estrid alone.
 ///
 /// Combinators only: `opt`/`tag`/`alt` for the prefix, then the shared
-/// `parse_type_phrase` for the filter. Requires the phrase to be fully consumed
+/// `parse_type_phrase_folding` for the filter. Requires the phrase to be fully consumed
 /// (modulo a trailing period) by a non-empty typed filter, so unrelated
 /// "do/repeat …" tails fall through to normal dispatch rather than being
 /// swallowed.
@@ -8848,7 +8848,7 @@ pub(super) fn try_parse_do_the_same_for_type(text: &str) -> Option<Vec<TypeFilte
         let (i, _) = tag::<_, _, OracleError<'_>>("do the same for ").parse(i)?;
         Ok((i, ()))
     })?;
-    let (filter, remainder) = parse_type_phrase(rest.trim().trim_end_matches('.').trim());
+    let (filter, remainder) = parse_type_phrase_folding(rest.trim().trim_end_matches('.').trim());
     if !remainder.trim().trim_end_matches('.').trim().is_empty() {
         return None;
     }
@@ -8876,7 +8876,7 @@ fn starts_do_the_same_for_type_before_then(text: &str) -> bool {
     .parse(lower.as_str()) else {
         return false;
     };
-    let (filter, remainder) = parse_type_phrase(type_text.trim());
+    let (filter, remainder) = parse_type_phrase_folding(type_text.trim());
     remainder.trim().is_empty() && pure_type_substitution(filter).is_some()
 }
 
@@ -11914,7 +11914,7 @@ mod tests {
     /// milled artifact (e.g. an Equipment, an artifact land) be moved to hand.
     ///
     /// End-to-end guard: the building-block fix lives in
-    /// `parse_type_phrase_with_ctx` (`oracle_target.rs`); this test pins the
+    /// `parse_type_phrase_folding_with_ctx` (`oracle_target.rs`); this test pins the
     /// full Oracle-text → typed-AST contract for the milled-card retrieval
     /// path so future refactors to the dig-from-among lowering can't silently
     /// regress the AND-of-types semantics.

--- a/crates/engine/src/parser/oracle_effect/subject.rs
+++ b/crates/engine/src/parser/oracle_effect/subject.rs
@@ -41,7 +41,8 @@ use super::super::oracle_static::{
     parse_static_line_multi, peel_compound_all_quantified_conjuncts,
 };
 use super::super::oracle_target::{
-    parse_target, parse_target_with_ctx, parse_target_with_syntax, parse_type_phrase, TargetSyntax,
+    parse_target, parse_target_with_ctx, parse_target_with_syntax, parse_type_phrase_folding,
+    TargetSyntax,
 };
 use super::super::oracle_util::{
     merge_or_filters, parse_number, TextPair, SELF_REF_PARSE_ONLY_PHRASES, SELF_REF_TYPE_PHRASES,
@@ -2736,7 +2737,7 @@ pub(super) fn parse_subject_application(
     {
         let consumed = lower.len() - rest_lower.len();
         let phrase = &subject[consumed..];
-        let (filter, rest) = parse_type_phrase(phrase);
+        let (filter, rest) = parse_type_phrase_folding(phrase);
         let filter = merge_partial_type_phrase_filter(filter, rest.trim());
         return subject_filter_application(filter, false);
     }
@@ -3361,7 +3362,7 @@ pub(super) fn parse_subject_application(
     {
         let consumed = lower.len() - rest_subject.len();
         let original_rest = &subject[consumed..];
-        let (filter, rem) = parse_type_phrase(original_rest);
+        let (filter, rem) = parse_type_phrase_folding(original_rest);
         if rem.trim().is_empty() && !matches!(filter, TargetFilter::Any) {
             return Some(SubjectApplication {
                 affected: TargetFilter::ParentTarget,
@@ -3382,7 +3383,7 @@ pub(super) fn parse_subject_application(
         // the remainder as a type phrase. Covers all "that [type]" patterns generically.
         let consumed = lower.len() - rest_subject.len();
         let original_rest = &subject[consumed..];
-        let (filter, rem) = parse_type_phrase(original_rest);
+        let (filter, rem) = parse_type_phrase_folding(original_rest);
         if rem.trim().is_empty() && !matches!(filter, TargetFilter::Any) {
             // CR 608.2k + CR 608.2c: Inside a trigger effect, "that [type]" is an
             // anaphoric back-reference to the triggering event's subject object (the
@@ -3411,7 +3412,7 @@ pub(super) fn parse_subject_application(
         }
     }
 
-    let (filter, rest) = parse_type_phrase(subject);
+    let (filter, rest) = parse_type_phrase_folding(subject);
     if rest.trim().is_empty() {
         return subject_filter_application(filter, false);
     }
@@ -3916,7 +3917,7 @@ fn merge_partial_type_phrase_filter(filter: TargetFilter, remainder: &str) -> Ta
     let TargetFilter::Typed(mut left) = filter else {
         return filter;
     };
-    let (suffix_filter, suffix_remainder) = parse_type_phrase(remainder);
+    let (suffix_filter, suffix_remainder) = parse_type_phrase_folding(remainder);
     let TargetFilter::Typed(right) = suffix_filter else {
         return TargetFilter::Typed(left);
     };
@@ -6067,12 +6068,12 @@ pub(crate) fn parse_restriction_modes(lower: &str) -> Option<Vec<StaticMode>> {
         // CR 105.4 + CR 608.2c (issue #327): Try the "of the chosen / of that"
         // qualifier parser first so "creatures of that color" lowers to a
         // typed filter with `FilterProp::IsChosenColor`. The plain
-        // `parse_type_phrase` would silently drop the trailing qualifier and
+        // `parse_type_phrase_folding` would silently drop the trailing qualifier and
         // leave the filter as a bare-creature match, making the restriction
         // accept ALL creatures rather than only those of the chosen color.
         let filter_tp = TextPair::new(filter_text, filter_text);
         let filter = parse_chosen_qualifier_subject(&filter_tp).unwrap_or_else(|| {
-            let (f, _) = parse_type_phrase(filter_text);
+            let (f, _) = parse_type_phrase_folding(filter_text);
             f
         });
         if !matches!(filter, TargetFilter::Any) {

--- a/crates/engine/src/parser/oracle_effect/tests.rs
+++ b/crates/engine/src/parser/oracle_effect/tests.rs
@@ -34739,7 +34739,7 @@ fn effect_from_the_rubble_chosen_type_graveyard_target() {
 
 /// CR 115.2: An already zone-qualified reanimation target ("return target
 /// creature card from your graveyard to the battlefield") must NOT be
-/// re-scoped by the inferred-origin pass. `parse_type_phrase` already parses
+/// re-scoped by the inferred-origin pass. `parse_type_phrase_folding` already parses
 /// "from your graveyard" into `InZone { Graveyard }` plus a single owner
 /// scope on the filter's `controller` field, so the candidate filter must
 /// carry exactly one owner-`You` scope — guarding against the 905-card
@@ -35645,7 +35645,7 @@ fn passive_cant_be_cast_single_clause_has_no_land_sub_ability() {
 }
 
 /// Pattern-coverage companion: the land-play axis is not limited to "chosen
-/// name" — `parse_type_phrase` resolves any type-phrase subject, so a
+/// name" — `parse_type_phrase_folding` resolves any type-phrase subject, so a
 /// hypothetical type-scoped land-play ban parses the same way (building for
 /// the class, not the single card).
 #[test]
@@ -54853,7 +54853,7 @@ fn ogre_geargrabber_lose_control_stays_unimplemented() {
 /// regardless of its individual disguise cost.
 #[test]
 fn parse_type_phrase_creatures_you_control_with_disguise() {
-    let (filter, rem) = parse_type_phrase("creatures you control with disguise");
+    let (filter, rem) = parse_type_phrase_folding("creatures you control with disguise");
     assert!(
         rem.trim().is_empty(),
         "must fully consume, leftover: {rem:?}"
@@ -59141,7 +59141,7 @@ fn nested_chosen_color_is_seen_at_every_depth_of_the_filter_closure() {
 /// That `false` is a DATED POOL CENSUS, not a structural property, and the
 /// distinction matters enough to spell out. `FilterProp::IsChosenColor` is
 /// stamped by the printed-qualifier arm inside the GENERAL type-phrase parser
-/// (`parser/oracle_target.rs` `parse_type_phrase_with_ctx`), gated only on
+/// (`parser/oracle_target.rs` `parse_type_phrase_folding_with_ctx`), gated only on
 /// `ChosenColorQualifierScope::ChainBound` — which `oracle_effect/mod.rs` sets
 /// for EVERY chunk of EVERY chain. So the grammar does not forbid the prop from
 /// landing in a sibling mass-effect object filter: `ChangeZoneAll`, `PumpAll`,
@@ -59511,7 +59511,7 @@ fn anaphor_color_cards_are_unchanged_by_the_printed_qualifier_arm() {
 ///
 /// The fixture must be MULTI-CLAUSE: a single-clause refusal cannot reach the
 /// guard, because if the clause lowered to `Unimplemented` then
-/// `parse_type_phrase_with_ctx` generally never ran on it, so
+/// `parse_type_phrase_folding_with_ctx` generally never ran on it, so
 /// `printed_color_choice` is `None` and the injector's `Some(_) | None` arm is
 /// taken instead — indistinguishable from the guard firing. That same argument
 /// is why the guard's own negative arm (the CARRIER itself refused, so

--- a/crates/engine/src/parser/oracle_ir/context.rs
+++ b/crates/engine/src/parser/oracle_ir/context.rs
@@ -79,7 +79,7 @@ pub(crate) enum TriggerConditionScope {
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub(crate) enum ChosenColorQualifierScope {
     /// Default, and the value every `ParseContext::default()` carries — which
-    /// is every `parse_type_phrase` call site, by construction of the wrapper
+    /// is every `parse_type_phrase_folding` call site, by construction of the wrapper
     /// in `oracle_target.rs`. The printed form must NOT be consumed here.
     #[default]
     Unbound,

--- a/crates/engine/src/parser/oracle_keyword.rs
+++ b/crates/engine/src/parser/oracle_keyword.rs
@@ -12,7 +12,7 @@ use super::oracle_cost::parse_oracle_cost;
 use super::oracle_nom::primitives as nom_primitives;
 use super::oracle_nom::primitives::{scan_at_word_boundaries, scan_contains, split_once_on};
 use super::oracle_quantity::parse_cda_quantity;
-use super::oracle_target::parse_type_phrase;
+use super::oracle_target::parse_type_phrase_folding;
 use super::oracle_util::{strip_reminder_text, strip_where_x_is_clause};
 use crate::types::ability::{
     AbilityCost, ActivationRestriction, AdditionalCost, ControllerRef, CostObjectCount,
@@ -768,7 +768,7 @@ fn parse_ward_cost_single(lower: &str) -> Option<WardCost> {
                     .or(rest.strip_prefix("an "))
                     .unwrap_or(rest),
             ));
-        let (filter, _) = parse_type_phrase(after_count);
+        let (filter, _) = parse_type_phrase_folding(after_count);
         return Some(WardCost::Sacrifice { count, filter });
     }
 
@@ -1187,7 +1187,7 @@ fn parse_craft_materials(input: &str) -> Option<(&str, (TargetFilter, CostObject
     {
         return None;
     } else {
-        let (filter, rest) = parse_type_phrase(materials_text);
+        let (filter, rest) = parse_type_phrase_folding(materials_text);
         if !rest.trim().is_empty() {
             return None;
         }
@@ -1990,7 +1990,7 @@ fn parse_emerge_from_quality_keyword_line(text: &str) -> Option<(Keyword, &str)>
     let (after_prefix, _) = tag::<_, _, OracleError<'_>>("emerge from ")
         .parse(text)
         .ok()?;
-    let (sacrifice_filter, after_quality) = parse_type_phrase(after_prefix);
+    let (sacrifice_filter, after_quality) = parse_type_phrase_folding(after_prefix);
     if after_quality.len() == after_prefix.len() {
         return None;
     }
@@ -6048,7 +6048,7 @@ mod router_registry_tests {
         // "Champion an Elf", "Splice onto Arcane {G}", "Craft with Cave {5}{G}",
         // bare "Partner", "Bloodthirst 1" — so the mana-cost combinator cannot
         // measure where the parameter ends, and each needs its own
-        // remainder-preserving noun/filter sub-parser (`parse_type_phrase` already
+        // remainder-preserving noun/filter sub-parser (`parse_type_phrase_folding` already
         // returns a remainder and is the obvious substrate).
         //
         // Pinned as an EXACT set so the gate still bites: a NEW leaking family, or a

--- a/crates/engine/src/parser/oracle_nom/condition.rs
+++ b/crates/engine/src/parser/oracle_nom/condition.rs
@@ -22,7 +22,7 @@ use super::primitives::{
 use super::quantity as nom_quantity;
 use super::target as nom_target;
 use crate::parser::oracle_target::{
-    cast_capable_zones_except, parse_shared_quality, parse_type_phrase, parse_zone_suffix,
+    cast_capable_zones_except, parse_shared_quality, parse_type_phrase_folding, parse_zone_suffix,
     parse_zone_word, peek_zone_boundary, superlative_property_filter_prop,
 };
 use crate::parser::oracle_util::parse_subtype;
@@ -493,10 +493,10 @@ fn parse_damage_dealt_this_turn_conditions(input: &str) -> OracleResult<'_, Stat
     .parse(input)
 }
 
-/// Wrapper around `parse_type_phrase` that fails (nom error) when the result is
+/// Wrapper around `parse_type_phrase_folding` that fails (nom error) when the result is
 /// `TargetFilter::Any`, used as a nom-compatible parser combinator.
 fn parse_type_phrase_nonempty(input: &str) -> OracleResult<'_, TargetFilter> {
-    let (filter, rest) = parse_type_phrase(input);
+    let (filter, rest) = parse_type_phrase_folding(input);
     if matches!(filter, TargetFilter::Any) {
         return Err(nom::Err::Error(nom::error::Error::new(
             input,
@@ -519,7 +519,7 @@ fn parse_type_phrase_nonempty(input: &str) -> OracleResult<'_, TargetFilter> {
 ///     to the one creature/permanent this trigger's damage went to.
 ///   - "a creature", "a permanent", etc. — bare indefinite references that stay
 ///     a generic type-phrase filter (the demonstrative binding does not apply).
-///   - Any `parse_type_phrase` result (e.g. "a creature or planeswalker an
+///   - Any `parse_type_phrase_folding` result (e.g. "a creature or planeswalker an
 ///     opponent controlled" from Rith, Liberated Primeval).
 ///
 /// All forms map to `DamageDealtThisTurn { source: Any, target: <filter>,
@@ -543,7 +543,7 @@ fn parse_subject_was_dealt_excess_damage_this_turn(
         ),
         value(TargetFilter::EventTarget, tag("that permanent")),
         // Bare article form: "a creature or planeswalker an opponent controlled"
-        // (Rith), "a creature", "a permanent", etc. Delegate to parse_type_phrase
+        // (Rith), "a creature", "a permanent", etc. Delegate to parse_type_phrase_folding
         // which handles "a/an <type>", "a/an <type> <controller-suffix>",
         // and compound "a <type> or <type>" forms.
         parse_type_phrase_nonempty,
@@ -619,7 +619,7 @@ fn parse_player_was_dealt_damage_threshold_this_turn(
 /// satisfied when at least one recipient matching the subject was dealt combat
 /// damage this turn by a source matching the `by` filter.
 ///
-/// Builds for the class — the source is parsed by `parse_type_phrase`, so any
+/// Builds for the class — the source is parsed by `parse_type_phrase_folding`, so any
 /// "by a <creature type / creature / permanent>" qualifier is covered, and the
 /// subject covers both "a player" and "an opponent" recipients. The resulting
 /// `QuantityRef::DamageDealtThisTurn` carries `damage_kind: CombatOnly`
@@ -641,7 +641,7 @@ fn parse_player_dealt_combat_damage_by_source_this_turn(
     .parse(input)?;
     let (rest, _) = tag(" was dealt combat damage by ").parse(rest)?;
     // CR 608.2i: the `by` source qualifier — "a Zombie", "a creature", etc.
-    let (source, after_source) = parse_type_phrase(rest);
+    let (source, after_source) = parse_type_phrase_folding(rest);
     if matches!(source, TargetFilter::Any) {
         return Err(nom::Err::Error(nom::error::Error::new(
             input,
@@ -896,7 +896,7 @@ fn parse_control_named_pair(input: &str) -> OracleResult<'_, StaticCondition> {
     let (after_named, type_text) = take_until(" named ").parse(rest)?;
     let (after_named, _) = tag(" named ").parse(after_named)?;
     let filter_base = parse_control_named_type_filter(type_text, input)?;
-    // Strip any FilterProp::Named that parse_type_phrase may have attached so the
+    // Strip any FilterProp::Named that parse_type_phrase_folding may have attached so the
     // synthesized per-name conjuncts carry exactly one Named property each.
     let filter_base = strip_filter_named_property(filter_base);
     let (rest_after_pair, (filters, connector)) =
@@ -926,7 +926,7 @@ fn parse_control_named_type_filter<'a>(
     type_text: &'a str,
     error_input: &'a str,
 ) -> Result<TargetFilter, nom::Err<OracleError<'a>>> {
-    let (filter, type_remainder) = parse_type_phrase(type_text);
+    let (filter, type_remainder) = parse_type_phrase_folding(type_text);
     if matches!(filter, TargetFilter::Any) || !type_remainder.trim().is_empty() {
         return Err(nom::Err::Error(nom::error::Error::new(
             error_input,
@@ -1284,7 +1284,7 @@ fn strip_filter_named_property(filter: TargetFilter) -> TargetFilter {
 fn parse_control_presence_tail(input: &str) -> OracleResult<'_, StaticCondition> {
     let _ = alt((parse_article, value((), tag("another ")))).parse(input)?;
 
-    let (filter, remainder) = parse_type_phrase(input);
+    let (filter, remainder) = parse_type_phrase_folding(input);
     if matches!(filter, TargetFilter::Any) {
         return Err(nom::Err::Error(nom::error::Error::new(
             input,
@@ -1633,7 +1633,7 @@ fn merge_attached_predicate_filter(
 /// the result into the subject filter) and the anaphoric "it" recipient path
 /// (`parse_recipient_is_filter_condition`, which uses the bare filter directly as
 /// the recipient match). Uses the same color / legendary-basic supertype /
-/// `parse_type_phrase` recognition the attached path historically used, so the
+/// `parse_type_phrase_folding` recognition the attached path historically used, so the
 /// downstream merged output is preserved byte-for-byte.
 fn parse_bare_predicate_tail(input: &str) -> OracleResult<'_, TargetFilter> {
     let (rest, _) = opt(parse_article).parse(input)?;
@@ -1670,7 +1670,7 @@ fn parse_bare_predicate_tail(input: &str) -> OracleResult<'_, TargetFilter> {
         }
     }
 
-    let (filter, remainder) = parse_type_phrase(rest);
+    let (filter, remainder) = parse_type_phrase_folding(rest);
     if remainder.len() == rest.len() {
         return Err(nom::Err::Error(nom::error::Error::new(
             input,
@@ -1770,7 +1770,7 @@ fn parse_top_of_library_condition(input: &str) -> OracleResult<'_, StaticConditi
     }
     // Fold any disjunction into a single gate over an `Or` *filter* (the runtime
     // `matches_target_filter` handles `TargetFilter::Or`). The common "X or Y
-    // card" form is already one `Or` filter (parse_type_phrase folds it); an
+    // card" form is already one `Or` filter (parse_type_phrase_folding folds it); an
     // article-delimited "a X or a Y" would yield multiple filters, which we wrap
     // here so the result is always one `TopOfLibraryMatches`.
     let filter = if filters.len() > 1 {
@@ -2548,7 +2548,7 @@ fn parse_source_is_type(input: &str) -> OracleResult<'_, StaticCondition> {
     ))
     .parse(rest)?;
     let (rest, _) = parse_article(rest)?;
-    let (filter, remainder) = parse_type_phrase(rest);
+    let (filter, remainder) = parse_type_phrase_folding(rest);
     let condition = StaticCondition::SourceMatchesFilter { filter };
     let condition = if negated {
         StaticCondition::Not {
@@ -3042,10 +3042,10 @@ fn parse_subject_property_inequality_form(input: &str) -> OracleResult<'_, Stati
     let (rest, (comparator, aggregate)) = parse_superlative_comparator_phrase(rest)?;
     // Aggregate scope: "each other <type>'s <prop>" / "every other <type>'s <prop>".
     let (rest, _) = alt((tag("each other "), tag("every other "))).parse(rest)?;
-    // <type> phrase. parse_type_phrase consumes "creature", "creature you
+    // <type> phrase. parse_type_phrase_folding consumes "creature", "creature you
     // control", etc. — without the "other" prefix (already stripped above so
     // we control the exclusion semantics through OtherThanTriggerObject).
-    let (filter, remainder) = parse_type_phrase(rest);
+    let (filter, remainder) = parse_type_phrase_folding(rest);
     if matches!(filter, TargetFilter::Any) {
         return Err(nom::Err::Error(nom::error::Error::new(
             input,
@@ -3088,7 +3088,7 @@ fn parse_subject_has_superlative_form(input: &str) -> OracleResult<'_, StaticCon
     let (rest, comparator) = parse_optional_tied_for_tail(rest, aggregate, property)?;
     // " among <filter>".
     let (rest, _) = tag(" among ").parse(rest)?;
-    let (filter, remainder) = parse_type_phrase(rest);
+    let (filter, remainder) = parse_type_phrase_folding(rest);
     if matches!(filter, TargetFilter::Any) {
         return Err(nom::Err::Error(nom::error::Error::new(
             input,
@@ -3213,7 +3213,7 @@ fn parse_you_control_superlative_object_condition(
     // reinterpret a partially consumed superlative as a weaker condition.
     let (rest, (object_filter, population_filter)) = cut(|rest| {
         // CR 109.2 + CR 109.4: `you control` describes a battlefield permanent,
-        // not an off-battlefield "card" or a stack "spell". `parse_type_phrase`
+        // not an off-battlefield "card" or a stack "spell". `parse_type_phrase_folding`
         // intentionally consumes those terminal nouns in other contexts, so
         // reject them before delegating the candidate noun phrase.
         if scan_at_word_boundaries(candidate_text, |word| {
@@ -3227,7 +3227,7 @@ fn parse_you_control_superlative_object_condition(
             return Err(oracle_err(candidate_text));
         }
 
-        let (object_filter, candidate_remainder) = parse_type_phrase(candidate_text);
+        let (object_filter, candidate_remainder) = parse_type_phrase_folding(candidate_text);
         if matches!(object_filter, TargetFilter::Any) || !candidate_remainder.is_empty() {
             return Err(oracle_err(candidate_remainder));
         }
@@ -3242,7 +3242,7 @@ fn parse_you_control_superlative_object_condition(
         let (rest, _) = parse_optional_tied_for_tail(rest, aggregate, property)?;
         let (rest, population_filter) =
             if let Ok((among_rest, _)) = tag::<_, _, OracleError<'_>>(" among ").parse(rest) {
-                let (filter, remainder) = parse_type_phrase(among_rest);
+                let (filter, remainder) = parse_type_phrase_folding(among_rest);
                 if matches!(filter, TargetFilter::Any) {
                     return Err(oracle_err(remainder));
                 }
@@ -3339,7 +3339,7 @@ pub(crate) fn parse_spell_target_has_superlative(
     // property with the leading clause is enforced by the shared combinator.
     let (rest, _) = parse_optional_tied_for_tail(rest, aggregate, property)?;
     let (rest, _) = tag::<_, _, OracleError<'_>>(" among ").parse(rest)?;
-    let (filter, remainder) = parse_type_phrase(rest);
+    let (filter, remainder) = parse_type_phrase_folding(rest);
     if matches!(filter, TargetFilter::Any) {
         return Err(oracle_err(remainder));
     }
@@ -3673,7 +3673,7 @@ fn parse_they_control_count_ge(input: &str) -> OracleResult<'_, StaticCondition>
     let (rest, _) = tag("they control ").parse(input)?;
     let (rest, n) = parse_ge_threshold(rest)?;
     let type_text = rest.trim_end_matches('.');
-    let (filter, remainder) = parse_type_phrase(type_text);
+    let (filter, remainder) = parse_type_phrase_folding(type_text);
     if matches!(filter, TargetFilter::Any) {
         return Err(nom::Err::Error(nom::error::Error::new(
             input,
@@ -4080,7 +4080,7 @@ fn parse_control_count_ge_distinct_quality(input: &str) -> OracleResult<'_, Stat
     let (rest, _) = tag("you control ").parse(input)?;
     let (rest, n) = parse_ge_threshold(rest)?;
     let type_text = rest.trim_end_matches('.');
-    let (filter, remainder) = parse_type_phrase(type_text);
+    let (filter, remainder) = parse_type_phrase_folding(type_text);
     if matches!(filter, TargetFilter::Any) {
         return Err(nom::Err::Error(nom::error::Error::new(
             input,
@@ -4114,7 +4114,7 @@ fn parse_control_count_ge_distinct_quality(input: &str) -> OracleResult<'_, Stat
 }
 
 /// Lift a GROUP shared-quality marker out of a filter produced by
-/// `parse_type_phrase`, returning its quality and removing the property.
+/// `parse_type_phrase_folding`, returning its quality and removing the property.
 ///
 /// `FilterProp::SharesQuality { reference: None }` is a GROUP-SELECTION
 /// constraint on a chosen candidate set: CR 601.2c is where the player
@@ -4213,7 +4213,7 @@ fn take_group_shared_quality(filter: &mut TargetFilter) -> Option<SharedQuality>
 /// Eternal Glory, Mechanized Production, Chrome Replicator). The two reach this
 /// function differently and so are two branches, not two parsers:
 ///
-///   * **Branch A (relative clause)** — `parse_type_phrase` has ALREADY consumed
+///   * **Branch A (relative clause)** — `parse_type_phrase_folding` has ALREADY consumed
 ///     the clause through `oracle_target::parse_that_clause_suffix`, leaving a
 ///     `FilterProp::SharesQuality` group marker on the filter and an empty
 ///     remainder. `take_group_shared_quality` lifts the marker onto this
@@ -4221,7 +4221,7 @@ fn take_group_shared_quality(filter: &mut TargetFilter) -> Option<SharedQuality>
 ///     `oracle_target::parse_shared_quality_clause` stays the single authority
 ///     for that vocabulary.
 ///   * **Branch B (postmodifier)** — not a `that …` clause, so
-///     `parse_type_phrase` leaves it in the remainder and the quality noun is
+///     `parse_type_phrase_folding` leaves it in the remainder and the quality noun is
 ///     delegated to the same shared authority, `parse_shared_quality`.
 ///
 /// The controller scope is parameterized on `parse_control_scope_prefix`, so
@@ -4244,7 +4244,7 @@ fn parse_control_count_ge_shared_quality(input: &str) -> OracleResult<'_, Static
     let (rest, ctrl) = parse_control_scope_prefix(input)?;
     let (rest, n) = parse_ge_threshold(rest)?;
     let type_text = rest.trim_end_matches('.');
-    let (mut filter, remainder) = parse_type_phrase(type_text);
+    let (mut filter, remainder) = parse_type_phrase_folding(type_text);
     if matches!(filter, TargetFilter::Any) {
         return Err(nom::Err::Error(nom::error::Error::new(
             input,
@@ -4301,7 +4301,7 @@ fn parse_control_count_ge_toughness_gt_power(input: &str) -> OracleResult<'_, St
     let (rest, _) = tag("you control ").parse(input)?;
     let (rest, n) = parse_ge_threshold(rest)?;
     let type_text = rest.trim_end_matches('.');
-    let (filter, remainder) = parse_type_phrase(type_text);
+    let (filter, remainder) = parse_type_phrase_folding(type_text);
     if matches!(filter, TargetFilter::Any) {
         return Err(nom::Err::Error(nom::error::Error::new(
             input,
@@ -4427,7 +4427,7 @@ pub fn parse_control_count_ge(input: &str) -> OracleResult<'_, StaticCondition> 
     let (rest, ctrl) = parse_control_scope_prefix(input)?;
     let (rest, n) = parse_ge_threshold(rest)?;
     let type_text = rest.trim_end_matches('.');
-    let (filter, remainder) = parse_type_phrase(type_text);
+    let (filter, remainder) = parse_type_phrase_folding(type_text);
     if matches!(filter, TargetFilter::Any) {
         return Err(nom::Err::Error(nom::error::Error::new(
             input,
@@ -4435,7 +4435,7 @@ pub fn parse_control_count_ge(input: &str) -> OracleResult<'_, StaticCondition> 
         )));
     }
     let filter = inject_controller(filter, ctrl);
-    // Map remainder back to original input slice — parse_type_phrase consumed
+    // Map remainder back to original input slice — parse_type_phrase_folding consumed
     // from a potentially trimmed copy, so use pointer arithmetic to get the
     // correct byte offset (remainder.len() would be wrong if trailing chars
     // were stripped by trim_end_matches).
@@ -4458,7 +4458,7 @@ pub fn parse_control_count_ge(input: &str) -> OracleResult<'_, StaticCondition> 
 /// cost reductions (bare "a creature is attacking you"), and the filtered Trap
 /// cycle's alternative costs — Nemesis Trap ("a white creature is attacking"),
 /// Slingbow Trap ("a black creature with flying is attacking"). The qualifier
-/// is delegated to `parse_type_phrase` (mirrors `parse_creature_has_keyword`)
+/// is delegated to `parse_type_phrase_folding` (mirrors `parse_creature_has_keyword`)
 /// so the whole class of attacker filters is covered by one combinator rather
 /// than the former bare-only literal. Lowers to `IsPresent` over the filter
 /// with `FilterProp::Attacking { defender }` appended — the same property
@@ -4469,7 +4469,7 @@ fn parse_filtered_creature_is_attacking(input: &str) -> OracleResult<'_, StaticC
     // "enchanted creature", "enchanted artifact", "enchanted land", "equipped
     // creature" (see `parse_attached_condition_subject_core`) — is
     // self-referential: the host of THIS Aura/Equipment, not a generic
-    // board-wide filter. `parse_type_phrase` would otherwise happily match
+    // board-wide filter. `parse_type_phrase_folding` would otherwise happily match
     // any of these as a permanent/creature/artifact/land with
     // `FilterProp::EnchantedBy`/`EquippedBy`, silently swapping "is the
     // specific permanent this Aura/Equipment is attached to attacking" for
@@ -4484,7 +4484,7 @@ fn parse_filtered_creature_is_attacking(input: &str) -> OracleResult<'_, StaticC
         return Err(oracle_err(input));
     }
     let (rest, _) = opt(parse_article).parse(input)?;
-    let (filter, remainder) = parse_type_phrase(rest);
+    let (filter, remainder) = parse_type_phrase_folding(rest);
     if matches!(filter, TargetFilter::Any) {
         return Err(oracle_err(input));
     }
@@ -4510,7 +4510,7 @@ fn parse_filtered_creature_is_attacking(input: &str) -> OracleResult<'_, StaticC
 /// state (Charging Hooligan: "If a Rat is attacking, ..."). Complements
 /// `parse_filtered_creature_is_attacking` (which owns the attacking / "attacking
 /// you" defender form): this arm uniquely adds the `is blocking` predicate over
-/// the same type axis (via `parse_type_phrase`, so any subtype/core type works).
+/// the same type axis (via `parse_type_phrase_folding`, so any subtype/core type works).
 /// The attacking case overlaps that combinator and yields the identical
 /// `IsPresent`; it is registered first, so this arm is reached for the blocking form.
 /// No controller restriction — a matching attacker/blocker controlled by any
@@ -4518,9 +4518,9 @@ fn parse_filtered_creature_is_attacking(input: &str) -> OracleResult<'_, StaticC
 /// form ("creatures are attacking"), which `parse_creatures_are_attacking_count_ge`
 /// owns.
 fn parse_a_type_is_in_combat(input: &str) -> OracleResult<'_, StaticCondition> {
-    // Require a singular article; `parse_type_phrase` strips it itself.
+    // Require a singular article; `parse_type_phrase_folding` strips it itself.
     nom::combinator::peek(alt((tag("a "), tag("an "))).map(|_| ())).parse(input)?;
-    let (filter, remainder) = parse_type_phrase(input);
+    let (filter, remainder) = parse_type_phrase_folding(input);
     let TargetFilter::Typed(mut typed) = filter else {
         return Err(oracle_err(input));
     };
@@ -4575,7 +4575,7 @@ fn parse_creatures_are_attacking_count_ge(input: &str) -> OracleResult<'_, Stati
 /// The verb is parameterized over the controller axis: the leading verb phrase
 /// selects `Some(ControllerRef::You)`, `Some(ControllerRef::Opponent)`, or
 /// `None` (any player), and the SAME downstream parse (required article,
-/// `parse_type_phrase`, full-consume) runs for all three. CR 611.3a: this is a
+/// `parse_type_phrase_folding`, full-consume) runs for all three. CR 611.3a: this is a
 /// static "as long as" gate, so the condition is re-evaluated continuously
 /// rather than locked in. CR 109.4: the injected `InZone { Battlefield }`
 /// reflects that only the battlefield (and stack) has a controller, so the
@@ -4600,11 +4600,11 @@ fn parse_you_control_a(input: &str) -> OracleResult<'_, StaticCondition> {
     // count, handled elsewhere). A required combinator (not opt) preserves the
     // hard rejection the previous starts_with guard enforced. `peek` requires
     // the article without consuming it, so the article-inclusive `rest` still
-    // flows to `parse_type_phrase` (which strips "a "/"an " itself and maps
+    // flows to `parse_type_phrase_folding` (which strips "a "/"an " itself and maps
     // "another " to `FilterProp::Another`).
     let (rest, _article) =
         nom::combinator::peek(alt((tag("a "), tag("an "), tag("another ")))).parse(rest)?;
-    let (filter, mut remainder) = parse_type_phrase(rest);
+    let (filter, mut remainder) = parse_type_phrase_folding(rest);
     if matches!(filter, TargetFilter::Any) {
         return Err(nom::Err::Error(nom::error::Error::new(
             input,
@@ -4618,7 +4618,7 @@ fn parse_you_control_a(input: &str) -> OracleResult<'_, StaticCondition> {
     // ("or a Plan") is NOT a standalone control condition, so the top-level
     // `parse_condition_connective` cannot split it; instead a single shared
     // verb governs both type filters. Each additional " or <article> <type>"
-    // segment is folded into a disjunction of presence filters. `parse_type_phrase`
+    // segment is folded into a disjunction of presence filters. `parse_type_phrase_folding`
     // (unchanged) parses each article-led segment; this loop only adds the
     // elided-verb continuation specific to the control-condition grammar, so the
     // recipient/attached `it's X or Y` paths (which DO repeat a parseable RHS)
@@ -4635,7 +4635,7 @@ fn parse_you_control_a(input: &str) -> OracleResult<'_, StaticCondition> {
         else {
             break;
         };
-        let (next_filter, next_remainder) = parse_type_phrase(after_or);
+        let (next_filter, next_remainder) = parse_type_phrase_folding(after_or);
         if matches!(next_filter, TargetFilter::Any) {
             break;
         }
@@ -4672,17 +4672,17 @@ fn parse_you_control_a(input: &str) -> OracleResult<'_, StaticCondition> {
 /// type phrase leads ("a creature you control") and is followed by a `has
 /// <keyword>` predicate, rather than the verb leading ("you control a
 /// creature"). Generalized over every evergreen keyword in the `KEYWORDS`
-/// table and every type phrase `parse_type_phrase` recognizes, so it covers
+/// table and every type phrase `parse_type_phrase_folding` recognizes, so it covers
 /// the whole class of "a/an <permanent> <controller-clause> has <keyword>"
 /// conditions, not one card.
 fn parse_creature_has_keyword(input: &str) -> OracleResult<'_, StaticCondition> {
-    // Optional leading article — `parse_type_phrase` also strips it, but the
+    // Optional leading article — `parse_type_phrase_folding` also strips it, but the
     // article may precede a non-type word, so guard it explicitly first.
     let (rest, _) = opt(parse_article).parse(input)?;
-    // `parse_type_phrase` consumes the type word AND any "you control" /
+    // `parse_type_phrase_folding` consumes the type word AND any "you control" /
     // "an opponent controls" controller suffix, setting `controller` on the
     // returned filter. The remainder begins at the `has <keyword>` predicate.
-    let (filter, remainder) = parse_type_phrase(rest);
+    let (filter, remainder) = parse_type_phrase_folding(rest);
     if matches!(filter, TargetFilter::Any) {
         return Err(nom::Err::Error(nom::error::Error::new(
             input,
@@ -4717,7 +4717,7 @@ fn parse_creature_has_keyword(input: &str) -> OracleResult<'_, StaticCondition> 
 ///     `this card`; "this card" is a parse-only self-reference not yet
 ///     normalized to `~`, so the literal `tag("this card")` arm in that
 ///     combinator is required here).
-///   - `parse_type_phrase` — folds the informational " card" qualifier and the
+///   - `parse_type_phrase_folding` — folds the informational " card" qualifier and the
 ///     attached "in your <zone>" clause into one `TargetFilter` (the same
 ///     grammar shape `parse_card_in_graveyard` relies on).
 ///   - `make_quantity_comparison` — the shared `ObjectCount == N` shape.
@@ -4736,7 +4736,7 @@ fn parse_creature_has_keyword(input: &str) -> OracleResult<'_, StaticCondition> 
 fn parse_source_is_only_type_in_zone(input: &str) -> OracleResult<'_, StaticCondition> {
     let (rest, ()) = parse_source_self_token(input)?;
     let (rest, _) = tag(" is the only ").parse(rest)?;
-    let (filter, remainder) = parse_type_phrase(rest);
+    let (filter, remainder) = parse_type_phrase_folding(rest);
     if matches!(filter, TargetFilter::Any) {
         return Err(nom::Err::Error(nom::error::Error::new(
             input,
@@ -4768,26 +4768,26 @@ fn parse_source_is_only_type_in_zone(input: &str) -> OracleResult<'_, StaticCond
 /// <keyword>" battlefield predicate, the subject's presence is checked in a
 /// graveyard. This is the gate half of a conditional continuous static (CR
 /// 611.3a) whose grant is a keyword ability (CR 702). Generalized over every
-/// type phrase `parse_type_phrase` recognizes and every keyword its "with
+/// type phrase `parse_type_phrase_folding` recognizes and every keyword its "with
 /// <keyword>" suffix folds in, so it covers the whole class, not one card:
 ///   - Tarmogoyf: "a land card is in a graveyard" (bare card-type gate)
 ///   - Cairn Wanderer: "a creature card with flying is in a graveyard"
 ///     (card-type + `WithKeyword { Flying }` gate)
 ///
 /// In a graveyard every object is a card, so "creature card" / "land card" is the
-/// card-type filter — `parse_type_phrase` folds the informational " card" suffix
+/// card-type filter — `parse_type_phrase_folding` folds the informational " card" suffix
 /// and the "with <keyword>" suffix, so no bespoke keyword parsing is needed here.
 /// "in a graveyard" is controller-agnostic (any graveyard); no controller is
 /// injected. The `is in a graveyard` suffix is required, so this never mis-claims
 /// a bare "a creature card ..." presence phrase handled elsewhere.
 pub(crate) fn parse_card_in_graveyard(input: &str) -> OracleResult<'_, StaticCondition> {
-    // Optional leading article — `parse_type_phrase` also strips it, but guard it
+    // Optional leading article — `parse_type_phrase_folding` also strips it, but guard it
     // explicitly first to mirror `parse_creature_has_keyword`.
     let (rest, _) = opt(parse_article).parse(input)?;
-    // `parse_type_phrase` consumes the type word, the informational " card"
+    // `parse_type_phrase_folding` consumes the type word, the informational " card"
     // suffix, and any "with <keyword>" clause (folded into the filter as
     // `FilterProp::WithKeyword`). The remainder begins at the presence predicate.
-    let (filter, remainder) = parse_type_phrase(rest);
+    let (filter, remainder) = parse_type_phrase_folding(rest);
     if matches!(filter, TargetFilter::Any) {
         return Err(nom::Err::Error(nom::error::Error::new(
             input,
@@ -4877,11 +4877,11 @@ fn parse_control_count_le(input: &str) -> OracleResult<'_, StaticCondition> {
     let (rest, _) = tag("or fewer ").parse(rest)?;
     // A named-count condition may be followed by an execute clause. Preserve
     // the comma-prefixed clause as the condition remainder before handing the
-    // typed, named phrase to `parse_type_phrase`; otherwise that parser treats
+    // typed, named phrase to `parse_type_phrase_folding`; otherwise that parser treats
     // the effect text as part of the literal card name.
     let (condition_remainder, type_text) = parse_control_named_final_name(rest)?;
     let type_text = type_text.trim_end_matches('.');
-    let (filter, remainder) = parse_type_phrase(type_text);
+    let (filter, remainder) = parse_type_phrase_folding(type_text);
     if matches!(filter, TargetFilter::Any) {
         return Err(nom::Err::Error(nom::error::Error::new(
             input,
@@ -4907,7 +4907,7 @@ fn parse_control_count_eq(input: &str) -> OracleResult<'_, StaticCondition> {
     let (rest, n) = parse_number(rest)?;
     let rest = rest.trim_start();
     let type_text = rest.trim_end_matches('.');
-    let (filter, remainder) = parse_type_phrase(type_text);
+    let (filter, remainder) = parse_type_phrase_folding(type_text);
     if matches!(filter, TargetFilter::Any) {
         return Err(nom::Err::Error(nom::error::Error::new(
             input,
@@ -4925,7 +4925,7 @@ fn parse_control_count_eq(input: &str) -> OracleResult<'_, StaticCondition> {
 /// Parse "you control no [type]" → Not(IsPresent { filter }).
 fn parse_you_control_no(input: &str) -> OracleResult<'_, StaticCondition> {
     let (rest, _) = tag("you control no ").parse(input)?;
-    let (filter, remainder) = parse_type_phrase(rest);
+    let (filter, remainder) = parse_type_phrase_folding(rest);
     if matches!(filter, TargetFilter::Any) {
         return Err(nom::Err::Error(nom::error::Error::new(
             input,
@@ -4955,7 +4955,7 @@ fn parse_no_opponent_controls_a(input: &str) -> OracleResult<'_, StaticCondition
     // Require an article — reject the bare-plural count form ("no opponent
     // controls creatures") exactly as the affirmative control arms do.
     let (rest, _) = parse_article(rest)?;
-    let (filter, remainder) = parse_type_phrase(rest);
+    let (filter, remainder) = parse_type_phrase_folding(rest);
     if matches!(filter, TargetFilter::Any) {
         return Err(nom::Err::Error(nom::error::Error::new(
             input,
@@ -4991,7 +4991,7 @@ fn parse_no_opponent_controls_a(input: &str) -> OracleResult<'_, StaticCondition
 /// control" semantics per iterated player (CR 109.5).
 fn parse_a_player_controls_no(input: &str) -> OracleResult<'_, StaticCondition> {
     let (rest, _) = tag("a player controls no ").parse(input)?;
-    let (filter, remainder) = parse_type_phrase(rest);
+    let (filter, remainder) = parse_type_phrase_folding(rest);
     if matches!(filter, TargetFilter::Any) {
         return Err(nom::Err::Error(nom::error::Error::new(
             input,
@@ -5023,7 +5023,7 @@ fn parse_a_player_controls_no(input: &str) -> OracleResult<'_, StaticCondition> 
 /// Kezzerdrix (creatures).
 fn parse_your_opponents_control_no(input: &str) -> OracleResult<'_, StaticCondition> {
     let (rest, _) = tag("your opponents control no ").parse(input)?;
-    let (filter, remainder) = parse_type_phrase(rest);
+    let (filter, remainder) = parse_type_phrase_folding(rest);
     if matches!(filter, TargetFilter::Any) {
         return Err(nom::Err::Error(nom::error::Error::new(
             input,
@@ -5047,7 +5047,7 @@ fn parse_your_opponents_control_no(input: &str) -> OracleResult<'_, StaticCondit
 fn parse_you_dont_control_a(input: &str) -> OracleResult<'_, StaticCondition> {
     let (rest, _) = tag("you don't control ").parse(input)?;
     let (rest, _) = parse_article(rest)?;
-    let (filter, remainder) = parse_type_phrase(rest);
+    let (filter, remainder) = parse_type_phrase_folding(rest);
     if matches!(filter, TargetFilter::Any) {
         return Err(nom::Err::Error(nom::error::Error::new(
             input,
@@ -5078,7 +5078,7 @@ fn parse_you_dont_control_a(input: &str) -> OracleResult<'_, StaticCondition> {
 /// the building block extends to any "<filter> have total <property> N or X"
 /// phrase.
 ///
-/// The `filter` subject reuses `parse_type_phrase`, so any subject-controller
+/// The `filter` subject reuses `parse_type_phrase_folding`, so any subject-controller
 /// combination it understands ("creatures you control", "creatures an opponent
 /// controls", etc.) flows through automatically.
 ///
@@ -5089,11 +5089,11 @@ fn parse_you_dont_control_a(input: &str) -> OracleResult<'_, StaticCondition> {
 ///   (`oracle_effect::conditions::strip_leading_general_conditional` →
 ///   `static_condition_to_ability_condition`).
 fn parse_filter_have_total_property(input: &str) -> OracleResult<'_, StaticCondition> {
-    // 1. Filter subject. parse_type_phrase consumes the noun phrase plus its
+    // 1. Filter subject. parse_type_phrase_folding consumes the noun phrase plus its
     //    trailing controller suffix ("creatures you control") and returns the
     //    typed filter with controller already injected. Reject `Any` so a bare
     //    "have total ..." prefix cannot accidentally match without a subject.
-    let (filter, remainder) = parse_type_phrase(input);
+    let (filter, remainder) = parse_type_phrase_folding(input);
     if matches!(filter, TargetFilter::Any) {
         return Err(nom::Err::Error(nom::error::Error::new(
             input,
@@ -5146,7 +5146,7 @@ fn parse_filter_have_total_property(input: &str) -> OracleResult<'_, StaticCondi
 }
 
 /// Inject a controller (CR 109.5 You / CR 102.2 Opponent) into a TargetFilter
-/// produced by `parse_type_phrase`, and ensure the filter is battlefield-scoped
+/// produced by `parse_type_phrase_folding`, and ensure the filter is battlefield-scoped
 /// (CR 109.4: only the battlefield and stack have a controller).
 /// CR 109.4: Add `InZone { Battlefield }` to a Typed filter (and each `Or`/`And`
 /// leg) if absent, WITHOUT constraining the controller. Used for "any player
@@ -5209,7 +5209,7 @@ pub(crate) fn inject_controller(filter: TargetFilter, ctrl: ControllerRef) -> Ta
     }
 }
 
-/// Inject `ControllerRef::You` into a TargetFilter produced by `parse_type_phrase`.
+/// Inject `ControllerRef::You` into a TargetFilter produced by `parse_type_phrase_folding`.
 /// Thin wrapper over `inject_controller` for the many "you control" call sites.
 pub(crate) fn inject_controller_you(filter: TargetFilter) -> TargetFilter {
     inject_controller(filter, ControllerRef::You)
@@ -5991,7 +5991,7 @@ fn parse_card_left_your_graveyard_this_turn(input: &str) -> OracleResult<'_, Sta
 /// or greater/more" — an additive two-term count threshold. Cavernous Maw:
 /// "the number of other Caves you control plus the number of Cave cards in your
 /// graveyard is three or greater". Term A is a live battlefield object count
-/// ("other Caves you control" → `parse_type_phrase` yields `Typed(Cave, You,
+/// ("other Caves you control" → `parse_type_phrase_folding` yields `Typed(Cave, You,
 /// [Another])` outright); term B is a subtype-filtered graveyard card count. The
 /// zone-/controlled-count combinators key on core card types, not land subtypes
 /// (CR 205.3i: Cave is a land type), so both terms are built explicitly. The two
@@ -5999,11 +5999,11 @@ fn parse_card_left_your_graveyard_this_turn(input: &str) -> OracleResult<'_, Sta
 fn parse_additive_two_term_count_threshold(input: &str) -> OracleResult<'_, StaticCondition> {
     let (rest, _) = tag("the number of ").parse(input)?;
     // Term A: the controlled-object subject up to the " plus the number of "
-    // joiner. `parse_type_phrase` owns the whole subject including the "other"
+    // joiner. `parse_type_phrase_folding` owns the whole subject including the "other"
     // (→ Another) qualifier and the "you control" controller suffix.
     let (rest, term_a_text) = take_until(" plus the number of ").parse(rest)?;
     let (rest, _) = tag(" plus the number of ").parse(rest)?;
-    let (a_filter, a_leftover) = parse_type_phrase(term_a_text.trim());
+    let (a_filter, a_leftover) = parse_type_phrase_folding(term_a_text.trim());
     if !a_leftover.trim().is_empty() || matches!(a_filter, TargetFilter::Any) {
         return Err(oracle_err(input));
     }
@@ -6030,12 +6030,12 @@ fn parse_additive_two_term_count_threshold(input: &str) -> OracleResult<'_, Stat
 /// CR 205.3i + CR 404.1: "<subtype> cards in your graveyard" → a subtype-filtered
 /// controller-graveyard card count. `parse_zone_card_count` keys on core card
 /// types, so the subtype filter (e.g. Cave) is built explicitly via
-/// `parse_type_phrase`; the count stays a `ZoneCardCount` with the filter set
+/// `parse_type_phrase_folding`; the count stays a `ZoneCardCount` with the filter set
 /// and scope `Controller` (your graveyard only).
 fn parse_subtype_cards_in_your_graveyard(input: &str) -> OracleResult<'_, QuantityRef> {
     let (rest, subtype_text) = take_until(" cards in your graveyard").parse(input)?;
     let (rest, _) = tag(" cards in your graveyard").parse(rest)?;
-    let (filter, leftover) = parse_type_phrase(subtype_text.trim());
+    let (filter, leftover) = parse_type_phrase_folding(subtype_text.trim());
     if !leftover.trim().is_empty() || matches!(filter, TargetFilter::Any) {
         return Err(oracle_err(input));
     }
@@ -6057,7 +6057,7 @@ fn parse_permanent_put_into_your_hand_from_battlefield_this_turn(
     let (rest, type_text) =
         take_until(" was put into your hand from the battlefield this turn").parse(rest)?;
     let (rest, _) = tag(" was put into your hand from the battlefield this turn").parse(rest)?;
-    let (filter, leftover) = parse_type_phrase(type_text.trim());
+    let (filter, leftover) = parse_type_phrase_folding(type_text.trim());
     if !leftover.trim().is_empty() || filter == TargetFilter::Any {
         return Err(nom::Err::Error(nom::error::Error::new(
             input,
@@ -6095,7 +6095,7 @@ fn parse_card_put_into_your_graveyard_from_anywhere_this_turn(
 /// count uses the shared "N or more"/"a(n)" (→ 1) threshold idiom. The bare
 /// "cards" noun carries no type, so `TargetFilter::Any` is accepted here (the
 /// owner + non-token tags still narrow it); a preceding type word
-/// ("artifact cards") narrows via `parse_type_phrase`.
+/// ("artifact cards") narrows via `parse_type_phrase_folding`.
 fn parse_opponent_cards_put_into_their_graveyard_from_anywhere_this_turn(
     input: &str,
 ) -> OracleResult<'_, StaticCondition> {
@@ -6140,7 +6140,7 @@ fn parse_opponent_cards_put_into_their_graveyard_from_anywhere_this_turn(
         // still bound the set.
         TargetFilter::Any
     } else {
-        let (filter, leftover) = parse_type_phrase(type_text);
+        let (filter, leftover) = parse_type_phrase_folding(type_text);
         if !leftover.trim().is_empty() || filter == TargetFilter::Any {
             return Err(nom::Err::Error(nom::error::Error::new(
                 input,
@@ -6174,7 +6174,7 @@ fn parse_your_card_put_into_your_graveyard_from_anywhere_this_turn(
     let suffix = " card was put into your graveyard from anywhere this turn";
     let (rest, type_text) = take_until(suffix).parse(rest)?;
     let (rest, _) = tag(suffix).parse(rest)?;
-    let (filter, leftover) = parse_type_phrase(type_text.trim());
+    let (filter, leftover) = parse_type_phrase_folding(type_text.trim());
     if !leftover.trim().is_empty() || filter == TargetFilter::Any {
         return Err(nom::Err::Error(nom::error::Error::new(
             input,
@@ -6202,7 +6202,7 @@ fn parse_object_put_into_graveyard_from_battlefield_this_turn(
     let suffix = " was put into a graveyard from the battlefield this turn";
     let (rest, type_text) = take_until(suffix).parse(rest)?;
     let (rest, _) = tag(suffix).parse(rest)?;
-    let (filter, leftover) = parse_type_phrase(type_text.trim());
+    let (filter, leftover) = parse_type_phrase_folding(type_text.trim());
     if !leftover.trim().is_empty() || filter == TargetFilter::Any {
         return Err(nom::Err::Error(nom::error::Error::new(
             input,
@@ -6550,7 +6550,7 @@ fn parse_attacked_with_creature_count(input: &str) -> OracleResult<'_, StaticCon
 }
 
 /// CR 508.1a: "a/an <type>[ this turn]" — the typed-attacker surface. The qualifier
-/// is delegated to `parse_type_phrase` so the whole class of attacker types
+/// is delegated to `parse_type_phrase_folding` so the whole class of attacker types
 /// (Spacecraft, Vehicle, any creature type) is covered by the shared combinator
 /// rather than a per-card literal. An unrecognized qualifier yields
 /// `TargetFilter::Any`, which is REJECTED so the phrase stays an honest gap
@@ -6562,7 +6562,7 @@ fn parse_attacked_with_creature_count(input: &str) -> OracleResult<'_, StaticCon
 /// phrase must otherwise be consumed in full, so an unabsorbed qualifying clause
 /// stays an honest gap rather than being silently truncated.
 fn parse_attacked_with_typed_filter(input: &str) -> OracleResult<'_, StaticCondition> {
-    let (filter, leftover) = parse_type_phrase(input);
+    let (filter, leftover) = parse_type_phrase_folding(input);
     if matches!(filter, TargetFilter::Any) {
         return Err(nom::Err::Error(nom::error::Error::new(
             input,
@@ -6598,7 +6598,7 @@ fn parse_no_attacked_this_turn(input: &str) -> OracleResult<'_, StaticCondition>
     let (rest, _) = tag("no ").parse(input)?;
     let (rest, type_text) = take_until(" attacked this turn").parse(rest)?;
     let (rest, _) = tag(" attacked this turn").parse(rest)?;
-    let (filter, leftover) = parse_type_phrase(type_text.trim());
+    let (filter, leftover) = parse_type_phrase_folding(type_text.trim());
     if !leftover.trim().is_empty() || matches!(filter, TargetFilter::Any) {
         return Err(nom::Err::Error(nom::error::Error::new(
             input,
@@ -6826,7 +6826,7 @@ fn parse_filtered_creature_died_this_turn(input: &str) -> OracleResult<'_, Stati
     let (rest, _) = parse_article(input)?;
     let (rest, type_text) = take_until(" died this turn").parse(rest)?;
     let (rest, _) = tag(" died this turn").parse(rest)?;
-    let (filter, leftover) = parse_type_phrase(type_text);
+    let (filter, leftover) = parse_type_phrase_folding(type_text);
     if !leftover.trim().is_empty() || filter == TargetFilter::Any {
         return Err(nom::Err::Error(nom::error::Error::new(
             input,
@@ -7223,8 +7223,8 @@ fn parse_combat_context_conditions(input: &str) -> OracleResult<'_, StaticCondit
 fn parse_defending_player_controls(input: &str) -> OracleResult<'_, StaticCondition> {
     let (rest, _) = tag("defending player controls ").parse(input)?;
     let (rest, _) = parse_article(rest)?;
-    // parse_type_phrase returns (filter, remaining_str) — bridge to nom remainder
-    let (filter, type_rest) = parse_type_phrase(rest);
+    // parse_type_phrase_folding returns (filter, remaining_str) — bridge to nom remainder
+    let (filter, type_rest) = parse_type_phrase_folding(rest);
     if matches!(filter, TargetFilter::Any) {
         return Err(nom::Err::Error(nom::error::Error::new(
             input,
@@ -7706,7 +7706,7 @@ fn parse_sacrificed_this_turn_tail(input: &str) -> OracleResult<'_, StaticCondit
     if let Ok((rest, n)) = parse_ge_threshold(input) {
         let (rest, type_text) = take_until(" this turn").parse(rest)?;
         let (rest, _) = tag(" this turn").parse(rest)?;
-        let (filter, leftover) = parse_type_phrase(type_text.trim());
+        let (filter, leftover) = parse_type_phrase_folding(type_text.trim());
         if leftover.trim().is_empty() && filter != TargetFilter::Any {
             return Ok((
                 rest,
@@ -7724,7 +7724,7 @@ fn parse_sacrificed_this_turn_tail(input: &str) -> OracleResult<'_, StaticCondit
     let (rest, _) = parse_article(input)?;
     let (rest, type_text) = take_until(" this turn").parse(rest)?;
     let (rest, _) = tag(" this turn").parse(rest)?;
-    let (filter, leftover) = parse_type_phrase(type_text.trim());
+    let (filter, leftover) = parse_type_phrase_folding(type_text.trim());
     if !leftover.trim().is_empty() || filter == TargetFilter::Any {
         return Err(nom::Err::Error(nom::error::Error::new(
             input,
@@ -7747,7 +7747,7 @@ fn parse_died_under_your_control_this_turn(input: &str) -> OracleResult<'_, Stat
     let (rest, _) = parse_article(input)?;
     let (rest, type_text) = take_until(" died under your control this turn").parse(rest)?;
     let (rest, _) = tag(" died under your control this turn").parse(rest)?;
-    let (filter, leftover) = parse_type_phrase(type_text);
+    let (filter, leftover) = parse_type_phrase_folding(type_text);
     if !leftover.trim().is_empty() || filter == TargetFilter::Any {
         return Err(nom::Err::Error(nom::error::Error::new(
             input,
@@ -7925,7 +7925,7 @@ pub(crate) fn parse_spell_history_filter(type_text: &str) -> Option<TargetFilter
             return Some(filter);
         }
     }
-    let (filter, leftover) = parse_type_phrase(type_text);
+    let (filter, leftover) = parse_type_phrase_folding(type_text);
     if leftover.trim().is_empty() && filter != TargetFilter::Any {
         return Some(filter);
     }
@@ -8236,7 +8236,7 @@ fn make_source_history_absence(prop: FilterProp) -> StaticCondition {
 /// subject-first form already lowered to, so both forms share one
 /// `QuantityComparison(ObjectCount == 0)` output and no controller restriction
 /// ("no creatures" / "no Zombies" / "no lands" counts *any* player's matching
-/// permanents). The `<type>` reuses `parse_type_phrase`, so a subtype
+/// permanents). The `<type>` reuses `parse_type_phrase_folding`, so a subtype
 /// ("Zombies"), a card type ("lands"), or a token phrase ("Reflection tokens")
 /// scopes the emptiness check exactly, and the trailing anchor is a bounded
 /// `tag` so the recognizer never runs into the effect clause.
@@ -8251,7 +8251,7 @@ fn parse_no_on_battlefield(input: &str) -> OracleResult<'_, StaticCondition> {
     .parse(input)?;
     let (rest, type_text) = take_until(anchor).parse(rest)?;
     let (rest, _) = tag(anchor).parse(rest)?;
-    let (filter, _) = parse_type_phrase(type_text);
+    let (filter, _) = parse_type_phrase_folding(type_text);
     if matches!(filter, TargetFilter::Any) {
         return Err(nom::Err::Error(nom::error::Error::new(
             input,
@@ -8319,7 +8319,7 @@ fn parse_entered_this_turn(input: &str) -> OracleResult<'_, StaticCondition> {
     {
         let (rest, type_text) = take_until(entered_suffix).parse(rest)?;
         let (rest, _) = tag(entered_suffix).parse(rest)?;
-        let (filter, _) = parse_type_phrase(type_text.trim());
+        let (filter, _) = parse_type_phrase_folding(type_text.trim());
         return Ok((
             rest,
             make_quantity_ge(
@@ -8369,7 +8369,7 @@ fn parse_or_more_entered_count<'a>(
     let (type_and_rest, _) = tag("or more ").parse(after_n.trim_start())?;
     let (rest, type_text) = take_until(suffix).parse(type_and_rest)?;
     let (rest, _) = tag(suffix).parse(rest)?;
-    let (filter, _) = parse_type_phrase(type_text.trim());
+    let (filter, _) = parse_type_phrase_folding(type_text.trim());
     Ok((
         rest,
         make_quantity_ge(
@@ -8389,7 +8389,7 @@ fn parse_entered_this_turn_subject<'a>(
     let (rest, _) = tag(suffix).parse(rest)?;
     let type_text = type_text.trim();
     let _ = alt((parse_article, value((), tag("another ")))).parse(type_text)?;
-    let (filter, _) = parse_type_phrase(type_text.trim());
+    let (filter, _) = parse_type_phrase_folding(type_text.trim());
     Ok((
         rest,
         make_quantity_ge(
@@ -8575,7 +8575,7 @@ fn parse_there_are_conditions_with_quantity(
 /// it into a lexical noun or a card-type list.
 ///
 /// The type phrase and locative zone are deliberately parsed by their separate
-/// authorities. `parse_type_phrase` owns the complete noun phrase, while
+/// authorities. `parse_type_phrase_folding` owns the complete noun phrase, while
 /// `parse_scoped_zone_count_ref` owns the player/zone scope after `in `.
 fn parse_filtered_zone_card_count(input: &str) -> OracleResult<'_, QuantityRef> {
     let (rest_after_noun, noun) = take_until(" in ").parse(input)?;
@@ -8583,7 +8583,7 @@ fn parse_filtered_zone_card_count(input: &str) -> OracleResult<'_, QuantityRef> 
     if !after_cards.is_empty() {
         return Err(oracle_err(input));
     }
-    let (filter, remainder) = parse_type_phrase(noun);
+    let (filter, remainder) = parse_type_phrase_folding(noun);
     if !remainder.trim().is_empty() || !is_admissible_zone_card_count_filter(&filter) {
         return Err(oracle_err(input));
     }
@@ -8699,7 +8699,7 @@ fn parse_no_cards_in_your_zone(input: &str) -> OracleResult<'_, StaticCondition>
     let filter = if type_text.is_empty() {
         None
     } else {
-        let (filter, remainder) = parse_type_phrase(type_text.trim());
+        let (filter, remainder) = parse_type_phrase_folding(type_text.trim());
         if matches!(filter, TargetFilter::Any) || !remainder.trim().is_empty() {
             return Err(oracle_err(input));
         }
@@ -8858,7 +8858,7 @@ fn parse_zone_card_type_text(type_text: &str) -> Vec<TypeFilter> {
             _ => {}
         }
     }
-    let (filter, _) = parse_type_phrase(type_text.trim());
+    let (filter, _) = parse_type_phrase_folding(type_text.trim());
     let mut card_types = Vec::new();
     collect_type_filters(filter, &mut card_types);
     card_types.retain(|type_filter| *type_filter != TypeFilter::Card);
@@ -8913,7 +8913,7 @@ fn parse_subject_first_card_subject(input: &str) -> OracleResult<'_, Vec<TypeFil
         },
     ))
     .parse(input)?;
-    let (filter, _) = parse_type_phrase(type_text.trim());
+    let (filter, _) = parse_type_phrase_folding(type_text.trim());
     let mut card_types = match filter {
         TargetFilter::Typed(TypedFilter { type_filters, .. }) => type_filters,
         _ => vec![],
@@ -9052,12 +9052,12 @@ fn parse_that_player_controls_more_comparison(input: &str) -> OracleResult<'_, S
     let (rest, type_text) = take_until::<_, _, OracleError<'_>>(" than you").parse(rest)?;
     let (rest, _) = tag(" than you").parse(rest)?;
 
-    let (filter, _) = parse_type_phrase(type_text.trim());
+    let (filter, _) = parse_type_phrase_folding(type_text.trim());
     let scoped_filter = match filter {
         TargetFilter::Typed(tf) => TargetFilter::Typed(tf.controller(ControllerRef::ScopedPlayer)),
         other => other,
     };
-    let you_filter = match parse_type_phrase(type_text.trim()) {
+    let you_filter = match parse_type_phrase_folding(type_text.trim()) {
         (TargetFilter::Typed(tf), _) => TargetFilter::Typed(tf.controller(ControllerRef::You)),
         (other, _) => other,
     };
@@ -9117,14 +9117,14 @@ fn parse_defending_player_comparison_conditions(input: &str) -> OracleResult<'_,
     let (rest, type_text) = take_until::<_, _, OracleError<'_>>(" than you").parse(rest)?;
     let (rest, _) = tag(" than you").parse(rest)?;
 
-    let (filter, _) = parse_type_phrase(type_text.trim());
+    let (filter, _) = parse_type_phrase_folding(type_text.trim());
     let defending_filter = match filter {
         TargetFilter::Typed(tf) => {
             TargetFilter::Typed(tf.controller(ControllerRef::DefendingPlayer))
         }
         other => other,
     };
-    let you_filter = match parse_type_phrase(type_text.trim()) {
+    let you_filter = match parse_type_phrase_folding(type_text.trim()) {
         (TargetFilter::Typed(tf), _) => TargetFilter::Typed(tf.controller(ControllerRef::You)),
         (other, _) => other,
     };
@@ -9258,7 +9258,7 @@ fn parse_opponent_comparison_conditions(input: &str) -> OracleResult<'_, StaticC
                 return Err(oracle_err(rest3));
             }
             let type_text = rest3.trim_end_matches('.');
-            let (filter, remainder) = parse_type_phrase(type_text);
+            let (filter, remainder) = parse_type_phrase_folding(type_text);
             if !matches!(filter, TargetFilter::Any) {
                 let filter = match filter {
                     TargetFilter::Typed(tf) => {
@@ -9535,7 +9535,7 @@ fn parse_opponent_controls_more_than_you(input: &str) -> OracleResult<'_, Static
 }
 
 fn player_count_comparison_filters(type_text: &str) -> Option<(TargetFilter, TargetFilter)> {
-    let (type_filter, remainder) = parse_type_phrase(type_text.trim());
+    let (type_filter, remainder) = parse_type_phrase_folding(type_text.trim());
     if !remainder.trim().is_empty() || matches!(type_filter, TargetFilter::Any | TargetFilter::None)
     {
         return None;
@@ -9701,7 +9701,7 @@ pub fn parse_zone_changed_this_way_clause_scoped(
         value((), tag::<_, _, OracleError<'_>>("at least one ")),
         value((), tag("one or more ")),
         // CR 608.2c: "another <type> … this way" (Arid Archway) — do NOT consume
-        // "another "; `parse_type_phrase` maps it to `FilterProp::Another` so the
+        // "another "; `parse_type_phrase_folding` maps it to `FilterProp::Another` so the
         // returned-this-way subject excludes the source.
         value((), nom::combinator::peek(tag("another "))),
         // CR 608.2c: "that <type> … this way" (Saw in Half, Tuktuk Scrapper) —
@@ -9716,7 +9716,7 @@ pub fn parse_zone_changed_this_way_clause_scoped(
     // type phrase — handled by the shared helper which already covers
     // top-level types (creature, artifact, enchantment, …) and subtypes
     // (Aura, Equipment, …) via the lowercase oracle subtype dictionary.
-    let (filter, after_filter) = parse_type_phrase(rest);
+    let (filter, after_filter) = parse_type_phrase_folding(rest);
     if matches!(filter, TargetFilter::Any) {
         return Err(nom::Err::Error(nom::error::Error::new(
             input,
@@ -9732,7 +9732,7 @@ pub fn parse_zone_changed_this_way_clause_scoped(
     // `parse_you_control_a`.
     let (filter, after_filter) = fold_this_way_subject_disjunction(filter, after_filter);
 
-    // `parse_type_phrase` returns a slice of `rest`; trim any leading whitespace
+    // `parse_type_phrase_folding` returns a slice of `rest`; trim any leading whitespace
     // it left between the type phrase and the tense verb so the next `tag`
     // matches cleanly.
     let after_filter = after_filter.trim_start();
@@ -9857,7 +9857,7 @@ pub enum DamagedThisWayRecipient {
 /// This is the plain-damage sibling of [`parse_zone_changed_this_way_clause`]
 /// (zone-change verbs) and of `parse_previous_effect_excess_damage_condition`
 /// (the `excess` channel). It shares the same article × subject × tense × verb
-/// axes, so a new recipient noun is a `parse_type_phrase` concern, not a new
+/// axes, so a new recipient noun is a `parse_type_phrase_folding` concern, not a new
 /// `tag` arm here.
 ///
 /// `"dealt excess damage this way"` cannot match: the `excess` token stops the
@@ -9886,7 +9886,7 @@ pub fn parse_damaged_this_way_clause(input: &str) -> OracleResult<'_, DamagedThi
     ))
     .parse(rest)?;
 
-    // `parse_type_phrase` returns a slice of its input; trim any whitespace it
+    // `parse_type_phrase_folding` returns a slice of its input; trim any whitespace it
     // left between the noun phrase and the tense verb so the next `tag` matches
     // cleanly (same normalization the zone-change sibling performs).
     let rest = rest.trim_start();
@@ -9907,14 +9907,14 @@ pub fn parse_damaged_this_way_clause(input: &str) -> OracleResult<'_, DamagedThi
 }
 
 /// CR 120.3 + CR 205: the typed-recipient arm of [`parse_damaged_this_way_clause`].
-/// Delegates the noun phrase to [`parse_type_phrase`] — the declared authority for
+/// Delegates the noun phrase to [`parse_type_phrase_folding`] — the declared authority for
 /// type/subtype phrases — and folds a `" or a [type]"` continuation through the
 /// shared [`fold_this_way_subject_disjunction`], so a disjunctive recipient sharing
 /// one verb ("a Dragon or a Wurm is dealt damage this way") stays one condition.
 fn parse_damaged_this_way_typed_recipient(
     input: &str,
 ) -> OracleResult<'_, DamagedThisWayRecipient> {
-    let (filter, after_filter) = parse_type_phrase(input);
+    let (filter, after_filter) = parse_type_phrase_folding(input);
     // Fail closed on a vacuous or non-consuming parse, mirroring the zone-change
     // sibling: `TargetFilter::Any` means the noun was not recognized at all.
     if matches!(filter, TargetFilter::Any) || after_filter.len() == input.len() {
@@ -10106,7 +10106,7 @@ pub fn parse_you_put_onto_battlefield_this_way_clause(
         parse_article,
     ))
     .parse(rest)?;
-    let (filter, after_filter) = parse_type_phrase(rest);
+    let (filter, after_filter) = parse_type_phrase_folding(rest);
     if matches!(filter, TargetFilter::Any) {
         return Err(nom::Err::Error(nom::error::Error::new(
             input,
@@ -10147,7 +10147,7 @@ pub fn parse_you_put_into_graveyard_this_way_clause(
         parse_article,
     ))
     .parse(rest)?;
-    let (filter, after_filter) = parse_type_phrase(rest);
+    let (filter, after_filter) = parse_type_phrase_folding(rest);
     if matches!(filter, TargetFilter::Any) {
         return Err(nom::Err::Error(nom::error::Error::new(
             input,
@@ -10178,7 +10178,7 @@ pub fn parse_you_put_into_graveyard_this_way_clause(
 /// The bare "a card" form parses to `TypeFilter::Card` (matches any card in any
 /// zone), which is the intended existential semantics — any card discarded this
 /// way. A leading type qualifier ("a creature card") narrows the filter via the
-/// shared `parse_type_phrase` helper, covering the whole class.
+/// shared `parse_type_phrase_folding` helper, covering the whole class.
 pub fn parse_you_discard_this_way_clause(input: &str) -> OracleResult<'_, (TargetFilter, bool)> {
     let (rest, _) = tag("you discard ").parse(input)?;
     let (rest, _) = alt((
@@ -10187,7 +10187,7 @@ pub fn parse_you_discard_this_way_clause(input: &str) -> OracleResult<'_, (Targe
         parse_article,
     ))
     .parse(rest)?;
-    let (filter, after_filter) = parse_type_phrase(rest);
+    let (filter, after_filter) = parse_type_phrase_folding(rest);
     if matches!(filter, TargetFilter::Any) {
         return Err(nom::Err::Error(nom::error::Error::new(
             input,
@@ -10211,7 +10211,7 @@ pub fn parse_you_discard_this_way_clause(input: &str) -> OracleResult<'_, (Targe
 /// `parse_you_discard_this_way_clause` existential check, differing only in the
 /// active verb ("sacrifice") and its fixed-graveyard destination. The optional
 /// trailing plural "s" lets "one or more artifacts" / "an artifact" / "a creature"
-/// all narrow through the shared `parse_type_phrase` helper, covering the class.
+/// all narrow through the shared `parse_type_phrase_folding` helper, covering the class.
 pub fn parse_you_sacrifice_this_way_clause(input: &str) -> OracleResult<'_, (TargetFilter, bool)> {
     let (rest, _) = tag("you sacrifice ").parse(input)?;
     let (rest, _) = alt((
@@ -10221,7 +10221,7 @@ pub fn parse_you_sacrifice_this_way_clause(input: &str) -> OracleResult<'_, (Tar
         parse_article,
     ))
     .parse(rest)?;
-    let (filter, after_filter) = parse_type_phrase(rest);
+    let (filter, after_filter) = parse_type_phrase_folding(rest);
     if matches!(filter, TargetFilter::Any) {
         return Err(nom::Err::Error(nom::error::Error::new(
             input,
@@ -10257,7 +10257,7 @@ pub fn parse_you_exile_this_way_clause(input: &str) -> OracleResult<'_, (TargetF
         parse_article,
     ))
     .parse(rest)?;
-    let (filter, after_filter) = parse_type_phrase(rest);
+    let (filter, after_filter) = parse_type_phrase_folding(rest);
     if matches!(filter, TargetFilter::Any) {
         return Err(nom::Err::Error(nom::error::Error::new(
             input,
@@ -10293,7 +10293,7 @@ fn fold_this_way_subject_disjunction(first: TargetFilter, remainder: &str) -> (T
         {
             break;
         }
-        let (next_filter, next_remainder) = parse_type_phrase(after_or);
+        let (next_filter, next_remainder) = parse_type_phrase_folding(after_or);
         if matches!(next_filter, TargetFilter::Any) {
             break;
         }
@@ -10343,7 +10343,7 @@ pub fn parse_you_put_into_hand_this_way_condition(
         ),
     ))
     .parse(rest)?;
-    let (filter, after_filter) = parse_type_phrase(rest);
+    let (filter, after_filter) = parse_type_phrase_folding(rest);
     if matches!(filter, TargetFilter::Any) {
         return Err(nom::Err::Error(nom::error::Error::new(
             input,
@@ -10388,7 +10388,7 @@ pub fn parse_you_put_counters_on_type_this_way_condition(
             )))
         }
     };
-    let (filter, after_filter) = parse_type_phrase(rest);
+    let (filter, after_filter) = parse_type_phrase_folding(rest);
     if matches!(filter, TargetFilter::Any) {
         return Err(nom::Err::Error(nom::error::Error::new(
             input,
@@ -10426,7 +10426,7 @@ pub fn parse_returned_to_hand_this_way_clause(input: &str) -> OracleResult<'_, T
         ),
     ))
     .parse(rest)?;
-    let (filter, after_filter) = parse_type_phrase(rest);
+    let (filter, after_filter) = parse_type_phrase_folding(rest);
     if matches!(filter, TargetFilter::Any) {
         return Err(nom::Err::Error(nom::error::Error::new(
             input,
@@ -10449,7 +10449,7 @@ pub fn parse_you_control_or_returned_this_way_condition(
 ) -> OracleResult<'_, AbilityCondition> {
     let (rest, _) = tag("you control ").parse(input)?;
     nom::combinator::peek(alt((tag("a "), tag("an "), tag("another ")))).parse(rest)?;
-    let (control_filter, after) = parse_type_phrase(rest);
+    let (control_filter, after) = parse_type_phrase_folding(rest);
     if matches!(control_filter, TargetFilter::Any) {
         return Err(nom::Err::Error(nom::error::Error::new(
             input,
@@ -12531,7 +12531,7 @@ mod tests {
     /// indestructible" must lower its CONDITION to a typed
     /// `IsPresent { Or[ Typed{[Artifact,Creature],You,Battlefield},
     /// Typed{[Plan],You,Battlefield} ] }`, NOT `StaticCondition::Unrecognized`.
-    /// DISCRIMINATING: pre-fix `parse_type_phrase` left " or a Plan" unconsumed
+    /// DISCRIMINATING: pre-fix `parse_type_phrase_folding` left " or a Plan" unconsumed
     /// (Plan unknown + non-comma connector rejected an article-led RHS), so the
     /// condition fell to `Unrecognized` — which `evaluate_condition` treats as
     /// `true`, making the keyword grant always-on (coverage-unsupported).
@@ -15835,7 +15835,7 @@ mod tests {
 
     #[test]
     fn test_recipient_guard_backtracks_to_attacking_alone() {
-        // GUARD: "it's attacking alone" leaves "alone" after parse_type_phrase
+        // GUARD: "it's attacking alone" leaves "alone" after parse_type_phrase_folding
         // matches "attacking " — the terminal-boundary guard rejects the pronoun
         // match so the combat combinator wins.
         let (rest, c) = parse_inner_condition("it's attacking alone").unwrap();
@@ -20331,7 +20331,7 @@ mod tests {
         assert_eq!(recipient, DamagedThisWayRecipient::Player);
     }
 
-    /// The recipient axis is a `parse_type_phrase` concern, so the whole class
+    /// The recipient axis is a `parse_type_phrase_folding` concern, so the whole class
     /// of nouns comes for free — plural verbs included.
     #[test]
     fn test_damaged_this_way_recipient_class() {
@@ -21686,9 +21686,9 @@ mod tests {
 
     /// CR 401.1: Mul Daya Channelers's "the top card of your library is a creature
     /// card" / "... a land card" parse to top-of-library core-type gates. The
-    /// informational " card" suffix is folded by `parse_type_phrase` (the same
+    /// informational " card" suffix is folded by `parse_type_phrase_folding` (the same
     /// helper the graveyard-presence gate uses), so the filter is exactly the bare
-    /// core-type filter — asserted against `parse_type_phrase`'s own output.
+    /// core-type filter — asserted against `parse_type_phrase_folding`'s own output.
     #[test]
     fn parse_inner_condition_top_of_library_is_type_card() {
         for (text, phrase) in [
@@ -21700,7 +21700,7 @@ mod tests {
         ] {
             let (rest, c) = parse_inner_condition(text).unwrap_or_else(|e| panic!("{text}: {e:?}"));
             assert!(rest.is_empty(), "{text}: leftover {rest:?}");
-            let (expected_filter, _) = parse_type_phrase(phrase);
+            let (expected_filter, _) = parse_type_phrase_folding(phrase);
             assert_eq!(
                 c,
                 StaticCondition::TopOfLibraryMatches {
@@ -21713,13 +21713,13 @@ mod tests {
 
     /// CR 401.1: Conspicuous Snoop's "the top card of your library is a Goblin
     /// card" parses to a top-of-library subtype gate (the subtype-word path of
-    /// `parse_type_phrase`). The condition parser runs on lowercased text.
+    /// `parse_type_phrase_folding`). The condition parser runs on lowercased text.
     #[test]
     fn parse_inner_condition_top_of_library_is_subtype_card() {
         let (rest, c) =
             parse_inner_condition("the top card of your library is a goblin card").unwrap();
         assert!(rest.is_empty(), "leftover: {rest:?}");
-        let (expected_filter, _) = parse_type_phrase("goblin card");
+        let (expected_filter, _) = parse_type_phrase_folding("goblin card");
         assert_eq!(
             c,
             StaticCondition::TopOfLibraryMatches {
@@ -21730,18 +21730,18 @@ mod tests {
 
     /// CR 401.1: Skill Borrower's "the top card of your library is an
     /// artifact or creature card" folds the "X or Y card" disjunction into a
-    /// single top-of-library gate over an `Or` *filter* — `parse_type_phrase`
+    /// single top-of-library gate over an `Or` *filter* — `parse_type_phrase_folding`
     /// consumes the whole compound (no per-disjunct article), so
     /// `parse_bare_predicate_disjunction` yields one filter and the runtime
     /// `matches_target_filter` disjunction handles the two card types. The `Or`
-    /// filter is asserted against `parse_type_phrase`'s own compound output.
+    /// filter is asserted against `parse_type_phrase_folding`'s own compound output.
     #[test]
     fn parse_inner_condition_top_of_library_is_disjunction() {
         let (rest, c) =
             parse_inner_condition("the top card of your library is an artifact or creature card")
                 .unwrap();
         assert!(rest.is_empty(), "leftover: {rest:?}");
-        let (expected_filter, _) = parse_type_phrase("artifact or creature card");
+        let (expected_filter, _) = parse_type_phrase_folding("artifact or creature card");
         assert!(
             matches!(&expected_filter, TargetFilter::Or { filters } if filters.len() == 2),
             "sanity: expected an Or filter, got {expected_filter:?}"
@@ -22046,7 +22046,7 @@ mod tests {
     /// CR 120.10 + CR 603.4: Rith, Liberated Primeval's "a creature or
     /// planeswalker an opponent controlled was dealt excess damage this turn"
     /// must parse as an opponent-filtered DamageDealtThisTurn with channel:Excess.
-    /// `parse_type_phrase` produces `TargetFilter::Or` for compound types, so
+    /// `parse_type_phrase_folding` produces `TargetFilter::Or` for compound types, so
     /// this test checks that the channel is Excess and the target is non-Any.
     #[test]
     fn parse_inner_condition_typed_subject_was_dealt_excess_damage_this_turn() {
@@ -22072,7 +22072,7 @@ mod tests {
             panic!("expected QuantityComparison(DamageDealtThisTurn), got: {cond:?}");
         };
         assert_eq!(channel, DamageChannel::Excess, "channel must be Excess");
-        // parse_type_phrase emits Or{Typed(Creature+Opp), Typed(Planeswalker+Opp)}
+        // parse_type_phrase_folding emits Or{Typed(Creature+Opp), Typed(Planeswalker+Opp)}
         // for compound types — verify the filter is non-trivial (not Any).
         assert!(
             !matches!(target.as_ref(), TargetFilter::Any),

--- a/crates/engine/src/parser/oracle_nom/enchant.rs
+++ b/crates/engine/src/parser/oracle_nom/enchant.rs
@@ -253,7 +253,7 @@ pub(crate) fn parse_enchant_target_full(input: &str) -> OracleResult<'_, TargetF
 
 /// CR 702.5a + CR 702.9: Optional trailing "without [keyword]" qualifier on an
 /// enchant line (Trapped in the Tower, Roots). Delegates to the shared target
-/// suffix authority so Aura legal-target sets match `parse_type_phrase`.
+/// suffix authority so Aura legal-target sets match `parse_type_phrase_folding`.
 fn parse_enchant_without_keyword_suffix(input: &str) -> OracleResult<'_, Vec<FilterProp>> {
     match parse_without_keyword_suffix(input) {
         Some((props, consumed)) => Ok((&input[consumed..], props)),

--- a/crates/engine/src/parser/oracle_nom/filter.rs
+++ b/crates/engine/src/parser/oracle_nom/filter.rs
@@ -300,7 +300,7 @@ pub fn parse_pt_comparison(input: &str) -> OracleResult<'_, FilterProp> {
 /// caller's business: an explicit "among `<set>`" (CR 109.2, owned by
 /// `oracle_target::parse_superlative_property_suffix`), or the enclosing noun
 /// phrase itself (CR 109.2, owned by the bare-form pass in
-/// `parse_type_phrase_with_ctx`).
+/// `parse_type_phrase_folding_with_ctx`).
 ///
 /// The `not(alphanumeric1)` tail guard enforces a word boundary so "mana values"
 /// or "powerstone" cannot half-match the property word. The `among`-form caller

--- a/crates/engine/src/parser/oracle_nom/quantity.rs
+++ b/crates/engine/src/parser/oracle_nom/quantity.rs
@@ -22,7 +22,7 @@ use super::primitives::{
 use super::target::parse_type_filter_word;
 use crate::parser::oracle_target::{
     parse_counter_suffix, parse_shared_quality, parse_shared_quality_clause,
-    parse_target_with_syntax, parse_type_phrase, TargetSyntax,
+    parse_target_with_syntax, parse_type_phrase_folding, TargetSyntax,
 };
 use crate::parser::oracle_util::parse_subtype;
 use crate::types::ability::{
@@ -469,7 +469,7 @@ fn parse_possessive_objects_they_control(input: &str) -> OracleResult<'_, Quanti
         ),
     ))
     .parse(rest)?;
-    let (mut filter, type_rest) = parse_type_phrase(type_phrase);
+    let (mut filter, type_rest) = parse_type_phrase_folding(type_phrase);
     if !type_rest.trim().is_empty() || !quantity_filter_has_meaningful_content(&filter) {
         return Err(nom::Err::Error(nom::error::Error::new(
             input,
@@ -1061,7 +1061,7 @@ pub fn parse_quantity_ref(input: &str) -> OracleResult<'_, QuantityRef> {
         // CR 105.1 + CR 105.2: bare "colors among <filter>" — reached after a
         // parent has consumed "there are N " (Puca's Eye: "there are five colors
         // among permanents you control"). The tail combinator (`tag("colors
-        // among ") + parse_type_phrase`) is shared with the "the number of
+        // among ") + parse_type_phrase_folding`) is shared with the "the number of
         // colors among ..." path; registering it here makes it reachable in the
         // bare-suffix context too.
         parse_distinct_colors_among_tail,
@@ -1081,7 +1081,7 @@ pub fn parse_quantity_ref(input: &str) -> OracleResult<'_, QuantityRef> {
         // against the threshold. Counter-side counterpart to
         // `parse_distinct_colors_among_tail` immediately above: the tail
         // combinator (`tag("different kind") + tag(" of counter") + "on"/"among"
-        // + parse_type_phrase`) is shared with the "the number of different kinds
+        // + parse_type_phrase_folding`) is shared with the "the number of different kinds
         // of counters among ..." path (`parse_number_of_inner`, used by Perrie,
         // the Pulverizer); registering it here makes it reachable in the
         // bare-suffix context too, so `parse_there_are_conditions` can build a
@@ -1155,7 +1155,7 @@ fn parse_type_count_on_battlefield_with_boundary(
             }
         }
     };
-    let (filter, type_rest) = parse_type_phrase(type_text);
+    let (filter, type_rest) = parse_type_phrase_folding(type_text);
     if matches!(filter, TargetFilter::Any) || !type_rest.trim().is_empty() {
         return Err(oracle_err(input));
     }
@@ -1191,7 +1191,7 @@ fn parse_object_count_by_shared_quality(input: &str) -> OracleResult<'_, Quantit
     let (rest, quality) = parse_shared_quality(rest)?;
     let (rest, _) = tag(" in common").parse(rest)?;
 
-    let (filter, type_remainder) = parse_type_phrase(type_text.trim());
+    let (filter, type_remainder) = parse_type_phrase_folding(type_text.trim());
     if !type_remainder.trim().is_empty()
         || matches!(filter, TargetFilter::Any)
         || !quantity_filter_has_meaningful_content(&filter)
@@ -1430,14 +1430,14 @@ fn parse_counters_among_ref(input: &str) -> OracleResult<'_, QuantityRef> {
     ))
     .parse(input)?;
     let type_text = rest.trim_end_matches('.').trim_end_matches(',');
-    let (filter, remainder) = parse_type_phrase(type_text);
+    let (filter, remainder) = parse_type_phrase_folding(type_text);
     if matches!(filter, TargetFilter::Any) {
         return Err(nom::Err::Error(nom::error::Error::new(
             input,
             nom::error::ErrorKind::Fail,
         )));
     }
-    // Map remainder back to original input slice — parse_type_phrase may have
+    // Map remainder back to original input slice — parse_type_phrase_folding may have
     // consumed from a trimmed copy, so use pointer arithmetic for the correct
     // byte offset.
     let consumed = remainder.as_ptr() as usize - input.as_ptr() as usize;
@@ -1843,7 +1843,7 @@ fn parse_object_property_aggregate_ref(input: &str) -> OracleResult<'_, Quantity
             ),
         ));
     }
-    let (filter, remainder) = parse_type_phrase(rest);
+    let (filter, remainder) = parse_type_phrase_folding(rest);
     let final_remainder = parse_cast_snapshot_suffix(remainder.trim_start())
         .ok()
         .and_then(|(snapshot_rest, _)| snapshot_rest.trim().is_empty().then_some(snapshot_rest))
@@ -2075,7 +2075,7 @@ fn parse_bare_mana_values_among_tail(input: &str) -> OracleResult<'_, QuantityRe
     let (rest, _) = tag("mana value").parse(input)?;
     let (rest, _) = opt(tag("s")).parse(rest)?;
     let (rest, _) = tag(" among ").parse(rest)?;
-    let (filter, remainder) = parse_type_phrase(rest);
+    let (filter, remainder) = parse_type_phrase_folding(rest);
     if !remainder.trim().is_empty() || !quantity_filter_has_meaningful_content(&filter) {
         return Err(nom::Err::Error(nom::error::Error::new(
             input,
@@ -2100,7 +2100,7 @@ fn parse_bare_mana_values_among_tail(input: &str) -> OracleResult<'_, QuantityRe
 fn parse_for_each_distinct_counter_kinds_among(input: &str) -> OracleResult<'_, QuantityRef> {
     let (rest, _) = tag("kind of counter ").parse(input)?;
     let (rest, _) = alt((tag("on "), tag("among "))).parse(rest)?;
-    let (filter, remainder) = parse_type_phrase(rest);
+    let (filter, remainder) = parse_type_phrase_folding(rest);
     if !remainder.trim().is_empty() || matches!(filter, TargetFilter::Any) {
         return Err(nom::Err::Error(nom::error::Error::new(
             input,
@@ -2114,7 +2114,7 @@ fn parse_for_each_distinct_counter_kinds_among(input: &str) -> OracleResult<'_, 
 /// "the number of" → `QuantityRef::ObjectCountDistinct { filter, qualities: [Name] }`.
 ///
 /// Composes by delegating the inner type phrase to the shared
-/// `oracle_target::parse_type_phrase` so any combination of supertype, color,
+/// `oracle_target::parse_type_phrase_folding` so any combination of supertype, color,
 /// negation, type words, "tokens" property suffix, and controller suffix
 /// ("you control", "an opponent controls", etc.) flows through one parser —
 /// no per-card phrasing arms. The remainder must be empty (or only trailing
@@ -2133,7 +2133,7 @@ fn parse_for_each_distinct_counter_kinds_among(input: &str) -> OracleResult<'_, 
 fn parse_distinct_named_objects(input: &str) -> OracleResult<'_, QuantityRef> {
     let (rest, _) = tag("differently named ").parse(input)?;
     let type_text = rest.trim_end_matches('.').trim_end_matches(',');
-    let (filter, remainder) = parse_type_phrase(type_text);
+    let (filter, remainder) = parse_type_phrase_folding(type_text);
     if !remainder.trim().is_empty() || !quantity_filter_has_meaningful_content(&filter) {
         return Err(nom::Err::Error(nom::error::Error::new(
             input,
@@ -2212,7 +2212,7 @@ fn parse_controlled_object_count_extremum(input: &str) -> OracleResult<'_, Quant
         ),
     ))
     .parse(input)?;
-    let (filter, filter_remainder) = parse_type_phrase(type_text);
+    let (filter, filter_remainder) = parse_type_phrase_folding(type_text);
     if !filter_remainder.trim().is_empty() || !quantity_filter_has_meaningful_content(&filter) {
         return Err(oracle_err(input));
     }
@@ -2359,14 +2359,14 @@ fn parse_number_of_controlled_type(input: &str) -> OracleResult<'_, QuantityRef>
 
 /// CR 201.2 + CR 109.2: Parse qualified controlled object counts like
 /// "permanents named Food Fight you control" or "other creature named Seven
-/// Dwarves you control". The named/card-quality parser (`parse_type_phrase`)
+/// Dwarves you control". The named/card-quality parser (`parse_type_phrase_folding`)
 /// owns the object description — type word plus any `other`/`named X`
 /// qualifier — and this quantity parser owns the trailing controller scope.
 /// Shared by the "the number of … you control" and "for each … you control"
 /// paths: a `named X` qualifier sits between the type word and the controller
 /// suffix, which the bare-`parse_type_filter_word` arms cannot reach.
 fn parse_qualified_controlled_type(input: &str) -> OracleResult<'_, QuantityRef> {
-    let (mut filter, rest) = parse_type_phrase(input);
+    let (mut filter, rest) = parse_type_phrase_folding(input);
     if !quantity_filter_has_meaningful_content(&filter) {
         return Err(nom::Err::Error(nom::error::Error::new(
             input,
@@ -2631,7 +2631,7 @@ enum TypePhraseGrammar {
     /// type lists (`parse_type_list`), no ownership / token / combat-relation
     /// grammar, fails with `Err`. The colours head reads with this.
     Strict,
-    /// [`crate::parser::oracle_target::parse_type_phrase`] — folds
+    /// [`crate::parser::oracle_target::parse_type_phrase_folding`] — folds
     /// `" and "` / `" and/or "` into type unions (`TYPE_SEPARATORS`) and carries
     /// ownership / token / combat-relation grammar. INFALLIBLE: on failure it
     /// yields an EMPTY `TypedFilter` plus the whole input — NOT
@@ -2981,7 +2981,7 @@ fn parse_objects_source(
     let type_text = input.trim_end_matches('.').trim_end_matches(',');
     let (filter, remainder) = match grammar {
         // `(filter, remainder)`, INFALLIBLE — never transpose with the Strict arm.
-        TypePhraseGrammar::Legacy => parse_type_phrase(type_text),
+        TypePhraseGrammar::Legacy => parse_type_phrase_folding(type_text),
         // `OracleResult` = `(remainder, filter)`.
         TypePhraseGrammar::Strict => {
             let (rem, filter) = super::target::parse_type_phrase(type_text)?;
@@ -3223,7 +3223,7 @@ fn parse_distinct_counter_kinds_among_tail(input: &str) -> OracleResult<'_, Quan
     let (rest, _) = opt(tag("s")).parse(rest)?;
     let (rest, _) = tag(" ").parse(rest)?;
     let (rest, _) = alt((tag("on "), tag("among "))).parse(rest)?;
-    let (filter, remainder) = parse_type_phrase(rest);
+    let (filter, remainder) = parse_type_phrase_folding(rest);
     if matches!(filter, TargetFilter::Any) || !remainder.trim().is_empty() {
         return Err(nom::Err::Error(nom::error::Error::new(
             input,
@@ -4670,7 +4670,7 @@ pub fn parse_for_each_clause_ref(input: &str) -> OracleResult<'_, QuantityRef> {
 fn parse_for_each_differently_named(input: &str) -> OracleResult<'_, QuantityRef> {
     let (rest, _) = tag("differently named ").parse(input)?;
     let type_text = rest.trim_end_matches('.').trim_end_matches(',');
-    let (filter, remainder) = parse_type_phrase(type_text);
+    let (filter, remainder) = parse_type_phrase_folding(type_text);
     if !remainder.trim().is_empty() || !quantity_filter_has_meaningful_content(&filter) {
         return Err(nom::Err::Error(nom::error::Error::new(
             input,
@@ -4700,7 +4700,7 @@ fn parse_distinct_quality_among_objects(input: &str) -> OracleResult<'_, Quantit
     let (rest, quality) = parse_shared_quality(rest)?;
     let (rest, _) = tag(" among ").parse(rest)?;
     let type_text = rest.trim_end_matches('.').trim_end_matches(',');
-    let (filter, remainder) = parse_type_phrase(type_text);
+    let (filter, remainder) = parse_type_phrase_folding(type_text);
     if !remainder.trim().is_empty() || !quantity_filter_has_meaningful_content(&filter) {
         return Err(nom::Err::Error(nom::error::Error::new(
             input,
@@ -4728,7 +4728,7 @@ fn parse_distinct_quality_among_objects(input: &str) -> OracleResult<'_, Quantit
 // color among", so widening it would be an untested grammar change.
 fn parse_for_each_distinct_colors_among_permanents(input: &str) -> OracleResult<'_, QuantityRef> {
     let (rest, _) = tag("color among ").parse(input)?;
-    let (filter, remainder) = parse_type_phrase(rest);
+    let (filter, remainder) = parse_type_phrase_folding(rest);
     if !remainder.trim().is_empty()
         || matches!(filter, TargetFilter::Any)
         || !quantity_filter_has_meaningful_content(&filter)
@@ -5098,7 +5098,7 @@ enum EnteredControlBinding {
 /// selects — see [`EnteredControlBinding`].
 fn parse_entered_this_turn_ref(input: &str) -> OracleResult<'_, QuantityRef> {
     let (rest, (type_text, binding)) = parse_entered_this_turn_clause(input)?;
-    let (filter, remainder) = parse_type_phrase(type_text.trim());
+    let (filter, remainder) = parse_type_phrase_folding(type_text.trim());
     if matches!(filter, TargetFilter::Any) || !remainder.trim().is_empty() {
         return Err(nom::Err::Error(nom::error::Error::new(
             input,
@@ -5185,7 +5185,7 @@ fn parse_entry_event_controller(input: &str) -> OracleResult<'_, PlayerScope> {
 fn parse_tokens_created_this_turn_tail(input: &str) -> OracleResult<'_, QuantityRef> {
     let (rest, type_text) = take_until(" you created this turn").parse(input)?;
     let (rest, _) = tag(" you created this turn").parse(rest)?;
-    let (filter, remainder) = parse_type_phrase(type_text.trim());
+    let (filter, remainder) = parse_type_phrase_folding(type_text.trim());
     if matches!(filter, TargetFilter::Any) || !remainder.trim().is_empty() {
         return Err(nom::Err::Error(nom::error::Error::new(
             input,
@@ -5288,7 +5288,7 @@ pub(crate) fn parse_mana_from_source_spent_to_cast(input: &str) -> OracleResult<
 }
 
 pub(crate) fn parse_mana_source_filter(input: &str) -> OracleResult<'_, TargetFilter> {
-    let (source_filter, rest) = parse_type_phrase(input);
+    let (source_filter, rest) = parse_type_phrase_folding(input);
     if rest.len() == input.len() {
         return Err(nom::Err::Error(nom::error::Error::new(
             input,
@@ -5911,7 +5911,7 @@ fn parse_number_of_creatures_died_this_turn(input: &str) -> OracleResult<'_, Qua
 fn parse_sacrificed_this_turn_filter(input: &str) -> OracleResult<'_, TargetFilter> {
     // CR 701.21a: sacrifice moves the permanent directly to its owner's graveyard
     // (not destroyed — bypasses indestructible and regeneration).
-    let (filter, rest) = parse_type_phrase(input);
+    let (filter, rest) = parse_type_phrase_folding(input);
     if !quantity_filter_has_meaningful_content(&filter) {
         return Err(nom::Err::Error(nom::error::Error::new(
             input,
@@ -5988,7 +5988,7 @@ fn parse_number_of_cards_put_into_graveyard_from_anywhere_this_turn(
         terminated(take_until(singular), tag(singular)),
     ))
     .parse(input)?;
-    let (filter, leftover) = parse_type_phrase(type_text.trim());
+    let (filter, leftover) = parse_type_phrase_folding(type_text.trim());
     if !leftover.trim().is_empty() {
         return Err(nom::Err::Error(nom::error::Error::new(
             leftover,
@@ -6958,7 +6958,7 @@ mod tests {
     /// Tazri) must stay an HONEST GAP, never a confident count over an
     /// unrebindable sentinel.
     ///
-    /// MEASURED CORRECTION to the plan: neither `parse_type_phrase` carries the
+    /// MEASURED CORRECTION to the plan: neither `parse_type_phrase_folding` carries the
     /// anaphor grammar — that lives in `parse_target`, not in either type-phrase
     /// reader. Strict `Err`s on "those creatures"; Legacy returns an EMPTY
     /// `TypedFilter` plus the whole input. So both refuse, but by different
@@ -6983,7 +6983,7 @@ mod tests {
             super::super::target::parse_type_phrase("those creatures").is_err(),
             "Strict rejects an anaphor outright"
         );
-        let (legacy_filter, legacy_rest) = parse_type_phrase("those creatures");
+        let (legacy_filter, legacy_rest) = parse_type_phrase_folding("those creatures");
         assert_eq!(
             legacy_rest, "those creatures",
             "Legacy's infallible failure consumes nothing"

--- a/crates/engine/src/parser/oracle_nom/target.rs
+++ b/crates/engine/src/parser/oracle_nom/target.rs
@@ -38,15 +38,11 @@ pub fn parse_declared_target_prefix(input: &str) -> OracleResult<'_, ()> {
 /// Handles: optional "non" prefix, optional supertype, optional color prefix,
 /// core type(s) joined by " or ", and optional controller suffix.
 ///
-/// # Not interchangeable with the other `parse_type_phrase`
-///
-/// `crate::parser::oracle_target::parse_type_phrase` has the same name and
-/// reads the same grammatical slot, but it is a different reader — it is not a
-/// legacy copy of this one, and this is not a drop-in nom port of it. Their
-/// accepted grammars diverge, so the choice of reader changes which cards a
-/// caller accepts. The measured differences are tabulated on the private
+/// Not a drop-in for `crate::parser::oracle_target::parse_type_phrase_folding`,
+/// which reads the same grammatical slot with a wider grammar and an infallible
+/// return. The measured differences are tabulated on the private
 /// `TypePhraseGrammar` enum in `oracle_nom/quantity.rs`, which selects between
-/// them as an explicit typed parameter; this reader is its `Strict` arm, and
+/// the two as an explicit typed parameter; this reader is its `Strict` arm, and
 /// reports an unrecognized phrase as `Err`.
 pub fn parse_type_phrase(input: &str) -> OracleResult<'_, TargetFilter> {
     // Optional "non" prefix (consumed separately from type negation)

--- a/crates/engine/src/parser/oracle_quantity.rs
+++ b/crates/engine/src/parser/oracle_quantity.rs
@@ -36,7 +36,9 @@ use super::oracle_nom::quantity as nom_quantity;
 use super::oracle_nom::target as nom_target;
 use crate::parser::oracle_effect::counter::normalize_counter_type;
 use crate::parser::oracle_effect::parse_controls_permanent_object;
-use crate::parser::oracle_target::{parse_target, parse_type_phrase, parse_type_phrase_with_ctx};
+use crate::parser::oracle_target::{
+    parse_target, parse_type_phrase_folding, parse_type_phrase_folding_with_ctx,
+};
 use crate::parser::oracle_util::{merge_or_filters, parse_count_multiplier};
 use crate::types::ability::{
     AggregateFunction, AttackScope, AttackSubject, CardTypeSetSource, Comparator, ControllerRef,
@@ -262,7 +264,7 @@ pub(crate) fn parse_quantity_ref_with_context(
                 continue;
             }
             let counter_type = normalize_counter_type(counter_text);
-            let (filter, remainder) = parse_type_phrase_with_ctx(after_filter, ctx);
+            let (filter, remainder) = parse_type_phrase_folding_with_ctx(after_filter, ctx);
             if remainder.trim().is_empty()
                 && !matches!(filter, TargetFilter::Any)
                 && !is_empty_typed_filter(&filter)
@@ -354,7 +356,7 @@ pub(crate) fn parse_quantity_ref_with_context(
         // cards" is an aggregate over the most recent chain tracked set, not over live
         // battlefield objects — the anaphor "those exiled cards" refers to the set
         // the preceding effect published (e.g. Ensnared by the Mara's `ExileTop`).
-        // Matched before `parse_type_phrase_with_ctx` so the exile anaphor isn't
+        // Matched before `parse_type_phrase_folding_with_ctx` so the exile anaphor isn't
         // mis-read as a type phrase. Reuses the established exile-anaphor pair from
         // `oracle_effect::mod` (`those exiled cards` / `the exiled cards`).
         if let Ok((anaphor_rest, _)) = alt((
@@ -381,7 +383,7 @@ pub(crate) fn parse_quantity_ref_with_context(
         // batched "whenever one or more creatures … die" trigger, "those
         // creatures" references the triggering event batch (its dying subjects),
         // NOT a live zone filter or a chain-published set. Matched before
-        // `parse_type_phrase_with_ctx` so the anaphor isn't mis-read as a type
+        // `parse_type_phrase_folding_with_ctx` so the anaphor isn't mis-read as a type
         // phrase (bare "creatures" would otherwise parse as a filter).
         //
         // Scoped narrowly because this parser is context-free and cannot see
@@ -428,7 +430,7 @@ pub(crate) fn parse_quantity_ref_with_context(
                 ));
             }
         }
-        let (filter, remainder) = parse_type_phrase_with_ctx(rest, ctx);
+        let (filter, remainder) = parse_type_phrase_folding_with_ctx(rest, ctx);
         // CR 608.2h: present-tense aggregate. Accept a bare empty remainder
         // (existing no-snapshot behavior) or a trailing cast/activation-time
         // snapshot suffix ("as you cast this spell") — the suffix is a pure
@@ -449,7 +451,7 @@ pub(crate) fn parse_quantity_ref_with_context(
         // control] this turn" aggregates over this turn's battlefield→graveyard
         // zone-change records, not live battlefield objects — the objects have
         // left play and carry their death-time P/T snapshot. Reuse the filter
-        // parse_type_phrase_with_ctx already produced (above) and run the shared
+        // parse_type_phrase_folding_with_ctx already produced (above) and run the shared
         // death-suffix combinator on its remainder. Placed before the past-tense
         // "you controlled" arm so it isn't shadowed, and after the present-tense
         // arm so plain "the total power of creatures you control" stays a live
@@ -479,7 +481,7 @@ pub(crate) fn parse_quantity_ref_with_context(
         // CR 608.2i: past-tense "you controlled" look-back. tag("you control") in
         // parse_zone_controller has no word boundary and would prefix-match
         // "you controlled", corrupting the remainder to "led …". Isolate the bare
-        // head via take_until(" you controlled ") BEFORE parse_type_phrase, then
+        // head via take_until(" you controlled ") BEFORE parse_type_phrase_folding, then
         // re-inject ControllerRef::You. Reuses the inject_controller_you building
         // block; same strip-controller-before-type-phrase ordering as
         // parse_controller_controlled_as_cast_condition
@@ -487,7 +489,7 @@ pub(crate) fn parse_quantity_ref_with_context(
         if let Ok((after_head_tag, head_text)) =
             take_until::<_, _, OracleError<'_>>(" you controlled ").parse(rest)
         {
-            let (head_filter, head_rem) = parse_type_phrase(head_text);
+            let (head_filter, head_rem) = parse_type_phrase_folding(head_text);
             if head_rem.trim().is_empty()
                 && !matches!(head_filter, TargetFilter::Any)
                 && !is_empty_typed_filter(&head_filter)
@@ -621,7 +623,7 @@ pub(crate) fn parse_quantity_ref_with_context(
         // CR 608.2c + CR 400.7: "the number of [filter] destroyed/sacrificed
         // this way" — count from the tracked set populated by the preceding
         // destroy/sacrifice in the sub_ability chain. Must run BEFORE
-        // `parse_type_phrase`, which would consume "creatures you controlled"
+        // `parse_type_phrase_folding`, which would consume "creatures you controlled"
         // and leave an unresolved "that were destroyed this way" tail.
         // Class: Kaya's Wrath (issue #2943), Ceaseless Conflict, and any
         // "equal to the number of … destroyed this way" lifegain phrasing.
@@ -652,8 +654,8 @@ pub(crate) fn parse_quantity_ref_with_context(
                 return Some(canonicalize_quantity_ref(qty));
             }
         }
-        let (filter, remainder) = parse_type_phrase_with_ctx(rest, ctx);
-        // CR 109.1: `parse_type_phrase_with_ctx` always returns `TargetFilter::Typed`,
+        let (filter, remainder) = parse_type_phrase_folding_with_ctx(rest, ctx);
+        // CR 109.1: `parse_type_phrase_folding_with_ctx` always returns `TargetFilter::Typed`,
         // including the empty-shaped form (no `type_filters`, no `controller`, no
         // `properties`) when the input has no recognized type word (e.g.
         // "opponents that were dealt combat damage this turn"). The empty shape
@@ -730,13 +732,13 @@ fn parse_shuffled_this_way_count(text: &str) -> Option<QuantityRef> {
     .then_some(QuantityRef::EventContextAmount)
 }
 
-/// CR 109.1: `parse_type_phrase` always returns `TargetFilter::Typed`, even
+/// CR 109.1: `parse_type_phrase_folding` always returns `TargetFilter::Typed`, even
 /// when no type word was matched — in that case all three of `type_filters`,
 /// `controller`, and `properties` are empty. An empty-shaped `Typed` matches
 /// *every* battlefield object, so callers that interpret a non-`Any` filter
 /// as "type phrase recognized" must reject this shape explicitly. The
 /// building-block guard lives here so every quantity parser that wraps
-/// `parse_type_phrase` shares one consistent rejection rule.
+/// `parse_type_phrase_folding` shares one consistent rejection rule.
 pub(crate) fn is_empty_typed_filter(filter: &TargetFilter) -> bool {
     matches!(
         filter,
@@ -1127,14 +1129,14 @@ fn parse_greatest_among_prefix(
 
 /// CR 202.3 + CR 208.2a: "the greatest <prop> among <A> and <B>" → Max of two
 /// single-zone Aggregates. Each operand is decoded through the shared
-/// `parse_type_phrase_with_ctx` filter grammar, so per-arm zone/controller
+/// `parse_type_phrase_folding_with_ctx` filter grammar, so per-arm zone/controller
 /// semantics (e.g. "noncreature cards in your graveyard" → InZone Graveyard) are
 /// unambiguous. Returns None unless both operands parse to non-empty typed
 /// filters with the conjunction fully consumed.
 fn parse_greatest_among_conjunction(text: &str, ctx: &mut ParseContext) -> Option<QuantityExpr> {
     let (rest, (func, prop)) = parse_greatest_among_prefix(text).ok()?;
 
-    let (filter_a, remainder) = parse_type_phrase_with_ctx(rest, ctx);
+    let (filter_a, remainder) = parse_type_phrase_folding_with_ctx(rest, ctx);
     if matches!(filter_a, TargetFilter::Any) || is_empty_typed_filter(&filter_a) {
         return None;
     }
@@ -1143,7 +1145,7 @@ fn parse_greatest_among_conjunction(text: &str, ctx: &mut ParseContext) -> Optio
         .parse(remainder.trim_end())
         .ok()?;
 
-    let (filter_b, tail) = parse_type_phrase_with_ctx(after_and, ctx);
+    let (filter_b, tail) = parse_type_phrase_folding_with_ctx(after_and, ctx);
     if !tail.trim().is_empty()
         || matches!(filter_b, TargetFilter::Any)
         || is_empty_typed_filter(&filter_b)
@@ -1736,7 +1738,7 @@ fn parse_battlefield_entries_attr_clause(input: &str) -> OracleResult<'_, (Quant
     let (input, type_text) =
         take_until(" enter the battlefield under their control this turn").parse(input)?;
     let (input, _) = tag(" enter the battlefield under their control this turn").parse(input)?;
-    let (filter, remainder) = parse_type_phrase(type_text.trim());
+    let (filter, remainder) = parse_type_phrase_folding(type_text.trim());
     if matches!(filter, TargetFilter::Any) || !remainder.trim().is_empty() {
         return Err(nom::Err::Error(OracleError::new(
             input,
@@ -2361,7 +2363,7 @@ fn filter_is_nontrivial_for_tracked_set(filter: &crate::types::ability::TargetFi
 ///   - exiled this way → `Exiled` (CR 701.13a).
 ///
 /// Uses `terminated(take_until(suffix), tag(suffix))` to split at each
-/// recognized suffix, then delegates the prefix to `parse_type_phrase`. The
+/// recognized suffix, then delegates the prefix to `parse_type_phrase_folding`. The
 /// `caused_by` action lets the resulting `FilteredTrackedSetSize` count only the
 /// members the matching verb produced within a merged chain set — disjoint from
 /// same-destination actions and stable under replacement redirection (#2932).
@@ -2400,13 +2402,13 @@ fn parse_destroyed_or_sacrificed_this_way_filter(
             terminated(take_until(suffix), tag(suffix)).parse(lower);
         if let Ok(("", filter_phrase)) = result {
             // CR 700.1: "card" is the zone-agnostic head noun for the discarded
-            // members ("nonland card discarded this way"). parse_type_phrase maps
+            // members ("nonland card discarded this way"). parse_type_phrase_folding maps
             // it to TypeFilter::Card (matches every card type), so "nonland card"
             // yields [Card, Non(Land)] — counting nonland instants/sorceries too.
             // It must NOT be narrowed to TypeFilter::Permanent: a nonland instant
             // discarded by Seasoned Pyromancer is still counted (CR 701.9a).
             let (filter, remainder) =
-                crate::parser::oracle_target::parse_type_phrase(filter_phrase.trim());
+                crate::parser::oracle_target::parse_type_phrase_folding(filter_phrase.trim());
             if remainder.trim().is_empty() {
                 return Some((Some(filter), cause));
             }
@@ -2444,10 +2446,10 @@ fn parse_destroyed_or_sacrificed_this_way_filter(
 fn parse_filtered_landing_zone_this_way(lower: &str) -> Option<QuantityRef> {
     // Composed landing-zone tail grammar (one nom production, not a string-table
     // loop): `<type phrase> [that was|that were]? (returned | put into a
-    // graveyard) this way`. `parse_type_phrase` consumes the noun phrase; the
+    // graveyard) this way`. `parse_type_phrase_folding` consumes the noun phrase; the
     // tail is a shared optional relative clause (`opt(alt(..))`) plus an `alt()`
     // over the landing-zone verb phrases, terminated by "this way".
-    let (filter, remainder) = crate::parser::oracle_target::parse_type_phrase(lower);
+    let (filter, remainder) = crate::parser::oracle_target::parse_type_phrase_folding(lower);
 
     // Require a specific, controller-agnostic type filter. A typeless or generic
     // "card" filter is the unfiltered count; a controller-bearing filter is
@@ -2493,7 +2495,7 @@ fn parse_filtered_revealed_this_way(lower: &str) -> Option<QuantityRef> {
             terminated(take_until(suffix), tag(suffix)).parse(lower);
         if let Ok(("", filter_phrase)) = result {
             let (filter, remainder) =
-                crate::parser::oracle_target::parse_type_phrase(filter_phrase.trim());
+                crate::parser::oracle_target::parse_type_phrase_folding(filter_phrase.trim());
             if !remainder.trim().is_empty() {
                 continue;
             }
@@ -3129,7 +3131,7 @@ fn parse_spell_history_clause(
         .parse(noun)
         .map(|(_, before)| before.trim())
         .unwrap_or(noun);
-        let (filter, remainder) = parse_type_phrase(qualifier);
+        let (filter, remainder) = parse_type_phrase_folding(qualifier);
         if remainder.trim().is_empty() && !matches!(filter, TargetFilter::Any) {
             return Some((scope, Some(filter)));
         }
@@ -3165,7 +3167,7 @@ fn parse_spell_history_clause(
 /// `caused_by: None` counts every filtered member of the most recent tracked set
 /// (the cards moved "this way").
 fn parse_filtered_tracked_set_this_way(clause: &str) -> Option<QuantityRef> {
-    let (filter, rest) = parse_type_phrase(clause);
+    let (filter, rest) = parse_type_phrase_folding(clause);
     let TargetFilter::Typed(ref typed) = filter else {
         return None;
     };
@@ -3295,7 +3297,7 @@ fn parse_for_each_clause_with_they_controller(
         .parse(clause)
         {
             if after.trim().is_empty() {
-                let (type_filter, type_rest) = parse_type_phrase(prefix);
+                let (type_filter, type_rest) = parse_type_phrase_folding(prefix);
                 if type_rest.trim().is_empty() && !matches!(type_filter, TargetFilter::Any) {
                     return Some(QuantityRef::ObjectCount {
                         filter: TargetFilter::And {
@@ -3513,10 +3515,10 @@ fn parse_for_each_clause_with_they_controller(
             // The counter suffix must consume the rest of the clause (possibly with
             // trailing whitespace / punctuation already stripped by trim_end_matches).
             if suffix_part[consumed..].trim().is_empty() {
-                let (filter, type_rest) = parse_type_phrase(type_part);
+                let (filter, type_rest) = parse_type_phrase_folding(type_part);
                 if type_rest.trim().is_empty() {
                     // Compose: attach the counter property onto the typed filter.
-                    // parse_type_phrase always emits TargetFilter::Typed for non-Any
+                    // parse_type_phrase_folding always emits TargetFilter::Typed for non-Any
                     // returns, so the other branch is defensive.
                     if let TargetFilter::Typed(typed) = filter {
                         let mut props = typed.properties.clone();
@@ -3627,19 +3629,19 @@ fn parse_for_each_clause_with_they_controller(
     }
 
     // "creature you control", "artifact you control", etc.
-    // Use parse_type_phrase_with_ctx (not parse_target) to avoid generating
+    // Use parse_type_phrase_folding_with_ctx (not parse_target) to avoid generating
     // spurious target-fallback warnings for quantity text that isn't a target
     // clause.
     //
     // CR 109.5 + CR 109.4: thread the relative player scope so "they control"
     // binds to the iterating/targeted/chosen player rather than collapsing to the
     // caster. "you control" still resolves to ControllerRef::You inside
-    // parse_type_phrase_with_ctx (its suffix arm is ctx-independent), so The Scarab
+    // parse_type_phrase_folding_with_ctx (its suffix arm is ctx-independent), so The Scarab
     // God and other caster-relative counts are unchanged. CR 608.2c: the controller
     // follows instructions in order, so a per-player-scoped count reads the
     // iterating player.
     let mut tp_ctx = for_each_anaphor_context(ctx, &they_controller);
-    let (filter, remainder) = parse_type_phrase_with_ctx(clause, &mut tp_ctx);
+    let (filter, remainder) = parse_type_phrase_folding_with_ctx(clause, &mut tp_ctx);
     if !matches!(filter, TargetFilter::Any) && remainder.trim().is_empty() {
         return Some(QuantityRef::ObjectCount { filter });
     }
@@ -3735,7 +3737,7 @@ fn parse_for_each_target_controlled_type(clause: &str) -> Option<QuantityRef> {
         return None;
     }
 
-    let (filter, remainder) = parse_type_phrase(type_text);
+    let (filter, remainder) = parse_type_phrase_folding(type_text);
     if remainder.trim().is_empty() {
         with_target_player_controller(filter).map(|filter| QuantityRef::ObjectCount { filter })
     } else {
@@ -5635,14 +5637,14 @@ mod tests {
         }
     }
 
-    /// CR 109.1: Defense-in-depth — when `parse_type_phrase` returns an
+    /// CR 109.1: Defense-in-depth — when `parse_type_phrase_folding` returns an
     /// empty-shaped `Typed` filter (no type words, no controller, no
     /// properties), `parse_quantity_ref` must decline rather than emit an
     /// `ObjectCount` that would match every battlefield permanent.
     ///
     /// The exact text exercised here ("opponents that were dealt combat
     /// damage this turn", without the `the number of` prefix) is the
-    /// substring that flows into `parse_type_phrase` for Tymna's body. If
+    /// substring that flows into `parse_type_phrase_folding` for Tymna's body. If
     /// `parse_quantity_ref` is ever called on it directly (e.g. by a future
     /// quantity context that didn't bind the `PlayerCount` arm), the
     /// empty-Typed guard ensures it declines rather than returning an
@@ -6739,8 +6741,8 @@ mod tests {
 
     /// CR 109.5 + CR 608.2c: "creature they control" inside a "for each [player]"
     /// clause threads the relative player scope into the `ObjectCount` filter's
-    /// controller. Edit 1b swapped the no-ctx fallback (`parse_type_phrase`) for
-    /// the ctx-aware `parse_type_phrase_with_ctx`. Reverting Edit 1b discards the
+    /// controller. Edit 1b swapped the no-ctx fallback (`parse_type_phrase_folding`) for
+    /// the ctx-aware `parse_type_phrase_folding_with_ctx`. Reverting Edit 1b discards the
     /// scope, so "they control" collapses to `ControllerRef::You` and this assert
     /// (ScopedPlayer) fails. Discriminating fail-on-revert guard for the parser fix.
     #[test]
@@ -7772,7 +7774,7 @@ mod tests {
     /// CR 608.2i: past-tense look-back — "the greatest power among creatures you
     /// controlled as you cast this spell" (Lifestream's Blessing). The
     /// discriminating ordering test: `take_until(" you controlled ")` must run
-    /// BEFORE parse_type_phrase so the controller is still resolved to You and
+    /// BEFORE parse_type_phrase_folding so the controller is still resolved to You and
     /// the head filter is "creatures" (not corrupted by "you control"
     /// prefix-matching "you controlled").
     #[test]
@@ -7928,7 +7930,7 @@ mod tests {
     /// destroyed this way" (Kaya's Wrath, issue #2943) must lower to
     /// `FilteredTrackedSetSize`, not `Effect::Unimplemented`. The for-each
     /// path already handled this shape; the `parse_quantity_ref` "the number
-    /// of …" path must mirror it before `parse_type_phrase` strips the tail.
+    /// of …" path must mirror it before `parse_type_phrase_folding` strips the tail.
     #[test]
     fn parse_quantity_ref_creatures_you_controlled_destroyed_this_way() {
         let qty = parse_quantity_ref(
@@ -8177,7 +8179,7 @@ mod tests {
     }
 
     /// NEGATIVE (Builder's Bane guard): a controller-bearing prefix that leaves
-    /// a `parse_type_phrase` remainder must fail cleanly, not produce a
+    /// a `parse_type_phrase_folding` remainder must fail cleanly, not produce a
     /// FilteredTrackedSetSize.
     #[test]
     fn artifacts_they_controlled_put_into_graveyard_this_way_is_none() {

--- a/crates/engine/src/parser/oracle_replacement.rs
+++ b/crates/engine/src/parser/oracle_replacement.rs
@@ -29,7 +29,7 @@ use super::oracle_nom::primitives as nom_primitives;
 use super::oracle_nom::quantity as nom_quantity;
 use super::oracle_nom::target::parse_type_filter_word;
 use super::oracle_quantity::capitalize_first;
-use super::oracle_target::{parse_target, parse_type_phrase};
+use super::oracle_target::{parse_target, parse_type_phrase_folding};
 use super::oracle_util::{
     normalize_card_name_refs, parse_count_expr, parse_number, parse_ordinal, strip_after,
     strip_reminder_text, TextPair,
@@ -1382,7 +1382,7 @@ fn parse_as_enters_exile_from_graveyards(
     };
 
     // Parse the type filter (e.g., "creature")
-    let (filter, remainder) = parse_type_phrase(filter_text.trim());
+    let (filter, remainder) = parse_type_phrase_folding(filter_text.trim());
     if !remainder.trim().is_empty() {
         return None;
     }
@@ -1598,7 +1598,7 @@ fn parse_assemble_contraption_subject(subject: &str) -> Option<TargetFilter> {
     };
     let (_, subject) = all_consuming(parse_leading_article).parse(subject).ok()?;
     let subject = subject.trim();
-    let (mut filter, leftover) = parse_type_phrase(subject);
+    let (mut filter, leftover) = parse_type_phrase_folding(subject);
     if !leftover.trim().is_empty() || filter == TargetFilter::Any {
         return None;
     }
@@ -1787,11 +1787,11 @@ fn parse_reveal_land(
     let remainder_lower = remainder.to_lowercase();
 
     // Parse the filter phrase (e.g., "Plains or Island", "Elf") into a TargetFilter.
-    // `parse_type_phrase` handles union types via `TargetFilter::Or` and single
+    // `parse_type_phrase_folding` handles union types via `TargetFilter::Or` and single
     // subtypes via `TargetFilter::Typed`. Reject phrases we cannot classify —
     // better to fall through to a generic enter-tapped parse than to synthesize
     // a misbehaving filter.
-    let (filter, filter_remainder) = parse_type_phrase(filter_phrase.trim());
+    let (filter, filter_remainder) = parse_type_phrase_folding(filter_phrase.trim());
     if !filter_remainder.trim().is_empty() {
         return None;
     }
@@ -1915,7 +1915,7 @@ fn parse_reveal_land_tail(
     })?;
     let first_filter_consumed = after_unless.len() - after_first_filter.len();
     let first_filter_phrase = &after_unless[..first_filter_consumed];
-    let (first_filter, first_remainder) = parse_type_phrase(first_filter_phrase.trim());
+    let (first_filter, first_remainder) = parse_type_phrase_folding(first_filter_phrase.trim());
     if !first_remainder.trim().is_empty() || first_filter != *expected_filter {
         return None;
     }
@@ -1935,7 +1935,7 @@ fn parse_reveal_land_tail(
         .parse(i)
     })?;
     let second_filter_phrase = after_or.trim().trim_end_matches('.').trim();
-    let (second_filter, second_remainder) = parse_type_phrase(second_filter_phrase);
+    let (second_filter, second_remainder) = parse_type_phrase_folding(second_filter_phrase);
     if !second_remainder.trim().is_empty() || second_filter != *expected_filter {
         return None;
     }
@@ -2443,7 +2443,7 @@ fn parse_as_enters_becomes(text: &str) -> Option<ReplacementDefinition> {
     type VE<'a> = OracleError<'a>;
     let lower = text.to_lowercase();
 
-    // Lead "as " + non-empty external subject up to " enters". `parse_type_phrase`
+    // Lead "as " + non-empty external subject up to " enters". `parse_type_phrase_folding`
     // lowercases internally, so the lowercase subject slice is sufficient here.
     let (after_as, _) = tag::<_, _, VE>("as ").parse(lower.as_str()).ok()?;
     let (after_subject, subject_lower) = take_until::<_, _, VE>(" enters").parse(after_as).ok()?;
@@ -2451,7 +2451,7 @@ fn parse_as_enters_becomes(text: &str) -> Option<ReplacementDefinition> {
         return None;
     }
 
-    // Strip the optional leading article so `parse_type_phrase` reaches the type
+    // Strip the optional leading article so `parse_type_phrase_folding` reaches the type
     // word. `opt` never fails, so the original slice is preserved when absent.
     let (subject_rest, _) = opt(alt((tag::<_, _, VE>("a "), tag("an "))))
         .parse(subject_lower)
@@ -2461,7 +2461,7 @@ fn parse_as_enters_becomes(text: &str) -> Option<ReplacementDefinition> {
     // you control" → Typed permanent / controller You / FilterProp::Historic).
     // Require a genuine non-self subset subject (`Typed`) with full consumption,
     // so self (`~ enters`) and copy ("enter as a copy") lines are not claimed.
-    let (valid_card, rest) = parse_type_phrase(subject_rest);
+    let (valid_card, rest) = parse_type_phrase_folding(subject_rest);
     if !matches!(valid_card, TargetFilter::Typed(_)) || !rest.trim().is_empty() {
         return None;
     }
@@ -3132,13 +3132,13 @@ fn parse_clone_replacement(
         .map_or(type_text, |(rest, _)| rest)
         .trim();
 
-    let (mut filter, leftover) = parse_type_phrase(type_text);
+    let (mut filter, leftover) = parse_type_phrase_folding(type_text);
     if !leftover.trim().is_empty() {
         return None;
     }
 
     // CR 400.1: Thread the source zone onto the filter when it isn't the default
-    // battlefield. `parse_type_phrase` does not emit `InZone` from a bare type
+    // battlefield. `parse_type_phrase_folding` does not emit `InZone` from a bare type
     // word like "creature", so the zone must be attached here. Skip for
     // battlefield to preserve existing Clone/Phantasmal Image filter shape.
     if source_zone != Zone::Battlefield {
@@ -3362,7 +3362,7 @@ fn split_on_clone_source_zone(
     }
     // CR 614.1c: no zone phrase and no "except" clause — the whole post-`copy
     // of` remainder is the type phrase. Drop the sentence-final period so the
-    // downstream `parse_type_phrase` leftover guard accepts plain
+    // downstream `parse_type_phrase_folding` leftover guard accepts plain
     // controller-scoped filters like "a creature you control" (Mirror Image)
     // or "an artifact or creature you control" (Waxen Shapethief), which carry
     // no zone/except boundary to absorb the trailing punctuation.
@@ -3374,8 +3374,8 @@ fn split_on_clone_source_zone(
     ))
 }
 
-/// Attach `FilterProp::InZone { zone }` to a filter produced by `parse_type_phrase`.
-/// `parse_type_phrase` handles its own "in a graveyard" suffix when present in
+/// Attach `FilterProp::InZone { zone }` to a filter produced by `parse_type_phrase_folding`.
+/// `parse_type_phrase_folding` handles its own "in a graveyard" suffix when present in
 /// the type text, but clone-replacement text carries the zone *outside* the type
 /// phrase ("any creature card in a graveyard"), so the zone must be merged in.
 fn attach_zone_to_filter(filter: TargetFilter, zone: Zone) -> TargetFilter {
@@ -3693,7 +3693,7 @@ fn parse_if_controls_count_condition(norm_lower: &str) -> Option<ReplacementCond
         .ok()?;
     let (minimum, type_text) = try_parse_quantity_prefix(rest)?;
 
-    let (filter, leftover) = parse_type_phrase(type_text);
+    let (filter, leftover) = parse_type_phrase_folding(type_text);
     // Allow trailing clause like ", this land enters tapped." — strip up to the comma.
     let leftover = leftover.trim().trim_start_matches(',').trim();
     if !leftover.trim_end_matches('.').is_empty()
@@ -3750,8 +3750,8 @@ fn parse_fast_condition(norm_lower: &str) -> Option<ReplacementCondition> {
         .ok()?;
     let type_text = after_or_fewer.trim_end_matches('.');
 
-    // parse_type_phrase handles "other lands" → TypedFilter { Land, [Another] }
-    let (filter, leftover) = parse_type_phrase(type_text);
+    // parse_type_phrase_folding handles "other lands" → TypedFilter { Land, [Another] }
+    let (filter, leftover) = parse_type_phrase_folding(type_text);
     if !leftover.trim().is_empty() {
         return None;
     }
@@ -3788,7 +3788,7 @@ fn parse_controls_typed_condition(norm_lower: &str) -> Option<ReplacementConditi
 
     // Try "N or more [type]" pattern first (e.g., "two or more other lands")
     if let Some((minimum, type_text)) = try_parse_quantity_prefix(rest) {
-        let (filter, leftover) = parse_type_phrase(type_text);
+        let (filter, leftover) = parse_type_phrase_folding(type_text);
         if !leftover.trim().trim_end_matches('.').is_empty() || filter == TargetFilter::Any {
             return None;
         }
@@ -3796,16 +3796,16 @@ fn parse_controls_typed_condition(norm_lower: &str) -> Option<ReplacementConditi
         return Some(ReplacementCondition::UnlessControlsCountMatching { minimum, filter });
     }
 
-    // Strip leading article — parse_type_phrase does NOT handle "a "/"an "
+    // Strip leading article — parse_type_phrase_folding does NOT handle "a "/"an "
     let rest = rest.trim_start_matches("a ").trim_start_matches("an ");
 
-    let (filter, leftover) = parse_type_phrase(rest);
+    let (filter, leftover) = parse_type_phrase_folding(rest);
     // Reject partial parse — all text must be consumed (modulo trailing period)
     if !leftover.trim().trim_end_matches('.').is_empty() {
         return None;
     }
 
-    // Reject if parse_type_phrase returned Any (nothing meaningful parsed)
+    // Reject if parse_type_phrase_folding returned Any (nothing meaningful parsed)
     if filter == TargetFilter::Any {
         return None;
     }
@@ -3825,7 +3825,7 @@ fn parse_controls_typed_condition(norm_lower: &str) -> Option<ReplacementConditi
 fn parse_opponents_control_condition(norm_lower: &str) -> Option<ReplacementCondition> {
     let rest = strip_after(norm_lower, "unless your opponents control ")?;
     let (minimum, type_text) = try_parse_quantity_prefix(rest)?;
-    let (filter, leftover) = parse_type_phrase(type_text);
+    let (filter, leftover) = parse_type_phrase_folding(type_text);
     if !leftover.trim().trim_end_matches('.').is_empty() || filter == TargetFilter::Any {
         return None;
     }
@@ -4238,7 +4238,7 @@ fn parse_enters_with_counters(
     //     self-application occurs here — but the class must not exclude itself.)
     //
     // `parse_distributive_subject` strips the prefix and reports the scope, then
-    // `parse_type_phrase` acts as the type detector: accept the subject iff the
+    // `parse_type_phrase_folding` acts as the type detector: accept the subject iff the
     // parse yields a typed filter with a concrete type/subtype (not the `Any`
     // fallback). A non-type subject parses to the `[Any]` fallback and is
     // rejected, falling through to the `SelfRef` self-ETB branch.
@@ -4260,7 +4260,7 @@ fn parse_enters_with_counters(
             // noun and the quality survives as a filter property.
             let (after_color, color_prop) =
                 crate::parser::oracle_static::peel_color_quality_prefix(subject_text);
-            let (filter, _) = parse_type_phrase(after_color);
+            let (filter, _) = parse_type_phrase_folding(after_color);
             let is_valid = matches!(
                 &filter,
                 TargetFilter::Typed(TypedFilter { type_filters, .. })
@@ -5244,9 +5244,9 @@ fn parse_cast_enters_with_prefix(norm_lower: &str) -> Option<(TypedFilter, &str)
     // `split_once_on` returns `Ok(("", (prefix, suffix)))`.
     let (_, (spell_filter_text, after_that_text)) =
         nom_primitives::split_once_on(rest, ", that ").ok()?;
-    let (spell_filter, filter_rest) = parse_type_phrase(spell_filter_text);
+    let (spell_filter, filter_rest) = parse_type_phrase_folding(spell_filter_text);
     // Require that the spell filter cleanly consumed its text (modulo trailing
-    // "spell" token which parse_type_phrase leaves in the remainder on some paths).
+    // "spell" token which parse_type_phrase_folding leaves in the remainder on some paths).
     let filter_rest = filter_rest.trim();
     if !filter_rest.is_empty() && filter_rest != "spell" && filter_rest != "spells" {
         return None;
@@ -5777,7 +5777,7 @@ fn build_external_entry_replacement(
         | ExternalEntryKind::PlayedByOpponents { enters_tapped } => enters_tapped,
     };
 
-    let (filter, rest) = parse_type_phrase(subject);
+    let (filter, rest) = parse_type_phrase_folding(subject);
     if !rest.trim().is_empty() {
         return None;
     }
@@ -5925,7 +5925,7 @@ fn parse_creature_die_exile_replacement(
     }
 
     // Parse the subject filter (e.g., "another creature", "a nontoken creature an opponent controls")
-    let (filter, subject_rest) = parse_type_phrase(subject_filter_text);
+    let (filter, subject_rest) = parse_type_phrase_folding(subject_filter_text);
     if matches!(&filter, TargetFilter::Any) || !subject_rest.trim().is_empty() {
         return None;
     }
@@ -6098,7 +6098,7 @@ fn parse_creature_enter_wasnt_cast_exile_replacement(
         .parse(subject)
         .map_or(subject, |(rest, _)| rest)
         .trim();
-    let (filter, subject_rest) = parse_type_phrase(subject);
+    let (filter, subject_rest) = parse_type_phrase_folding(subject);
     if matches!(&filter, TargetFilter::Any) || !subject_rest.trim().is_empty() {
         return None;
     }
@@ -6209,7 +6209,7 @@ fn parse_typed_permanent_you_controlled_damage_source(
     let (after_type, type_text) =
         take_until::<_, _, OracleError<'_>>(" you controlled").parse(rest)?;
     let (after, _) = tag::<_, _, OracleError<'_>>(" you controlled").parse(after_type)?;
-    let (filter, leftover) = parse_type_phrase(type_text);
+    let (filter, leftover) = parse_type_phrase_folding(type_text);
     if !leftover.trim().is_empty() {
         return Err(nom::Err::Error(OracleError::new(
             leftover,
@@ -7829,14 +7829,14 @@ fn parse_oneshot_source_filter(body: &str) -> Option<TargetFilter> {
 /// Protection cycle, Rune of Protection cycle) — the qualifier restricts which
 /// source may be chosen and is retained on the variant so the resolver can (a)
 /// offer only matching candidates when prompting the choice and (b) recheck
-/// source qualities at damage time. Parses the qualifier with `parse_type_phrase`
+/// source qualities at damage time. Parses the qualifier with `parse_type_phrase_folding`
 /// directly (the shared color/type/supertype phrase combinator used throughout
 /// this file), which resolves a bare core type word like "land" to the correct
-/// `TypeFilter::Land` — so any future color/type/supertype word `parse_type_phrase`
+/// `TypeFilter::Land` — so any future color/type/supertype word `parse_type_phrase_folding`
 /// recognizes is covered for free, not just the 13 Circle/Rune of Protection cards.
 fn parse_qualified_chosen_damage_source(subject: &str) -> Option<TargetFilter> {
     let (rest, _) = nom_primitives::parse_article.parse(subject).ok()?;
-    let (filter, rest) = parse_type_phrase(rest.trim_start());
+    let (filter, rest) = parse_type_phrase_folding(rest.trim_start());
     if matches!(filter, TargetFilter::Any) {
         // Bare "source" — not a qualifier; the caller's bare-anaphor branch
         // handles "a source of your choice" directly.
@@ -7897,7 +7897,7 @@ pub(crate) fn parse_choose_damage_source_candidate(input: &str) -> Option<Target
     // CR 609.7a: interactive "Choose a source …" — only the leading clause
     // (Desperate Gambit: "Choose a source you control. Flip a coin. …").
     // Must NOT reuse `parse_damage_source_subject_filter`'s typed-target fallback
-    // (`parse_type_phrase`), which would misroute "choose a creature …" /
+    // (`parse_type_phrase_folding`), which would misroute "choose a creature …" /
     // "choose a creature or land" to damage-source selection.
     let first_clause = nom_primitives::split_once_on(input, ".")
         .map(|(_, (before, _))| before.trim().trim_end_matches('.'))
@@ -7974,7 +7974,7 @@ fn finish_damage_source_subject(subject: &str) -> Option<TargetFilter> {
         .trim();
 
     // "a spell" — any spell is the source; no typed filter (Benevolent Unicorn).
-    // Must precede `parse_type_phrase`, which maps bare "spell" to Card.
+    // Must precede `parse_type_phrase_folding`, which maps bare "spell" to Card.
     if subject == "spell" {
         return None;
     }
@@ -8115,7 +8115,7 @@ pub(crate) fn parse_damage_source_subject_filter(subject: &str) -> Option<Target
     // "creatures you control with counters on them", ...) share the normal
     // target grammar; damage replacement parsing should not maintain a parallel
     // counter/property grammar.
-    let (filter, rest) = parse_type_phrase(subject);
+    let (filter, rest) = parse_type_phrase_folding(subject);
     if rest.trim().is_empty() && !matches!(filter, TargetFilter::Any) {
         return Some(filter);
     }
@@ -8970,7 +8970,7 @@ fn parse_connive_replacement(lower: &str, original_text: &str) -> Option<Replace
 /// CR 502.3 + CR 502.4 + CR 614.1a: untap-step replacement —
 /// "If [filter] would untap during [its controller's | your] untap step,
 /// [effect] instead" (Freyalise's Winds, Edge of Malacol). The `valid_card`
-/// filter scopes WHICH permanent (parsed generically via `parse_type_phrase`),
+/// filter scopes WHICH permanent (parsed generically via `parse_type_phrase_folding`),
 /// and `ReplacementCondition::DuringUntapStep` scopes WHEN (so effect-untaps at
 /// other times are unaffected). The alternative effect appears BEFORE "instead"
 /// ("remove all wind counters from it instead", "put two +1/+1 counters on it
@@ -9049,12 +9049,12 @@ fn parse_untap_step_replacement(original_text: &str, lower: &str) -> Option<Repl
         return None;
     }
     // CR 614.1a: consume the leading "if " with a `tag` combinator, then parse
-    // the subject as a typed filter (lowercase, as `parse_type_phrase` expects).
+    // the subject as a typed filter (lowercase, as `parse_type_phrase_folding` expects).
     let head_lc = head.trim().to_ascii_lowercase();
     let (subject_lc, _) = tag::<_, _, OracleError<'_>>("if ")
         .parse(head_lc.as_str())
         .ok()?;
-    let (filter, subject_rest) = parse_type_phrase(subject_lc.trim());
+    let (filter, subject_rest) = parse_type_phrase_folding(subject_lc.trim());
     if matches!(&filter, TargetFilter::Any) || !subject_rest.trim().is_empty() {
         return None;
     }
@@ -10382,7 +10382,7 @@ fn parse_counter_replacement(lower: &str, original_text: &str) -> Option<Replace
 fn parse_counter_replacement_valid_card(lower: &str) -> Option<TargetFilter> {
     let (_, (), after_anchor) =
         nom_primitives::scan_preceded(lower, parse_counter_replacement_scope_anchor)?;
-    let (filter, rest) = parse_type_phrase(after_anchor);
+    let (filter, rest) = parse_type_phrase_folding(after_anchor);
     if !is_counter_replacement_object_scope(&filter)
         || parse_counter_replacement_scope_tail(rest).is_err()
     {
@@ -10720,7 +10720,7 @@ fn parse_cant_become_untapped_replacement(
 /// unblocked creatures is dealt to ~ instead." (Veteran Bodyguard, Weathered
 /// Bodyguards). Delegates entirely to `parse_damage_source_subject_filter`
 /// (the same subject-typing helper every other damage-source clause in this
-/// module already uses), which itself falls back to `parse_type_phrase` — the
+/// module already uses), which itself falls back to `parse_type_phrase_folding` — the
 /// SAME combinator that already resolves "unblocked creatures" / "unblocked
 /// attacking creatures" to `FilterProp::Unblocked` via
 /// `parse_combat_status_prefix` (`oracle_target.rs`), proven by the existing
@@ -12015,7 +12015,7 @@ fn parse_damage_recipient_scope(working_lower: &str) -> Option<DamageTargetFilte
 fn parse_damage_recipient_after_prefix(working_lower: &str, prefix: &str) -> Option<TargetFilter> {
     nom_primitives::scan_at_word_boundaries(working_lower, |input| {
         let (after_to, _) = tag::<_, _, OracleError<'_>>(prefix).parse(input)?;
-        let (filter, rest) = parse_type_phrase(after_to);
+        let (filter, rest) = parse_type_phrase_folding(after_to);
         if matches!(filter, TargetFilter::Any) {
             return Err(nom::Err::Error(OracleError::new(
                 after_to,
@@ -12521,7 +12521,7 @@ fn parse_opponent_put_land_sacrifice_replacement(
     // type the applicability gate counts onto the battlefield. Rather than hardcode
     // "a land" (which silently diverges from the already-parsed gate type), match
     // the structural frame and re-derive the entering permanent's filter from the
-    // event noun via the shared `parse_type_phrase` combinator, then require it to
+    // event noun via the shared `parse_type_phrase_folding` combinator, then require it to
     // equal the gate's `type_filter`. This keeps the condition, the replaced event,
     // and the sacrifice rider bound to one type — so the same construction with a
     // different permanent noun stays internally consistent instead of half generic.
@@ -12534,7 +12534,7 @@ fn parse_opponent_put_land_sacrifice_replacement(
     let (rest, _) = tag::<_, _, OracleError<'_>>(" onto the battlefield")
         .parse(rest)
         .ok()?;
-    let (event_filter, event_rem) = parse_type_phrase(event_noun.trim());
+    let (event_filter, event_rem) = parse_type_phrase_folding(event_noun.trim());
     if !event_rem.trim().is_empty() || event_filter != type_filter {
         return None;
     }
@@ -12925,7 +12925,7 @@ fn parse_life_floor_damage_replacement(norm_lower: &str) -> Option<ReplacementDe
     .ok()?;
 
     // Build the controller-scoped filter (e.g., "creature you control").
-    let (filter, leftover) = parse_type_phrase(filter_text);
+    let (filter, leftover) = parse_type_phrase_folding(filter_text);
     if filter == TargetFilter::Any || !leftover.trim().is_empty() {
         return None;
     }
@@ -17326,7 +17326,7 @@ mod tests {
     #[test]
     fn each_non_type_subject_falls_through_to_selfref() {
         // "each opponent" — "opponent" is not a `TypeFilter` variant, so
-        // `parse_type_phrase` yields the `[Any]` fallback and the subject is
+        // `parse_type_phrase_folding` yields the `[Any]` fallback and the subject is
         // rejected, leaving the self-ETB `SelfRef`/`Moved` result.
         let def = parse_replacement_line(
             "Each opponent enters with a +1/+1 counter on it.",
@@ -20587,7 +20587,7 @@ mod tests {
     /// CR 707.9 + CR 614.1c: Mirror Image / Waxen Shapethief — "enter as a copy
     /// of a creature you control" with no zone phrase and no except clause. The
     /// controller-scoped filter must parse despite the sentence-final period
-    /// (previously left as `parse_type_phrase` leftover, dropping the clone).
+    /// (previously left as `parse_type_phrase_folding` leftover, dropping the clone).
     #[test]
     fn clone_creature_you_control_no_zone_phrase() {
         let mirror = parse_replacement_line(
@@ -20932,7 +20932,7 @@ mod tests {
     /// copy of a creature card in exile with a takeover counter on it." The copy
     /// SOURCE is an exile-zoned card constrained by a takeover-counter predicate.
     /// The full source phrase (zone clause THEN counter clause) must flow through
-    /// `parse_type_phrase` with no leftover, so the optional Moved/Battlefield
+    /// `parse_type_phrase_folding` with no leftover, so the optional Moved/Battlefield
     /// clone replacement registers and its `BecomeCopy` target filter carries both
     /// `InZone { Exile }` and the `Counters { OfType("takeover"), GE, 1 }` source
     /// predicate (honored at runtime by `find_copy_targets` scanning exile).

--- a/crates/engine/src/parser/oracle_static/anthem.rs
+++ b/crates/engine/src/parser/oracle_static/anthem.rs
@@ -117,7 +117,7 @@ pub(crate) fn parse_typed_you_control(
                 // descriptor ("Nontoken creatures you control") or supertype
                 // descriptor ("Legendary creatures you control") is NOT a
                 // subtype. Bail so dispatch falls through to the subject parser,
-                // which routes the full phrase through `parse_type_phrase`.
+                // which routes the full phrase through `parse_type_phrase_folding`.
                 } else if descriptor_is_negation(descriptor) || descriptor_is_supertype(descriptor)
                 {
                     return None;
@@ -133,7 +133,7 @@ pub(crate) fn parse_typed_you_control(
                 // \"bands with other legendary creatures.\"" (issue #6332).
                 // None of the bespoke arms above recognize a compound
                 // descriptor, so delegate the full subject to
-                // `parse_type_phrase` — the general subject-filter grammar
+                // `parse_type_phrase_folding` — the general subject-filter grammar
                 // that already composes a color prefix and a supertype prefix
                 // in either order (see its leading and post-negation
                 // supertype/color passes in `oracle_target.rs`) — rather than
@@ -142,19 +142,19 @@ pub(crate) fn parse_typed_you_control(
                 // Accept ONLY when the fully-consumed result carries BOTH a
                 // `HasColor` and a `HasSupertype` property — i.e. genuinely a
                 // color+supertype compound, not merely "some descriptor
-                // `parse_type_phrase` happens to accept." A full-consumption
+                // `parse_type_phrase_folding` happens to accept." A full-consumption
                 // check alone is not narrow enough: descriptors this function
                 // has no OTHER arm for (e.g. Saryth, the Viper's Fang / Augusta,
                 // Dean of Order's "Other tapped creatures you control .../Other
                 // untapped creatures you control ...") also fully consume
-                // through `parse_type_phrase`, and unconditionally accepting
+                // through `parse_type_phrase_folding`, and unconditionally accepting
                 // them here would silently reroute cards that are unrelated to
                 // this fix onto a different (and untested, for them) filter
                 // path. Requiring both properties scopes acceptance to exactly
                 // the class this fix targets.
                 } else {
                     let subject_and_type = tp.original[..creatures_pos + " creatures".len()].trim();
-                    let (compound_filter, remainder) = parse_type_phrase(subject_and_type);
+                    let (compound_filter, remainder) = parse_type_phrase_folding(subject_and_type);
                     match compound_filter {
                         TargetFilter::Typed(typed)
                             if remainder.trim().is_empty()

--- a/crates/engine/src/parser/oracle_static/cost_mod.rs
+++ b/crates/engine/src/parser/oracle_static/cost_mod.rs
@@ -168,7 +168,7 @@ pub(crate) fn parse_cost_payment_prohibition_statics(
     let (_, _) = (opt(tag::<_, _, OracleError<'_>>(".")), eof)
         .parse(after_suffix)
         .ok()?;
-    let (filter, filter_remainder) = parse_type_phrase(filter_text.trim());
+    let (filter, filter_remainder) = parse_type_phrase_folding(filter_text.trim());
     if !filter_remainder.trim().is_empty() || matches!(filter, TargetFilter::Any) {
         return None;
     }
@@ -308,7 +308,7 @@ fn parse_cast_spells_alternative_cost(text: &str) -> Option<StaticDefinition> {
         .parse(remainder_lower.as_str())
         .is_ok();
 
-    let base_filter = parse_type_phrase(filter_original).0;
+    let base_filter = parse_type_phrase_folding(filter_original).0;
     let affected = apply_spell_keyword_subject_constraints(base_filter, None, None, Vec::new());
 
     let cost = parse_oracle_cost(cost_slice);
@@ -523,7 +523,7 @@ pub(crate) fn parse_spells_alternative_cost(text: &str) -> Option<StaticDefiniti
             .parse(prefix_lower)
             .map_or(prefix_lower, |(rest, _)| rest);
         // CR 105.2: peel a color-quality prefix ("colorless spell" — Darksteel
-        // Monolith) via the shared authority — `parse_type_phrase` drops the
+        // Monolith) via the shared authority — `parse_type_phrase_folding` drops the
         // word, which would silently over-broaden the grant to any spell. The
         // helper expects the word with its trailing space, so re-pad the
         // trimmed prefix slice.
@@ -537,7 +537,7 @@ pub(crate) fn parse_spells_alternative_cost(text: &str) -> Option<StaticDefiniti
             // the remaining type words are the last `rest.len()` bytes of the
             // trimmed original slice (the TextPair length-mapping convention).
             let tail = &type_prefix_original[type_prefix_original.len() - rest.len()..];
-            parse_type_phrase(tail).0
+            parse_type_phrase_folding(tail).0
         };
         (base, color_prop.into_iter().collect::<Vec<_>>())
     };
@@ -610,7 +610,7 @@ pub(crate) fn parse_collect_evidence_alt_cost(text: &str) -> Option<StaticDefini
     let base_filter = if type_prefix_original.is_empty() {
         TargetFilter::Typed(TypedFilter::card())
     } else {
-        parse_type_phrase(type_prefix_original).0
+        parse_type_phrase_folding(type_prefix_original).0
     };
     let affected = apply_spell_keyword_subject_constraints(base_filter, None, None, Vec::new());
 
@@ -812,13 +812,13 @@ pub(crate) fn parse_cast_by_paying_life_alt_cost(text: &str) -> Option<StaticDef
         };
 
     // Strip trailing "spell" / "spells" before type parsing — "enchantment spell" →
-    // "enchantment". `parse_type_phrase` expects bare type words.
+    // "enchantment". `parse_type_phrase_folding` expects bare type words.
     let filter_for_parse = strip_cost_mod_spell_noun_suffix(filter_for_parse);
 
     let base_filter = if filter_for_parse.is_empty() {
         TargetFilter::Typed(TypedFilter::card())
     } else {
-        let (filter, remainder) = parse_type_phrase(filter_for_parse);
+        let (filter, remainder) = parse_type_phrase_folding(filter_for_parse);
         if !remainder.trim().is_empty() {
             return None;
         }

--- a/crates/engine/src/parser/oracle_static/dispatch.rs
+++ b/crates/engine/src/parser/oracle_static/dispatch.rs
@@ -80,7 +80,7 @@ fn parse_enchanted_is_copy_of_chosen(tp: &TextPair, text: &str) -> Option<Static
     // Subject type of the enchanted host (creature / permanent). Trim the
     // trailing period first so the donor phrase parses to an empty remainder.
     let subject_lower = rest.lower.trim_end_matches('.').trim();
-    let (subject_filter, after_subject) = parse_type_phrase(subject_lower);
+    let (subject_filter, after_subject) = parse_type_phrase_folding(subject_lower);
     let TargetFilter::Typed(mut subject) = subject_filter else {
         return None;
     };
@@ -90,7 +90,7 @@ fn parse_enchanted_is_copy_of_chosen(tp: &TextPair, text: &str) -> Option<Static
     // The donor type ("creature" / "permanent") must parse and fully consume the
     // remainder — a trailing rider (e.g. "except it has flying") is not modeled
     // by the marker, so bail rather than silently drop it.
-    let (_donor_filter, donor_rest) = parse_type_phrase(donor_lower);
+    let (_donor_filter, donor_rest) = parse_type_phrase_folding(donor_lower);
     if !donor_rest.trim().is_empty() {
         return None;
     }
@@ -284,9 +284,9 @@ fn parse_max_untap_per_type_static(tp: &TextPair<'_>, text: &str) -> Option<Stat
 
     let rest = nom_tag_tp(tp, "players can't untap more than ")?;
     let (after_count, count) = nom_primitives::parse_number(rest.lower).ok()?;
-    let (filter, remainder) = parse_type_phrase(after_count.trim_start());
+    let (filter, remainder) = parse_type_phrase_folding(after_count.trim_start());
     parse_during_their_untap_step_suffix(remainder).ok()?;
-    // Require a real permanent-type filter (parse_type_phrase returns a typed
+    // Require a real permanent-type filter (parse_type_phrase_folding returns a typed
     // filter for "creature"/"artifact"/"permanent"/"nonbasic land"); a bare
     // unrecognized subject would over-broaden the cap.
     if !matches!(&filter, TargetFilter::Typed(_)) {
@@ -336,10 +336,10 @@ fn parse_untaps_during_each_other_players_untap_step(
     // "Untap all/each <type> you control during each other player's untap
     // step." — Seedborn Muse prints "all"; Prop Room and Ivorytusk Fortress
     // print "each" for the same subject shape, so both tags share this arm.
-    // Delegate the subject to `parse_type_phrase`, which handles the full
+    // Delegate the subject to `parse_type_phrase_folding`, which handles the full
     // range of type + controller + property phrases.
     if let Some(rest) = nom_tag_tp(tp, "untap all ").or_else(|| nom_tag_tp(tp, "untap each ")) {
-        let (filter, remainder) = parse_type_phrase(rest.original);
+        let (filter, remainder) = parse_type_phrase_folding(rest.original);
         let remainder_lower = remainder.to_lowercase();
         let during_ok = nom_on_lower(
             remainder,
@@ -657,7 +657,7 @@ pub(crate) fn parse_damage_not_removed_during_cleanup(
     {
         (TargetFilter::SelfRef, rest)
     } else {
-        let (filter, rest) = parse_type_phrase(body);
+        let (filter, rest) = parse_type_phrase_folding(body);
         if matches!(&filter, TargetFilter::Any) {
             return None;
         }
@@ -1315,7 +1315,7 @@ pub(crate) fn parse_static_line_inner(
         tp.lower.trim_end_matches('.'),
         "you control enchanted ",
     ) {
-        let (type_filter, remainder) = parse_type_phrase(type_word);
+        let (type_filter, remainder) = parse_type_phrase_folding(type_word);
         if remainder.is_empty() {
             if let TargetFilter::Typed(mut tf) = type_filter {
                 tf.properties.push(FilterProp::EnchantedBy);
@@ -2260,14 +2260,14 @@ pub(crate) fn parse_static_line_inner(
                 // CR 105.4 + CR 608.2c (issue #327): Try the chosen-qualifier
                 // parser first so "creatures of that color" / "creatures of
                 // the chosen color" produces a filter with
-                // `FilterProp::IsChosenColor`. Falls back to `parse_type_phrase`
+                // `FilterProp::IsChosenColor`. Falls back to `parse_type_phrase_folding`
                 // for non-anaphor filter shapes.
                 let by_rest_tp = TextPair::new(by_rest, by_rest);
                 let (filter, remainder) =
                     if let Some(chosen) = parse_chosen_qualifier_subject(&by_rest_tp) {
                         (chosen, "")
                     } else {
-                        parse_type_phrase(by_rest)
+                        parse_type_phrase_folding(by_rest)
                     };
                 if !matches!(filter, TargetFilter::Any) {
                     let mut def = StaticDefinition::new(StaticMode::CantBeBlockedBy { filter })
@@ -2969,7 +2969,7 @@ pub(crate) fn parse_static_line_inner(
         Ok((i, n as u8))
     }) {
         // Parse the affected filter from the beginning of the text (before "can boast")
-        let (affected, _) = parse_type_phrase(tp.original);
+        let (affected, _) = parse_type_phrase_folding(tp.original);
         return Some(
             StaticDefinition::new(StaticMode::ModifyActivationLimit {
                 keyword: "boast".to_string(),
@@ -3042,7 +3042,7 @@ pub(crate) fn parse_static_line_inner(
     // ("power-up", "exhaust", "boast", "outlast"); the static runtime gate
     // (`apply_static_activated_ability_cost_reduction`) matches the activating
     // ability's `AbilityTag::keyword_str()`. The `<subject>` filter is routed
-    // through `parse_type_phrase`, which handles the "other" self-exclusion.
+    // through `parse_type_phrase_folding`, which handles the "other" self-exclusion.
     //   - Hulk / Gamma Goliath: "Power-up abilities of other creatures you control…"
     //   - Boom Scholar: "Exhaust abilities of other permanents you control…"
     if let Some(((keyword, subject, amount), _)) = nom_on_lower(tp.original, tp.lower, |i| {
@@ -3055,7 +3055,7 @@ pub(crate) fn parse_static_line_inner(
         let (i, _) = tag(" less to activate").parse(i)?;
         Ok((i, (keyword, subject.to_string(), amount)))
     }) {
-        let (affected, _rest) = parse_type_phrase(&subject);
+        let (affected, _rest) = parse_type_phrase_folding(&subject);
         return Some(
             StaticDefinition::new(StaticMode::ReduceAbilityCost {
                 mode: CostModifyMode::Reduce,
@@ -3103,7 +3103,7 @@ pub(crate) fn parse_static_line_inner(
         {
             TargetFilter::SelfRef
         } else {
-            parse_type_phrase(&subject).0
+            parse_type_phrase_folding(&subject).0
         };
         let minimum_mana = matches!(mode, CostModifyMode::Reduce)
             .then(|| parse_activated_cost_reduction_minimum_mana(tp.lower))
@@ -3135,7 +3135,7 @@ pub(crate) fn parse_static_line_inner(
         let (i, _) = tag(" can be activated an additional time").parse(i)?;
         Ok((i, subject.to_string()))
     }) {
-        let (affected, _rest) = parse_type_phrase(&subject);
+        let (affected, _rest) = parse_type_phrase_folding(&subject);
         return Some(
             StaticDefinition::new(StaticMode::ModifyActivationLimit {
                 keyword: "power-up".to_string(),
@@ -3163,7 +3163,7 @@ pub(crate) fn parse_static_line_inner(
         Ok((i, (prefix, filter_part.to_string(), amount)))
     }) {
         let filter_text = format!("{prefix}{filter_part}");
-        let (affected, _rest) = parse_type_phrase(&filter_text);
+        let (affected, _rest) = parse_type_phrase_folding(&filter_text);
         return Some(
             StaticDefinition::new(StaticMode::ReduceAbilityCost {
                 mode: CostModifyMode::Reduce,
@@ -3235,7 +3235,7 @@ pub(crate) fn parse_static_line_inner(
             // CR 113.6 + CR 201.2: "sources with the chosen name" → HasChosenName,
             // shared with the CantBeActivated name-picker class. Otherwise a type phrase.
             let affected = parse_chosen_name_source_filter(&subject_filter)
-                .unwrap_or_else(|| parse_type_phrase(&subject_filter).0);
+                .unwrap_or_else(|| parse_type_phrase_folding(&subject_filter).0);
             // CR 118.7: a one-mana floor only applies to reductions.
             let minimum_mana = matches!(mode, CostModifyMode::Reduce)
                 .then(|| parse_activated_cost_reduction_minimum_mana(tp.lower))
@@ -3900,7 +3900,7 @@ fn parse_counters_cant_be_removed_static(
     // Composed grammar (CR 122.1d + CR 101.2):
     //   <counter_type> " counters can't be removed from " <subject> [.] EOF
     // Uses nom combinators for the counter-type prefix and the fixed anchor,
-    // then parse_type_phrase for the subject (same pattern as
+    // then parse_type_phrase_folding for the subject (same pattern as
     // parse_damage_not_removed_during_cleanup).
 
     // Step 1: Parse the counter type from the start of the lowercase text.
@@ -3917,7 +3917,7 @@ fn parse_counters_cant_be_removed_static(
     // offset as `body` within `tp.lower`.
     let consumed = tp.lower.len() - body.len();
     let subject_original = tp.original[consumed..].trim_end_matches('.').trim();
-    let (filter, remainder) = parse_type_phrase(subject_original);
+    let (filter, remainder) = parse_type_phrase_folding(subject_original);
     if matches!(&filter, TargetFilter::Any) || !remainder.trim().is_empty() {
         return None;
     }

--- a/crates/engine/src/parser/oracle_static/evasion.rs
+++ b/crates/engine/src/parser/oracle_static/evasion.rs
@@ -102,7 +102,7 @@ pub(crate) fn parse_doubler_source_filter(lower: &str) -> Option<TargetFilter> {
 
     // CR 603.2d: The source may be a flat type union sharing one trailing
     // controller scope — "a Shaman or another Wizard you control" (Harmonic
-    // Prodigy). `parse_type_phrase`'s own disjunction recursion only fires when
+    // Prodigy). `parse_type_phrase_folding`'s own disjunction recursion only fires when
     // the trailing disjunct opens with a bare type word, not an article or an
     // "another"/"other" designation ("another Wizard"), so it stops after the
     // first disjunct and leaves the connector in the remainder. Dispatch on that
@@ -174,13 +174,13 @@ fn doubler_source_is_restrictive(filter: &TargetFilter) -> bool {
 }
 
 /// CR 603.2d + CR 301.5a: Parse one disjunct of a trigger-doubler's source
-/// phrase, handling the two source-relative referents `parse_type_phrase` cannot
+/// phrase, handling the two source-relative referents `parse_type_phrase_folding` cannot
 /// express before falling back to it for ordinary typed clauses:
 /// - `~` — the normalized source name → [`TargetFilter::SelfRef`] (Cloud doubling
 ///   "a triggered ability of ~").
 /// - "an Equipment attached to it" — here "it" is anaphoric on the doubler's own
 ///   source, so it is the source-relative [`FilterProp::AttachedToSource`] set.
-///   `parse_type_phrase` maps "attached to it" to `AttachedToRecipient` (an
+///   `parse_type_phrase_folding` maps "attached to it" to `AttachedToRecipient` (an
 ///   enchanted-creature host), which is the wrong referent in a doubler, so this
 ///   clause is hand-built.
 fn parse_doubler_disjunct(phrase: &str) -> (TargetFilter, &str) {
@@ -202,7 +202,7 @@ fn parse_doubler_disjunct(phrase: &str) -> (TargetFilter, &str) {
     {
         return (filter, rest);
     }
-    parse_type_phrase(phrase)
+    parse_type_phrase_folding(phrase)
 }
 
 pub(crate) fn parse_max_combat_creatures_static(lower: &str) -> Option<StaticMode> {
@@ -396,12 +396,12 @@ pub(crate) fn parse_leading_except_for_rule_static(
 /// [`parse_leading_except_for_rule_static`]: a bare type-phrase exemption
 /// ("artifact creatures") or a named exemption within a type class ("creatures
 /// named Akron Legionnaire"). The " named " split happens BEFORE
-/// `parse_type_phrase` runs (mirroring `parse_control_named_type_filter` in
-/// `oracle_nom/condition.rs`) — `parse_type_phrase` has no grammar for a
+/// `parse_type_phrase_folding` runs (mirroring `parse_control_named_type_filter` in
+/// `oracle_nom/condition.rs`) — `parse_type_phrase_folding` has no grammar for a
 /// trailing "named `<Name>`" clause and would otherwise leave it unconsumed.
 fn parse_exempt_conjunct(conjunct: &str) -> Option<TargetFilter> {
     if let Ok((_, (type_text, name_text))) = nom_primitives::split_once_on(conjunct, " named ") {
-        let (filter, remainder) = parse_type_phrase(type_text);
+        let (filter, remainder) = parse_type_phrase_folding(type_text);
         // `merge_filter_prop` silently no-ops on a non-`Typed` filter (Or/And/
         // SelfRef/…), which would drop the Named constraint and over-claim
         // every object of the bare type instead of just the named one — fail
@@ -420,7 +420,7 @@ fn parse_exempt_conjunct(conjunct: &str) -> Option<TargetFilter> {
             },
         ));
     }
-    let (filter, remainder) = parse_type_phrase(conjunct);
+    let (filter, remainder) = parse_type_phrase_folding(conjunct);
     if remainder.trim().is_empty() && !matches!(filter, TargetFilter::Any) {
         return Some(filter);
     }
@@ -475,7 +475,7 @@ pub(crate) fn parse_compound_subject_keyword_static(
     // leading comma leaves the 2-item path's existing fallthrough to
     // `parse_rule_static_subject_filter` (which itself resolves an object
     // subject with an internal bare "and", e.g. "artifacts and creatures you
-    // control", via `parse_type_phrase`'s own trailing-suffix distribution)
+    // control", via `parse_type_phrase_folding`'s own trailing-suffix distribution)
     // completely unchanged.
     let (after_you, multi_object) = match nom_tag_tp(&body, "you, ") {
         Some(rest) => (rest, true),
@@ -554,7 +554,7 @@ pub(crate) fn parse_compound_subject_keyword_static(
 /// other creatures you control".
 ///
 /// Each conjunct is a COMPLETE, independently-resolvable subject phrase — unlike
-/// the Silkguard-class object list in `parse_type_phrase` (`oracle_target.rs`),
+/// the Silkguard-class object list in `parse_type_phrase_folding` (`oracle_target.rs`),
 /// where a single trailing suffix distributes backward across bare type nouns
 /// with no clause of their own ("Auras, Equipment, and modified creatures you
 /// control"). So every conjunct here is resolved one at a time through the same
@@ -562,7 +562,7 @@ pub(crate) fn parse_compound_subject_keyword_static(
 /// bespoke list grammar. Splitting is nom-based (`split_once_on`), peeling
 /// `", "`-separated conjuncts and stripping the final conjunct's `"and "`
 /// connector — never a bare `" and "` split, so the 2-item form's own
-/// internal-"and" handling (via `parse_type_phrase`'s trailing-suffix
+/// internal-"and" handling (via `parse_type_phrase_folding`'s trailing-suffix
 /// distribution) is never shadowed.
 ///
 /// Declines (returns `None`, the strict-fail signal) if any conjunct fails to
@@ -792,7 +792,7 @@ pub(crate) fn is_extra_blockers_static_candidate(lower: &str) -> bool {
 ///   old single `tag`, so unfiltered lines are unchanged.
 /// - Slot B — "<type-phrase> able to block " (Talruum Piper "creatures with
 ///   flying", Marble Priest "Walls") → `Some(filter)`. The type slot is parsed by
-///   the shared `parse_type_phrase` building block; the phrase must fully consume
+///   the shared `parse_type_phrase_folding` building block; the phrase must fully consume
 ///   up to the literal " able to block " (else the Some form is rejected as
 ///   mis-scoped and this returns `None`, letting the line fall through).
 ///
@@ -809,12 +809,12 @@ pub(crate) fn parse_forced_block_blocker_slot(input: &str) -> Option<(&str, Opti
         return Some((rest, None));
     }
     // Slot B: "<type-phrase> able to block " → Some(filter). Scope the type phrase
-    // to the text before the literal " able to block " so `parse_type_phrase`
+    // to the text before the literal " able to block " so `parse_type_phrase_folding`
     // cannot over-consume into the subject.
     let (rest, type_text) = take_until::<_, _, OracleError<'_>>(" able to block ")
         .parse(input)
         .ok()?;
-    let (filter, filter_remainder) = parse_type_phrase(type_text);
+    let (filter, filter_remainder) = parse_type_phrase_folding(type_text);
     if !filter_remainder.trim().is_empty() {
         return None; // mis-scoped Some — reject rather than accept a partial filter.
     }
@@ -1723,7 +1723,7 @@ pub(crate) fn cant_be_blocked_mode(clause: &str) -> Option<(StaticMode, Option<S
         let (filter, remainder) = if let Some(filter) = parse_chosen_qualifier_subject(&filter_tp) {
             (filter, "")
         } else {
-            parse_type_phrase(filter_text)
+            parse_type_phrase_folding(filter_text)
         };
         if !matches!(filter, TargetFilter::Any) {
             let condition = parse_compound_cant_be_blocked_condition(remainder);

--- a/crates/engine/src/parser/oracle_static/grammar.rs
+++ b/crates/engine/src/parser/oracle_static/grammar.rs
@@ -570,9 +570,9 @@ pub(crate) fn parse_must_be_blocked_by_quality(input: &str) -> OracleResult<'_, 
 /// CR 509.1c + CR 105.4: Lower a captured "<quality>" span (e.g.
 /// "a Dalek", "an Eldrazi", "a creature of the chosen color") to the blocker
 /// `TargetFilter`. Composes the SAME quality combinators `CantBeBlockedBy` uses
-/// (`parse_chosen_qualifier_subject`, then `parse_type_phrase`). Returns `None`
+/// (`parse_chosen_qualifier_subject`, then `parse_type_phrase_folding`). Returns `None`
 /// when the quality fails to constrain the blocker at all — either
-/// `TargetFilter::Any` or the empty `Typed` filter `parse_type_phrase` yields for
+/// `TargetFilter::Any` or the empty `Typed` filter `parse_type_phrase_folding` yields for
 /// an UNRECOGNIZED noun — so an unparseable requirement is never silently
 /// weakened to "any blocker satisfies".
 fn must_be_blocked_quality_to_filter(quality: &str) -> Option<TargetFilter> {
@@ -583,7 +583,7 @@ fn must_be_blocked_quality_to_filter(quality: &str) -> Option<TargetFilter> {
     let quality_lower = quality.to_lowercase();
     let quality_tp = TextPair::new(quality, &quality_lower);
     let filter = parse_chosen_qualifier_subject(&quality_tp).unwrap_or_else(|| {
-        let (f, _) = parse_type_phrase(&quality_lower);
+        let (f, _) = parse_type_phrase_folding(&quality_lower);
         f
     });
     filter_constrains_blocker(&filter).then_some(filter)
@@ -591,7 +591,7 @@ fn must_be_blocked_quality_to_filter(quality: &str) -> Option<TargetFilter> {
 
 /// CR 509.1c: Does `filter` actually narrow the set of legal blockers? An
 /// unconstrained filter — `TargetFilter::Any`, or an empty `Typed` carrying no
-/// type, property, or controller constraint (what `parse_type_phrase` returns for
+/// type, property, or controller constraint (what `parse_type_phrase_folding` returns for
 /// an unrecognized noun like "a splorf") — matches every blocker and therefore
 /// expresses no quality requirement. Lowering such a filter into a
 /// `MustBeBlocked { by }` would silently degrade "must be blocked by <X>" to
@@ -920,7 +920,7 @@ pub(crate) fn parse_enchanted_equipped_predicate(
             // `parse_static_line_inner`'s CantBeBlockedBy branch.
             let filter_text_tp = TextPair::new(filter_text, filter_text);
             let filter = parse_chosen_qualifier_subject(&filter_text_tp).unwrap_or_else(|| {
-                let (f, _) = parse_type_phrase(filter_text);
+                let (f, _) = parse_type_phrase_folding(filter_text);
                 f
             });
             if !matches!(filter, TargetFilter::Any) {
@@ -1962,7 +1962,7 @@ pub(crate) fn parse_basic_landwalk_qualifier(input: &str) -> OracleResult<'_, &'
 /// flag: when `true`, the caller restricts the static to
 /// `active_zones: [Graveyard]` (CR 113.6b — a zone-restricted ability functions
 /// only from the zones it names). A non-self-reference filter (e.g. a creature
-/// type) falls through to `parse_type_phrase` and is not zone-restricted here.
+/// type) falls through to `parse_type_phrase_folding` and is not zone-restricted here.
 pub(crate) fn parse_graveyard_permission_filter(input: &str) -> (TargetFilter, bool) {
     // The self-reference token `~` is substituted for type phrases ("this
     // creature", "this permanent", ...) by `normalize_self_references` before
@@ -1977,7 +1977,7 @@ pub(crate) fn parse_graveyard_permission_filter(input: &str) -> (TargetFilter, b
             return (TargetFilter::SelfRef, true);
         }
     }
-    let (filter, _) = parse_type_phrase(input);
+    let (filter, _) = parse_type_phrase_folding(input);
     (filter, false)
 }
 
@@ -2182,7 +2182,7 @@ fn parse_ordinal_word(i: &str) -> OracleResult<'_, u32> {
 /// Builds for the class, not the card. The subject decomposes into three
 /// independent axes, each parsed by a shared building block:
 ///   1. Pre-spell type qualifier ("non-Lemur creature spell with flying") — via
-///      `parse_type_phrase`, which preserves keyword qualifiers.
+///      `parse_type_phrase_folding`, which preserves keyword qualifiers.
 ///   2. Post-spell modifier ("with {X} in its mana cost", CR 107.3 + CR 202.1) —
 ///      via `oracle_trigger::parse_post_spell_modifier`, the same combinator the
 ///      paired "whenever you cast your first spell with {X}…" trigger uses.
@@ -2269,10 +2269,10 @@ pub(crate) fn parse_nth_qualified_spell_filter(lower: &str) -> NthQualifiedSpell
         .is_ok()
     {
         // CR 700.6: bare "historic" is a card-property adjective, not a type word.
-        // `parse_type_phrase` only emits `FilterProp::Historic` when a type word
+        // `parse_type_phrase_folding` only emits `FilterProp::Historic` when a type word
         // follows (oracle_target.rs), so the bare "historic spell" subject must
         // lower the property here. Covers every "first historic spell you cast …"
-        // grantor (Peri Brown class) without weakening the `parse_type_phrase`
+        // grantor (Peri Brown class) without weakening the `parse_type_phrase_folding`
         // guard, and benefits both the keyword-grant and cost-modifier callers.
         Some(TargetFilter::Typed(
             TypedFilter::card().properties(vec![FilterProp::Historic]),
@@ -2287,7 +2287,7 @@ pub(crate) fn parse_nth_qualified_spell_filter(lower: &str) -> NthQualifiedSpell
             TypedFilter::card().properties(vec![FilterProp::WasKicked]),
         ))
     } else {
-        let (filter, remainder) = parse_type_phrase(pre_type);
+        let (filter, remainder) = parse_type_phrase_folding(pre_type);
         if remainder.trim().is_empty() && !matches!(filter, TargetFilter::Any) {
             Some(filter)
         } else {
@@ -2477,7 +2477,7 @@ pub(crate) fn parse_self_spell_target_cost_filter(lower: &str) -> Option<TargetF
     .ok()?;
 
     let target_text = target_text.trim().trim_end_matches('.');
-    let (target_filter, remainder) = parse_type_phrase(target_text);
+    let (target_filter, remainder) = parse_type_phrase_folding(target_text);
     if !remainder.trim().is_empty() || matches!(target_filter, TargetFilter::Any) {
         return None;
     }
@@ -2513,7 +2513,7 @@ pub(crate) fn parse_cost_modifier_target_filter(lower: &str) -> Option<TargetFil
         Some(TargetFilter::SelfRef)
     } else {
         parse_commander_subject_filter(target_text).or_else(|| {
-            let (filter, remainder) = parse_type_phrase(target_text);
+            let (filter, remainder) = parse_type_phrase_folding(target_text);
             if remainder.trim().is_empty() && !matches!(filter, TargetFilter::Any) {
                 Some(filter)
             } else {

--- a/crates/engine/src/parser/oracle_static/keyword_grant.rs
+++ b/crates/engine/src/parser/oracle_static/keyword_grant.rs
@@ -77,7 +77,7 @@ pub(crate) fn try_parse_graveyard_keyword_grant_clause(
     )?
     .0;
 
-    let (filter, remainder) = parse_type_phrase(subject);
+    let (filter, remainder) = parse_type_phrase_folding(subject);
     // CR 113.6b: the affected filter's zone must match the keyword's functional
     // zone (graveyard for flashback/escape/…, hand for foretell/miracle). A
     // mismatch (foretell-in-graveyard, flashback-in-hand) declines the grant.
@@ -460,10 +460,10 @@ pub(crate) fn parse_spells_have_keyword(tp: &TextPair<'_>, text: &str) -> Option
             // "Spells you cast" (no type prefix) — applies to all spells
             TargetFilter::Typed(TypedFilter::card())
         } else {
-            // CR 205.4a: peel leading supertype word(s) BEFORE parse_type_phrase, which only
+            // CR 205.4a: peel leading supertype word(s) BEFORE parse_type_phrase_folding, which only
             // emits HasSupertype for a supertype prefixed before a type word (requires a trailing
             // space); a bare "legendary" would otherwise be dropped, and an un-peeled prefix would
-            // double-emit. Peel here (emit once) and pass only the remainder to parse_type_phrase.
+            // double-emit. Peel here (emit once) and pass only the remainder to parse_type_phrase_folding.
             let type_prefix_original = tp.original[..marker_pos].trim();
             let lower_prefix = type_prefix_original.to_lowercase();
             let prefix_tp = TextPair::new(type_prefix_original, &lower_prefix);
@@ -496,7 +496,7 @@ pub(crate) fn parse_spells_have_keyword(tp: &TextPair<'_>, text: &str) -> Option
             if type_remainder.is_empty() {
                 TargetFilter::Typed(TypedFilter::card())
             } else {
-                parse_type_phrase(type_remainder).0
+                parse_type_phrase_folding(type_remainder).0
             }
         };
         let mut extra_props = supertype_props;
@@ -545,7 +545,7 @@ pub(crate) fn parse_spells_have_keyword(tp: &TextPair<'_>, text: &str) -> Option
     // path (`effective_off_zone_keywords`) sees the grant and the card becomes
     // castable from the graveyard.
     {
-        let (base_filter, rest) = parse_type_phrase(subject);
+        let (base_filter, rest) = parse_type_phrase_folding(subject);
         if rest.trim().is_empty() && target_filter_is_your_graveyard(&base_filter) {
             let keyword = finalize_graveyard_zone_grant_keyword(keyword, where_x.clone());
             let mut def = StaticDefinition::continuous()
@@ -588,7 +588,7 @@ pub(crate) fn parse_spells_have_keyword(tp: &TextPair<'_>, text: &str) -> Option
         let base_filter = if type_part.is_empty() {
             TargetFilter::Typed(TypedFilter::card())
         } else {
-            parse_type_phrase(type_part).0
+            parse_type_phrase_folding(type_part).0
         };
         let mut def = StaticDefinition::new(StaticMode::CastWithKeyword { keyword })
             .affected(base_filter)
@@ -659,7 +659,7 @@ pub(crate) fn parse_cast_as_though_flash_static(
         TargetFilter::Typed(TypedFilter::card())
     } else {
         let phrase = format!("{type_text} spells");
-        parse_type_phrase(&phrase).0
+        parse_type_phrase_folding(&phrase).0
     };
     let affected = if all_players {
         base_filter

--- a/crates/engine/src/parser/oracle_static/mod.rs
+++ b/crates/engine/src/parser/oracle_static/mod.rs
@@ -36,7 +36,7 @@ mod prelude {
     };
     pub(super) use super::super::oracle_target::{
         distribute_controller_to_or, parse_combat_status_prefix, parse_counter_suffix,
-        parse_mana_value_suffix, parse_target, parse_that_clause_suffix, parse_type_phrase,
+        parse_mana_value_suffix, parse_target, parse_that_clause_suffix, parse_type_phrase_folding,
         scope_target_spell_phrase,
     };
     pub(super) use super::super::oracle_util::{

--- a/crates/engine/src/parser/oracle_static/restriction.rs
+++ b/crates/engine/src/parser/oracle_static/restriction.rs
@@ -326,7 +326,7 @@ pub(crate) fn parse_cant_be_activated_exemption_in_text(lower: &str) -> Activati
 /// Source filter dispatch:
 /// - `"sources with the chosen name"` → `TargetFilter::HasChosenName` (Pithing Needle,
 ///   Phyrexian Revoker, Sorcerous Spyglass — the chosen-name name-picker class).
-/// - Otherwise delegates to `parse_type_phrase` for type-list + controller-suffix
+/// - Otherwise delegates to `parse_type_phrase_folding` for type-list + controller-suffix
 ///   forms (Karn, Clarion Conqueror).
 ///
 /// The scope on the activator axis is always `AllPlayers` — CR 602.5 prohibits the
@@ -395,15 +395,15 @@ pub(crate) fn parse_filter_scoped_cant_be_activated(
     // abilities of artifacts and creatures can't be activated unless they're mana
     // abilities") is parsed the same way as the chosen-name branch above.
     // CR 605.1a: accept both apostrophe glyphs on the type-list predicate too.
-    // `parse_type_phrase` consumes the filter and leaves the predicate. Re-wrap
+    // `parse_type_phrase_folding` consumes the filter and leaves the predicate. Re-wrap
     // that tail as a TextPair so the predicate stays in the nom parser family.
-    let (source_filter, filter_tail) = parse_type_phrase(rest_tp.original);
+    let (source_filter, filter_tail) = parse_type_phrase_folding(rest_tp.original);
     let filter_end = rest_tp.original.len().checked_sub(filter_tail.len())?;
     let filter_tail = TextPair::new(
         &rest_tp.original[filter_end..],
         &rest_tp.lower[filter_end..],
     );
-    // `parse_type_phrase` returns `SelfRef` for unparseable input — treat that as a
+    // `parse_type_phrase_folding` returns `SelfRef` for unparseable input — treat that as a
     // parse failure and fall through to the self-ref branch in parse_static_line.
     if matches!(source_filter, TargetFilter::SelfRef) {
         return None;
@@ -779,10 +779,10 @@ pub(crate) fn parse_suppress_triggers(tp: &TextPair<'_>, text: &str) -> Option<S
     use crate::types::statics::SuppressedTriggerEvent;
 
     // Consume the type-list + optional controller suffix (e.g., "Creatures your
-    // opponents control"). `parse_type_phrase` returns the unconsumed tail.
-    let (source_filter, tail) = parse_type_phrase(tp.original);
+    // opponents control"). `parse_type_phrase_folding` returns the unconsumed tail.
+    let (source_filter, tail) = parse_type_phrase_folding(tp.original);
     // Require a meaningful type constraint — reject the `SelfRef` fallback that
-    // `parse_type_phrase` returns when it fails to identify any type.
+    // `parse_type_phrase_folding` returns when it fails to identify any type.
     if matches!(source_filter, TargetFilter::SelfRef) {
         return None;
     }
@@ -817,7 +817,7 @@ pub(crate) fn parse_suppress_triggers(tp: &TextPair<'_>, text: &str) -> Option<S
     let after_verb = nom_tag_lower(after_dying, &after_dying_lower, "don't cause abilities")?;
     let trigger_source_filter =
         if let Some(rest) = nom_tag_lower(after_verb, &after_verb.to_lowercase(), " of ") {
-            let (filter, remainder) = parse_type_phrase(rest);
+            let (filter, remainder) = parse_type_phrase_folding(rest);
             if matches!(filter, TargetFilter::SelfRef)
                 || !matches!(remainder.trim(), "to trigger" | "to trigger.")
             {
@@ -941,8 +941,8 @@ pub(crate) fn parse_conditional_subject_per_turn_cast_limit(
     }
 
     // Both type phrases must canonicalize identically to preserve the `max=1` equivalence.
-    let (subject_filter, subject_rest) = parse_type_phrase(subject_type_text.trim());
-    let (object_filter, object_rest) = parse_type_phrase(object_type_text.trim());
+    let (subject_filter, subject_rest) = parse_type_phrase_folding(subject_type_text.trim());
+    let (object_filter, object_rest) = parse_type_phrase_folding(object_type_text.trim());
     if !subject_rest.trim().is_empty() || !object_rest.trim().is_empty() {
         return None;
     }
@@ -1023,7 +1023,7 @@ pub(crate) fn parse_per_turn_cast_limit(tp: &str, text: &str) -> Option<StaticDe
     let spell_filter = if type_text.is_empty() {
         None
     } else {
-        let (filter, _) = parse_type_phrase(type_text);
+        let (filter, _) = parse_type_phrase_folding(type_text);
         match &filter {
             TargetFilter::Typed(tf) if !tf.type_filters.is_empty() => Some(filter),
             _ => None,
@@ -1442,7 +1442,7 @@ pub(crate) fn parse_cant_cast_type_spells(
     let spell_filter = if type_text.is_empty() {
         None
     } else {
-        let (filter, _) = parse_type_phrase(type_text);
+        let (filter, _) = parse_type_phrase_folding(type_text);
         match &filter {
             TargetFilter::Typed(tf) if !tf.type_filters.is_empty() => Some(filter),
             _ => None,
@@ -1478,7 +1478,7 @@ pub(crate) fn parse_passive_cant_be_cast_spell_filter(before_cant: &str) -> Opti
         // allow-noncombinator: moved legacy static parser code; refactor-only split preserves behavior.
         let type_text = &before_cant[..pos];
         let mv_rest = &before_cant[pos + " spells with mana value ".len()..];
-        let (filter, remainder) = parse_type_phrase(type_text);
+        let (filter, remainder) = parse_type_phrase_folding(type_text);
         if !remainder.trim().is_empty() {
             return None;
         }
@@ -1521,7 +1521,7 @@ pub(crate) fn parse_passive_cant_be_cast_spell_filter(before_cant: &str) -> Opti
         Ok((input, type_text))
     }
     if let Ok((_, type_text)) = parse_passive_x_mana_cost_prefix(before_cant) {
-        let (filter, remainder) = parse_type_phrase(type_text);
+        let (filter, remainder) = parse_type_phrase_folding(type_text);
         if remainder.trim().is_empty() {
             // Only accept Typed filters with concrete type_filters; reject
             // unsupported shapes (AnyOf, bare Any) to avoid silently broadening
@@ -1550,7 +1550,7 @@ pub(crate) fn parse_passive_cant_be_cast_spell_filter(before_cant: &str) -> Opti
     // Require " spells" at the end of the subject
     let type_text = before_cant.strip_suffix(" spells")?; // allow-noncombinator: moved legacy static parser code; refactor-only split preserves behavior.
 
-    let (filter, remainder) = parse_type_phrase(type_text);
+    let (filter, remainder) = parse_type_phrase_folding(type_text);
     if !remainder.trim().is_empty() {
         return None;
     }
@@ -1625,7 +1625,7 @@ pub(crate) fn parse_temporal_prefix_cant_cast(tp: &str, text: &str) -> Option<St
         if type_text.is_empty() || type_text == "spells" {
             None
         } else {
-            let (filter, _) = parse_type_phrase(type_text);
+            let (filter, _) = parse_type_phrase_folding(type_text);
             match &filter {
                 TargetFilter::Typed(tf) if !tf.type_filters.is_empty() => Some(filter),
                 _ => None,
@@ -1665,7 +1665,7 @@ pub(crate) fn parse_enchanted_controller_cant_cast(
     let spell_filter = if type_text.is_empty() {
         None
     } else {
-        let (filter, _) = parse_type_phrase(type_text);
+        let (filter, _) = parse_type_phrase_folding(type_text);
         match &filter {
             TargetFilter::Typed(tf) if !tf.type_filters.is_empty() => Some(filter),
             _ => None,
@@ -2078,7 +2078,7 @@ pub(crate) fn try_parse_graveyard_cast_permission(
         .or_else(|| nom_tag_lower(filter_text, filter_text, "an "))
         .unwrap_or(filter_text);
 
-    // Remove " spell"/" spells" — parse_type_phrase expects bare type words.
+    // Remove " spell"/" spells" — parse_type_phrase_folding expects bare type words.
     // "lands" is already a valid type phrase, so no stripping needed for Play mode.
     let cleaned: Cow<str> = if nom_primitives::scan_contains(filter_text, "spells") {
         Cow::Owned(filter_text.replacen(" spells", "", 1))
@@ -2488,7 +2488,7 @@ fn parse_graveyard_branch_filter(branch: &str) -> Option<TargetFilter> {
         .or_else(|| nom_tag_lower(branch, branch, "an "))
         .unwrap_or(branch);
 
-    // Drop " spell"/" spells" so `parse_type_phrase` sees the bare type word;
+    // Drop " spell"/" spells" so `parse_type_phrase_folding` sees the bare type word;
     // "land"/"lands" is already a valid type phrase and needs no stripping.
     let cleaned: Cow<str> = if nom_primitives::scan_contains(branch, "spells") {
         Cow::Owned(branch.replacen(" spells", "", 1))
@@ -2624,7 +2624,7 @@ pub(crate) fn try_parse_exile_cast_permission(text: &str, lower: &str) -> Option
         (rest, CastFrequency::Unlimited)
     };
 
-    // Strip the leading article — `parse_type_phrase` expects the bare noun.
+    // Strip the leading article — `parse_type_phrase_folding` expects the bare noun.
     let rest = nom_tag_lower(rest, rest, "a ")
         .or_else(|| nom_tag_lower(rest, rest, "an "))
         .unwrap_or(rest);
@@ -2647,7 +2647,7 @@ pub(crate) fn try_parse_exile_cast_permission(text: &str, lower: &str) -> Option
         return None;
     };
 
-    // Drop trailing " spell"/" spells" so `parse_type_phrase` sees the bare
+    // Drop trailing " spell"/" spells" so `parse_type_phrase_folding` sees the bare
     // type. Mirrors the graveyard / top-of-library / hand sibling parsers.
     let cleaned: Cow<str> = if nom_primitives::scan_contains(filter_text, "spells") {
         Cow::Owned(filter_text.replacen(" spells", "", 1))
@@ -2657,12 +2657,12 @@ pub(crate) fn try_parse_exile_cast_permission(text: &str, lower: &str) -> Option
         Cow::Borrowed(filter_text)
     };
 
-    // `parse_type_phrase` already composes the dynamic "with mana value …"
+    // `parse_type_phrase_folding` already composes the dynamic "with mana value …"
     // suffix through `parse_mana_value_suffix`, so Maralen's filter
     // ("spell with mana value less than or equal to the number of Elves and
     // Faeries you control") resolves through one call — no bespoke combinator
     // chain needed here.
-    let (filter, remainder) = parse_type_phrase(&cleaned);
+    let (filter, remainder) = parse_type_phrase_folding(&cleaned);
     if !remainder.trim().is_empty() {
         // Strict: any unconsumed remainder is a filter shape we don't yet
         // model. Decline so the line either dispatches to the next handler or
@@ -3027,7 +3027,7 @@ pub(crate) fn try_parse_spend_any_color_to_activate_abilities(
 ///
 /// The spell-filter is parsed with the same idiom as
 /// [`try_parse_top_of_library_cast_permission`]: strip the leading article and
-/// the trailing " spell"/" spells", then delegate to `parse_type_phrase` so one
+/// the trailing " spell"/" spells", then delegate to `parse_type_phrase_folding` so one
 /// branch covers every spell class (creature, artifact, …), not just creatures.
 pub(crate) fn try_parse_filtered_spend_any_type_to_cast(
     text: &str,
@@ -3043,13 +3043,13 @@ pub(crate) fn try_parse_filtered_spend_any_type_to_cast(
     // Trailing period is optional; strip it so the type phrase is clean.
     let rest = rest.trim_end().trim_end_matches('.').trim_end();
 
-    // Strip a leading article — `parse_type_phrase` expects the bare noun.
+    // Strip a leading article — `parse_type_phrase_folding` expects the bare noun.
     let rest_lower = rest.to_ascii_lowercase();
     let filter_text = nom_tag_lower(rest, &rest_lower, "a ")
         .or_else(|| nom_tag_lower(rest, &rest_lower, "an "))
         .unwrap_or(rest);
 
-    // Drop the trailing " spells"/" spell" token so `parse_type_phrase` sees the
+    // Drop the trailing " spells"/" spell" token so `parse_type_phrase_folding` sees the
     // bare type/subtype phrase. `strip_suffix` (not `replacen`) anchors to the
     // end, so an interior "spell" (e.g. a hypothetical "spellshaper spells") is
     // never clipped. Without the "spell(s)" anchor this is not the targeted
@@ -3058,12 +3058,12 @@ pub(crate) fn try_parse_filtered_spend_any_type_to_cast(
         .strip_suffix(" spells") // allow-noncombinator: suffix cleanup on the pre-tokenized filter chunk, not parse dispatch
         .or_else(|| filter_text.strip_suffix(" spell"))?; // allow-noncombinator: suffix cleanup on the pre-tokenized filter chunk, not parse dispatch
 
-    let (filter, tail) = parse_type_phrase(cleaned);
+    let (filter, tail) = parse_type_phrase_folding(cleaned);
     // A non-empty unconsumed tail means an unrecognised spell class — defer.
     if !tail.trim().is_empty() {
         return None;
     }
-    // `parse_type_phrase` never yields `SelfRef`; for input it cannot classify
+    // `parse_type_phrase_folding` never yields `SelfRef`; for input it cannot classify
     // (e.g. an empty `cleaned` from "to cast  spells") it returns a degenerate
     // `Typed` carrying no type constraints and no properties, which would match
     // EVERY spell — exactly the board-wide concession this filtered handler must
@@ -3182,12 +3182,12 @@ pub(crate) fn try_parse_top_of_library_cast_permission(
             .ok()
             .map(|(_, pair)| pair)?;
 
-    // Strip leading article — `parse_type_phrase` expects the bare noun.
+    // Strip leading article — `parse_type_phrase_folding` expects the bare noun.
     let filter_text = nom_tag_lower(filter_text, filter_text, "a ")
         .or_else(|| nom_tag_lower(filter_text, filter_text, "an "))
         .unwrap_or(filter_text);
 
-    // Drop trailing " spell"/" spells" so `parse_type_phrase` sees the bare
+    // Drop trailing " spell"/" spells" so `parse_type_phrase_folding` sees the bare
     // type/subtype phrase. "lands" is already a valid type phrase.
     let cleaned: Cow<str> = if nom_primitives::scan_contains(filter_text, "spells") {
         Cow::Owned(filter_text.replacen(" spells", "", 1))
@@ -3197,7 +3197,7 @@ pub(crate) fn try_parse_top_of_library_cast_permission(
         Cow::Borrowed(filter_text)
     };
 
-    let (filter, _) = parse_type_phrase(&cleaned);
+    let (filter, _) = parse_type_phrase_folding(&cleaned);
 
     let alt_cost = parse_top_of_library_alt_cost_rider(trailing, text);
 
@@ -3244,12 +3244,12 @@ pub(crate) fn try_parse_top_of_library_plot_permission(
             .ok()
             .map(|(_, pair)| pair)?;
 
-    // Strip a leading article so `parse_type_phrase` sees the bare noun.
+    // Strip a leading article so `parse_type_phrase_folding` sees the bare noun.
     let filter_text = nom_tag_lower(filter_text, filter_text, "a ")
         .or_else(|| nom_tag_lower(filter_text, filter_text, "an "))
         .unwrap_or(filter_text);
 
-    // Drop trailing " cards"/" card" so `parse_type_phrase` sees the bare
+    // Drop trailing " cards"/" card" so `parse_type_phrase_folding` sees the bare
     // type/subtype phrase ("nonland cards" → "nonland"). Mirrors the
     // " spells"/" spell" replacen idiom of the cast-permission arm; plot
     // operates on cards (it exiles a card), so the noun is "card(s)".
@@ -3261,7 +3261,7 @@ pub(crate) fn try_parse_top_of_library_plot_permission(
         Cow::Borrowed(filter_text)
     };
 
-    let (filter, _) = parse_type_phrase(&cleaned);
+    let (filter, _) = parse_type_phrase_folding(&cleaned);
 
     Some(
         StaticDefinition::new(StaticMode::TopOfLibraryPlotPermission)
@@ -3441,7 +3441,7 @@ pub(crate) fn try_parse_cast_free_permission(text: &str, lower: &str) -> Option<
         Cow::Borrowed(filter_text)
     };
 
-    let (filter, remainder) = parse_type_phrase(&cleaned);
+    let (filter, remainder) = parse_type_phrase_folding(&cleaned);
     if !remainder.trim().is_empty() && matches!(origin, CastFreeOrigin::DefaultCastPermission) {
         // Unqualified branch is strict: an unconsumed remainder signals a
         // complex filter we don't yet model (e.g. Fires of Invention's
@@ -3747,14 +3747,14 @@ mod filtered_spend_any_type_tests {
 
     /// CR 609.4b: a degenerate input whose spell class is empty (here a double
     /// space before "spells", so `cleaned` is "") reaches the empty-`Typed`
-    /// path in `parse_type_phrase` — a filter that would match EVERY spell, i.e.
+    /// path in `parse_type_phrase_folding` — a filter that would match EVERY spell, i.e.
     /// the board-wide concession. The empty-filter guard must decline it.
     ///
     /// Non-vacuity: this is the exact input the guard exists for. Remove the
     /// empty-filter guard and this assertion flips (the helper returns
     /// `Some(SpendManaAsAnyColor { Some(Typed{}) })`, an over-match), proving the
     /// guard is load-bearing. The dead `SelfRef` guard the WIP shipped never
-    /// fired on this input because `parse_type_phrase` does not yield `SelfRef`.
+    /// fired on this input because `parse_type_phrase_folding` does not yield `SelfRef`.
     #[test]
     fn declines_degenerate_empty_spell_class() {
         let text = "You can spend mana of any type to cast  spells.";

--- a/crates/engine/src/parser/oracle_static/shared.rs
+++ b/crates/engine/src/parser/oracle_static/shared.rs
@@ -64,7 +64,7 @@ pub(crate) fn parse_ignore_hexproof_static(
 
     // Map the subject phrase to a typed filter; require it to fully consume so a
     // partial parse never silently scopes the bypass wider than written.
-    let (filter, filter_remainder) = parse_type_phrase(subject.trim());
+    let (filter, filter_remainder) = parse_type_phrase_folding(subject.trim());
     if !filter_remainder.trim().is_empty() || matches!(filter, TargetFilter::Any) {
         return None;
     }
@@ -1733,7 +1733,7 @@ pub(crate) fn parse_static_line_multi_inner(text: &str) -> Vec<StaticDefinition>
 /// keywords. Modeling it as one static with a shared condition (the prior fallback
 /// left the condition `Unrecognized`) made every keyword apply unconditionally.
 fn parse_keyword_grant_from_exiled_object_static(text: &str) -> Option<Vec<StaticDefinition>> {
-    // "As long as a[n] exiled " → the object phrase (original case for parse_type_phrase).
+    // "As long as a[n] exiled " → the object phrase (original case for parse_type_phrase_folding).
     let lower = text.to_lowercase();
     let (_, obj) = nom_on_lower(text, &lower, |i| {
         let (i, _) = tag::<_, _, OracleError<'_>>("as long as ").parse(i)?;
@@ -1743,7 +1743,7 @@ fn parse_keyword_grant_from_exiled_object_static(text: &str) -> Option<Vec<Stati
     })?;
 
     // The object type phrase; the remainder begins at " has <keyword>".
-    let (base_filter, remainder) = parse_type_phrase(obj);
+    let (base_filter, remainder) = parse_type_phrase_folding(obj);
     let TargetFilter::Typed(mut typed) = base_filter else {
         return None;
     };
@@ -1993,7 +1993,7 @@ fn parse_cant_attack_you_or_block_predicate(
 /// production in [`parse_subject_combat_rule_static`], so the object lowers
 /// through one grammar in both.
 ///
-/// Delegates to the full `parse_type_phrase` grammar, so the class covers any
+/// Delegates to the full `parse_type_phrase_folding` grammar, so the class covers any
 /// object that grammar can express — a subtype ("Warriors"), a controller
 /// scope ("creatures you control"), a card type ("artifact creatures"), a
 /// color ("black creatures"), a static or dynamic power comparison — rather
@@ -2006,7 +2006,7 @@ fn parse_cant_attack_you_or_block_predicate(
 /// callers that must additionally reject a self-referential object apply that
 /// rule themselves, so no caller inherits a restriction it did not ask for.
 pub(crate) fn parse_block_object_filter(input: &str) -> OracleResult<'_, TargetFilter> {
-    let (filter, rest) = parse_type_phrase(input);
+    let (filter, rest) = parse_type_phrase_folding(input);
     if rest.len() >= input.len() || matches!(filter, TargetFilter::Any) {
         return Err(super::oracle_nom::error::oracle_err(input));
     }
@@ -4249,7 +4249,7 @@ pub(crate) fn parse_there_are_count_on_battlefield_condition(
 /// `exists_on_battlefield_condition`, which anchors "is on the battlefield").
 ///
 /// The indefinite article "a "/"an " is stripped, but "another " is preserved so
-/// `parse_type_phrase` attaches the source-exclusion `Another` prop — "another
+/// `parse_type_phrase_folding` attaches the source-exclusion `Another` prop — "another
 /// creature" must count creatures OTHER than the source (else the source itself
 /// would satisfy its own gate and the restriction would never lift).
 pub(crate) fn parse_there_is_exists_on_battlefield_condition(
@@ -4268,7 +4268,7 @@ fn there_is_exists_on_battlefield_condition(input: &str) -> OracleResult<'_, Sta
     // Strip the indefinite article ("a"/"an") but keep "another " — parse_article's
     // trailing-space word boundary leaves "another <type>" (source exclusion) intact.
     let (type_text, _) = opt(nom_primitives::parse_article).parse(subject)?;
-    let (filter, remainder) = parse_type_phrase(type_text.trim());
+    let (filter, remainder) = parse_type_phrase_folding(type_text.trim());
     if matches!(filter, TargetFilter::Any) || !remainder.trim().is_empty() {
         return Err(nom::Err::Error(OracleError::new(
             input,
@@ -4293,7 +4293,7 @@ fn there_are_count_on_battlefield_condition(input: &str) -> OracleResult<'_, Sta
     let (input, _) = tag(" or more ").parse(input)?;
     let (input, type_text) = take_until(" on the battlefield").parse(input)?;
     let (input, _) = tag(" on the battlefield").parse(input)?;
-    let (filter, remainder) = parse_type_phrase(type_text.trim());
+    let (filter, remainder) = parse_type_phrase_folding(type_text.trim());
     if matches!(filter, TargetFilter::Any) || !remainder.trim().is_empty() {
         return Err(nom::Err::Error(OracleError::new(
             input,
@@ -4317,7 +4317,7 @@ fn count_on_battlefield_condition(input: &str) -> OracleResult<'_, StaticConditi
     let (input, _) = tag(" or more ").parse(input)?;
     let (input, type_text) = take_until(" are on the battlefield").parse(input)?;
     let (input, _) = tag(" are on the battlefield").parse(input)?;
-    let (filter, remainder) = parse_type_phrase(type_text.trim());
+    let (filter, remainder) = parse_type_phrase_folding(type_text.trim());
     if matches!(filter, TargetFilter::Any) || !remainder.trim().is_empty() {
         return Err(nom::Err::Error(OracleError::new(
             input,
@@ -4352,7 +4352,7 @@ fn exists_on_battlefield_condition(input: &str) -> OracleResult<'_, StaticCondit
     let (input, _) = alt((tag("an "), tag("a "))).parse(input)?;
     let (input, type_text) = take_until(" is on the battlefield").parse(input)?;
     let (input, _) = tag(" is on the battlefield").parse(input)?;
-    let (filter, remainder) = parse_type_phrase(type_text.trim());
+    let (filter, remainder) = parse_type_phrase_folding(type_text.trim());
     if matches!(filter, TargetFilter::Any) || !remainder.trim().is_empty() {
         return Err(nom::Err::Error(OracleError::new(
             input,
@@ -4403,7 +4403,7 @@ pub(crate) fn find_continuous_predicate_start(lower: &str) -> Option<usize> {
 /// silently dropped from the affected filter. Returns the
 /// `FilterProp::Owned { Opponent }` property ("controller doesn't own it") and
 /// the remaining predicate text when the qualifier is present. The companion
-/// "but don't own" handling in `parse_type_phrase` covers the full-subject path
+/// "but don't own" handling in `parse_type_phrase_folding` covers the full-subject path
 /// (Laughing Jasper Flint's "Creatures you control but don't own are
 /// Mercenaries …"); this is the controller-prefix-consumed sibling.
 pub(crate) fn strip_negated_ownership_qualifier(after_prefix: &str) -> Option<(FilterProp, &str)> {
@@ -4632,7 +4632,7 @@ pub(crate) fn parse_hand_cards_have_derived_cost_keyword(text: &str) -> Option<S
     // Affected: the parsed type phrase (e.g. "nonland card"), owned by "you",
     // restricted to your hand. The off-zone applier reads each recipient's mana
     // cost to derive the granted cost.
-    let (base_filter, rest) = parse_type_phrase(type_tp.original.trim());
+    let (base_filter, rest) = parse_type_phrase_folding(type_tp.original.trim());
     if !rest.trim().is_empty() {
         return None;
     }
@@ -4665,7 +4665,7 @@ fn parse_controlled_by_anchor_subject_filter(subject: &TextPair<'_>) -> Option<T
     let (type_tp, label_tp) = subject
         .split_around(" controlled by players who last chose ")
         .or_else(|| subject.split_around(" controlled by player who last chose "))?;
-    let (type_filter, rest) = parse_type_phrase(type_tp.original.trim());
+    let (type_filter, rest) = parse_type_phrase_folding(type_tp.original.trim());
     if !rest.trim().is_empty() || matches!(type_filter, TargetFilter::Any) {
         return None;
     }
@@ -4757,7 +4757,7 @@ pub(crate) fn parse_continuous_subject_filter(subject: &str) -> Option<TargetFil
     // Strip "Each " / "All " quantifier prefixes — "Each creature you control" and
     // "All Sliver creatures" are semantically identical to the bare type phrase for
     // filter purposes (CR 205.3 / CR 700.1). Without this, "All Sliver creatures"
-    // flows into parse_type_phrase which treats "All Sliver" as a verbatim subtype
+    // flows into parse_type_phrase_folding which treats "All Sliver" as a verbatim subtype
     // string and matches zero real creatures.
     if let Some(rest_tp) = nom_tag_tp(&tp, "each ").or_else(|| nom_tag_tp(&tp, "all ")) {
         return parse_continuous_subject_filter(rest_tp.original.trim());
@@ -4864,7 +4864,7 @@ pub(crate) fn parse_continuous_subject_filter(subject: &str) -> Option<TargetFil
         nom_primitives::split_once_on(tp.lower, " with the chosen name")
     {
         let type_part_original = tp.original[..type_part.len()].trim();
-        let (type_filter, type_rest) = parse_type_phrase(type_part_original);
+        let (type_filter, type_rest) = parse_type_phrase_folding(type_part_original);
         if type_rest.trim().is_empty() && !matches!(type_filter, TargetFilter::Any) {
             return Some(TargetFilter::And {
                 filters: vec![type_filter, TargetFilter::HasChosenName],
@@ -4918,13 +4918,13 @@ pub(crate) fn parse_continuous_subject_filter(subject: &str) -> Option<TargetFil
     // Revisit once an off-zone characteristics path exists for non-keyword
     // modifications.
 
-    let (filter, rest) = parse_type_phrase(trimmed);
+    let (filter, rest) = parse_type_phrase_folding(trimmed);
     if rest.trim().is_empty() {
         // CR 109.2: a bare "spell(s)" head noun in a static-ability subject
         // ("permanent spells you control", Secret Arcade) means the affected
         // objects sit on the stack, not the battlefield — the same rule
         // `parse_target_with_ctx` already applies to targeting noun phrases.
-        // `parse_type_phrase` has no notion of this (it's a bare type-phrase
+        // `parse_type_phrase_folding` has no notion of this (it's a bare type-phrase
         // grammar shared by many non-targeting callers), so without this the
         // "spell(s)" word is silently swallowed and the filter collapses to a
         // battlefield-permanent filter that never reaches the stack.
@@ -4972,7 +4972,7 @@ pub(crate) fn parse_owned_off_battlefield_subject_filter(subject: &str) -> Optio
     .parse(remainder)
     .ok()?;
     let type_part = &trimmed[..prefix.len()];
-    let (base_filter, rest) = parse_type_phrase(type_part);
+    let (base_filter, rest) = parse_type_phrase_folding(type_part);
     if !rest.trim().is_empty() {
         return None;
     }
@@ -5107,7 +5107,7 @@ pub(crate) fn strip_one_trailing_ascii_s(text: &str) -> &str {
 
 /// CR 205.3m: Parse "creature [you control] that's a Wolf or a Werewolf" subjects.
 /// Splits on "that's a " / "that is a ", parses the base phrase (with controller/zone
-/// suffix) via `parse_type_phrase`, then parses a comma/or/and-separated subtype list
+/// suffix) via `parse_type_phrase_folding`, then parses a comma/or/and-separated subtype list
 /// and composes with `TargetFilter::And`.
 pub(crate) fn parse_thats_a_subject_filter(text: &str, lower: &str) -> Option<TargetFilter> {
     type VE<'a> = OracleError<'a>;
@@ -5122,7 +5122,7 @@ pub(crate) fn parse_thats_a_subject_filter(text: &str, lower: &str) -> Option<Ta
     let base_text = text[..before.len()].trim();
     let subtype_text = text[text.len() - subtype_lower.len()..].trim();
 
-    let (base_filter, base_rest) = parse_type_phrase(base_text);
+    let (base_filter, base_rest) = parse_type_phrase_folding(base_text);
     if !base_rest.trim().is_empty() || matches!(base_filter, TargetFilter::Any) {
         return None;
     }
@@ -5477,7 +5477,7 @@ pub(crate) fn parse_commander_subject_filter_prefix(subject: &str) -> Option<(Ta
 /// descriptor and then route capitalized descriptors through a
 /// `subtype`-fabricating fallback. A sentence-leading "Nontoken" is
 /// capitalized but is NOT a subtype — it is a type/token-identity negation.
-/// This guard lets such descriptors fall through to `parse_type_phrase`, whose
+/// This guard lets such descriptors fall through to `parse_type_phrase_folding`, whose
 /// negation loop maps the negated word to `FilterProp`/`TypeFilter::Non` via
 /// `classify_negation` (the single authority).
 ///
@@ -5498,7 +5498,7 @@ pub(crate) fn descriptor_is_negation(descriptor: &str) -> bool {
 
 /// CR 205.4a: Supertype descriptors include legendary, basic, snow, and world;
 /// parse supported supertype words through the shared target combinator so they
-/// fall through to `parse_type_phrase` instead of becoming fabricated subtypes.
+/// fall through to `parse_type_phrase_folding` instead of becoming fabricated subtypes.
 pub(crate) fn descriptor_is_supertype(descriptor: &str) -> bool {
     let lower = descriptor.to_lowercase();
     let is_supertype = all_consuming(nom_target::parse_supertype_word)
@@ -5729,7 +5729,7 @@ pub(crate) fn parse_creature_subject_filter(subject: &str) -> Option<TargetFilte
     // (e.g. "Nontoken creatures") or a supertype descriptor (e.g. "Legendary
     // creatures") is NOT a subtype. `is_capitalized_words` below would
     // otherwise fabricate a bogus subtype. Bail so `parse_continuous_subject_filter`
-    // falls through to its own `parse_type_phrase` call, whose typed grammar
+    // falls through to its own `parse_type_phrase_folding` call, whose typed grammar
     // maps these descriptors onto properties.
     if descriptor_is_negation(descriptor) || descriptor_is_supertype(descriptor) {
         return None;
@@ -5958,12 +5958,12 @@ pub(crate) fn parse_rule_static_subject_filter(subject: &str) -> Option<TargetFi
 
     // CR 205.3 + CR 604.1: "All/Each <subtype>" universal-quantifier subject for a
     // rule-static grant (e.g. "All Slivers have shroud"). Strip the quantifier and
-    // delegate to parse_type_phrase (mirroring parse_target), so the subtype filter
+    // delegate to parse_type_phrase_folding (mirroring parse_target), so the subtype filter
     // is recognized and the line lands as a top-level continuous static (CR 604.1)
     // instead of a spell-resolution GenericEffect. Runs AFTER the player-scope match
     // above so it never shadows "all players"/"each player".
     if let Some(rest_tp) = nom_tag_tp(&tp, "all ").or_else(|| nom_tag_tp(&tp, "each ")) {
-        let (filter, rest) = parse_type_phrase(rest_tp.original);
+        let (filter, rest) = parse_type_phrase_folding(rest_tp.original);
         if rest.trim().is_empty() {
             return Some(match attachment_prop {
                 Some(prop) => merge_filter_prop(filter, prop),
@@ -5990,7 +5990,7 @@ pub(crate) fn parse_rule_static_subject_filter(subject: &str) -> Option<TargetFi
         ));
     }
 
-    let (filter, rest) = parse_type_phrase(subject);
+    let (filter, rest) = parse_type_phrase_folding(subject);
     if rest.trim().is_empty() {
         return Some(match attachment_prop {
             Some(prop) => merge_filter_prop(filter, prop),

--- a/crates/engine/src/parser/oracle_static/static_helpers.rs
+++ b/crates/engine/src/parser/oracle_static/static_helpers.rs
@@ -11,7 +11,7 @@ use nom::character::complete::multispace0;
 /// Shared by the chosen-name name-picker classes — the `CantBeActivated`
 /// prohibition (Pithing Needle / Phyrexian Revoker / Sorcerous Spyglass) and the
 /// directional activated-ability cost modifier (Skyseer's Chariot). Returns
-/// `None` for any other subject so callers fall back to `parse_type_phrase`.
+/// `None` for any other subject so callers fall back to `parse_type_phrase_folding`.
 pub(crate) fn parse_chosen_name_source_filter(subject_lower: &str) -> Option<TargetFilter> {
     let trimmed = subject_lower.trim();
     value(
@@ -39,7 +39,7 @@ pub(crate) fn parse_chosen_name_source_filter(subject_lower: &str) -> Option<Tar
 /// `"cost"`. Handles compound subjects such as Goblin Anarchomancer's
 /// "Each spell you cast that's red or green" via `parse_that_clause_suffix`.
 /// CR 205.4a: A bare supertype spell subject ("Legendary spells you cast cost
-/// {1} less", Kethis, the Hidden Hand) — `parse_type_phrase` doesn't consume a
+/// {1} less", Kethis, the Hidden Hand) — `parse_type_phrase_folding` doesn't consume a
 /// lone supertype word (it requires a following type noun), so the restriction
 /// would otherwise drop and reduce the cost of EVERY spell. Emit a `HasSupertype`
 /// card filter instead.
@@ -56,7 +56,7 @@ fn parse_bare_supertype_spell_filter(base: &str) -> Option<TargetFilter> {
 /// CR 105.2 + CR 700.6 + CR 205.4a + CR 601.2f: Resolve a BARE-word spell-subject
 /// filter for a cost modifier — a color or color-CATEGORY ("white", "colorless",
 /// "monocolored", "multicolored"), "historic", or a supertype ("legendary").
-/// `parse_type_phrase` declines all of these because they carry no trailing type
+/// `parse_type_phrase_folding` declines all of these because they carry no trailing type
 /// noun (it needs "white creature", not a lone "white"), so without this the
 /// whole restriction dropped and the cost modifier (mis)applied to EVERY spell.
 ///
@@ -172,7 +172,7 @@ fn parse_cost_mod_spell_type_prefix(type_desc: &str) -> Option<TargetFilter> {
     // <color> spells" (the Prophecy Familiar cycle: Nightscape / Stormscape /
     // Sunscape / Thornscape / Thunderscape Familiar). The single-subject path
     // below maps a lone bare color via `parse_named_color`, and
-    // `parse_type_phrase` decomposes compounds whose operands carry a type noun
+    // `parse_type_phrase_folding` decomposes compounds whose operands carry a type noun
     // ("Angel spells and Human spells", "red creature spells and green creature
     // spells"). A two-BARE-color compound falls through both and yields
     // `None` — which silently drops the color restriction and reduces EVERY
@@ -220,7 +220,7 @@ fn parse_cost_mod_spell_type_prefix(type_desc: &str) -> Option<TargetFilter> {
     let typed_filter = if base_part.is_empty() {
         None
     } else {
-        let (filter, remainder) = parse_type_phrase(base_part);
+        let (filter, remainder) = parse_type_phrase_folding(base_part);
         let remainder = remainder.trim();
         match &filter {
             TargetFilter::Typed(tf)
@@ -234,7 +234,7 @@ fn parse_cost_mod_spell_type_prefix(type_desc: &str) -> Option<TargetFilter> {
             }
             // Bare color/color-category words ("white", "colorless",
             // "multicolored"), "historic", and bare supertype words ("legendary")
-            // are not consumed by parse_type_phrase, which requires a trailing type
+            // are not consumed by parse_type_phrase_folding, which requires a trailing type
             // noun ("white creature", "legendary permanent"). Route them through
             // the single bare-subject authority so the color-category axis is not
             // dropped (CR 105.2 + CR 700.6 + CR 205.4a).
@@ -274,7 +274,7 @@ fn parse_cost_mod_spell_type_prefix(type_desc: &str) -> Option<TargetFilter> {
 /// Thornscape / Thunderscape Familiar) is the exemplar class. Requires two or
 /// more colors and full consumption, so a lone bare color ("Red spells …") and
 /// a noun-bearing operand ("red creature spells and …") both decline here and
-/// fall through to the single-subject path and `parse_type_phrase` respectively.
+/// fall through to the single-subject path and `parse_type_phrase_folding` respectively.
 fn parse_cost_mod_compound_color_subject(base: &str) -> Option<TargetFilter> {
     // Operand: a bare color name, optionally followed by the spell noun. The
     // trailing " spell[s]" is present on every operand except the last (the
@@ -662,7 +662,7 @@ pub(crate) fn try_parse_cost_modification(
         // qualifier (Cloud Key, Umori, Stenn, Herald's Horn: "Spells you cast of
         // the chosen type cost {1} less"). A "you cast" infix sits between the
         // type word and this qualifier, so the trim chain below can't reach the
-        // type word and `parse_type_phrase` never extracts the chosen-type
+        // type word and `parse_type_phrase_folding` never extracts the chosen-type
         // discriminator. Strip it here and re-attach IsChosenCardType /
         // IsChosenCreatureType after the base type is parsed — mirrors the
         // "with the chosen name" handling above.
@@ -803,7 +803,7 @@ pub(crate) fn try_parse_cost_modification(
                 }
             })
             .or_else(|| {
-                let (count_filter, _) = parse_type_phrase(count_text);
+                let (count_filter, _) = parse_type_phrase_folding(count_text);
                 Some(QuantityRef::ObjectCount {
                     filter: count_filter,
                 })

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -6587,7 +6587,7 @@ fn static_spells_cost_less() {
 
 // CR 205.4a: Kethis, the Hidden Hand — "Legendary spells you cast cost {1} less
 // to cast" must restrict to legendary spells via a HasSupertype filter, not drop
-// the restriction (spell_filter: None) and cheapen EVERY spell. `parse_type_phrase`
+// the restriction (spell_filter: None) and cheapen EVERY spell. `parse_type_phrase_folding`
 // doesn't consume a lone supertype word, so it needed an explicit arm.
 #[test]
 fn static_legendary_spells_cost_less_keeps_supertype_filter() {
@@ -7218,7 +7218,7 @@ fn static_instant_sorcery_spells_cost_less() {
             "Expected spell_filter for instant/sorcery"
         );
         let filter = spell_filter.as_ref().unwrap();
-        // parse_type_phrase("instant and sorcery") → TargetFilter::Or { [Typed(Instant), Typed(Sorcery)] }
+        // parse_type_phrase_folding("instant and sorcery") → TargetFilter::Or { [Typed(Instant), Typed(Sorcery)] }
         fn contains_type(f: &TargetFilter, expected: TypeFilter) -> bool {
             match f {
                 TargetFilter::Typed(tf) => tf.type_filters.contains(&expected),
@@ -8227,7 +8227,8 @@ fn static_top_of_library_creature_gate_mul_daya_channelers() {
     .unwrap();
 
     assert_eq!(def.mode, StaticMode::Continuous);
-    let (creature_filter, _) = crate::parser::oracle_target::parse_type_phrase("creature card");
+    let (creature_filter, _) =
+        crate::parser::oracle_target::parse_type_phrase_folding("creature card");
     assert_eq!(
         def.condition,
         Some(StaticCondition::TopOfLibraryMatches {
@@ -10727,7 +10728,7 @@ fn static_as_long_as_equipped_creature_is_attacking_grants_first_strike_to_host(
 
     // CR 509.1c: the lure is the typed MustBeBlocked { by: Some(Dalek) }, gated
     // on the same attacking condition, affecting the equipped creature.
-    let dalek = crate::parser::oracle_target::parse_type_phrase("a dalek").0;
+    let dalek = crate::parser::oracle_target::parse_type_phrase_folding("a dalek").0;
     assert_ne!(dalek, TargetFilter::Any, "Dalek subtype must be recognized");
     assert_eq!(defs[1].mode, StaticMode::MustBeBlocked { by: Some(dalek) });
     assert_eq!(defs[1].affected, Some(equipped_creature_filter()));
@@ -11025,7 +11026,7 @@ fn slayers_cleaver_lure_conjunct_models_typed_must_be_blocked() {
         .contains(&ContinuousModification::AddToughness { value: 1 }));
     assert_eq!(defs[0].condition, None);
 
-    let eldrazi = crate::parser::oracle_target::parse_type_phrase("an eldrazi").0;
+    let eldrazi = crate::parser::oracle_target::parse_type_phrase_folding("an eldrazi").0;
     assert_ne!(
         eldrazi,
         TargetFilter::Any,
@@ -11054,7 +11055,7 @@ fn attached_subject_pure_filtered_lure_models_typed_must_be_blocked() {
         1,
         "pure filtered lure → one static, got {defs:?}"
     );
-    let eldrazi = crate::parser::oracle_target::parse_type_phrase("an eldrazi").0;
+    let eldrazi = crate::parser::oracle_target::parse_type_phrase_folding("an eldrazi").0;
     assert_eq!(
         defs[0].mode,
         StaticMode::MustBeBlocked { by: Some(eldrazi) }
@@ -11082,11 +11083,11 @@ fn parse_must_be_blocked_by_filter_building_block() {
     // Filter lowering for both known subtypes (case-insensitive canonicalization).
     assert_eq!(
         parse_must_be_blocked_by_filter("must be blocked by a Dalek if able"),
-        Some(crate::parser::oracle_target::parse_type_phrase("a dalek").0),
+        Some(crate::parser::oracle_target::parse_type_phrase_folding("a dalek").0),
     );
     assert_eq!(
         parse_must_be_blocked_by_filter("must be blocked by an Eldrazi if able"),
-        Some(crate::parser::oracle_target::parse_type_phrase("an eldrazi").0),
+        Some(crate::parser::oracle_target::parse_type_phrase_folding("an eldrazi").0),
     );
     // Bare form yields no filter.
     assert_eq!(
@@ -11114,7 +11115,7 @@ fn extract_must_be_blocked_by_conjunct_classifies_quality() {
 
     // Guard: the fixture quality is genuinely unrecognized — it constrains no
     // blocker, so the lowering helper rejects it (returns no filter). NOTE:
-    // `parse_type_phrase` yields an empty `Typed` (not `TargetFilter::Any`) here.
+    // `parse_type_phrase_folding` yields an empty `Typed` (not `TargetFilter::Any`) here.
     assert!(parse_must_be_blocked_by_filter("must be blocked by a splorf if able").is_none());
     // Unrecognized quality → Unrecognized(diagnostic), NOT collapsed to None.
     let conjunct = extract_must_be_blocked_by_conjunct("must be blocked by a Splorf if able");
@@ -14244,7 +14245,7 @@ fn graveyard_cast_permission_gisa_geralf() {
             ..
         }
     ));
-    // "zombie creature" → parse_type_phrase recognizes "zombie" as subtype.
+    // "zombie creature" → parse_type_phrase_folding recognizes "zombie" as subtype.
     // card_type may be None (subtype alone) or Creature depending on parser —
     // either is functionally correct since Zombie is exclusively a creature subtype.
     if let Some(TargetFilter::Typed(tf)) = &def.affected {
@@ -15942,7 +15943,7 @@ fn continuous_subject_filter_nontoken_is_negation_not_subtype() {
     // CR 111.1 / CR 205.3: "Nontoken creatures you control" (Ashaya, Soul of
     // the Wild) is a type phrase with a token-identity negation, NOT a
     // subtype. The negation guard in `parse_creature_subject_filter` must
-    // return None so the phrase falls through to `parse_type_phrase`, which
+    // return None so the phrase falls through to `parse_type_phrase_folding`, which
     // produces a `Creature` filter with the `NonToken` property.
     let filter = parse_continuous_subject_filter("Nontoken creatures you control")
         .expect("nontoken creature subject should parse");
@@ -16166,7 +16167,7 @@ fn continuous_subject_filter_capitalized_subtype_still_works() {
 fn continuous_subject_filter_noncreature_word_boundary_anchor() {
     // Word-boundary anchor check: the `non` guard fires for genuine negation
     // descriptors ("Nonland creatures"), and the negated word reaches
-    // `classify_negation` via `parse_type_phrase`. This confirms the guard
+    // `classify_negation` via `parse_type_phrase_folding`. This confirms the guard
     // is not over-broad — it only fires when `non` heads a real descriptor
     // token, which is always true for a `parse_creature_subject_filter`
     // descriptor extracted by stripping " creatures".
@@ -16195,7 +16196,7 @@ fn static_pump_line_nontoken_subject_routes_through_negation_guard() {
     // negation descriptor ("Nontoken creatures you control get/have ...")
     // must NOT fabricate a `Subtype("Nontoken")`. This exercises the
     // `parse_typed_you_control` negation guard (`:2764`/`:2783`): the guard
-    // returns None, dispatch falls through, and `parse_type_phrase`'s
+    // returns None, dispatch falls through, and `parse_type_phrase_folding`'s
     // negation loop yields the correct `Creature` + `NonToken` filter.
     for line in [
         "Nontoken creatures you control get +1/+1.",
@@ -23678,7 +23679,7 @@ fn static_reduce_exhaust_ability_cost_other_permanents() {
     // less to activate." The generalized "<keyword> abilities of [subject]" arm
     // keys the reduction on the "exhaust" ability tag (CR 602.1 / CR 601.2f) and
     // routes the "other permanents you control" self-exclusion through
-    // parse_type_phrase.
+    // parse_type_phrase_folding.
     let def = parse_static_line(
         "Exhaust abilities of other permanents you control cost {2} less to activate.",
     )
@@ -24638,7 +24639,7 @@ fn apply_spell_keyword_subject_constraints_recurses_and() {
 //  (1) `Keyword::from_str("affinity for creatures")` previously returned
 //      `Keyword::Unknown` — so `apply_affinity_reduction` silently skipped
 //      the granted keyword and no cost reduction was applied at cast time.
-//  (2) `parse_type_phrase("Instant and sorcery")` returns `TargetFilter::Or`,
+//  (2) `parse_type_phrase_folding("Instant and sorcery")` returns `TargetFilter::Or`,
 //      which the old `match TargetFilter::Typed(tf) => tf, _ => card()`
 //      arm discarded — leaving the static affecting every spell card the
 //      player casts (CR 113.3a: affected filter must scope recipients).
@@ -25201,7 +25202,7 @@ fn death_baron_compound_get_have_predicate_unaffected_by_typed_you_control_guard
 // CR 205.4a (supertype) + CR 105.2 (color count). Amazing Spider-Man's back
 // face grants web-slinging only to "legendary spells … that's one or more
 // colors"; the affected filter must carry BOTH qualifiers, and the supertype
-// must be emitted exactly once (no parse_type_phrase double-emit).
+// must be emitted exactly once (no parse_type_phrase_folding double-emit).
 
 #[test]
 fn static_legendary_colored_spells_have_web_slinging() {
@@ -25254,7 +25255,7 @@ fn static_legendary_colored_spells_have_web_slinging() {
 #[test]
 fn static_legendary_creature_spells_emit_supertype_once() {
     // Compound subject: supertype must be emitted exactly once (peel here OR
-    // parse_type_phrase, never both) and the Creature type must be present.
+    // parse_type_phrase_folding, never both) and the Creature type must be present.
     let def = parse_static_line("Each legendary creature spell you cast has flash.").unwrap();
     assert_eq!(
         def.mode,
@@ -26245,7 +26246,7 @@ fn cant_be_activated_clarion_multi_type_filter() {
     // CR 602.5 + CR 603.2a: Clarion Conqueror — "Activated abilities of artifacts,
     // creatures, and planeswalkers your opponents control can't be activated."
     // The activator axis is AllPlayers; opponent-ness rides on the filter's
-    // `ControllerRef::Opponent`. `parse_type_phrase` emits an `Or`-disjunction of
+    // `ControllerRef::Opponent`. `parse_type_phrase_folding` emits an `Or`-disjunction of
     // `Typed` filters when a comma-separated type list is present — each variant
     // inherits the shared controller suffix via the post-process pass.
     let def = parse_static_line(
@@ -29179,7 +29180,7 @@ fn tiered_enters_with_additional_counters_static_one_counter_otherwise_singular(
 /// Sliver) must land as a TOP-LEVEL continuous static granting Shroud to a
 /// `Typed(Subtype:"Sliver")` subject — NOT a spell-resolution GenericEffect.
 /// The "all " universal quantifier on the rule-static subject must be stripped
-/// and delegated to `parse_type_phrase`.
+/// and delegated to `parse_type_phrase_folding`.
 #[test]
 fn static_all_slivers_have_shroud_top_level_typed_subtype() {
     let def =
@@ -31074,7 +31075,7 @@ fn static_creatures_enchanted_player_controls_get_minus_1_minus_1() {
 fn static_creatures_target_player_controls_not_via_suffix_parser() {
     // Negative test: "target player controls" must NOT be accepted by
     // parse_static_controller_suffix (the restricted subject-suffix grammar).
-    // The full parse_static_line may still succeed via the parse_type_phrase
+    // The full parse_static_line may still succeed via the parse_type_phrase_folding
     // fallback, but the controller must NOT originate from our suffix helper.
     // We verify by checking parse_creature_subject_filter directly — it should
     // return None for this subject since the suffix parser rejects TargetPlayer.
@@ -31947,7 +31948,7 @@ fn static_self_dynamic_pump_for_each_other_creature_you_control_with_counter() {
 /// granted instance. It must also carry `InZone{Hand}`.
 #[test]
 fn without_foretell_routes_to_keyword_kind_not_concrete() {
-    let (filter, remainder) = crate::parser::oracle_target::parse_type_phrase(
+    let (filter, remainder) = crate::parser::oracle_target::parse_type_phrase_folding(
         "nonland card in your hand without foretell",
     );
     assert!(
@@ -33806,7 +33807,7 @@ fn parse_legendary_black_creatures_you_control() {
     )));
 }
 
-// Decline guard: the new fallback delegates to `parse_type_phrase` and
+// Decline guard: the new fallback delegates to `parse_type_phrase_folding` and
 // requires FULL consumption of the subject as a single `Typed` filter. An
 // unrecognized leading word before "legendary" must not be silently accepted
 // as a fabricated filter — it must still fall through to `Unimplemented`
@@ -33820,7 +33821,7 @@ fn parse_unrecognized_word_legendary_creatures_you_control_declines() {
 }
 
 // Review finding: the compound-descriptor fallback must decline for a
-// descriptor `parse_type_phrase` fully consumes but that carries NEITHER a
+// descriptor `parse_type_phrase_folding` fully consumes but that carries NEITHER a
 // color NOR a supertype — a full-consumption check alone is not a narrow
 // enough acceptance gate. Saryth, the Viper's Fang and Augusta, Dean of Order
 // both read "Other tapped creatures you control have/get <predicate>." and
@@ -33828,7 +33829,7 @@ fn parse_unrecognized_word_legendary_creatures_you_control_declines() {
 // "untapped" are combat-status words, not colors or supertypes. Before the
 // property gate, `parse_typed_you_control`'s unconditional final `else`
 // wrongly claimed BOTH of these (each fully consumes through
-// `parse_type_phrase` as a bare `Typed(Creature)` filter with a `Tapped`/
+// `parse_type_phrase_folding` as a bare `Typed(Creature)` filter with a `Tapped`/
 // `Untapped` property, satisfying the old remainder-only check), preventing
 // dispatch from ever reaching whichever OTHER handler correctly resolves
 // these two real, unrelated cards and silently changing their parsed

--- a/crates/engine/src/parser/oracle_static/type_change.rs
+++ b/crates/engine/src/parser/oracle_static/type_change.rs
@@ -2085,7 +2085,7 @@ pub(crate) fn parse_each_noncreature_subject_is_creature_with_pt_mv(
 /// resolved through a hand-rolled conjunct splitter), this class has a SINGLE
 /// leading `each` quantifier and per-conjunct negated-type exclusions
 /// ("non-Equipment", "non-Aura") — so the subject is delegated wholesale to
-/// the general target-phrase grammar (`parse_type_phrase`) instead. That
+/// the general target-phrase grammar (`parse_type_phrase_folding`) instead. That
 /// grammar already recurses per "and"-leg (restarting its own leading `non-`
 /// scan on each recursive call — see `starts_with_type_word`'s `non-` arm) and
 /// backfills the shared trailing qualifiers (controller, mana value) from the
@@ -2126,7 +2126,7 @@ pub(crate) fn parse_each_compound_subject_type_change(
 
     // STEP D — delegate the ENTIRE subject phrase to the general target-phrase
     // grammar instead of hand-rolling a conjunct splitter (see doc comment).
-    let (affected, subject_rest) = parse_type_phrase(subject_tp.original);
+    let (affected, subject_rest) = parse_type_phrase_folding(subject_tp.original);
     if !subject_rest.trim().is_empty() {
         return None;
     }

--- a/crates/engine/src/parser/oracle_target.rs
+++ b/crates/engine/src/parser/oracle_target.rs
@@ -829,7 +829,7 @@ pub fn parse_target_with_syntax<'a>(
                 return (TargetFilter::TriggeringSource, orig_after, syntax);
             }
         }
-        let (filter, rem) = parse_type_phrase_with_ctx(original_rest, ctx);
+        let (filter, rem) = parse_type_phrase_folding_with_ctx(original_rest, ctx);
         if !matches!(filter, TargetFilter::Any) {
             // CR 601.2c + CR 608.2c: when the chain declared multiple target
             // slots and "that <type>" names exactly one of them (Stolen Uniform's
@@ -874,7 +874,7 @@ pub fn parse_target_with_syntax<'a>(
             .is_ok_and(|(after, _)| after.is_empty() || after.starts_with([' ', ',', '.']));
         if !is_player_ordinal_anaphor {
             let original_rest = &text[lower.len() - rest_subject.len()..];
-            let (filter, rem) = parse_type_phrase_with_ctx(original_rest, ctx);
+            let (filter, rem) = parse_type_phrase_folding_with_ctx(original_rest, ctx);
             if !matches!(filter, TargetFilter::Any) {
                 return (TargetFilter::ParentTarget, rem, syntax);
             }
@@ -939,7 +939,8 @@ pub fn parse_target_with_syntax<'a>(
 
     // "all " + type phrase
     if let Ok((rest, _)) = tag::<_, _, OracleError<'_>>("all ").parse(lower.as_str()) {
-        let (filter, rest) = parse_type_phrase_with_ctx(&text[lower.len() - rest.len()..], ctx);
+        let (filter, rest) =
+            parse_type_phrase_folding_with_ctx(&text[lower.len() - rest.len()..], ctx);
         return (filter, rest, syntax);
     }
 
@@ -1103,7 +1104,7 @@ pub fn parse_target_with_syntax<'a>(
                     let mut leg_text = &text[lower.len() - object_tail.len()..];
                     let mut merged_any = false;
                     loop {
-                        let (leg, rest) = parse_type_phrase_with_ctx(leg_text, ctx);
+                        let (leg, rest) = parse_type_phrase_folding_with_ctx(leg_text, ctx);
                         if matches!(leg, TargetFilter::Any) {
                             if merged_any {
                                 return (combined, leg_text, syntax);
@@ -1137,10 +1138,10 @@ pub fn parse_target_with_syntax<'a>(
             );
         }
         // "target" + type phrase (generic). CR 903.3 + CR 108.3: "commander[s]"
-        // is recognized as a typed-phrase prefix inside `parse_type_phrase_with_ctx`
+        // is recognized as a typed-phrase prefix inside `parse_type_phrase_folding_with_ctx`
         // — it pushes `IsCommander` and composes uniformly with the existing
         // suffix machinery (ownership, control, counters, "with X", etc.).
-        let (filter, rest) = parse_type_phrase_with_ctx(&text[target_offset..], ctx);
+        let (filter, rest) = parse_type_phrase_folding_with_ctx(&text[target_offset..], ctx);
         let consumed_end = lower.len() - rest.len();
         return (
             scope_target_spell_phrase(filter, &lower[target_offset..consumed_end]),
@@ -1592,7 +1593,7 @@ pub fn parse_target_with_syntax<'a>(
     // uses the bare creatures/permanents/cards arms). A typed tail ("Vampires",
     // "Zombies you control") intersects the tracked set with the type filter;
     // without this arm, "each of those Vampires" fell through to `each ` +
-    // `parse_type_phrase("of those Vampires")`, producing an empty TypedFilter
+    // `parse_type_phrase_folding("of those Vampires")`, producing an empty TypedFilter
     // that matched every permanent on the battlefield.
     if let Ok((rest_lower, _)) =
         tag::<_, _, OracleError<'_>>("each of those ").parse(lower.as_str())
@@ -1607,7 +1608,7 @@ pub fn parse_target_with_syntax<'a>(
         // predicate PROPERTY beyond the head type noun, wrap it. A bare noun
         // ("creatures"/"permanents"/"cards") with no trailing predicate yields
         // only a head `type_filter` and no properties → the plain `TrackedSet`.
-        let (filter, remainder) = parse_type_phrase_with_ctx(phrase, ctx);
+        let (filter, remainder) = parse_type_phrase_folding_with_ctx(phrase, ctx);
         if target_filter_carries_predicate_property(&filter) {
             return (
                 TargetFilter::TrackedSetFiltered {
@@ -1689,7 +1690,7 @@ pub fn parse_target_with_syntax<'a>(
     // distribution (handled upstream by the counter.rs strip), NOT an all-matching
     // "each" filter. For any non-counter effect that reaches here, route the type
     // through "target" parsing rather than the bare "each " path below — which
-    // would call `parse_type_phrase_with_ctx("of <count> target <type>")` and
+    // would call `parse_type_phrase_folding_with_ctx("of <count> target <type>")` and
     // degenerate to an all-matching TypedFilter.
     if let Ok((rest_lower, ())) = (|i| {
         let (i, ()) = value((), tag::<_, _, OracleError<'_>>("each of ")).parse(i)?;
@@ -1706,7 +1707,8 @@ pub fn parse_target_with_syntax<'a>(
 
     // "each " + type phrase
     if let Ok((rest, _)) = tag::<_, _, OracleError<'_>>("each ").parse(lower.as_str()) {
-        let (filter, rest) = parse_type_phrase_with_ctx(&text[lower.len() - rest.len()..], ctx);
+        let (filter, rest) =
+            parse_type_phrase_folding_with_ctx(&text[lower.len() - rest.len()..], ctx);
         return (filter, rest, syntax);
     }
 
@@ -1724,7 +1726,7 @@ pub fn parse_target_with_syntax<'a>(
     // "enchanted [type phrase]" → parse the type after "enchanted " and add EnchantedBy
     if let Ok((rest_lower, _)) = tag::<_, _, OracleError<'_>>("enchanted ").parse(lower.as_str()) {
         let after_enchanted = &text[lower.len() - rest_lower.len()..];
-        let (filter, rest) = parse_type_phrase_with_ctx(after_enchanted, ctx);
+        let (filter, rest) = parse_type_phrase_folding_with_ctx(after_enchanted, ctx);
         if target_filter_has_meaningful_content(&filter) {
             let enchanted = match filter {
                 TargetFilter::Typed(mut tf) => {
@@ -1862,15 +1864,15 @@ pub fn parse_target_with_syntax<'a>(
         }
     }
 
-    // Bare type phrase fallback: try parse_type_phrase before giving up.
+    // Bare type phrase fallback: try parse_type_phrase_folding before giving up.
     // Handles "commander[s] you own / they control" (non-possessive — the
     // possessive form is matched inside the typed-phrase grammar), bare "commander" (Witch's Clinic
     // class), and combinations like "commander creature you control"
     // (Drillworks Mole class). The commander recognition itself lives in
-    // `parse_type_phrase_with_ctx` so it composes with the full suffix grammar
+    // `parse_type_phrase_folding_with_ctx` so it composes with the full suffix grammar
     // (ownership, control, counter, "with X", etc.) — CR 903.3 + CR 108.3.
     // Handles "other nonland permanents you own and control" after quantifier stripping.
-    let (filter, rest) = parse_type_phrase_with_ctx(text, ctx);
+    let (filter, rest) = parse_type_phrase_folding_with_ctx(text, ctx);
     if target_filter_has_meaningful_content(&filter) {
         let consumed_end = lower.len() - rest.len();
         (
@@ -2171,16 +2173,16 @@ fn parse_named_filter_terminator(input: &str) -> Result<(&str, ()), nom::Err<Ora
 /// Parse a type phrase like "creature", "nonland permanent", "artifact or enchantment",
 /// "creature you control", "creature an opponent controls".
 ///
-/// Prefer `parse_type_phrase_with_ctx` when a `ParseContext` is available —
-/// it enables relative-player scope resolution for "that player controls".
+/// The name records the grammar: this reader FOLDS a type list across all of
+/// `TYPE_SEPARATORS` (`" and "`, `" and/or "`, and the comma forms), where
+/// [`crate::parser::oracle_nom::target::parse_type_phrase`] joins on `" or "`
+/// alone. The measured differences are tabulated on the private
+/// `TypePhraseGrammar` enum in `oracle_nom/quantity.rs`, which selects between
+/// the two as an explicit typed parameter; this reader is its `Legacy` arm.
 ///
-/// # Not interchangeable with the other `parse_type_phrase`
-///
-/// [`crate::parser::oracle_nom::target::parse_type_phrase`] has the same name
-/// and reads the same grammatical slot, but it is a different reader, and their
-/// accepted grammars diverge — the measured differences are tabulated on the
-/// private `TypePhraseGrammar` enum in `oracle_nom/quantity.rs`, which selects
-/// between them as an explicit typed parameter; this reader is its `Legacy` arm.
+/// Prefer `parse_type_phrase_folding_with_ctx` when a `ParseContext` is
+/// available — it enables relative-player scope resolution for "that player
+/// controls".
 ///
 /// One consequence is load-bearing for every caller: this reader is
 /// INFALLIBLE. There is no `Err` to propagate — an unrecognized phrase
@@ -2188,8 +2190,8 @@ fn parse_named_filter_terminator(input: &str) -> Result<(&str, ()), nom::Err<Ora
 /// whole input, which is NOT `TargetFilter::Any`. A caller that means to
 /// decline unrecognized input needs an emptiness check (or a whole-clause
 /// remainder check); an `Any` guard will not catch it.
-pub fn parse_type_phrase(text: &str) -> (TargetFilter, &str) {
-    parse_type_phrase_with_ctx(text, &mut ParseContext::default())
+pub fn parse_type_phrase_folding(text: &str) -> (TargetFilter, &str) {
+    parse_type_phrase_folding_with_ctx(text, &mut ParseContext::default())
 }
 
 /// CR 608.2c: separator byte length for a mass-target union continuation
@@ -2254,9 +2256,9 @@ pub(crate) fn parse_mass_type_union<'a>(
     (acc, rest)
 }
 
-/// Context-aware variant of `parse_type_phrase`. Enables relative-player scope
+/// Context-aware variant of `parse_type_phrase_folding`. Enables relative-player scope
 /// resolution via `ctx.relative_player_scope`.
-pub fn parse_type_phrase_with_ctx<'a>(
+pub fn parse_type_phrase_folding_with_ctx<'a>(
     text: &'a str,
     ctx: &mut ParseContext,
 ) -> (TargetFilter, &'a str) {
@@ -2875,7 +2877,7 @@ pub fn parse_type_phrase_with_ctx<'a>(
     // that a following article-led "or a <type> card" is a card-type disjunction
     // (Overlord of the Balemurk, #5331) rather than an elided-verb "you control X
     // or a Y" clause the condition layer folds one level up (which must stay as
-    // `parse_type_phrase` remainder — `parse_type_phrase_leaves_article_led_or_rhs_as_remainder`).
+    // `parse_type_phrase_folding` remainder — `parse_type_phrase_leaves_article_led_or_rhs_as_remainder`).
     let mut left_card_suffix = false;
     if card_type.is_some() && !matches!(card_type, Some(TypeFilter::Card) | Some(TypeFilter::Any)) {
         let rest_trimmed = lower[pos..].trim_start();
@@ -2972,7 +2974,7 @@ pub fn parse_type_phrase_with_ctx<'a>(
                 starts_with_type_word(after_trimmed)
                     // CR 205.4a + CR 205.2a: a disjunct may lead with a SUPERTYPE
                     // before its type word — "legendary creature", "basic land",
-                    // "snow permanent". `parse_type_phrase_with_ctx` already
+                    // "snow permanent". `parse_type_phrase_folding_with_ctx` already
                     // consumes exactly this prefix on the LEFT of a separator (the
                     // `parse_supertype_prefix` call in the prefix scan above), and
                     // the COMMA branch already accepts it on the right via
@@ -3014,7 +3016,7 @@ pub fn parse_type_phrase_with_ctx<'a>(
             };
             if can_recurse {
                 let sep_text = &text[pos + rest_offset + separator.len()..];
-                let (other_filter, final_rest) = parse_type_phrase_with_ctx(sep_text, ctx);
+                let (other_filter, final_rest) = parse_type_phrase_folding_with_ctx(sep_text, ctx);
                 // CR 205.2a: The left branch of a type disjunction must retain
                 // every type word that bound to it before the connector — the
                 // primary core type (`card_type`), the trailing core types from
@@ -4110,7 +4112,7 @@ fn classify_negation(negated: &str) -> NegationResult {
 /// CR 903.3 + CR 108.3: does `text` start with the "commander"/"commanders"
 /// class word (word-bounded)? Commander is not a card type or subtype — it is a
 /// per-object `IsCommander` flag recognized by the commander atom in
-/// `parse_type_phrase_with_ctx` — so `starts_with_type_phrase_lead` deliberately
+/// `parse_type_phrase_folding_with_ctx` — so `starts_with_type_phrase_lead` deliberately
 /// does not report it. The indefinite-article guard uses this to strip "a "/"an "
 /// before a commander subject ("a commander you own", Hellkite Courser).
 fn starts_with_commander_word(text: &str) -> bool {
@@ -4119,7 +4121,7 @@ fn starts_with_commander_word(text: &str) -> bool {
         .is_ok_and(|(after, _)| after.is_empty() || after.starts_with([' ', ',', '.', ';']))
 }
 
-/// Guard: does text start with something `parse_type_phrase` would recognize?
+/// Guard: does text start with something `parse_type_phrase_folding` would recognize?
 /// Used to prevent comma/and/or recursion on non-type text.
 pub(crate) fn starts_with_type_word(text: &str) -> bool {
     // Core type: "creature", "artifact", "permanent", etc.
@@ -4136,7 +4138,7 @@ pub(crate) fn starts_with_type_word(text: &str) -> bool {
         return true;
     }
     // CR 105.1: Color adjective prefix: "blue creature", "red permanent", etc.
-    // parse_type_phrase handles color prefixes internally, but the article guard
+    // parse_type_phrase_folding handles color prefixes internally, but the article guard
     // must recognize them to strip "a "/"an " correctly.
     if let Ok((rest, _)) = nom_primitives::parse_color(text) {
         if let Ok((after_space, _)) = tag::<_, _, OracleError<'_>>(" ").parse(rest) {
@@ -4494,7 +4496,7 @@ pub(super) fn distribute_shared_properties(
 }
 
 /// Returns true when the given property is leg-local (produced by an adjective
-/// prefix during `parse_type_phrase` scanning, or by a type-scoped keyword
+/// prefix during `parse_type_phrase_folding` scanning, or by a type-scoped keyword
 /// suffix on only the final disjunct) and must NOT distribute back across
 /// earlier legs of a comma-OR list. Every other property is assumed to
 /// originate from a trailing-suffix parser and is eligible for distribution —
@@ -4510,7 +4512,7 @@ pub(super) fn distribute_shared_properties(
 ///
 /// SHARED LEG-LOCALITY AUTHORITY: this predicate is the single registry of
 /// inherently-leg-local `FilterProp`s for BOTH disjunctive grammars — the
-/// target-phrase grammar (`parse_type_phrase`) and the search-filter
+/// target-phrase grammar (`parse_type_phrase_folding`) and the search-filter
 /// disjunction grammar (`oracle_effect::search::parse_search_filter_disjunction`,
 /// CR 701.23a). Every `FilterProp` that an adjective prefix or a type-scoped
 /// suffix binds to exactly one disjunct MUST be registered here, or it will be
@@ -5046,7 +5048,7 @@ fn leg_admits_creature_pt(type_filters: &[TypeFilter]) -> bool {
 /// `distribute_shared_properties`, so the search-filter disjunction grammar
 /// (`oracle_effect::search`, CR 701.23a) inherits it with no extra code.
 ///
-/// ORDERING DEPENDENCY — PRECISION, NOT SAFETY. `parse_type_phrase_with_ctx`
+/// ORDERING DEPENDENCY — PRECISION, NOT SAFETY. `parse_type_phrase_folding_with_ctx`
 /// calls `distribute_core_type_to_or` and `distribute_neg_type_filters_to_or`
 /// BEFORE both distributors that consult this gate, so a leg that receives its
 /// core type (or an inherited `Non(Creature)`) by backfill already carries it
@@ -5111,7 +5113,7 @@ fn pt_hosting_leg_props(filters: &[TargetFilter]) -> Vec<FilterProp> {
 /// Relocate (never delete) a mis-placed power/toughness restriction off an `Or`
 /// leg that pins a noncreature core type.
 ///
-/// 1. WHY RELOCATION IS NEEDED AT ALL. `parse_type_phrase_with_ctx` recurses
+/// 1. WHY RELOCATION IS NEEDED AT ALL. `parse_type_phrase_folding_with_ctx` recurses
 ///    right-to-left over `TYPE_SEPARATORS`, so the LAST noun in the list is the
 ///    leg that parses the trailing suffix and becomes the harvest source. For
 ///    "artifact, creature, or enchantment with power 4 or greater" that is the
@@ -5138,7 +5140,7 @@ fn pt_hosting_leg_props(filters: &[TargetFilter]) -> Vec<FilterProp> {
 ///    `type_filter_guarantees_creature`).
 ///
 /// 3. FLATTENING PRECONDITION. This sweep runs from
-///    `distribute_properties_to_or`, which `parse_type_phrase_with_ctx` invokes
+///    `distribute_properties_to_or`, which `parse_type_phrase_folding_with_ctx` invokes
 ///    on EVERY separator merge, not once at the top. For
 ///    "creature, artifact, or enchantment with power 4 or greater" the inner
 ///    merge yields `Or[Artifact{}, Enchantment{Pt}]` — every leg is gate-
@@ -5201,7 +5203,7 @@ fn strip_misplaced_pt_props_from_or_legs(filters: &mut [TargetFilter]) {
 /// an exactly-equal witness on a creature-guaranteeing sibling leg, so a printed
 /// restriction is never silently deleted.
 ///
-/// NOTE: `parse_type_phrase_with_ctx` calls this on EVERY separator merge, not
+/// NOTE: `parse_type_phrase_folding_with_ctx` calls this on EVERY separator merge, not
 /// once at the top; both the gate and the sweep are therefore written to be
 /// idempotent and to no-op harmlessly at intermediate recursion levels.
 ///
@@ -5907,7 +5909,7 @@ fn parse_attacking_alone_suffix_status(input: &str) -> OracleResult<'_, FilterPr
 /// Cub), which SATISFIES `parse_attacking_status_clause_boundary` rather than
 /// being rejected by it. The boundary guard is therefore NOT what keeps them
 /// safe. What keeps them safe is that none of those positions ever routes the
-/// phrase through `parse_type_phrase`'s suffix chain, because each consuming
+/// phrase through `parse_type_phrase_folding`'s suffix chain, because each consuming
 /// path removes or absorbs the clause first:
 ///
 /// 1. Inline token specs — `oracle_effect::token` scans word boundaries for the
@@ -6052,7 +6054,7 @@ pub(crate) fn superlative_property_filter_prop(
 /// mirroring the library-search path in
 /// `oracle_effect/search.rs::parse_highest_mana_value_library_suffix`.
 /// The eligible set after "among " is parsed by the authoritative
-/// `parse_type_phrase_with_ctx` combinator (type list + controller suffix).
+/// `parse_type_phrase_folding_with_ctx` combinator (type list + controller suffix).
 /// CR 109.2: the postnominal superlative qualifier with an EXPLICIT eligible set —
 /// "with the <superlative> <property> among <set>". This function owns ONLY the
 /// explicit-set clause; an explicit set overrides the enclosing noun phrase as
@@ -6062,7 +6064,7 @@ pub(crate) fn superlative_property_filter_prop(
 /// `oracle_nom::filter::parse_superlative_property_head`. The BARE form (no
 /// "among" clause), whose population is the enclosing noun phrase, is handled by
 /// `parse_bare_superlative_property_suffix` + the deferred materialization in
-/// `parse_type_phrase_with_ctx`.
+/// `parse_type_phrase_folding_with_ctx`.
 fn parse_superlative_property_suffix(
     text: &str,
     ctx: &mut ParseContext,
@@ -6073,7 +6075,7 @@ fn parse_superlative_property_suffix(
     // Delegate the "<type-set> <controller> control(s)" clause to the
     // authoritative type-phrase combinator — it parses the multi-type
     // or/and list, any leading article, and the trailing controller suffix.
-    let (eligible, after) = parse_type_phrase_with_ctx(rest, ctx);
+    let (eligible, after) = parse_type_phrase_folding_with_ctx(rest, ctx);
     let prop = superlative_property_filter_prop(function, property, eligible);
     Some((prop, text.len() - after.len()))
 }
@@ -6508,7 +6510,7 @@ pub(crate) fn parse_mana_value_suffix(
         // (per-player zones are CR 400.1, keyed by owner CR 108.3). Aether Vial's
         // "the number of charge counters on ~ from your hand" parses only after
         // the "from your hand" tail is cut, leaving it for the caller's
-        // `parse_zone_suffix` pass (see `parse_type_phrase_with_ctx`) to attach as
+        // `parse_zone_suffix` pass (see `parse_type_phrase_folding_with_ctx`) to attach as
         // `InZone { Hand }` + controller; without the cut the whole tail parsed as
         // one quantity, failed, and dropped the zone scope entirely — letting the
         // resolver collect cards from every player's hand (issue #1980). Cutting
@@ -7385,7 +7387,7 @@ fn parse_ownership_or_controller_suffix(
     }
     // CR 108.3 + CR 109.4: bare "you don't own"/"you do not own" — negated
     // ownership with no "but" lead (distinct from the "but don't own" block in
-    // `parse_type_phrase`, which requires a controller already set). Placed after
+    // `parse_type_phrase_folding`, which requires a controller already set). Placed after
     // the affirmative "you own"/"you own and control" arms ("you own" is not a
     // prefix of "you don't own", so no shadowing) and before the anaphoric
     // subject×action block. `Owned { Opponent }` is runtime-evaluated as
@@ -8548,7 +8550,7 @@ fn preceded_color_separator(input: &str) -> super::oracle_nom::error::OracleResu
 /// — a plain type-list exclusion suffix (Scourglass: "Destroy all permanents
 /// except for artifacts and lands"; Elspeth Tirel: "except for lands and
 /// tokens"). Distinct from `parse_that_isnt_subtype_suffix`/the "except those
-/// that <relative-clause>" suffix in `parse_type_phrase_with_ctx`, which
+/// that <relative-clause>" suffix in `parse_type_phrase_folding_with_ctx`, which
 /// handle predicate-based exclusions, not bare type lists.
 ///
 /// Reuses `classify_negation` per list item — it already produces
@@ -8708,7 +8710,7 @@ fn parse_except_for_type_list_suffix(
 /// WHERE the decline happens decides whether it is honest, and the two sites
 /// differ. Declining HERE returns `None`, which propagates through `?` at the
 /// mass-return call sites, so no effect is built and the card is unsupported.
-/// Declining at the SUFFIX-POSITION site in `parse_type_phrase_with_ctx` only
+/// Declining at the SUFFIX-POSITION site in `parse_type_phrase_folding_with_ctx` only
 /// drops the clause — that caller still builds its effect, and because
 /// `swallow_check` has no "except for" detector the card keeps reporting
 /// supported (measured: "mageta the lion", "flame sweep", both of which decline
@@ -8716,7 +8718,7 @@ fn parse_except_for_type_list_suffix(
 /// is a separate issue and is NOT claimed here.
 ///
 /// The application is the `TargetFilter`-level form of the two lines the
-/// suffix-position call site in `parse_type_phrase_with_ctx` already runs
+/// suffix-position call site in `parse_type_phrase_folding_with_ctx` already runs
 /// (`neg_type_filters.extend(excl_types); properties.extend(excl_props);`).
 /// That site cannot call this function — it accumulates into local vectors
 /// *before* its `TypedFilter` exists — so what is shared is the grammar, and
@@ -8755,7 +8757,7 @@ pub(crate) fn apply_except_for_type_list_exclusion(
     text: &str,
 ) -> Option<TargetFilter> {
     // Both callers of `parse_except_for_type_list_suffix` must hand it the same
-    // shape. The suffix-position site in `parse_type_phrase_with_ctx` passes a
+    // shape. The suffix-position site in `parse_type_phrase_folding_with_ctx` passes a
     // slice of the already-lowercased text; this one is handed the original-case
     // `dest_remainder`. `classify_negation` matches lowercase literals only, so a
     // capitalized core-type item ("except for Artifacts") would otherwise miss
@@ -9252,7 +9254,7 @@ fn parse_targets_constraint(text: &str, prefix_len: usize) -> Option<(Vec<Filter
     if let Ok((_, matched)) = you_or_result {
         let you_or_len = matched.len();
         let after_you_or = &text[you_or_len..];
-        let (type_filter, remainder) = parse_type_phrase(after_you_or);
+        let (type_filter, remainder) = parse_type_phrase_folding(after_you_or);
         let consumed = after_you_or.len() - remainder.len();
         let combined = TargetFilter::Or {
             filters: vec![TargetFilter::Controller, type_filter],
@@ -9284,7 +9286,7 @@ fn parse_targets_constraint(text: &str, prefix_len: usize) -> Option<(Vec<Filter
     }
 
     // Bare type phrase (no article) — e.g., "creatures you control"
-    let (filter, remainder) = parse_type_phrase(text);
+    let (filter, remainder) = parse_type_phrase_folding(text);
     let consumed = text.len() - remainder.len();
     if consumed > 0 {
         let props = vec![FilterProp::Targets {
@@ -9298,14 +9300,14 @@ fn parse_targets_constraint(text: &str, prefix_len: usize) -> Option<(Vec<Filter
 
 /// Parse the type-or-player constraint inside "that targets only a [single] ...".
 /// Handles "player" as `TargetFilter::Player` and "[type] or player" as
-/// `Or(Typed(type), Player)`, since `parse_type_phrase` doesn't recognize "player".
+/// `Or(Typed(type), Player)`, since `parse_type_phrase_folding` doesn't recognize "player".
 fn parse_targets_only_type_or_player(text: &str) -> (TargetFilter, usize) {
     // Check for bare "player" at start with word boundary
     if parse_word_bounded(text, "player").is_ok() {
         return (TargetFilter::Player, 6);
     }
 
-    // Check for "[type] or player" — parse_type_phrase would consume "or" as part of
+    // Check for "[type] or player" — parse_type_phrase_folding would consume "or" as part of
     // its compound type handling, but "player" isn't a card type, producing a broken filter.
     // Intercept this pattern: find "or player" in the text, parse only the part before it,
     // then compose with TargetFilter::Player.
@@ -9318,7 +9320,7 @@ fn parse_targets_only_type_or_player(text: &str) -> (TargetFilter, usize) {
         match after.chars().next() {
             None | Some(',' | '.' | ' ') => {
                 let type_part = tp.split_at(or_pos).0.original;
-                let (type_filter, _) = parse_type_phrase(type_part);
+                let (type_filter, _) = parse_type_phrase_folding(type_part);
                 let combined = TargetFilter::Or {
                     filters: vec![type_filter, TargetFilter::Player],
                 };
@@ -9328,7 +9330,7 @@ fn parse_targets_only_type_or_player(text: &str) -> (TargetFilter, usize) {
         }
     }
 
-    let (filter, remainder) = parse_type_phrase(text);
+    let (filter, remainder) = parse_type_phrase_folding(text);
     let consumed = text.len() - remainder.len();
     (filter, consumed)
 }
@@ -10002,7 +10004,7 @@ mod tests {
     /// colorless land instead of a blue creature.
     #[test]
     fn nontoken_color_creature_captures_color_and_type() {
-        let (filter, rest) = parse_type_phrase("nontoken blue creature");
+        let (filter, rest) = parse_type_phrase_folding("nontoken blue creature");
         assert_eq!(rest.trim(), "");
         let tf = typed_leg(&filter).expect("expected typed filter");
         assert!(tf.type_filters.contains(&TypeFilter::Creature));
@@ -10018,7 +10020,8 @@ mod tests {
     /// supertype-prefix scan only ran BEFORE the `non-` negation loop.
     #[test]
     fn nontoken_legendary_permanent_captures_supertype() {
-        let (filter, rest) = parse_type_phrase("another nontoken legendary permanent you control");
+        let (filter, rest) =
+            parse_type_phrase_folding("another nontoken legendary permanent you control");
         assert_eq!(rest.trim(), "");
         let tf = typed_leg(&filter).expect("expected typed filter");
         assert!(tf.type_filters.contains(&TypeFilter::Permanent));
@@ -10035,7 +10038,7 @@ mod tests {
     /// "modified" adjective scan only ran BEFORE the `non-` negation loop.
     #[test]
     fn nontoken_modified_creature_captures_modified_property() {
-        let (filter, rest) = parse_type_phrase("a nontoken modified creature you control");
+        let (filter, rest) = parse_type_phrase_folding("a nontoken modified creature you control");
         assert_eq!(rest.trim(), "");
         let tf = typed_leg(&filter).expect("expected typed filter");
         assert!(tf.type_filters.contains(&TypeFilter::Creature));
@@ -10046,13 +10049,13 @@ mod tests {
 
     /// GitHub #4710 (Scourglass): "permanents except for artifacts and lands"
     /// must exclude BOTH types, not silently drop the exception clause. Before
-    /// the fix, `parse_type_phrase_with_ctx` had no suffix parser for "except
+    /// the fix, `parse_type_phrase_folding_with_ctx` had no suffix parser for "except
     /// for <type-list>" (only the predicate-based "except those that ..." was
     /// recognized), so the trailing clause was left unconsumed and the filter
     /// silently matched every permanent.
     #[test]
     fn except_for_type_list_excludes_both_types() {
-        let (filter, rest) = parse_type_phrase("permanents except for artifacts and lands");
+        let (filter, rest) = parse_type_phrase_folding("permanents except for artifacts and lands");
         assert_eq!(rest.trim(), "");
         let tf = typed_leg(&filter).expect("expected typed filter");
         assert!(tf.type_filters.contains(&TypeFilter::Permanent));
@@ -10073,7 +10076,8 @@ mod tests {
     /// same two categories.
     #[test]
     fn except_for_type_list_splits_type_and_token_property() {
-        let (filter, rest) = parse_type_phrase("other permanents except for lands and tokens");
+        let (filter, rest) =
+            parse_type_phrase_folding("other permanents except for lands and tokens");
         assert_eq!(rest.trim(), "");
         let tf = typed_leg(&filter).expect("expected typed filter");
         assert!(tf
@@ -10101,8 +10105,9 @@ mod tests {
     /// every item in a list, not just the first.
     #[test]
     fn parse_type_phrase_except_for_subtype_list() {
-        let (filter, rest) =
-            parse_type_phrase("creatures except for Krakens, Leviathans, Octopuses, and Serpents");
+        let (filter, rest) = parse_type_phrase_folding(
+            "creatures except for Krakens, Leviathans, Octopuses, and Serpents",
+        );
         assert_eq!(rest.trim(), "");
         let tf = typed_leg(&filter).expect("expected typed filter");
         assert!(tf.type_filters.contains(&TypeFilter::Creature));
@@ -10117,7 +10122,7 @@ mod tests {
             );
         }
 
-        let (filter, rest) = parse_type_phrase(
+        let (filter, rest) = parse_type_phrase_folding(
             "creatures except for Merfolk, Krakens, Leviathans, Octopuses, and Serpents",
         );
         assert_eq!(rest.trim(), "");
@@ -10145,7 +10150,7 @@ mod tests {
     #[test]
     fn parse_type_phrase_except_for_mixed_core_types_and_subtype() {
         let (filter, rest) =
-            parse_type_phrase("permanents except for artifacts, lands, and Phyrexians");
+            parse_type_phrase_folding("permanents except for artifacts, lands, and Phyrexians");
         assert_eq!(rest.trim(), "");
         let tf = typed_leg(&filter).expect("expected typed filter");
         assert!(tf.type_filters.contains(&TypeFilter::Permanent));
@@ -10173,7 +10178,7 @@ mod tests {
     /// a negated Subtype that the old guard declined outright.
     #[test]
     fn parse_type_phrase_except_for_basic_land_type() {
-        let (filter, rest) = parse_type_phrase("permanents except for Islands");
+        let (filter, rest) = parse_type_phrase_folding("permanents except for Islands");
         assert_eq!(rest.trim(), "");
         let tf = typed_leg(&filter).expect("expected typed filter");
         assert!(tf.type_filters.contains(&TypeFilter::Permanent));
@@ -10193,7 +10198,7 @@ mod tests {
     /// vacuous `Non(Subtype("Sorcery"))`.
     #[test]
     fn parse_type_phrase_except_for_card_type_plural() {
-        let (filter, rest) = parse_type_phrase("permanents except for sorceries");
+        let (filter, rest) = parse_type_phrase_folding("permanents except for sorceries");
         assert_eq!(rest.trim(), "");
         let tf = typed_leg(&filter).expect("expected typed filter");
         assert!(tf
@@ -10231,7 +10236,7 @@ mod tests {
     /// Serpents from a spell that never mentioned them.
     #[test]
     fn except_for_named_exception_does_not_misfire_as_subtype_negation() {
-        let (filter, rest) = parse_type_phrase("creatures except for Mageta");
+        let (filter, rest) = parse_type_phrase_folding("creatures except for Mageta");
         let tf = typed_leg(&filter).expect("expected typed filter");
         assert_eq!(tf.type_filters, vec![TypeFilter::Creature]);
         assert!(
@@ -10241,7 +10246,7 @@ mod tests {
             "the unrecognized exception clause must be left unconsumed, got rest={rest:?}"
         );
 
-        let (filter, rest) = parse_type_phrase("creatures except for Krakens and Mageta");
+        let (filter, rest) = parse_type_phrase_folding("creatures except for Krakens and Mageta");
         let tf = typed_leg(&filter).expect("expected typed filter");
         assert_eq!(tf.type_filters, vec![TypeFilter::Creature]);
         assert!(
@@ -10251,7 +10256,7 @@ mod tests {
             "a mixed real-subtype + name list must be left unconsumed, got rest={rest:?}"
         );
 
-        let (filter, rest) = parse_type_phrase("permanents except for Serpentine");
+        let (filter, rest) = parse_type_phrase_folding("permanents except for Serpentine");
         let tf = typed_leg(&filter).expect("expected typed filter");
         assert_eq!(tf.type_filters, vec![TypeFilter::Permanent]);
         assert!(
@@ -10375,7 +10380,7 @@ mod tests {
     fn named_filter_terminates_at_clause_boundary() {
         fn named_of(text: &str) -> (String, String) {
             let mut ctx = ParseContext::default();
-            let (filter, rest) = parse_type_phrase_with_ctx(text, &mut ctx);
+            let (filter, rest) = parse_type_phrase_folding_with_ctx(text, &mut ctx);
             let name = typed_leg(&filter)
                 .and_then(|tf| {
                     tf.properties.iter().find_map(|p| match p {
@@ -10437,7 +10442,7 @@ mod tests {
     #[test]
     fn named_filter_terminates_at_locative_zone() {
         fn named_and_props(text: &str) -> (String, Vec<FilterProp>, Option<ControllerRef>, String) {
-            let (filter, rest) = parse_type_phrase(text);
+            let (filter, rest) = parse_type_phrase_folding(text);
             let tf = typed_leg(&filter)
                 .unwrap_or_else(|| panic!("expected a Typed filter in {filter:?}"));
             let name = tf
@@ -10751,7 +10756,7 @@ mod tests {
         let (f, rest) =
             parse_target_with_ctx("commander they control from the battlefield", &mut ctx);
         // CR 903.3: a commander is targeted on the battlefield. Routing through
-        // `parse_type_phrase_with_ctx` (instead of the former bare-commander
+        // `parse_type_phrase_folding_with_ctx` (instead of the former bare-commander
         // branch) means the explicit "from the battlefield" zone suffix is
         // consumed into `FilterProp::InZone` like any other typed target, so
         // the remainder is empty.
@@ -10783,7 +10788,7 @@ mod tests {
         // Sanctum of Eternity — ownership suffix, distinct from control.
         // CR 903.3: a targetable commander resides on the battlefield. The
         // explicit "from the battlefield" zone suffix is consumed into
-        // `FilterProp::InZone` by `parse_type_phrase_with_ctx`, leaving an
+        // `FilterProp::InZone` by `parse_type_phrase_folding_with_ctx`, leaving an
         // empty remainder.
         let bf = FilterProp::InZone {
             zone: Zone::Battlefield,
@@ -10809,7 +10814,7 @@ mod tests {
         // "Your commander" is owner-scoped. This matters for trigger subjects
         // like Tome of Legends; a stolen opponent's commander must not satisfy
         // the phrase just because its current controller is you.
-        let (f, rest) = parse_type_phrase("your commander enters or attacks");
+        let (f, rest) = parse_type_phrase_folding("your commander enters or attacks");
         assert_eq!(
             f,
             TargetFilter::Typed(TypedFilter {
@@ -10826,7 +10831,7 @@ mod tests {
         );
         assert_eq!(rest, "enters or attacks");
 
-        let (f, rest) = parse_type_phrase("your commanders attack");
+        let (f, rest) = parse_type_phrase_folding("your commanders attack");
         assert_eq!(
             f,
             TargetFilter::Typed(TypedFilter {
@@ -11044,7 +11049,7 @@ mod tests {
             )),
             ..Default::default()
         };
-        let (filter, remainder) = parse_type_phrase_with_ctx(
+        let (filter, remainder) = parse_type_phrase_folding_with_ctx(
             "other attacking creature that shares a creature type with it",
             &mut ctx,
         );
@@ -11071,7 +11076,7 @@ mod tests {
 
     #[test]
     fn attacking_creatures_you_control() {
-        let (f, rest) = parse_type_phrase("attacking creatures you control");
+        let (f, rest) = parse_type_phrase_folding("attacking creatures you control");
         assert_eq!(
             f,
             TargetFilter::Typed(
@@ -11132,7 +11137,7 @@ mod tests {
     #[test]
     fn parse_target_creature_attacking_you_if_controlled_does_not_consume_if_clause() {
         let phrase = "creature that's attacking you if it's controlled by the chosen player";
-        let (filter, remainder) = parse_type_phrase(phrase);
+        let (filter, remainder) = parse_type_phrase_folding(phrase);
         let TargetFilter::Typed(typed) = filter else {
             panic!("expected typed filter, got {filter:?}");
         };
@@ -11164,7 +11169,7 @@ mod tests {
     // Scapegoat, Deadly Complication, and the broader suspected-creature filter class.
     #[test]
     fn suspected_creatures_you_control() {
-        let (f, rest) = parse_type_phrase("suspected creatures you control");
+        let (f, rest) = parse_type_phrase_folding("suspected creatures you control");
         assert_eq!(
             f,
             TargetFilter::Typed(
@@ -11178,7 +11183,7 @@ mod tests {
 
     #[test]
     fn creature_tokens_you_control() {
-        let (f, rest) = parse_type_phrase("creature tokens you control");
+        let (f, rest) = parse_type_phrase_folding("creature tokens you control");
         assert_eq!(
             f,
             TargetFilter::Typed(
@@ -11705,7 +11710,7 @@ mod tests {
 
     #[test]
     fn white_creature_you_control() {
-        let (f, _) = parse_type_phrase("white creature you control");
+        let (f, _) = parse_type_phrase_folding("white creature you control");
         assert_eq!(
             f,
             TargetFilter::Typed(
@@ -11720,7 +11725,7 @@ mod tests {
 
     #[test]
     fn red_spell() {
-        let (f, _) = parse_type_phrase("red spell");
+        let (f, _) = parse_type_phrase_folding("red spell");
         assert_eq!(
             f,
             TargetFilter::Typed(TypedFilter::card().properties(vec![FilterProp::HasColor {
@@ -11731,7 +11736,8 @@ mod tests {
 
     #[test]
     fn colorless_creature_card() {
-        let (f, rest) = parse_type_phrase("colorless creature card with mana value 7 or greater");
+        let (f, rest) =
+            parse_type_phrase_folding("colorless creature card with mana value 7 or greater");
         assert!(rest.trim().is_empty(), "remainder: '{rest}'");
         assert_eq!(
             f,
@@ -11761,7 +11767,7 @@ mod tests {
 
     #[test]
     fn distributive_each_linker_preserves_mana_value_suffix() {
-        let (f, rest) = parse_type_phrase("creatures, each with mana value 2 or less");
+        let (f, rest) = parse_type_phrase_folding("creatures, each with mana value 2 or less");
         assert!(rest.trim().is_empty(), "remainder: '{rest}'");
         assert_eq!(
             f,
@@ -11806,7 +11812,7 @@ mod tests {
 
     #[test]
     fn distributive_each_linker_preserves_counter_suffix() {
-        let (f, rest) = parse_type_phrase("creatures, each with ice counters on them");
+        let (f, rest) = parse_type_phrase_folding("creatures, each with ice counters on them");
         assert!(rest.trim().is_empty(), "remainder: '{rest}'");
         assert_eq!(
             f,
@@ -11822,7 +11828,7 @@ mod tests {
 
     #[test]
     fn distributive_each_linker_preserves_keyword_suffix() {
-        let (f, rest) = parse_type_phrase("creatures, each with flying");
+        let (f, rest) = parse_type_phrase_folding("creatures, each with flying");
         assert!(rest.trim().is_empty(), "remainder: '{rest}'");
         assert_eq!(
             f,
@@ -11839,7 +11845,7 @@ mod tests {
         // CR 113.1 + CR 113.3: "creatures with no abilities" → Creature type +
         // HasNoAbilities property, fully consumed (Muraganda Petroglyphs anthem
         // subject).
-        let (f, rest) = parse_type_phrase("creatures with no abilities");
+        let (f, rest) = parse_type_phrase_folding("creatures with no abilities");
         assert!(rest.trim().is_empty(), "remainder: '{rest}'");
         let TargetFilter::Typed(tf) = f else {
             panic!("expected Typed filter, got {f:?}");
@@ -11852,7 +11858,7 @@ mod tests {
     fn no_abilities_suffix_singular() {
         // CR 113.1 + CR 113.3: singular "creature with no abilities" parses the
         // same predicate.
-        let (f, rest) = parse_type_phrase("creature with no abilities");
+        let (f, rest) = parse_type_phrase_folding("creature with no abilities");
         assert!(rest.trim().is_empty(), "remainder: '{rest}'");
         let TargetFilter::Typed(tf) = f else {
             panic!("expected Typed filter, got {f:?}");
@@ -11863,7 +11869,7 @@ mod tests {
 
     #[test]
     fn colorless_adjective_does_not_distribute_across_or() {
-        let (f, rest) = parse_type_phrase("artifact or colorless creature");
+        let (f, rest) = parse_type_phrase_folding("artifact or colorless creature");
         assert!(rest.trim().is_empty(), "remainder: '{rest}'");
         let TargetFilter::Or { filters } = f else {
             panic!("expected Or filter");
@@ -11895,7 +11901,7 @@ mod tests {
 
     #[test]
     fn monocolored_creature() {
-        let (f, rest) = parse_type_phrase("monocolored creature");
+        let (f, rest) = parse_type_phrase_folding("monocolored creature");
         assert!(rest.trim().is_empty(), "remainder: '{rest}'");
         assert_eq!(
             f,
@@ -11910,7 +11916,7 @@ mod tests {
 
     #[test]
     fn multicolored_card() {
-        let (f, rest) = parse_type_phrase("multicolored card");
+        let (f, rest) = parse_type_phrase_folding("multicolored card");
         assert!(rest.trim().is_empty(), "remainder: '{rest}'");
         assert_eq!(
             f,
@@ -11927,7 +11933,7 @@ mod tests {
     /// filter, Stern Scolding's counter target, Warping Wail mode 1, etc.
     #[test]
     fn creature_with_power_or_toughness_1_or_less() {
-        let (f, _) = parse_type_phrase("creature with power or toughness 1 or less");
+        let (f, _) = parse_type_phrase_folding("creature with power or toughness 1 or less");
         assert_eq!(
             f,
             TargetFilter::Typed(TypedFilter::creature().properties(vec![FilterProp::AnyOf {
@@ -11952,7 +11958,7 @@ mod tests {
     /// Disjunctive "or greater" form, mirror of the "or less" case.
     #[test]
     fn creature_with_power_or_toughness_3_or_greater() {
-        let (f, _) = parse_type_phrase("creature with power or toughness 3 or greater");
+        let (f, _) = parse_type_phrase_folding("creature with power or toughness 3 or greater");
         assert_eq!(
             f,
             TargetFilter::Typed(TypedFilter::creature().properties(vec![FilterProp::AnyOf {
@@ -11978,7 +11984,7 @@ mod tests {
     /// toughness 1 or less" reads base P/T (after layer 7b, ignoring counters).
     #[test]
     fn creature_with_base_power_or_toughness_1_or_less() {
-        let (f, _) = parse_type_phrase("creature with base power or toughness 1 or less");
+        let (f, _) = parse_type_phrase_folding("creature with base power or toughness 1 or less");
         assert_eq!(
             f,
             TargetFilter::Typed(TypedFilter::creature().properties(vec![FilterProp::AnyOf {
@@ -12004,7 +12010,7 @@ mod tests {
     /// less" form, routed through the shared combinator.
     #[test]
     fn creature_with_toughness_2_or_less() {
-        let (f, _) = parse_type_phrase("creature with toughness 2 or less");
+        let (f, _) = parse_type_phrase_folding("creature with toughness 2 or less");
         assert_eq!(
             f,
             TargetFilter::Typed(TypedFilter::creature().properties(vec![
@@ -12020,7 +12026,7 @@ mod tests {
 
     #[test]
     fn creature_with_toughness_less_than_domain_count() {
-        let (f, rest) = parse_type_phrase(
+        let (f, rest) = parse_type_phrase_folding(
             "creature with toughness less than the number of basic land types among lands you control",
         );
         assert!(rest.trim().is_empty(), "remainder: '{rest}'");
@@ -12046,7 +12052,7 @@ mod tests {
 
     #[test]
     fn creature_with_power_less_than_or_equal_to_controlled_count() {
-        let (f, rest) = parse_type_phrase(
+        let (f, rest) = parse_type_phrase_folding(
             "creature with power less than or equal to the number of allies you control",
         );
         assert!(rest.trim().is_empty(), "remainder: '{rest}'");
@@ -12073,7 +12079,7 @@ mod tests {
 
     #[test]
     fn spell_with_mana_value_4_or_greater() {
-        let (f, _) = parse_type_phrase("spell with mana value 4 or greater");
+        let (f, _) = parse_type_phrase_folding("spell with mana value 4 or greater");
         assert_eq!(
             f,
             TargetFilter::Typed(TypedFilter::card().properties(vec![FilterProp::Cmc {
@@ -12085,7 +12091,8 @@ mod tests {
 
     #[test]
     fn artifact_card_with_mana_value_4_or_5() {
-        let (f, rest) = parse_type_phrase("artifact card with mana value 4 or 5, reveal it");
+        let (f, rest) =
+            parse_type_phrase_folding("artifact card with mana value 4 or 5, reveal it");
         assert_eq!(rest, ", reveal it");
         assert_eq!(
             f,
@@ -12111,7 +12118,7 @@ mod tests {
     /// resolved at effect time against the spell's announced X.
     #[test]
     fn creature_with_mana_value_x_or_less() {
-        let (f, _) = parse_type_phrase("creature card with mana value x or less");
+        let (f, _) = parse_type_phrase_folding("creature card with mana value x or less");
         assert_eq!(
             f,
             TargetFilter::Typed(TypedFilter::creature().properties(vec![FilterProp::Cmc {
@@ -12127,7 +12134,7 @@ mod tests {
 
     #[test]
     fn spell_with_mana_value_x_or_greater() {
-        let (f, _) = parse_type_phrase("spell with mana value x or greater");
+        let (f, _) = parse_type_phrase_folding("spell with mana value x or greater");
         assert_eq!(
             f,
             TargetFilter::Typed(TypedFilter::card().properties(vec![FilterProp::Cmc {
@@ -12143,7 +12150,7 @@ mod tests {
 
     #[test]
     fn card_with_mana_value_equal_to_lands_you_control() {
-        let (f, rest) = parse_type_phrase(
+        let (f, rest) = parse_type_phrase_folding(
             "creature card with mana value equal to the number of lands you control",
         );
         assert!(rest.trim().is_empty(), "remainder: '{rest}'");
@@ -12171,7 +12178,7 @@ mod tests {
     /// `parse_zone_suffix` pass attaches `InZone { Hand }` + `controller: You`.
     #[test]
     fn dynamic_mana_value_suffix_leaves_trailing_zone_clause() {
-        let (f, rest) = parse_type_phrase(
+        let (f, rest) = parse_type_phrase_folding(
             "creature card with mana value equal to the number of charge counters on ~ from your hand",
         );
         assert!(rest.trim().is_empty(), "remainder: '{rest}'");
@@ -12216,7 +12223,7 @@ mod tests {
     /// dropped the mana-value bound entirely for this whole class.
     #[test]
     fn dynamic_mana_value_suffix_keeps_zone_bearing_quantity_whole() {
-        let (f, rest) = parse_type_phrase(
+        let (f, rest) = parse_type_phrase_folding(
             "creature card with mana value equal to the number of cards in your graveyard",
         );
         assert!(rest.trim().is_empty(), "remainder: '{rest}'");
@@ -12237,7 +12244,7 @@ mod tests {
 
     #[test]
     fn card_with_mana_value_equal_to_offset_event_source() {
-        let (f, rest) = parse_type_phrase(
+        let (f, rest) = parse_type_phrase_folding(
             "creature card with mana value equal to 1 plus the sacrificed creature's mana value, put it",
         );
         assert_eq!(rest, ", put it");
@@ -12259,7 +12266,8 @@ mod tests {
 
     #[test]
     fn card_with_mana_value_equal_to_that_damage() {
-        let (f, rest) = parse_type_phrase("artifact card with mana value equal to that damage");
+        let (f, rest) =
+            parse_type_phrase_folding("artifact card with mana value equal to that damage");
         assert!(rest.trim().is_empty(), "remainder: '{rest}'");
         assert_eq!(
             f,
@@ -12276,7 +12284,8 @@ mod tests {
 
     #[test]
     fn card_with_lesser_mana_value_uses_event_source() {
-        let (f, rest) = parse_type_phrase("creature card with lesser mana value, reveal it");
+        let (f, rest) =
+            parse_type_phrase_folding("creature card with lesser mana value, reveal it");
         assert_eq!(rest, ", reveal it");
         assert_eq!(
             f,
@@ -12293,7 +12302,8 @@ mod tests {
 
     #[test]
     fn card_with_greater_mana_value_than_discarded_card() {
-        let (f, rest) = parse_type_phrase("card with greater mana value than the discarded card");
+        let (f, rest) =
+            parse_type_phrase_folding("card with greater mana value than the discarded card");
         assert!(rest.trim().is_empty(), "remainder: '{rest}'");
         assert_eq!(
             f,
@@ -12310,7 +12320,7 @@ mod tests {
 
     #[test]
     fn card_with_same_mana_value_as_that_spell_uses_parent_target() {
-        let (f, rest) = parse_type_phrase("card with the same mana value as that spell");
+        let (f, rest) = parse_type_phrase_folding("card with the same mana value as that spell");
         assert!(rest.trim().is_empty(), "remainder: '{rest}'");
         assert_eq!(
             f,
@@ -12328,7 +12338,7 @@ mod tests {
     #[test]
     fn card_with_same_mana_value_as_chosen_spell_uses_parent_target() {
         let (f, rest) =
-            parse_type_phrase("creature card with the same mana value as the chosen spell");
+            parse_type_phrase_folding("creature card with the same mana value as the chosen spell");
         assert!(rest.trim().is_empty(), "remainder: '{rest}'");
         assert_eq!(
             f,
@@ -12345,7 +12355,8 @@ mod tests {
 
     #[test]
     fn card_with_mana_value_equal_to_that_cards_mana_value() {
-        let (f, rest) = parse_type_phrase("card with mana value equal to that card's mana value");
+        let (f, rest) =
+            parse_type_phrase_folding("card with mana value equal to that card's mana value");
         assert!(rest.trim().is_empty(), "remainder: '{rest}'");
         assert_eq!(
             f,
@@ -12362,7 +12373,7 @@ mod tests {
 
     #[test]
     fn card_with_mana_value_of_that_card_plus_one_uses_offset_target() {
-        let (f, rest) = parse_type_phrase(
+        let (f, rest) = parse_type_phrase_folding(
             "creature card with mana value equal to the mana value of that card plus one",
         );
         assert!(rest.trim().is_empty(), "remainder: '{rest}'");
@@ -12384,7 +12395,8 @@ mod tests {
 
     #[test]
     fn creature_you_control_with_power_2_or_less() {
-        let (f, rest) = parse_type_phrase("creature you control with power 2 or less enter");
+        let (f, rest) =
+            parse_type_phrase_folding("creature you control with power 2 or less enter");
         assert_eq!(
             f,
             TargetFilter::Typed(
@@ -12404,7 +12416,7 @@ mod tests {
 
     #[test]
     fn creature_with_power_3_or_greater() {
-        let (f, rest) = parse_type_phrase("creature with power 3 or greater");
+        let (f, rest) = parse_type_phrase_folding("creature with power 3 or greater");
         assert!(rest.trim().is_empty(), "remainder: '{rest}'");
         assert_eq!(
             f,
@@ -12421,7 +12433,7 @@ mod tests {
 
     #[test]
     fn creature_you_control_with_exact_base_power() {
-        let (f, rest) = parse_type_phrase("creature you control with base power 1");
+        let (f, rest) = parse_type_phrase_folding("creature you control with base power 1");
         assert_eq!(rest, "");
         assert_eq!(
             f,
@@ -12480,7 +12492,7 @@ mod tests {
 
     #[test]
     fn creatures_with_ice_counters_on_them() {
-        let (f, _) = parse_type_phrase("creatures with ice counters on them");
+        let (f, _) = parse_type_phrase_folding("creatures with ice counters on them");
         assert_eq!(
             f,
             TargetFilter::Typed(
@@ -12495,7 +12507,7 @@ mod tests {
 
     #[test]
     fn cards_in_graveyards() {
-        let (f, _) = parse_type_phrase("cards in graveyards");
+        let (f, _) = parse_type_phrase_folding("cards in graveyards");
         assert_eq!(
             f,
             TargetFilter::Typed(TypedFilter::card().properties(vec![FilterProp::InZone {
@@ -12518,7 +12530,7 @@ mod tests {
 
     #[test]
     fn elf_on_the_battlefield() {
-        let (f, rest) = parse_type_phrase("Elf on the battlefield");
+        let (f, rest) = parse_type_phrase_folding("Elf on the battlefield");
         assert_eq!(
             f,
             TargetFilter::Typed(
@@ -12674,7 +12686,7 @@ mod tests {
 
     #[test]
     fn card_with_flashback_uses_keyword_kind_filter() {
-        let (f, _) = parse_type_phrase("card with flashback");
+        let (f, _) = parse_type_phrase_folding("card with flashback");
         assert_eq!(
             f,
             TargetFilter::Typed(
@@ -12687,7 +12699,7 @@ mod tests {
 
     #[test]
     fn card_with_augment_uses_keyword_kind_filter() {
-        let (f, _) = parse_type_phrase("card with augment");
+        let (f, _) = parse_type_phrase_folding("card with augment");
         assert_eq!(
             f,
             TargetFilter::Typed(
@@ -12703,7 +12715,7 @@ mod tests {
         // CR 702.140: "creature card with mutate" refers to the keyword class regardless
         // of its mana-cost parameter, so it must lower to a discriminant-level keyword-kind
         // filter rather than a concrete `Keyword::Mutate(cost)` exact match.
-        let (f, _) = parse_type_phrase("creature card with mutate");
+        let (f, _) = parse_type_phrase_folding("creature card with mutate");
         let TargetFilter::Typed(TypedFilter {
             type_filters,
             properties,
@@ -12746,7 +12758,7 @@ mod tests {
 
     #[test]
     fn cards_with_flashback_you_own_in_exile() {
-        let (f, _) = parse_type_phrase("cards with flashback you own in exile");
+        let (f, _) = parse_type_phrase_folding("cards with flashback you own in exile");
         assert_eq!(
             f,
             TargetFilter::Typed(TypedFilter::card().properties(vec![
@@ -12764,7 +12776,7 @@ mod tests {
     #[test]
     fn card_with_flashback_or_disturb_uses_keyword_kind_filters() {
         let (f, rest) =
-            parse_type_phrase("card with flashback or disturb, put it into your graveyard");
+            parse_type_phrase_folding("card with flashback or disturb, put it into your graveyard");
         assert_eq!(rest, "put it into your graveyard");
         let TargetFilter::Or { filters } = f else {
             panic!("expected Or filter, got {f:?}");
@@ -12785,7 +12797,7 @@ mod tests {
 
     #[test]
     fn creature_of_the_chosen_type() {
-        let (f, _) = parse_type_phrase("creature you control of the chosen type");
+        let (f, _) = parse_type_phrase_folding("creature you control of the chosen type");
         assert_eq!(
             f,
             TargetFilter::Typed(
@@ -12798,7 +12810,7 @@ mod tests {
 
     #[test]
     fn creatures_you_control_with_flying() {
-        let (f, _) = parse_type_phrase("creatures you control with flying");
+        let (f, _) = parse_type_phrase_folding("creatures you control with flying");
         assert_eq!(
             f,
             TargetFilter::Typed(
@@ -12813,7 +12825,7 @@ mod tests {
 
     #[test]
     fn creature_with_first_strike_and_vigilance() {
-        let (f, _) = parse_type_phrase("creature with first strike and vigilance");
+        let (f, _) = parse_type_phrase_folding("creature with first strike and vigilance");
         assert_eq!(
             f,
             TargetFilter::Typed(TypedFilter::creature().properties(vec![
@@ -12829,7 +12841,7 @@ mod tests {
 
     #[test]
     fn creature_with_trample_or_haste_is_keyword_disjunction() {
-        let (f, _) = parse_type_phrase("creature with trample or haste");
+        let (f, _) = parse_type_phrase_folding("creature with trample or haste");
         let TargetFilter::Or { filters } = f else {
             panic!("expected Or filter, got {f:?}");
         };
@@ -12850,7 +12862,7 @@ mod tests {
 
     #[test]
     fn creature_with_keyword_list_or_separator() {
-        let (f, rest) = parse_type_phrase(
+        let (f, rest) = parse_type_phrase_folding(
             "creature with deathtouch, hexproof, reach, or trample and reveal it",
         );
         assert_eq!(rest, "reveal it");
@@ -12880,7 +12892,7 @@ mod tests {
 
     #[test]
     fn other_nonland_permanents_you_own_and_control() {
-        let (f, _) = parse_type_phrase("other nonland permanents you own and control");
+        let (f, _) = parse_type_phrase_folding("other nonland permanents you own and control");
         assert_eq!(
             f,
             TargetFilter::Typed(
@@ -12899,7 +12911,7 @@ mod tests {
 
     #[test]
     fn permanents_you_own() {
-        let (f, _) = parse_type_phrase("permanents you own");
+        let (f, _) = parse_type_phrase_folding("permanents you own");
         assert_eq!(
             f,
             TargetFilter::Typed(TypedFilter::permanent().properties(vec![FilterProp::Owned {
@@ -12915,7 +12927,7 @@ mod tests {
     // consumed (empty remainder).
     #[test]
     fn permanents_you_own_that_your_opponents_control() {
-        let (f, rest) = parse_type_phrase("permanents you own that your opponents control");
+        let (f, rest) = parse_type_phrase_folding("permanents you own that your opponents control");
         assert_eq!(rest, "");
         assert_eq!(
             f,
@@ -12951,7 +12963,7 @@ mod tests {
 
     #[test]
     fn other_creatures_you_control() {
-        let (f, _) = parse_type_phrase("other creatures you control");
+        let (f, _) = parse_type_phrase_folding("other creatures you control");
         assert_eq!(
             f,
             TargetFilter::Typed(
@@ -13604,7 +13616,7 @@ mod tests {
 
     #[test]
     fn parse_type_phrase_creature_that_had_counters_put_on_it_this_way() {
-        let (f, rest) = parse_type_phrase("creature that had counters put on it this way");
+        let (f, rest) = parse_type_phrase_folding("creature that had counters put on it this way");
         assert_eq!(rest, "", "remainder was {rest:?}");
         assert_eq!(
             f,
@@ -13667,7 +13679,7 @@ mod tests {
     //
     // Building-block coverage for the "<type-phrase> with the chosen name" /
     // "<type-phrase> with a name chosen for this enchantment" suffix recognized
-    // inside parse_type_phrase_with_ctx. This is verb-agnostic: every
+    // inside parse_type_phrase_folding_with_ctx. This is verb-agnostic: every
     // object-target effect clause (goad/destroy/exile/tap/...) funnels through
     // this chokepoint, so the recognizer must compose the HasChosenName leg onto
     // the typed filter regardless of the surrounding verb. Day of the Moon is
@@ -13893,7 +13905,7 @@ mod tests {
     #[test]
     fn bare_type_phrase_fallback() {
         let (f, _) = parse_target("other nonland permanents you own and control");
-        // Should be Typed (not Any) — parse_type_phrase picks up the permanent type + properties
+        // Should be Typed (not Any) — parse_type_phrase_folding picks up the permanent type + properties
         match f {
             TargetFilter::Typed(tf) => {
                 assert!(
@@ -14165,7 +14177,7 @@ mod tests {
     #[test]
     fn parse_type_phrase_zone_then_counter_suffix_consumes_both() {
         let (filter, leftover) =
-            parse_type_phrase("creature card in exile with a takeover counter on it");
+            parse_type_phrase_folding("creature card in exile with a takeover counter on it");
         assert_eq!(
             leftover.trim(),
             "",
@@ -14200,7 +14212,7 @@ mod tests {
     #[test]
     fn parse_type_phrase_counter_then_zone_suffix_still_consumes_both() {
         let (filter, leftover) =
-            parse_type_phrase("creature card with a takeover counter on it in exile");
+            parse_type_phrase_folding("creature card with a takeover counter on it in exile");
         assert_eq!(leftover.trim(), "", "got leftover {leftover:?}");
         let TargetFilter::Typed(tf) = filter else {
             panic!("expected Typed filter, got {filter:?}");
@@ -14286,7 +14298,7 @@ mod tests {
 
     #[test]
     fn parse_type_phrase_creature_with_stun_counter() {
-        let (filter, _rest) = parse_type_phrase("creature with a stun counter on it");
+        let (filter, _rest) = parse_type_phrase_folding("creature with a stun counter on it");
         match filter {
             TargetFilter::Typed(ref tf) => {
                 assert!(tf.type_filters.contains(&TypeFilter::Creature));
@@ -14305,7 +14317,7 @@ mod tests {
 
     #[test]
     fn creatures_your_opponents_control() {
-        let (f, rest) = parse_type_phrase("creatures your opponents control");
+        let (f, rest) = parse_type_phrase_folding("creatures your opponents control");
         assert_eq!(
             f,
             TargetFilter::Typed(TypedFilter::creature().controller(ControllerRef::Opponent))
@@ -14321,7 +14333,7 @@ mod tests {
     /// is preserved.
     #[test]
     fn other_creature_target_player_controls() {
-        let (f, rest) = parse_type_phrase("other creature target player controls");
+        let (f, rest) = parse_type_phrase_folding("other creature target player controls");
         match f {
             TargetFilter::Typed(ref tf) => {
                 assert!(tf.type_filters.contains(&TypeFilter::Creature));
@@ -14363,7 +14375,7 @@ mod tests {
     /// modifier words.
     #[test]
     fn creatures_target_player_controls() {
-        let (f, rest) = parse_type_phrase("creatures target player controls");
+        let (f, rest) = parse_type_phrase_folding("creatures target player controls");
         assert_eq!(
             f,
             TargetFilter::Typed(TypedFilter::creature().controller(ControllerRef::TargetPlayer))
@@ -14386,7 +14398,7 @@ mod tests {
     /// already `supported: true` on main).
     #[test]
     fn compound_creatures_and_lands_target_opponent_controls() {
-        let (f, rest) = parse_type_phrase("creatures and lands target opponent controls");
+        let (f, rest) = parse_type_phrase_folding("creatures and lands target opponent controls");
         match f {
             TargetFilter::Or { ref filters } => {
                 assert_eq!(filters.len(), 2, "expected 2 disjuncts, got {filters:?}");
@@ -14415,7 +14427,8 @@ mod tests {
         // planeswalker card"), which the bare "or"/"and" separator previously
         // rejected, silently dropping the planeswalker leg so the card could only
         // return creatures. Both legs must survive.
-        let (f, _rest) = parse_type_phrase("non-Avatar creature card or a planeswalker card");
+        let (f, _rest) =
+            parse_type_phrase_folding("non-Avatar creature card or a planeswalker card");
         match f {
             TargetFilter::Or { ref filters } => {
                 assert_eq!(filters.len(), 2, "both disjuncts kept: {filters:?}");
@@ -14444,7 +14457,8 @@ mod tests {
         // leg; the article-led "an artifact creature card" is an independent noun
         // phrase and must NOT inherit `HasColor(Red)` — otherwise a colorless
         // artifact creature (e.g. Ornithopter) would be wrongly rejected.
-        let (f, _rest) = parse_type_phrase("red creature card or an artifact creature card");
+        let (f, _rest) =
+            parse_type_phrase_folding("red creature card or an artifact creature card");
         let TargetFilter::Or { filters } = f else {
             panic!("expected Or, got {f:?}");
         };
@@ -14481,7 +14495,7 @@ mod tests {
 
     #[test]
     fn artifacts_and_creatures_your_opponents_control() {
-        let (f, rest) = parse_type_phrase("artifacts and creatures your opponents control");
+        let (f, rest) = parse_type_phrase_folding("artifacts and creatures your opponents control");
         match f {
             TargetFilter::Or { ref filters } => {
                 assert_eq!(filters.len(), 2);
@@ -14505,7 +14519,7 @@ mod tests {
 
     #[test]
     fn creature_an_opponent_controls_still_works() {
-        let (f, rest) = parse_type_phrase("creature an opponent controls");
+        let (f, rest) = parse_type_phrase_folding("creature an opponent controls");
         assert_eq!(
             f,
             TargetFilter::Typed(TypedFilter::creature().controller(ControllerRef::Opponent))
@@ -14517,7 +14531,8 @@ mod tests {
 
     #[test]
     fn comma_list_three_types_with_opponent_control() {
-        let (f, rest) = parse_type_phrase("artifacts, creatures, and lands your opponents control");
+        let (f, rest) =
+            parse_type_phrase_folding("artifacts, creatures, and lands your opponents control");
         match f {
             TargetFilter::Or { ref filters } => {
                 assert_eq!(filters.len(), 3);
@@ -14547,7 +14562,7 @@ mod tests {
 
     #[test]
     fn comma_list_three_types_no_controller() {
-        let (f, rest) = parse_type_phrase("artifacts, creatures, and enchantments");
+        let (f, rest) = parse_type_phrase_folding("artifacts, creatures, and enchantments");
         match f {
             TargetFilter::Or { ref filters } => {
                 assert_eq!(filters.len(), 3);
@@ -14568,7 +14583,8 @@ mod tests {
 
     #[test]
     fn comma_list_you_control() {
-        let (f, rest) = parse_type_phrase("creatures, artifacts, and enchantments you control");
+        let (f, rest) =
+            parse_type_phrase_folding("creatures, artifacts, and enchantments you control");
         match f {
             TargetFilter::Or { ref filters } => {
                 assert_eq!(filters.len(), 3);
@@ -14598,7 +14614,7 @@ mod tests {
     fn modified_adjective_creates_filter_prop() {
         // CR 700.9: "modified creature" is a first-class adjective
         // attaching FilterProp::Modified to a typed creature filter.
-        let (f, rest) = parse_type_phrase("modified creature you control");
+        let (f, rest) = parse_type_phrase_folding("modified creature you control");
         assert_eq!(
             f,
             TargetFilter::Typed(
@@ -14613,7 +14629,7 @@ mod tests {
     #[test]
     fn renowned_adjective_creates_filter_prop() {
         // CR 702.112b: "renowned creature" is a designation adjective.
-        let (f, rest) = parse_type_phrase("renowned creature you control");
+        let (f, rest) = parse_type_phrase_folding("renowned creature you control");
         assert_eq!(
             f,
             TargetFilter::Typed(
@@ -14629,7 +14645,7 @@ mod tests {
     fn goaded_adjective_creates_filter_prop() {
         // CR 701.15b/c: "goaded creature" is a designation adjective (Gap A, site 15).
         // This is the exact path Serene Sleuth's "goaded creature you control" takes.
-        let (f, rest) = parse_type_phrase("goaded creature you control");
+        let (f, rest) = parse_type_phrase_folding("goaded creature you control");
         assert_eq!(
             f,
             TargetFilter::Typed(
@@ -14647,7 +14663,7 @@ mod tests {
         // misread as the `FilterProp::Goaded` designation. The adjective strip is
         // `tag("goaded ")` guarded on a trailing type word, so the bare verb "goad "
         // never fires it.
-        let (f, _rest) = parse_type_phrase("goad target creature");
+        let (f, _rest) = parse_type_phrase_folding("goad target creature");
         let has_goaded = match &f {
             TargetFilter::Typed(t) => t.properties.contains(&FilterProp::Goaded),
             _ => false,
@@ -14667,7 +14683,7 @@ mod tests {
         //
         // This is a DIRECT unit guard rather than a behavioral multi-leg parse: I
         // measured that the natural "goaded X or Y" disjunction does not route through
-        // `parse_type_phrase`'s Or distributor — `parse_type_phrase("goaded creature or
+        // `parse_type_phrase_folding`'s Or distributor — `parse_type_phrase_folding("goaded creature or
         // an artifact")` leaves " or an artifact" unconsumed (no in-repo grammar emits a
         // goaded disjunction), which the plan anticipated as the fallback case. The
         // direct guard is nonetheless a genuine revert-probe: dropping the
@@ -14687,7 +14703,8 @@ mod tests {
         // of Aura (subtype), Equipment (subtype), and creature-with-Modified.
         // The trailing "you control" controller scope distributes across all
         // three legs via `distribute_controller_to_or`.
-        let (f, rest) = parse_type_phrase("auras, equipment, and modified creatures you control");
+        let (f, rest) =
+            parse_type_phrase_folding("auras, equipment, and modified creatures you control");
         match f {
             TargetFilter::Or { ref filters } => {
                 assert_eq!(filters.len(), 3, "expected 3-way OR, got {filters:#?}");
@@ -14808,9 +14825,9 @@ mod tests {
     #[test]
     fn or_color_disjunction_backfills_core_type_self_inflicted_wound() {
         // Self-Inflicted Wound: "a green or white creature of their choice".
-        // The filter-phrase level (parse_type_phrase) is what the parser produces;
+        // The filter-phrase level (parse_type_phrase_folding) is what the parser produces;
         // load-bearing assertion is that BOTH legs carry [Creature].
-        let (f, _rest) = parse_type_phrase("green or white creature");
+        let (f, _rest) = parse_type_phrase_folding("green or white creature");
         let TargetFilter::Or { filters } = f else {
             panic!("expected Or filter, got {f:?}");
         };
@@ -14997,7 +15014,7 @@ mod tests {
     fn or_disjunction_distinct_explicit_types_untouched() {
         // No-regression: "artifact or creature" — neither leg is [Any], so the
         // backfill must NOT collapse the distinct types into one.
-        let (f, rest) = parse_type_phrase("artifact or creature");
+        let (f, rest) = parse_type_phrase_folding("artifact or creature");
         assert_eq!(rest.trim(), "");
         let TargetFilter::Or { filters } = f else {
             panic!("expected Or filter, got {f:?}");
@@ -15018,7 +15035,7 @@ mod tests {
     #[test]
     fn or_disjunction_artifact_or_enchantment_untouched() {
         // No-regression: both legs explicit, neither [Any] — untouched.
-        let (f, rest) = parse_type_phrase("artifact or enchantment");
+        let (f, rest) = parse_type_phrase_folding("artifact or enchantment");
         assert_eq!(rest.trim(), "");
         let TargetFilter::Or { filters } = f else {
             panic!("expected Or filter, got {f:?}");
@@ -15037,7 +15054,7 @@ mod tests {
     #[test]
     fn single_green_creature_not_or_early_returns() {
         // No-regression: a non-Or phrase early-returns from the distributor.
-        let (f, rest) = parse_type_phrase("green creature");
+        let (f, rest) = parse_type_phrase_folding("green creature");
         assert_eq!(rest.trim(), "");
         match f {
             TargetFilter::Typed(tf) => {
@@ -15198,7 +15215,7 @@ mod tests {
     fn historic_adjective_creates_filter_prop() {
         // CR 700.6: "historic permanent" is a first-class adjective attaching
         // FilterProp::Historic to a typed permanent filter.
-        let (f, rest) = parse_type_phrase("historic permanent you control");
+        let (f, rest) = parse_type_phrase_folding("historic permanent you control");
         assert_eq!(
             f,
             TargetFilter::Typed(
@@ -15217,7 +15234,8 @@ mod tests {
         // adjective, the Another property, and the You controller — all in
         // sequence. The historic adjective parses AFTER the `non` negation
         // sweep, exercising the post-negation arm.
-        let (f, rest) = parse_type_phrase("another nontoken historic permanent you control");
+        let (f, rest) =
+            parse_type_phrase_folding("another nontoken historic permanent you control");
         match f {
             TargetFilter::Typed(tf) => {
                 assert_eq!(tf.controller, Some(ControllerRef::You));
@@ -15252,7 +15270,7 @@ mod tests {
         // CR 700.6: `FilterProp::Historic` is leg-local — in a
         // comma OR list it must NOT distribute back to earlier legs. Mirrors
         // the Modified adjective handling for Silkguard.
-        let (f, _rest) = parse_type_phrase("artifacts and historic creatures you control");
+        let (f, _rest) = parse_type_phrase_folding("artifacts and historic creatures you control");
         let TargetFilter::Or { ref filters } = f else {
             panic!("Expected Or filter, got {f:?}");
         };
@@ -15274,7 +15292,7 @@ mod tests {
 
     #[test]
     fn comma_list_four_elements() {
-        let (f, rest) = parse_type_phrase("artifacts, creatures, enchantments, and lands");
+        let (f, rest) = parse_type_phrase_folding("artifacts, creatures, enchantments, and lands");
         match f {
             TargetFilter::Or { ref filters } => {
                 assert_eq!(filters.len(), 4);
@@ -15299,7 +15317,7 @@ mod tests {
 
     #[test]
     fn comma_list_per_item_articles() {
-        let (f, rest) = parse_type_phrase("an artifact, a creature, or a land");
+        let (f, rest) = parse_type_phrase_folding("an artifact, a creature, or a land");
         match f {
             TargetFilter::Or { ref filters } => {
                 assert_eq!(filters.len(), 3);
@@ -15320,7 +15338,8 @@ mod tests {
 
     #[test]
     fn comma_list_no_oxford_comma() {
-        let (f, rest) = parse_type_phrase("artifacts, creatures and lands your opponents control");
+        let (f, rest) =
+            parse_type_phrase_folding("artifacts, creatures and lands your opponents control");
         match f {
             TargetFilter::Or { ref filters } => {
                 assert_eq!(filters.len(), 3);
@@ -15350,7 +15369,7 @@ mod tests {
 
     #[test]
     fn comma_list_remainder() {
-        let (f, rest) = parse_type_phrase("artifacts, creatures, and lands enter tapped");
+        let (f, rest) = parse_type_phrase_folding("artifacts, creatures, and lands enter tapped");
         match f {
             TargetFilter::Or { ref filters } => {
                 assert_eq!(filters.len(), 3);
@@ -15364,7 +15383,7 @@ mod tests {
 
     #[test]
     fn noncreature_nonland_permanent() {
-        let (f, rest) = parse_type_phrase("noncreature, nonland permanent");
+        let (f, rest) = parse_type_phrase_folding("noncreature, nonland permanent");
         assert_eq!(
             f,
             TargetFilter::Typed(
@@ -15378,7 +15397,7 @@ mod tests {
 
     #[test]
     fn noncreature_nonland_permanents_you_control() {
-        let (f, rest) = parse_type_phrase("noncreature, nonland permanents you control");
+        let (f, rest) = parse_type_phrase_folding("noncreature, nonland permanents you control");
         assert_eq!(
             f,
             TargetFilter::Typed(
@@ -15394,7 +15413,7 @@ mod tests {
     #[test]
     fn nonartifact_nonblack_creature() {
         // CR 205.2a + CR 105.2: "nonartifact" → Non(Artifact) in type_filters, "nonblack" → NotColor in properties
-        let (f, rest) = parse_type_phrase("nonartifact, nonblack creature");
+        let (f, rest) = parse_type_phrase_folding("nonartifact, nonblack creature");
         assert_eq!(
             f,
             TargetFilter::Typed(
@@ -15410,7 +15429,7 @@ mod tests {
 
     #[test]
     fn triple_stacked_negation() {
-        let (f, _) = parse_type_phrase("noncreature, nonland, nonartifact permanent");
+        let (f, _) = parse_type_phrase_folding("noncreature, nonland, nonartifact permanent");
         match f {
             TargetFilter::Typed(ref tf) => {
                 assert!(tf.type_filters.contains(&TypeFilter::Permanent));
@@ -15461,7 +15480,7 @@ mod tests {
     fn except_those_sharing_type_with_convoker_negates() {
         // CR 608.2c: "creatures except those that share a creature type with a
         // creature that convoked this spell" → creature + Not(SharesQuality).
-        let (f, _) = parse_type_phrase(
+        let (f, _) = parse_type_phrase_folding(
             "creatures except those that share a creature type with a creature that convoked this spell",
         );
         let expected_ref = TargetFilter::Typed(
@@ -15487,8 +15506,9 @@ mod tests {
         // per-prop `Not(X) AND Not(Y)` (which would exclude objects matching X *or*
         // Y, far too many). Exercised with a clause that `parse_that_clause_suffix`
         // returns as two props ([Not(AttackedThisTurn), Not(EnteredThisTurn)]).
-        let (f, _) =
-            parse_type_phrase("creatures except those that didn't attack or enter this turn");
+        let (f, _) = parse_type_phrase_folding(
+            "creatures except those that didn't attack or enter this turn",
+        );
         // The two negated-verb predicates negate (double `Not`) and fold into one
         // `AnyOf` — the structural signature that distinguishes the De Morgan-correct
         // disjunction from the broken per-prop conjunction.
@@ -15579,7 +15599,7 @@ mod tests {
 
     #[test]
     fn zombies_you_control() {
-        let (f, rest) = parse_type_phrase("zombies you control");
+        let (f, rest) = parse_type_phrase_folding("zombies you control");
         assert_eq!(
             f,
             TargetFilter::Typed(
@@ -15593,7 +15613,7 @@ mod tests {
 
     #[test]
     fn elves_you_control_irregular_plural() {
-        let (f, rest) = parse_type_phrase("elves you control");
+        let (f, rest) = parse_type_phrase_folding("elves you control");
         assert_eq!(
             f,
             TargetFilter::Typed(
@@ -15607,7 +15627,7 @@ mod tests {
 
     #[test]
     fn equipment_subtype() {
-        let (f, _) = parse_type_phrase("equipment you control");
+        let (f, _) = parse_type_phrase_folding("equipment you control");
         assert_eq!(
             f,
             TargetFilter::Typed(
@@ -15620,7 +15640,7 @@ mod tests {
 
     #[test]
     fn spacecraft_artifact_subtype() {
-        let (f, _) = parse_type_phrase("Spacecraft");
+        let (f, _) = parse_type_phrase_folding("Spacecraft");
         assert_eq!(
             f,
             TargetFilter::Typed(TypedFilter::default().subtype("Spacecraft".to_string()))
@@ -15629,7 +15649,7 @@ mod tests {
 
     #[test]
     fn creatures_and_spacecraft_type_union() {
-        let (f, rest) = parse_type_phrase("creatures and Spacecraft");
+        let (f, rest) = parse_type_phrase_folding("creatures and Spacecraft");
         match f {
             TargetFilter::Or { ref filters } => {
                 assert_eq!(filters.len(), 2);
@@ -15654,8 +15674,10 @@ mod tests {
     /// it drops the whole right conjunct AND the shared trailing suffix.
     #[test]
     fn bare_and_supertype_led_conjunct_matches_comma_form() {
-        let (bare, bare_rest) = parse_type_phrase("Spider and legendary creature you control");
-        let (comma, comma_rest) = parse_type_phrase("Spider, and legendary creature you control");
+        let (bare, bare_rest) =
+            parse_type_phrase_folding("Spider and legendary creature you control");
+        let (comma, comma_rest) =
+            parse_type_phrase_folding("Spider, and legendary creature you control");
         assert_eq!(
             bare, comma,
             "the bare-\"and\" form must build the same union as the comma form"
@@ -15701,7 +15723,7 @@ mod tests {
             "artifact and legendary creature you control",
             "land and basic land you control",
         ] {
-            let (filter, _) = parse_type_phrase(phrase);
+            let (filter, _) = parse_type_phrase_folding(phrase);
             let TargetFilter::Or { ref filters } = filter else {
                 panic!("{phrase:?} must build an Or union, got {filter:?}");
             };
@@ -15719,7 +15741,7 @@ mod tests {
     fn bare_and_non_supertype_lead_is_not_a_type_union() {
         // Positive reach-guard in the SAME test: the harness does see a working
         // union, so the negatives below are not vacuous.
-        let (positive, _) = parse_type_phrase("Spider and legendary creature you control");
+        let (positive, _) = parse_type_phrase_folding("Spider and legendary creature you control");
         assert!(
             matches!(positive, TargetFilter::Or { .. }),
             "reach-guard: the supertype lead must still union, got {positive:?}"
@@ -15741,7 +15763,7 @@ mod tests {
             "legendary and snow in addition to its other types",
             "legendary and snow",
         ] {
-            let (filter, _) = parse_type_phrase(phrase);
+            let (filter, _) = parse_type_phrase_folding(phrase);
             assert!(
                 !matches!(filter, TargetFilter::Or { .. }),
                 "{phrase:?} must stay collapsed (no type union), got {filter:?}"
@@ -15823,7 +15845,7 @@ mod tests {
 
     #[test]
     fn forest_land_subtype() {
-        let (f, _) = parse_type_phrase("forest");
+        let (f, _) = parse_type_phrase_folding("forest");
         match f {
             TargetFilter::Typed(ref tf) => {
                 assert_eq!(tf.get_subtype(), Some("Forest"));
@@ -15836,7 +15858,7 @@ mod tests {
 
     #[test]
     fn legendary_creature() {
-        let (f, _) = parse_type_phrase("legendary creature");
+        let (f, _) = parse_type_phrase_folding("legendary creature");
         assert_eq!(
             f,
             TargetFilter::Typed(TypedFilter::creature().properties(vec![
@@ -15849,7 +15871,7 @@ mod tests {
 
     #[test]
     fn basic_lands_you_control() {
-        let (f, _) = parse_type_phrase("basic lands you control");
+        let (f, _) = parse_type_phrase_folding("basic lands you control");
         assert_eq!(
             f,
             TargetFilter::Typed(
@@ -15899,7 +15921,7 @@ mod tests {
 
     #[test]
     fn snow_permanents() {
-        let (f, _) = parse_type_phrase("snow permanents");
+        let (f, _) = parse_type_phrase_folding("snow permanents");
         assert_eq!(
             f,
             TargetFilter::Typed(TypedFilter::permanent().properties(vec![
@@ -15913,7 +15935,7 @@ mod tests {
     #[test]
     fn legendary_white_creature() {
         // CR 205.4a: Supertype + color compose in properties
-        let (f, _) = parse_type_phrase("legendary white creature");
+        let (f, _) = parse_type_phrase_folding("legendary white creature");
         assert_eq!(
             f,
             TargetFilter::Typed(TypedFilter::creature().properties(vec![
@@ -15930,7 +15952,7 @@ mod tests {
     #[test]
     fn nonbasic_land() {
         // CR 205.4a: "nonbasic" → NotSupertype (property), not TypeFilter::Non
-        let (f, _) = parse_type_phrase("nonbasic land");
+        let (f, _) = parse_type_phrase_folding("nonbasic land");
         assert_eq!(
             f,
             TargetFilter::Typed(
@@ -15943,7 +15965,7 @@ mod tests {
 
     #[test]
     fn nonbasic_lands_opponent_controls() {
-        let (f, _) = parse_type_phrase("nonbasic lands an opponent controls");
+        let (f, _) = parse_type_phrase_folding("nonbasic lands an opponent controls");
         assert_eq!(
             f,
             TargetFilter::Typed(
@@ -15965,7 +15987,7 @@ mod tests {
     /// correctly restricts the player's selectable set during DigChoice.
     #[test]
     fn creature_and_or_land_composes_to_or_filter() {
-        let (f, _) = parse_type_phrase("creature and/or land");
+        let (f, _) = parse_type_phrase_folding("creature and/or land");
         match f {
             TargetFilter::Or { ref filters } => {
                 assert_eq!(filters.len(), 2);
@@ -15984,7 +16006,7 @@ mod tests {
 
     #[test]
     fn artifact_and_or_enchantment() {
-        let (f, _) = parse_type_phrase("artifact and/or enchantment");
+        let (f, _) = parse_type_phrase_folding("artifact and/or enchantment");
         match f {
             TargetFilter::Or { ref filters } => {
                 assert_eq!(filters.len(), 2);
@@ -16003,7 +16025,7 @@ mod tests {
 
     #[test]
     fn instant_and_or_sorcery() {
-        let (f, _) = parse_type_phrase("instant and/or sorcery");
+        let (f, _) = parse_type_phrase_folding("instant and/or sorcery");
         match f {
             TargetFilter::Or { ref filters } => {
                 assert_eq!(filters.len(), 2);
@@ -16014,7 +16036,7 @@ mod tests {
 
     #[test]
     fn creature_and_or_planeswalker_you_control() {
-        let (f, _) = parse_type_phrase("creature and/or planeswalker you control");
+        let (f, _) = parse_type_phrase_folding("creature and/or planeswalker you control");
         match f {
             TargetFilter::Or { ref filters } => {
                 assert_eq!(filters.len(), 2);
@@ -16036,7 +16058,7 @@ mod tests {
     #[test]
     fn existing_nonland_still_works() {
         // Single non-prefix (not stacked) should work as before
-        let (f, _) = parse_type_phrase("nonland permanent");
+        let (f, _) = parse_type_phrase_folding("nonland permanent");
         assert_eq!(
             f,
             TargetFilter::Typed(
@@ -16048,7 +16070,7 @@ mod tests {
     #[test]
     fn and_still_works_with_non_type_text() {
         // "creature and draw a card" — "and" should NOT recurse because "draw" isn't a type
-        let (f, rest) = parse_type_phrase("creature and draw a card");
+        let (f, rest) = parse_type_phrase_folding("creature and draw a card");
         assert_eq!(f, TargetFilter::Typed(TypedFilter::creature()));
         assert!(rest.contains("and draw"), "rest = {:?}", rest);
     }
@@ -17046,7 +17068,7 @@ mod tests {
     #[test]
     fn distribute_properties_across_or_branches() {
         // "artifacts and creatures with mana value 2 or less" → both branches get CmcLE(2)
-        let (f, _) = parse_type_phrase("artifacts and creatures with mana value 2 or less");
+        let (f, _) = parse_type_phrase_folding("artifacts and creatures with mana value 2 or less");
         if let TargetFilter::Or { filters } = &f {
             assert_eq!(filters.len(), 2, "should have 2 Or branches");
             for branch in filters {
@@ -17078,7 +17100,7 @@ mod tests {
         use crate::types::ability::{
             Comparator, FilterProp, PtStat, PtValueScope, QuantityExpr, TypeFilter,
         };
-        let (filter, _rest) = parse_type_phrase("a 1/1 creature you control");
+        let (filter, _rest) = parse_type_phrase_folding("a 1/1 creature you control");
         let TargetFilter::Typed(tf) = filter else {
             panic!("expected Typed filter, got {filter:?}");
         };
@@ -17111,7 +17133,7 @@ mod tests {
             tf.properties
         );
 
-        let (colored_filter, _rest) = parse_type_phrase("a 1/1 white creature you control");
+        let (colored_filter, _rest) = parse_type_phrase_folding("a 1/1 white creature you control");
         let TargetFilter::Typed(colored_tf) = colored_filter else {
             panic!("expected Typed filter, got {colored_filter:?}");
         };
@@ -17160,7 +17182,8 @@ mod tests {
     fn parse_type_phrase_positive_subtype_relative_clause() {
         use crate::types::ability::TypeFilter;
 
-        let (filter, _rest) = parse_type_phrase("creature you control that's an Ape or a Monkey");
+        let (filter, _rest) =
+            parse_type_phrase_folding("creature you control that's an Ape or a Monkey");
         let TargetFilter::Typed(tf) = filter else {
             panic!("expected Typed filter, got {filter:?}");
         };
@@ -17181,7 +17204,7 @@ mod tests {
         assert_eq!(tf.controller, Some(ControllerRef::You));
 
         // Single-subtype form → a bare Subtype (no AnyOf wrapper).
-        let (single, _) = parse_type_phrase("creature you control that's a Goblin");
+        let (single, _) = parse_type_phrase_folding("creature you control that's a Goblin");
         let TargetFilter::Typed(stf) = single else {
             panic!("expected Typed filter");
         };
@@ -17193,9 +17216,9 @@ mod tests {
     #[test]
     fn parse_type_phrase_ninja_or_rogue_creatures_you_control() {
         // CR 205.3a: "ninja or rogue creatures you control" — compound subtype+type phrase.
-        // parse_type_phrase handles "or" between subtypes when the second branch includes
+        // parse_type_phrase_folding handles "or" between subtypes when the second branch includes
         // a core type ("rogue creatures"), producing an Or filter.
-        let (filter, remainder) = parse_type_phrase("ninja or rogue creatures you control");
+        let (filter, remainder) = parse_type_phrase_folding("ninja or rogue creatures you control");
         assert!(
             remainder.trim().is_empty(),
             "remainder should be empty, got: '{remainder}'"
@@ -17209,7 +17232,7 @@ mod tests {
 
     #[test]
     fn parse_type_phrase_outlaw_creatures_you_control() {
-        let (filter, remainder) = parse_type_phrase("outlaw creatures you control");
+        let (filter, remainder) = parse_type_phrase_folding("outlaw creatures you control");
         assert!(
             remainder.trim().is_empty(),
             "remainder should be empty, got: '{remainder}'"
@@ -17226,7 +17249,7 @@ mod tests {
 
     #[test]
     fn parse_type_phrase_handles_plural_head_subtype() {
-        let (filter, remainder) = parse_type_phrase("Heads");
+        let (filter, remainder) = parse_type_phrase_folding("Heads");
         assert!(
             remainder.trim().is_empty(),
             "remainder should be empty, got: '{remainder}'"
@@ -17244,7 +17267,8 @@ mod tests {
     #[test]
     fn parse_type_phrase_comma_or_with_controller() {
         // "artifact, creature, or enchantment you control" — controller distributes
-        let (filter, rest) = parse_type_phrase("artifact, creature, or enchantment you control");
+        let (filter, rest) =
+            parse_type_phrase_folding("artifact, creature, or enchantment you control");
         assert!(rest.trim().is_empty(), "remainder: '{rest}'");
         if let TargetFilter::Or { filters } = &filter {
             assert_eq!(filters.len(), 3);
@@ -17268,7 +17292,7 @@ mod tests {
     #[test]
     fn parse_type_phrase_aura_card_stays_generic() {
         let (filter, rest) =
-            parse_type_phrase("Aura card with mana value less than or equal to that Aura");
+            parse_type_phrase_folding("Aura card with mana value less than or equal to that Aura");
         assert_eq!(rest.trim(), "Aura", "remainder: '{rest}'");
         let TargetFilter::Typed(typed) = filter else {
             panic!("Expected Typed filter, got {filter:?}");
@@ -17280,7 +17304,7 @@ mod tests {
                 .iter()
                 .position(|type_filter| *type_filter == TypeFilter::Enchantment)
                 .is_none(),
-            "search-only normalization should not happen in parse_type_phrase: {typed:?}"
+            "search-only normalization should not happen in parse_type_phrase_folding: {typed:?}"
         );
         assert!(typed.properties.iter().any(|property| matches!(
             property,
@@ -17309,7 +17333,8 @@ mod tests {
 
     #[test]
     fn parse_type_phrase_unblocked_attacking_creatures_you_control() {
-        let (filter, remainder) = parse_type_phrase("unblocked attacking creatures you control");
+        let (filter, remainder) =
+            parse_type_phrase_folding("unblocked attacking creatures you control");
         assert!(remainder.trim().is_empty(), "remainder: '{remainder}'");
         if let TargetFilter::Typed(tf) = &filter {
             assert!(tf.properties.contains(&FilterProp::Unblocked));
@@ -17324,7 +17349,7 @@ mod tests {
 
     #[test]
     fn parse_type_phrase_attacking_or_blocking_creature() {
-        let (filter, remainder) = parse_type_phrase("attacking or blocking creature");
+        let (filter, remainder) = parse_type_phrase_folding("attacking or blocking creature");
         assert!(remainder.trim().is_empty(), "remainder: '{remainder}'");
         let TargetFilter::Or { filters } = &filter else {
             panic!("expected Or filter, got {filter:?}");
@@ -17343,7 +17368,7 @@ mod tests {
     #[test]
     fn parse_type_phrase_cross_products_multiple_property_disjunctions() {
         let (filter, remainder) =
-            parse_type_phrase("attacking or blocking creature with flying or vigilance");
+            parse_type_phrase_folding("attacking or blocking creature with flying or vigilance");
         assert!(remainder.trim().is_empty(), "remainder: '{remainder}'");
         let TargetFilter::Or { filters } = &filter else {
             panic!("expected Or filter, got {filter:?}");
@@ -17373,7 +17398,7 @@ mod tests {
 
     #[test]
     fn parse_type_phrase_tapped_creature() {
-        let (filter, rest) = parse_type_phrase("tapped creature");
+        let (filter, rest) = parse_type_phrase_folding("tapped creature");
         assert!(rest.trim().is_empty(), "remainder: '{rest}'");
         if let TargetFilter::Typed(tf) = &filter {
             assert!(tf.type_filters.contains(&TypeFilter::Creature));
@@ -17385,7 +17410,7 @@ mod tests {
 
     #[test]
     fn parse_type_phrase_untapped_land() {
-        let (filter, rest) = parse_type_phrase("untapped land");
+        let (filter, rest) = parse_type_phrase_folding("untapped land");
         assert!(rest.trim().is_empty(), "remainder: '{rest}'");
         if let TargetFilter::Typed(tf) = &filter {
             assert!(tf.type_filters.contains(&TypeFilter::Land));
@@ -17400,7 +17425,7 @@ mod tests {
         // "tapped artifact or creature" — tapped is a leading prefix, applied to the left branch.
         // The "or" handler applies right→left property distribution only, so tapped stays
         // on the artifact branch. (Full leading-property distribution is a separate concern.)
-        let (filter, rest) = parse_type_phrase("tapped artifact or creature");
+        let (filter, rest) = parse_type_phrase_folding("tapped artifact or creature");
         assert!(rest.trim().is_empty(), "remainder: '{rest}'");
         if let TargetFilter::Or { filters } = &filter {
             assert_eq!(filters.len(), 2);
@@ -17425,7 +17450,8 @@ mod tests {
     #[test]
     fn that_share_creature_type_consumed() {
         // "that share a creature type" is consumed into SharesQuality.
-        let (filter, rest) = parse_type_phrase("creatures you control that share a creature type");
+        let (filter, rest) =
+            parse_type_phrase_folding("creatures you control that share a creature type");
         if let TargetFilter::Typed(ref tf) = filter {
             assert!(tf
                 .type_filters
@@ -17446,7 +17472,7 @@ mod tests {
 
     #[test]
     fn that_share_no_creature_types_consumed() {
-        let (filter, rest) = parse_type_phrase("creatures that share no creature types");
+        let (filter, rest) = parse_type_phrase_folding("creatures that share no creature types");
         if let TargetFilter::Typed(ref tf) = filter {
             assert!(tf.properties.iter().any(|p| matches!(
                 p,
@@ -17468,7 +17494,7 @@ mod tests {
     #[test]
     fn that_shares_card_type_with_exiled_card_consumed() {
         let (filter, rest) =
-            parse_type_phrase("permanent that shares a card type with the exiled card");
+            parse_type_phrase_folding("permanent that shares a card type with the exiled card");
         let TargetFilter::Typed(ref tf) = filter else {
             panic!("expected Typed filter, got {filter:?}");
         };
@@ -17509,7 +17535,8 @@ mod tests {
         // to a SharesQuality{PermanentType} constraint (CR 110.4 narrowing:
         // NOT CardType, so a shared Kindred-only pairing does not match;
         // previously the clause was silently dropped).
-        let (filter, rest) = parse_type_phrase("permanent that shares a permanent type with it");
+        let (filter, rest) =
+            parse_type_phrase_folding("permanent that shares a permanent type with it");
         let TargetFilter::Typed(ref tf) = filter else {
             panic!("expected Typed filter, got {filter:?}");
         };
@@ -17527,7 +17554,7 @@ mod tests {
     #[test]
     fn that_dont_share_card_type_with_discarded_card_consumed() {
         let (filter, rest) =
-            parse_type_phrase("cards that don't share a card type with the discarded card");
+            parse_type_phrase_folding("cards that don't share a card type with the discarded card");
         let TargetFilter::Typed(ref tf) = filter else {
             panic!("expected Typed filter, got {filter:?}");
         };
@@ -17544,8 +17571,9 @@ mod tests {
 
     #[test]
     fn that_shares_card_type_with_one_discarded_card_consumed() {
-        let (filter, rest) =
-            parse_type_phrase("card that shares a card type with one of the discarded cards");
+        let (filter, rest) = parse_type_phrase_folding(
+            "card that shares a card type with one of the discarded cards",
+        );
         let TargetFilter::Typed(ref tf) = filter else {
             panic!("expected Typed filter, got {filter:?}");
         };
@@ -17562,8 +17590,9 @@ mod tests {
 
     #[test]
     fn that_doesnt_share_land_type_with_land_you_control_consumed() {
-        let (filter, rest) =
-            parse_type_phrase("land that doesn't share a land type with a land you control");
+        let (filter, rest) = parse_type_phrase_folding(
+            "land that doesn't share a land type with a land you control",
+        );
         let TargetFilter::Typed(ref tf) = filter else {
             panic!("expected Typed filter, got {filter:?}");
         };
@@ -17758,7 +17787,7 @@ mod tests {
 
     #[test]
     fn that_entered_this_turn() {
-        let (filter, rest) = parse_type_phrase("token you control that entered this turn");
+        let (filter, rest) = parse_type_phrase_folding("token you control that entered this turn");
         if let TargetFilter::Typed(ref tf) = filter {
             assert_eq!(tf.controller, Some(ControllerRef::You));
             assert!(tf.properties.iter().any(|p| matches!(p, FilterProp::Token)));
@@ -17777,7 +17806,8 @@ mod tests {
 
     #[test]
     fn that_entered_the_battlefield_this_turn() {
-        let (filter, rest) = parse_type_phrase("creature that entered the battlefield this turn");
+        let (filter, rest) =
+            parse_type_phrase_folding("creature that entered the battlefield this turn");
         if let TargetFilter::Typed(ref tf) = filter {
             assert!(tf.type_filters.contains(&TypeFilter::Creature));
             assert!(tf
@@ -17795,7 +17825,7 @@ mod tests {
 
     #[test]
     fn type_phrase_cards_put_there_from_battlefield_this_turn() {
-        let (filter, rest) = parse_type_phrase(
+        let (filter, rest) = parse_type_phrase_folding(
             "artifact and creature cards in your graveyard that were put there from the battlefield this turn",
         );
         let TargetFilter::Or { filters } = filter else {
@@ -18320,14 +18350,14 @@ mod tests {
     }
 
     /// The Fifth Doctor end-to-end: the mass-target type phrase (the "each"
-    /// quantifier is stripped upstream before `parse_type_phrase` is reached)
+    /// quantifier is stripped upstream before `parse_type_phrase_folding` is reached)
     /// must carry both negated props alongside the controller scope, so the
     /// counter (and the chained TrackedSet untap) follow only the qualifying
     /// subset.
     #[test]
     fn creature_you_control_that_didnt_attack_or_enter_full_phrase() {
         let (filter, rest) =
-            parse_type_phrase("creature you control that didn't attack or enter this turn");
+            parse_type_phrase_folding("creature you control that didn't attack or enter this turn");
         assert!(rest.trim().is_empty(), "remainder: '{rest}'");
         let TargetFilter::Typed(tf) = filter else {
             panic!("expected Typed filter, got {filter:?}");
@@ -18361,7 +18391,7 @@ mod tests {
             relative_player_scope: Some(ControllerRef::ScopedPlayer),
             ..ParseContext::default()
         };
-        let (filter, rest) = parse_type_phrase_with_ctx(
+        let (filter, rest) = parse_type_phrase_folding_with_ctx(
             "untapped creatures that player controls that didn't attack this turn",
             &mut ctx,
         );
@@ -18554,7 +18584,7 @@ mod tests {
     fn type_phrase_with_targets_only_self() {
         // "instant or sorcery spell that targets only ~"
         let (filter, rest) =
-            parse_type_phrase("instant or sorcery spell that targets only ~, copy");
+            parse_type_phrase_folding("instant or sorcery spell that targets only ~, copy");
         assert_eq!(rest.trim_start().trim_start_matches(',').trim(), "copy");
         // The filter should be Or(Instant + TargetsOnly, Sorcery + TargetsOnly)
         if let TargetFilter::Or { filters } = &filter {
@@ -18678,8 +18708,8 @@ mod tests {
 
     #[test]
     fn type_phrase_spell_that_targets_self() {
-        // "spell that targets this creature" via parse_type_phrase
-        let (filter, rest) = parse_type_phrase("spell that targets this creature, put");
+        // "spell that targets this creature" via parse_type_phrase_folding
+        let (filter, rest) = parse_type_phrase_folding("spell that targets this creature, put");
         assert_eq!(rest.trim_start().trim_start_matches(',').trim(), "put");
         if let TargetFilter::Typed(tf) = &filter {
             assert!(tf.type_filters.contains(&TypeFilter::Card));
@@ -18699,7 +18729,7 @@ mod tests {
 
     #[test]
     fn parse_type_phrase_creature_or_planeswalker() {
-        let (filter, rest) = parse_type_phrase("creature or planeswalker");
+        let (filter, rest) = parse_type_phrase_folding("creature or planeswalker");
         assert!(rest.trim().is_empty(), "remainder: '{rest}'");
         if let TargetFilter::Or { filters } = &filter {
             assert_eq!(filters.len(), 2);
@@ -18715,7 +18745,7 @@ mod tests {
 
     #[test]
     fn parse_type_phrase_nonland_permanent() {
-        let (filter, rest) = parse_type_phrase("nonland permanent");
+        let (filter, rest) = parse_type_phrase_folding("nonland permanent");
         assert!(rest.trim().is_empty(), "remainder: '{rest}'");
         if let TargetFilter::Typed(tf) = &filter {
             assert!(tf.type_filters.contains(&TypeFilter::Permanent));
@@ -18730,7 +18760,7 @@ mod tests {
     #[test]
     fn parse_type_phrase_creature_with_greater_power() {
         // CR 509.1b: "creatures with greater power" — relative to source
-        let (filter, rest) = parse_type_phrase("creatures with greater power");
+        let (filter, rest) = parse_type_phrase_folding("creatures with greater power");
         assert!(rest.trim().is_empty(), "remainder: '{rest}'");
         if let TargetFilter::Typed(tf) = &filter {
             assert!(tf.type_filters.contains(&TypeFilter::Creature));
@@ -18748,7 +18778,7 @@ mod tests {
 
     #[test]
     fn parse_type_phrase_creature_without_flying() {
-        let (filter, rest) = parse_type_phrase("creature without flying");
+        let (filter, rest) = parse_type_phrase_folding("creature without flying");
         assert!(rest.trim().is_empty(), "remainder: '{rest}'");
         if let TargetFilter::Typed(tf) = &filter {
             assert!(tf.type_filters.contains(&TypeFilter::Creature));
@@ -18766,7 +18796,7 @@ mod tests {
 
     #[test]
     fn parse_type_phrase_creature_without_first_strike() {
-        let (filter, rest) = parse_type_phrase("creature without first strike");
+        let (filter, rest) = parse_type_phrase_folding("creature without first strike");
         assert!(rest.trim().is_empty(), "remainder: '{rest}'");
         if let TargetFilter::Typed(tf) = &filter {
             assert!(tf.type_filters.contains(&TypeFilter::Creature));
@@ -18784,7 +18814,7 @@ mod tests {
 
     #[test]
     fn parse_type_phrase_another_creature() {
-        let (filter, rest) = parse_type_phrase("another creature");
+        let (filter, rest) = parse_type_phrase_folding("another creature");
         assert!(rest.trim().is_empty(), "remainder: '{rest}'");
         if let TargetFilter::Typed(tf) = &filter {
             assert!(tf.type_filters.contains(&TypeFilter::Creature));
@@ -18800,7 +18830,7 @@ mod tests {
 
     #[test]
     fn parse_type_phrase_another_creature_you_control() {
-        let (filter, rest) = parse_type_phrase("another creature you control");
+        let (filter, rest) = parse_type_phrase_folding("another creature you control");
         assert!(rest.trim().is_empty(), "remainder: '{rest}'");
         if let TargetFilter::Typed(tf) = &filter {
             assert!(tf.type_filters.contains(&TypeFilter::Creature));
@@ -18815,7 +18845,7 @@ mod tests {
     /// over a type/subtype subject must be stripped to reach the type word — it
     /// must NOT leak into the subtype string (e.g. Subtype("Each Vehicle")) and
     /// must NOT add `FilterProp::Another` (it selects the source too, unlike
-    /// "other"). Consumers of `parse_type_phrase` that exercise this: the
+    /// "other"). Consumers of `parse_type_phrase_folding` that exercise this: the
     /// "sacrifice all <type> you control" additional/activation cost filters
     /// (Soulblast — creatures; Kaervek's Spite — permanents; Tomb of Urami —
     /// lands) and the "Whenever all <type> you control attack" trigger
@@ -18829,7 +18859,7 @@ mod tests {
             ("all Cats you control", "Cat"),
             ("every Skeleton you control", "Skeleton"),
         ] {
-            let (filter, rest) = parse_type_phrase(text);
+            let (filter, rest) = parse_type_phrase_folding(text);
             assert!(rest.trim().is_empty(), "remainder for '{text}': '{rest}'");
             let TargetFilter::Typed(tf) = &filter else {
                 panic!("Expected Typed filter for '{text}', got {filter:?}");
@@ -18865,7 +18895,7 @@ mod tests {
             "each other creature you control",
             "all other creatures you control",
         ] {
-            let (filter, rest) = parse_type_phrase(text);
+            let (filter, rest) = parse_type_phrase_folding(text);
             assert!(rest.trim().is_empty(), "remainder for '{text}': '{rest}'");
             let TargetFilter::Typed(tf) = &filter else {
                 panic!("Expected Typed filter for '{text}', got {filter:?}");
@@ -18900,7 +18930,7 @@ mod tests {
     /// other creature", "sacrifice any other creature you control").
     #[test]
     fn parse_type_phrase_any_other_creature_you_control() {
-        let (filter, rest) = parse_type_phrase("any other creature you control");
+        let (filter, rest) = parse_type_phrase_folding("any other creature you control");
         assert!(rest.trim().is_empty(), "remainder: '{rest}'");
         let TargetFilter::Typed(tf) = &filter else {
             panic!("Expected Typed filter, got {filter:?}");
@@ -18946,7 +18976,7 @@ mod tests {
             ("Elf Warrior", "Elf", "Warrior"),
             ("Human Wizard", "Human", "Wizard"),
         ] {
-            let (filter, rest) = parse_type_phrase(text);
+            let (filter, rest) = parse_type_phrase_folding(text);
             assert!(rest.trim().is_empty(), "remainder for '{text}': '{rest}'");
             let TargetFilter::Typed(tf) = &filter else {
                 panic!("Expected Typed filter for '{text}', got {filter:?}");
@@ -18986,7 +19016,7 @@ mod tests {
     /// that specialized handler still sees it.
     #[test]
     fn parse_type_phrase_urzas_possessive_prefix_does_not_chain() {
-        let (filter, rest) = parse_type_phrase("urza's mine");
+        let (filter, rest) = parse_type_phrase_folding("urza's mine");
         assert_eq!(
             rest.trim(),
             "mine",
@@ -19058,7 +19088,7 @@ mod tests {
     /// for non-"any" phrasing (issue #6321 / PR #6533 review).
     #[test]
     fn parse_type_phrase_any_creature_on_the_battlefield() {
-        let (filter, rest) = parse_type_phrase("any creature on the battlefield");
+        let (filter, rest) = parse_type_phrase_folding("any creature on the battlefield");
         assert!(rest.trim().is_empty(), "remainder: '{rest}'");
         let TargetFilter::Typed(tf) = &filter else {
             panic!("Expected Typed filter, got {filter:?}");
@@ -19088,7 +19118,8 @@ mod tests {
     /// omits the source permanent.
     #[test]
     fn parse_type_phrase_modified_creatures_other_than_self() {
-        let (filter, rest) = parse_type_phrase("modified creatures you control other than ~");
+        let (filter, rest) =
+            parse_type_phrase_folding("modified creatures you control other than ~");
         assert!(rest.trim().is_empty(), "remainder: '{rest}'");
         let TargetFilter::Typed(tf) = &filter else {
             panic!("Expected Typed filter, got {filter:?}");
@@ -19111,7 +19142,8 @@ mod tests {
     /// `FilterProp::Another` via the "other than <self-ref>" suffix.
     #[test]
     fn parse_type_phrase_other_than_this_creature() {
-        let (filter, rest) = parse_type_phrase("creatures you control other than this creature");
+        let (filter, rest) =
+            parse_type_phrase_folding("creatures you control other than this creature");
         assert!(rest.trim().is_empty(), "remainder: '{rest}'");
         let TargetFilter::Typed(tf) = &filter else {
             panic!("Expected Typed filter, got {filter:?}");
@@ -19147,7 +19179,7 @@ mod tests {
     #[test]
     fn parse_target_another_target_creature() {
         // "another target creature" via parse_target: "target " prefix consumed,
-        // then parse_type_phrase("another creature") should add Another property.
+        // then parse_type_phrase_folding("another creature") should add Another property.
         let (filter, rest) = parse_target("target another creature");
         assert!(rest.trim().is_empty(), "remainder: '{rest}'");
         if let TargetFilter::Typed(tf) = &filter {
@@ -19242,7 +19274,7 @@ mod tests {
     #[test]
     fn parse_type_phrase_artifact_creature_or_enchantment() {
         // 3-way Or: "artifact, creature, or enchantment"
-        let (filter, rest) = parse_type_phrase("artifact, creature, or enchantment");
+        let (filter, rest) = parse_type_phrase_folding("artifact, creature, or enchantment");
         assert!(rest.trim().is_empty(), "remainder: '{rest}'");
         if let TargetFilter::Or { filters } = &filter {
             assert_eq!(
@@ -19275,7 +19307,7 @@ mod tests {
     /// cast an artifact creature spell" previously dropped the Creature type.
     #[test]
     fn parse_type_phrase_artifact_creature_conjunction() {
-        let (filter, rest) = parse_type_phrase("artifact creature");
+        let (filter, rest) = parse_type_phrase_folding("artifact creature");
         assert!(rest.trim().is_empty(), "remainder: '{rest}'");
         let TargetFilter::Typed(tf) = &filter else {
             panic!("Expected Typed filter, got {filter:?}");
@@ -19296,7 +19328,7 @@ mod tests {
     /// suffix is informational and should be stripped after the conjunction.
     #[test]
     fn parse_type_phrase_artifact_creature_spell() {
-        let (filter, rest) = parse_type_phrase("artifact creature spell");
+        let (filter, rest) = parse_type_phrase_folding("artifact creature spell");
         assert!(rest.trim().is_empty(), "remainder: '{rest}'");
         let TargetFilter::Typed(tf) = &filter else {
             panic!("Expected Typed filter, got {filter:?}");
@@ -19310,7 +19342,7 @@ mod tests {
     /// type_filters alongside Artifact.
     #[test]
     fn parse_type_phrase_noncreature_artifact() {
-        let (filter, rest) = parse_type_phrase("noncreature artifact");
+        let (filter, rest) = parse_type_phrase_folding("noncreature artifact");
         assert!(rest.trim().is_empty(), "remainder: '{rest}'");
         let TargetFilter::Typed(tf) = &filter else {
             panic!("Expected Typed filter, got {filter:?}");
@@ -19328,7 +19360,7 @@ mod tests {
     /// type. Must remain a single-type filter with a HasSupertype property.
     #[test]
     fn parse_type_phrase_legendary_creature_keeps_supertype_prop() {
-        let (filter, rest) = parse_type_phrase("legendary creature");
+        let (filter, rest) = parse_type_phrase_folding("legendary creature");
         assert!(rest.trim().is_empty(), "remainder: '{rest}'");
         let TargetFilter::Typed(tf) = &filter else {
             panic!("Expected Typed filter, got {filter:?}");
@@ -19382,7 +19414,7 @@ mod tests {
     /// followed by a controller suffix.
     #[test]
     fn parse_type_phrase_artifact_creature_you_control() {
-        let (filter, rest) = parse_type_phrase("artifact creature you control");
+        let (filter, rest) = parse_type_phrase_folding("artifact creature you control");
         assert!(rest.trim().is_empty(), "remainder: '{rest}'");
         let TargetFilter::Typed(tf) = &filter else {
             panic!("Expected Typed filter, got {filter:?}");
@@ -19681,7 +19713,7 @@ mod tests {
     /// objects you own, so stolen objects count and native objects do not.
     #[test]
     fn parse_type_phrase_you_control_but_dont_own_composes_not_owned() {
-        let (filter, rest) = parse_type_phrase("land you control but don't own");
+        let (filter, rest) = parse_type_phrase_folding("land you control but don't own");
         assert_eq!(rest, "");
         match filter {
             TargetFilter::And { filters } => {
@@ -19712,7 +19744,8 @@ mod tests {
 
     #[test]
     fn parse_type_phrase_opponent_controls_but_doesnt_own_composes_not_owned() {
-        let (filter, rest) = parse_type_phrase("creature an opponent controls but doesn't own");
+        let (filter, rest) =
+            parse_type_phrase_folding("creature an opponent controls but doesn't own");
         assert_eq!(rest, "");
         match filter {
             TargetFilter::And { filters } => {
@@ -19751,7 +19784,7 @@ mod tests {
     #[test]
     fn parse_type_phrase_permanents_you_dont_own_pushes_owned_opponent() {
         for text in ["permanents you don't own", "permanents you do not own"] {
-            let (filter, rest) = parse_type_phrase(text);
+            let (filter, rest) = parse_type_phrase_folding(text);
             assert_eq!(rest, "", "fully consumed for {text:?}");
             let TargetFilter::Typed(tf) = filter else {
                 panic!("expected single Typed filter for {text:?}, got {filter:?}");
@@ -19777,7 +19810,7 @@ mod tests {
     /// the additive bare "you don't own" arm. (CR 108.3 + CR 109.4.)
     #[test]
     fn parse_type_phrase_but_dont_own_shape_unchanged_by_bare_arm() {
-        let (filter, rest) = parse_type_phrase("creature you control but don't own");
+        let (filter, rest) = parse_type_phrase_folding("creature you control but don't own");
         assert_eq!(rest, "");
         let TargetFilter::And { filters } = filter else {
             panic!("expected And filter, got {filter:?}");
@@ -20312,7 +20345,8 @@ mod tests {
     /// "draws a card" and the remainder is empty.
     #[test]
     fn named_card_terminates_at_verb_boundary() {
-        let (filter, rest) = parse_type_phrase("a permanent named Bonder's Ornament draws a card");
+        let (filter, rest) =
+            parse_type_phrase_folding("a permanent named Bonder's Ornament draws a card");
         let TargetFilter::Typed(tf) = &filter else {
             panic!("expected Typed filter, got {filter:?}");
         };
@@ -20330,7 +20364,8 @@ mod tests {
     /// to contain verb-like substrings when followed by a comma delimiter.
     #[test]
     fn named_card_with_comma_delimiter_still_works() {
-        let (filter, rest) = parse_type_phrase("a creature named Falkenrath Gorger, it gains");
+        let (filter, rest) =
+            parse_type_phrase_folding("a creature named Falkenrath Gorger, it gains");
         let TargetFilter::Typed(tf) = &filter else {
             panic!("expected Typed filter, got {filter:?}");
         };
@@ -20348,7 +20383,7 @@ mod tests {
     fn parse_non_saga_token_you_control_issue_3294() {
         use crate::types::ability::{ControllerRef, FilterProp, TypeFilter};
 
-        let (filter, rest) = parse_type_phrase("non-saga token you control");
+        let (filter, rest) = parse_type_phrase_folding("non-saga token you control");
         let TargetFilter::Typed(tf) = filter else {
             panic!("expected Typed filter, got {filter:?}");
         };
@@ -20375,7 +20410,7 @@ mod tests {
     #[test]
     fn parse_non_lesson_instant_and_sorcery_distributes_negation() {
         let (filter, rest) =
-            parse_type_phrase("non-Lesson instant and sorcery card in your graveyard");
+            parse_type_phrase_folding("non-Lesson instant and sorcery card in your graveyard");
         assert!(rest.trim().is_empty(), "unexpected remainder: {rest:?}");
         let TargetFilter::Or { filters } = filter else {
             panic!("expected Or filter, got {filter:?}");
@@ -20398,7 +20433,7 @@ mod tests {
 
     #[test]
     fn parse_artifact_or_noncreature_permanent_keeps_negation_on_second_branch() {
-        let (filter, rest) = parse_type_phrase("artifact or noncreature permanent");
+        let (filter, rest) = parse_type_phrase_folding("artifact or noncreature permanent");
         assert!(rest.trim().is_empty(), "unexpected remainder: {rest:?}");
         let TargetFilter::Or { filters } = filter else {
             panic!("expected Or filter, got {filter:?}");
@@ -20537,15 +20572,15 @@ mod tests {
         assert!(tf.properties.contains(&FilterProp::Another));
     }
 
-    /// CR 205.3h: `parse_type_phrase` parses "a Plan" — "Plan" is an enchantment
+    /// CR 205.3h: `parse_type_phrase_folding` parses "a Plan" — "Plan" is an enchantment
     /// subtype (Marvel's Spider-Man) — to `Typed{[Subtype("Plan")]}`, fully
     /// consumed. The elided-verb "or" disjunction ("you control an artifact
     /// creature or a Plan") is assembled one level up in `parse_you_control_a`,
-    /// so `parse_type_phrase` itself stops at the first segment and leaves the
+    /// so `parse_type_phrase_folding` itself stops at the first segment and leaves the
     /// connector as remainder (asserted below).
     #[test]
     fn parse_type_phrase_recognizes_plan() {
-        let (f, rest) = parse_type_phrase("a Plan");
+        let (f, rest) = parse_type_phrase_folding("a Plan");
         assert!(rest.trim().is_empty(), "remainder must be empty: {rest:?}");
         let TargetFilter::Typed(tf) = f else {
             panic!("expected single Typed filter, got {f:?}");
@@ -20556,13 +20591,13 @@ mod tests {
         );
     }
 
-    /// `parse_type_phrase` does NOT swallow an article-led "or" RHS — it stops at
+    /// `parse_type_phrase_folding` does NOT swallow an article-led "or" RHS — it stops at
     /// the first segment and leaves " or a Plan" as remainder. This is the
     /// load-bearing precondition for the `parse_you_control_a` elided-verb loop:
     /// the connector must survive so the condition layer can fold the disjuncts.
     #[test]
     fn parse_type_phrase_leaves_article_led_or_rhs_as_remainder() {
-        let (f, rest) = parse_type_phrase("an artifact creature or a Plan");
+        let (f, rest) = parse_type_phrase_folding("an artifact creature or a Plan");
         assert_eq!(rest, " or a Plan", "article-led or RHS must remain");
         let TargetFilter::Typed(tf) = f else {
             panic!("expected single Typed filter, got {f:?}");
@@ -20575,7 +20610,7 @@ mod tests {
     /// parses to a single Typed filter (not an Or).
     #[test]
     fn single_artifact_creature_still_typed_not_or() {
-        let (f, rest) = parse_type_phrase("an artifact creature");
+        let (f, rest) = parse_type_phrase_folding("an artifact creature");
         assert!(rest.trim().is_empty(), "remainder must be empty: {rest:?}");
         let TargetFilter::Typed(tf) = f else {
             panic!("expected single Typed filter, got {f:?}");
@@ -20588,7 +20623,7 @@ mod tests {
     /// the existing non-comma separator branch (unchanged by this work).
     #[test]
     fn bare_connector_rhs_still_or() {
-        let (f, rest) = parse_type_phrase("artifact creature or enchantment");
+        let (f, rest) = parse_type_phrase_folding("artifact creature or enchantment");
         assert!(rest.trim().is_empty(), "remainder must be empty: {rest:?}");
         assert!(
             matches!(f, TargetFilter::Or { .. }),
@@ -20948,9 +20983,9 @@ mod tests {
     fn printed_color_choice_qualifier_is_gated_on_chain_bound_scope() {
         const PHRASE: &str = "permanents of the color of your choice";
 
-        // NEGATIVE — the exact throwaway call every `parse_type_phrase` call
+        // NEGATIVE — the exact throwaway call every `parse_type_phrase_folding` call
         // site makes (the wrapper builds a fresh `ParseContext::default()`).
-        let (unbound_filter, unbound_rest) = parse_type_phrase(PHRASE);
+        let (unbound_filter, unbound_rest) = parse_type_phrase_folding(PHRASE);
         let unbound = typed_leg(&unbound_filter).expect("typed");
         assert!(
             !unbound
@@ -20973,7 +21008,7 @@ mod tests {
             chosen_color_qualifier: ChosenColorQualifierScope::ChainBound,
             ..Default::default()
         };
-        let (bound_filter, bound_rest) = parse_type_phrase_with_ctx(PHRASE, &mut bound_ctx);
+        let (bound_filter, bound_rest) = parse_type_phrase_folding_with_ctx(PHRASE, &mut bound_ctx);
         let bound = typed_leg(&bound_filter).expect("typed");
         assert!(
             bound
@@ -20999,8 +21034,10 @@ mod tests {
             chosen_color_qualifier: ChosenColorQualifierScope::ChainBound,
             ..Default::default()
         };
-        let (ws_filter, _) =
-            parse_type_phrase_with_ctx("permanents  of the color of your choice", &mut ws_ctx);
+        let (ws_filter, _) = parse_type_phrase_folding_with_ctx(
+            "permanents  of the color of your choice",
+            &mut ws_ctx,
+        );
         let ws = typed_leg(&ws_filter).expect("typed");
         assert!(
             ws.properties
@@ -21017,7 +21054,7 @@ mod tests {
             ..Default::default()
         };
         let (anaphor_filter, anaphor_rest) =
-            parse_type_phrase_with_ctx("permanents of the chosen color", &mut anaphor_ctx);
+            parse_type_phrase_folding_with_ctx("permanents of the chosen color", &mut anaphor_ctx);
         let anaphor = typed_leg(&anaphor_filter).expect("typed");
         assert!(
             !anaphor

--- a/crates/engine/src/parser/oracle_tests.rs
+++ b/crates/engine/src/parser/oracle_tests.rs
@@ -8177,7 +8177,7 @@ fn land_grant_reveal_hand_alternative_cost_option() {
 // except for artifacts and lands" must exclude both types (including artifact
 // creatures, per CR 205.2b's multi-type-object rule), not silently drop the
 // exception clause and destroy everything. Drives the full ability-line parse
-// (not just `parse_type_phrase` in isolation) so the interaction with the
+// (not just `parse_type_phrase_folding` in isolation) so the interaction with the
 // trailing "Activate only during your upkeep." restriction sentence is
 // covered too.
 #[test]
@@ -21756,7 +21756,7 @@ fn quantum_riddler_draw_line_parses_as_replacement_not_static() {
 
 /// CR 205.3a: "[Subtype] [CoreType]" subject-predicate patterns like
 /// "Wizard creatures gain flying until end of turn" — the subtype+type compound
-/// must be fully consumed by parse_type_phrase so the subject-predicate parser
+/// must be fully consumed by parse_type_phrase_folding so the subject-predicate parser
 /// can extract the filter.
 #[test]
 fn test_subtype_creatures_gain_keyword() {
@@ -26814,7 +26814,7 @@ fn target_filter_has_defending_player_anaphor(filter: &TargetFilter) -> bool {
 /// attacked player, not to `TargetFilter::Any`.
 ///
 /// Revert-failing: without `parse_attacking_defender_anaphor`,
-/// `parse_type_phrase` leaves "attacking that player" unconsumed,
+/// `parse_type_phrase_folding` leaves "attacking that player" unconsumed,
 /// `parse_subject_application`'s rest-empty gate fails, and the clause falls
 /// through to `parse_numeric_imperative_ast`, which emits the documented
 /// `Effect::Pump { target: TargetFilter::Any }` sentinel — a board-wide pump
@@ -26935,7 +26935,7 @@ fn definition_chain_has_defending_player_anaphor(def: &AbilityDefinition) -> boo
 /// corpus. Many of them terminate with a bare "." right after the phrase, which
 /// SATISFIES the clause boundary, so the boundary guard is not what protects
 /// them — the excluded positions never route the phrase through
-/// `parse_type_phrase`'s suffix chain at all.
+/// `parse_type_phrase_folding`'s suffix chain at all.
 #[test]
 fn excluded_attacking_that_player_positions_are_not_stolen() {
     // Inline token spec, bare "." terminator. Verbatim Oracle text (MTGJSON) —

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -39,8 +39,8 @@ use super::oracle_nom::primitives::{
 use super::oracle_nom::target::parse_type_phrase as parse_type_phrase_nom;
 use super::oracle_static::{parse_commander_subject_filter_prefix, typed_filter_for_subtype};
 use super::oracle_target::{
-    attachment_kinds_filter_prop, parse_attachment_kind_disjunction, parse_type_phrase,
-    parse_type_phrase_with_ctx, starts_with_type_list_continuation, starts_with_type_word,
+    attachment_kinds_filter_prop, parse_attachment_kind_disjunction, parse_type_phrase_folding,
+    parse_type_phrase_folding_with_ctx, starts_with_type_list_continuation, starts_with_type_word,
 };
 use super::oracle_util::{
     canonicalize_subtype_name, is_core_type_name, is_non_subtype_subject_name, merge_or_filters,
@@ -6608,7 +6608,7 @@ fn extract_if_condition_with_card_name(
     }
 
     // CR 509.1a + CR 603.4: "if defending player controls no [type]"
-    // Nom combinator prefix dispatch + parse_type_phrase for the remainder.
+    // Nom combinator prefix dispatch + parse_type_phrase_folding for the remainder.
     {
         fn def_prefix(i: &str) -> nom::IResult<&str, (), OracleError<'_>> {
             let (i, _) = tag("if defending player controls no ").parse(i)?;
@@ -6618,7 +6618,7 @@ fn extract_if_condition_with_card_name(
             let pos = before.len();
             let prefix_len = "if defending player controls no ".len();
             let after = &text[pos + prefix_len..];
-            let (filter, rest) = parse_type_phrase(after);
+            let (filter, rest) = parse_type_phrase_folding(after);
             if !matches!(filter, TargetFilter::Any) {
                 let consumed = after.len() - rest.len();
                 return (
@@ -6779,7 +6779,7 @@ fn parse_gendered_dies_event_object_condition<'a>(
         DiesEventObjectPronoun::It | DiesEventObjectPronoun::He | DiesEventObjectPronoun::She => {}
     }
 
-    let (filter, rest) = parse_type_phrase(descriptor);
+    let (filter, rest) = parse_type_phrase_folding(descriptor);
     if matches!(filter, TargetFilter::Any) {
         return Err(oracle_err(input));
     }
@@ -9980,7 +9980,7 @@ fn continues_player_action_list(after_comma: &str) -> bool {
 }
 
 fn type_phrase_continues_to_combat_damage_player_event(text: &str) -> bool {
-    let (filter, rest) = parse_type_phrase(text);
+    let (filter, rest) = parse_type_phrase_folding(text);
     if matches!(filter, TargetFilter::Any) || rest.len() >= text.len() {
         return false;
     }
@@ -10338,7 +10338,7 @@ fn parse_spell_chosen_number_quality(spell_clause: &str) -> Option<TypedFilter> 
     let base_tf = if rest.is_empty() || rest == "spell" {
         TypedFilter::default()
     } else {
-        let (filter, _) = parse_type_phrase(rest);
+        let (filter, _) = parse_type_phrase_folding(rest);
         match filter {
             TargetFilter::Typed(tf) => tf,
             _ => TypedFilter::default(),
@@ -11272,7 +11272,7 @@ fn parse_single_subject<'a>(text: &'a str, ctx: &mut ParseContext) -> (TargetFil
     // "another <type phrase>" — compose with FilterProp::Another
     if let Ok((after_another, ())) = value((), tag::<_, _, OracleError<'_>>("another ")).parse(text)
     {
-        let (filter, rest) = parse_type_phrase(after_another);
+        let (filter, rest) = parse_type_phrase_folding(after_another);
         let with_another = add_another_prop(filter);
         return (with_another, rest);
     }
@@ -11319,7 +11319,7 @@ fn parse_single_subject<'a>(text: &'a str, ctx: &mut ParseContext) -> (TargetFil
             return (filter, trimmed);
         }
 
-        let (filter, rest) = parse_type_phrase(after_quantifier);
+        let (filter, rest) = parse_type_phrase_folding(after_quantifier);
         if rest.len() < after_quantifier.len() {
             return (filter, rest);
         }
@@ -11338,8 +11338,8 @@ fn parse_single_subject<'a>(text: &'a str, ctx: &mut ParseContext) -> (TargetFil
 
     // CR 608.2k: Player subjects for pronoun resolution in trigger effects.
     // "an opponent", "a player", "each opponent" — these are player-type subjects,
-    // not object types. Must fire before the generic "a "/"an " + parse_type_phrase
-    // path, which would send "opponent" to parse_type_phrase and return Any.
+    // not object types. Must fire before the generic "a "/"an " + parse_type_phrase_folding
+    // path, which would send "opponent" to parse_type_phrase_folding and return Any.
     // "each opponent" maps to the same filter as "an opponent" for subject extraction;
     // the trigger mode (not the subject filter) determines per-opponent firing.
     if let Ok((rest, filter)) = alt((
@@ -11381,7 +11381,7 @@ fn parse_single_subject<'a>(text: &'a str, ctx: &mut ParseContext) -> (TargetFil
         .parse(rest)
         {
             if let Some((clause_text, verb_rest)) = find_clause_verb_boundary(after_who) {
-                let (clause_filter, clause_remainder) = parse_type_phrase(clause_text);
+                let (clause_filter, clause_remainder) = parse_type_phrase_folding(clause_text);
                 // Only treat this as a control-relative clause when the clause
                 // text parsed cleanly into a typed filter.
                 if clause_remainder.trim().is_empty() && !matches!(clause_filter, TargetFilter::Any)
@@ -11399,14 +11399,14 @@ fn parse_single_subject<'a>(text: &'a str, ctx: &mut ParseContext) -> (TargetFil
     // caller's `relative_player_scope` — e.g. the counter-placement actor for
     // Bold Plagiarist ("an opponent puts … on a creature they control"). With a
     // default ctx (`relative_player_scope == None`) this is identical to the
-    // scope-free `parse_type_phrase`, so every other subject is unchanged.
+    // scope-free `parse_type_phrase_folding`, so every other subject is unchanged.
     if let Ok((after, ())) = alt((
         value((), tag::<_, _, OracleError<'_>>("a ")),
         value((), tag("an ")),
     ))
     .parse(text)
     {
-        let (filter, rest) = parse_type_phrase_with_ctx(after, ctx);
+        let (filter, rest) = parse_type_phrase_folding_with_ctx(after, ctx);
         return (filter, rest);
     }
 
@@ -11414,7 +11414,7 @@ fn parse_single_subject<'a>(text: &'a str, ctx: &mut ParseContext) -> (TargetFil
         return (filter, rest.trim_start());
     }
 
-    let (filter, rest) = parse_type_phrase(text);
+    let (filter, rest) = parse_type_phrase_folding(text);
     if rest.len() < text.len() {
         return (filter, rest);
     }
@@ -11688,7 +11688,7 @@ fn parse_object_recipient_pt_gate(
     let (rest, ()) =
         value((), tag::<_, _, OracleError<'_>>("to ")).parse(after_verb.trim_start())?;
     // CR 120.1: object recipient ("a creature" / "a permanent" / typed). The
-    // leading article is consumed before delegating to `parse_type_phrase`.
+    // leading article is consumed before delegating to `parse_type_phrase_folding`.
     let (rest, _) = alt((tag("a "), tag("an "))).parse(rest)?;
     let (rest, filter) = parse_type_phrase_nom(rest)?;
     // The equal-to-P/T qualifier is mandatory: without it this is an ordinary
@@ -11730,7 +11730,7 @@ fn parse_object_recipient_filter(after_verb: &str) -> OracleResult<'_, TargetFil
     // parse and the trigger fell back to `valid_target = None` (fires on ANY
     // recipient, including a player). Consume the leading `FilterProp`s and merge
     // them into the typed recipient so the trigger gates on the damaged object's
-    // combat state. Mirrors the prefix loop in `oracle_target::parse_type_phrase`.
+    // combat state. Mirrors the prefix loop in `oracle_target::parse_type_phrase_folding`.
     let (rest, prefix_props) = many0(terminated(parse_property_filter, space1)).parse(rest)?;
     let (rest, mut filter) = parse_type_phrase_nom(rest)?;
     // Phrase-terminator guard: accept only end-of-string or a non-alphanumeric
@@ -11942,7 +11942,7 @@ fn append_trigger_condition(
 /// active-voice mill trigger ("mills **a nonland card**", "mills **one or more
 /// creature cards**"). Optionally consumes a leading "one or more " quantifier
 /// (semantically redundant — `valid_card` matching is per-object), then
-/// delegates the typed-filter recognition to `parse_type_phrase` (which strips
+/// delegates the typed-filter recognition to `parse_type_phrase_folding` (which strips
 /// the "a "/"an " article itself). Returns `None` when the tail is not a
 /// recognizable type phrase, so the caller falls through to the next arm.
 fn parse_milled_object_filter(input: &str) -> Option<TargetFilter> {
@@ -11950,7 +11950,7 @@ fn parse_milled_object_filter(input: &str) -> Option<TargetFilter> {
         .parse(input)
         .map(|(rest, _)| rest)
         .unwrap_or(input);
-    let (filter, rest) = parse_type_phrase(after_quantifier);
+    let (filter, rest) = parse_type_phrase_folding(after_quantifier);
     // Require the type phrase to have consumed something — a bare fallthrough
     // (rest == after_quantifier) means no typed filter was recognized.
     if rest.len() < after_quantifier.len() {
@@ -13106,7 +13106,7 @@ fn try_parse_event(
             return Ok((remaining, SimpleEvent::BecomesUnattached(None)));
         }
         let (host, _) = tag(" from ").parse(remaining)?;
-        let (filter, rest) = parse_type_phrase(host);
+        let (filter, rest) = parse_type_phrase_folding(host);
         if !rest.trim().is_empty() {
             return Err(nom::Err::Error(OracleError::new(
                 rest,
@@ -13362,7 +13362,7 @@ fn try_parse_event(
         let (type_phrase, _) = alt((tag::<_, _, OracleError<'_>>(" by a "), tag(" by an ")))
             .parse(input)
             .ok()?;
-        let (filter, rest) = parse_type_phrase(type_phrase);
+        let (filter, rest) = parse_type_phrase_folding(type_phrase);
         rest.trim().is_empty().then_some(filter)
     }
     /// CR 509.3b: "blocks a <filter>" carries a target-side (attacker) qualifier —
@@ -13371,7 +13371,7 @@ fn try_parse_event(
         let (type_phrase, _) = alt((tag::<_, _, OracleError<'_>>(" a "), tag(" an ")))
             .parse(input)
             .ok()?;
-        let (filter, rest) = parse_type_phrase(type_phrase);
+        let (filter, rest) = parse_type_phrase_folding(type_phrase);
         rest.trim().is_empty().then_some(filter)
     }
     if let Ok((remaining, event)) = parse_simple_event.parse(rest) {
@@ -13658,7 +13658,7 @@ fn try_parse_event(
                 if matches!(subject, TargetFilter::SelfRef) {
                     // Pattern 1: "Whenever ~ becomes attached to [host]"
                     if !remaining.is_empty() {
-                        let (filter, rest) = parse_type_phrase(remaining);
+                        let (filter, rest) = parse_type_phrase_folding(remaining);
                         if !rest.trim().is_empty() {
                             return None;
                         }
@@ -15137,7 +15137,7 @@ fn try_parse_n_or_more_attacks(lower: &str) -> Option<(TriggerMode, TriggerDefin
         // relative clause and capture it as a non-source-relative attachment filter.
         let (subject_core, attachment_prop) = strip_attachment_relative_clause(subject_text);
 
-        let (filter, remainder) = parse_type_phrase(subject_core);
+        let (filter, remainder) = parse_type_phrase_folding(subject_core);
         if !remainder.trim().is_empty() {
             continue;
         }
@@ -15306,7 +15306,7 @@ fn try_parse_attack_with_n_creatures(lower: &str) -> Option<(TriggerMode, Trigge
     // Count==1 needs only the matcher's valid_card gate; count>1 additionally
     // uses AttackersDeclaredCount when the type phrase narrows beyond bare
     // "creatures".
-    let (filter, remainder) = parse_type_phrase(after_quantifier);
+    let (filter, remainder) = parse_type_phrase_folding(after_quantifier);
     // Accept optional trailing " each turn" / " this turn" qualifier (unused here,
     // but keeps the matcher permissive for CR 603.4 timing qualifiers). Must end
     // at the condition boundary — the caller already split the effect text off,
@@ -15392,7 +15392,7 @@ fn try_parse_one_or_more_die(lower: &str) -> Option<(TriggerMode, TriggerDefinit
             continue;
         };
 
-        let (filter, remainder) = parse_type_phrase(subject_text);
+        let (filter, remainder) = parse_type_phrase_folding(subject_text);
         if !remainder.trim().is_empty() {
             continue;
         }
@@ -15468,7 +15468,7 @@ fn try_parse_one_or_more_tokens_created(lower: &str) -> Option<(TriggerMode, Tri
     let valid_card = if subject_text.trim().is_empty() {
         None
     } else {
-        let (filter, remainder) = parse_type_phrase(subject_text);
+        let (filter, remainder) = parse_type_phrase_folding(subject_text);
         if !remainder.trim().is_empty() {
             return None;
         }
@@ -15516,7 +15516,7 @@ fn try_parse_one_or_more_leave_graveyard(lower: &str) -> Option<(TriggerMode, Tr
                 let filters: Vec<TargetFilter> = parts
                     .iter()
                     .filter_map(|part| {
-                        let (f, rem) = parse_type_phrase(part.trim());
+                        let (f, rem) = parse_type_phrase_folding(part.trim());
                         if rem.trim().is_empty() {
                             Some(f)
                         } else {
@@ -15530,7 +15530,7 @@ fn try_parse_one_or_more_leave_graveyard(lower: &str) -> Option<(TriggerMode, Tr
                     continue;
                 }
             } else {
-                let (filter, remainder) = parse_type_phrase(type_text);
+                let (filter, remainder) = parse_type_phrase_folding(type_text);
                 if !remainder.trim().is_empty() {
                     continue;
                 }
@@ -15712,7 +15712,7 @@ fn try_parse_one_or_more_combat_damage_to_player(
             continue;
         };
 
-        let (filter, remainder) = parse_type_phrase(subject_text);
+        let (filter, remainder) = parse_type_phrase_folding(subject_text);
         let filter = if remainder.trim().is_empty() {
             filter
         } else if let Some(or_filter) = try_split_or_compound_type_phrase(subject_text) {
@@ -15788,7 +15788,7 @@ fn parse_controlled_subtype_subject(subject_text: &str) -> Option<TargetFilter> 
 }
 
 /// CR 205.3m: Try to split "subtype or subtype [card_type] [you control]" into an Or filter.
-/// Handles patterns like "ninja or rogue creatures you control" where parse_type_phrase
+/// Handles patterns like "ninja or rogue creatures you control" where parse_type_phrase_folding
 /// can't natively handle the "or" compound with a shared card_type suffix.
 /// Parses the full right-side phrase ("rogue creatures you control") as a complete type phrase,
 /// then applies the shared card_type and controller to the left-side bare subtype.
@@ -15796,15 +15796,15 @@ fn try_split_or_compound_type_phrase(text: &str) -> Option<TargetFilter> {
     let (_, (left, right)) = nom_primitives::split_once_on(text, " or ").ok()?;
     let left_trimmed = left.trim();
     // Parse the full right side as a type phrase — "rogue creatures you control" is a complete phrase
-    // that parse_type_phrase handles as subtype-only + trailing text. Instead, parse the whole
-    // "subtype card_type controller" suffix manually by feeding "right" to parse_type_phrase
+    // that parse_type_phrase_folding handles as subtype-only + trailing text. Instead, parse the whole
+    // "subtype card_type controller" suffix manually by feeding "right" to parse_type_phrase_folding
     // but appending it to make a single-subtype phrase.
     // The simplest correct approach: parse the entire text AFTER stripping the "subtype or " prefix
     // from the left, treating the rest as a single type phrase that gives us card_type + controller.
     let right_trimmed = right.trim();
     // Try parsing the entire right side as a type phrase
-    let (right_filter, right_remainder) = parse_type_phrase(right_trimmed);
-    // If parse_type_phrase didn't fully consume, the right side has "subtype card_type you control"
+    let (right_filter, right_remainder) = parse_type_phrase_folding(right_trimmed);
+    // If parse_type_phrase_folding didn't fully consume, the right side has "subtype card_type you control"
     // pattern. Reconstruct: the right_filter has subtype, and remainder has "card_type you control".
     let (primary_type, controller) = if right_remainder.trim().is_empty() {
         // Fully consumed
@@ -15815,7 +15815,7 @@ fn try_split_or_compound_type_phrase(text: &str) -> Option<TargetFilter> {
         }
     } else if let TargetFilter::Typed(ref tf) = right_filter {
         // Partially consumed: right_filter has subtype, remainder has "creatures you control"
-        let (suffix_filter, suffix_rem) = parse_type_phrase(right_remainder.trim());
+        let (suffix_filter, suffix_rem) = parse_type_phrase_folding(right_remainder.trim());
         if !suffix_rem.trim().is_empty() {
             return None;
         }
@@ -15873,7 +15873,7 @@ fn try_parse_self_or_another_controlled_subtype_enters(
         let Some(subtype_text) = subject_text.trim().strip_suffix(" you control") else {
             continue;
         };
-        let (_, remainder) = parse_type_phrase(subtype_text);
+        let (_, remainder) = parse_type_phrase_folding(subtype_text);
         if remainder.len() < subtype_text.len() {
             continue;
         }
@@ -15952,8 +15952,8 @@ fn try_parse_controlled_chosen_type_enters(
     }
 
     // Parse the type word (e.g. "permanent", "creature", "nontoken creature").
-    // Use parse_type_phrase which handles "nontoken" prefixes and type words.
-    let (filter, remainder) = parse_type_phrase(type_text);
+    // Use parse_type_phrase_folding which handles "nontoken" prefixes and type words.
+    let (filter, remainder) = parse_type_phrase_folding(type_text);
     if !remainder.is_empty() {
         return None;
     }
@@ -15972,7 +15972,7 @@ fn try_parse_controlled_chosen_type_enters(
             TargetFilter::Typed(typed)
         }
         _ => {
-            // parse_type_phrase should always return Typed for a type word;
+            // parse_type_phrase_folding should always return Typed for a type word;
             // if not, bail.
             return None;
         }
@@ -16026,7 +16026,7 @@ fn try_parse_controlled_subtype_enters(lower: &str) -> Option<(TriggerMode, Trig
         return None;
     }
 
-    let (_, remainder) = parse_type_phrase(subtype_text);
+    let (_, remainder) = parse_type_phrase_folding(subtype_text);
     if remainder.len() < subtype_text.len() {
         return None;
     }
@@ -16059,7 +16059,7 @@ fn try_parse_another_controlled_subtype_enters(
         let Some(subtype_text) = subject_text.trim().strip_suffix(" you control") else {
             continue;
         };
-        let (_, remainder) = parse_type_phrase(subtype_text);
+        let (_, remainder) = parse_type_phrase_folding(subtype_text);
         if remainder.len() < subtype_text.len() {
             continue;
         }
@@ -16090,7 +16090,7 @@ fn try_parse_controlled_subtype_attacks(lower: &str) -> Option<(TriggerMode, Tri
         let Some(subtype_text) = subject_text.trim().strip_suffix(" you control") else {
             continue;
         };
-        let (_, remainder) = parse_type_phrase(subtype_text);
+        let (_, remainder) = parse_type_phrase_folding(subtype_text);
         if remainder.len() < subtype_text.len() {
             continue;
         }
@@ -16573,7 +16573,7 @@ fn try_parse_player_trigger(lower: &str) -> Option<(TriggerMode, TriggerDefiniti
     // [from <zone>]" fires on the CR 305 special action. Handles both the
     // third-person "plays a land" form (a player, an opponent) and the
     // second-person "play a land" form (you — e.g. Fastbond). The optional
-    // from-zone tail rides through `parse_type_phrase`, matching the existing
+    // from-zone tail rides through `parse_type_phrase_folding`, matching the existing
     // cast-spell trigger shape used by Rocco, Street Chef.
     if let Some((valid_target, land_filter)) = parse_land_play_trigger_subject(lower) {
         let mut def = make_base();
@@ -16942,7 +16942,7 @@ fn try_parse_player_trigger(lower: &str) -> Option<(TriggerMode, TriggerDefiniti
         }
 
         // CR 601.2a: pre-extract the "from <zone>" cast-origin tail BEFORE
-        // running the type-phrase parser. `parse_type_phrase`'s
+        // running the type-phrase parser. `parse_type_phrase_folding`'s
         // `parse_zone_suffix` would otherwise attach the zone as a
         // `FilterProp::InZone` on `valid_card` — semantically wrong for
         // SpellCast triggers because the spell object's zone at
@@ -16967,7 +16967,7 @@ fn try_parse_player_trigger(lower: &str) -> Option<(TriggerMode, TriggerDefiniti
 
         // CR 700.2: Peel an optional leading "modal " qualifier off the payload
         // BEFORE the type-phrase / spell-qualifier parsers run. "modal" is not a
-        // card type, so `parse_type_phrase("modal spell")` yields an empty filter
+        // card type, so `parse_type_phrase_folding("modal spell")` yields an empty filter
         // and `parse_spell_qualifier_payload` treats "modal" as an unknown pre-
         // spell word — either way the modality is silently dropped and
         // `valid_card` is left `None`, over-triggering on every spell (issue
@@ -17006,7 +17006,7 @@ fn try_parse_player_trigger(lower: &str) -> Option<(TriggerMode, TriggerDefiniti
         }
 
         // Fall back to the classic type-phrase parser for bare type filters.
-        let (filter, _rest) = parse_type_phrase(payload);
+        let (filter, _rest) = parse_type_phrase_folding(payload);
         let filter = if is_another {
             add_another_prop(filter)
         } else {
@@ -17065,7 +17065,7 @@ fn try_parse_player_trigger(lower: &str) -> Option<(TriggerMode, TriggerDefiniti
             }
 
             // Parse the spell quality generically (e.g., "creature spell", "multicolored spell")
-            // using the same parse_type_phrase building block as the "you cast" branch above.
+            // using the same parse_type_phrase_folding building block as the "you cast" branch above.
             // The condition/effect boundary was already split by `split_trigger`; do not
             // truncate on ", " here — spell qualities may contain commas (Talion:
             // "mana value, power, or toughness equal to the chosen number").
@@ -17138,7 +17138,7 @@ fn try_parse_player_trigger(lower: &str) -> Option<(TriggerMode, TriggerDefiniti
                 };
                 def.valid_card = Some(filter);
             } else {
-                let (filter, _rest) = parse_type_phrase(spell_clause);
+                let (filter, _rest) = parse_type_phrase_folding(spell_clause);
                 let is_meaningful = match &filter {
                     TargetFilter::Typed(tf) => tf.has_meaningful_type_constraint(),
                     TargetFilter::Or { .. } => true,
@@ -18093,7 +18093,7 @@ fn parse_spell_qualifier_payload(qualifier: &str) -> Option<TargetFilter> {
         None
     } else {
         // Non-empty post-spell text that does NOT match a recognized modifier
-        // (e.g. "that targets only ~" — handled by the legacy `parse_type_phrase`
+        // (e.g. "that targets only ~" — handled by the legacy `parse_type_phrase_folding`
         // pathway). `?` propagates None so the caller can fall back.
         Some(parse_post_spell_modifier(post_spell)?)
     };
@@ -18108,7 +18108,7 @@ fn parse_spell_qualifier_payload(qualifier: &str) -> Option<TargetFilter> {
 }
 
 /// Parse a bare type phrase (e.g. "noncreature", "creature") as a `TargetFilter`.
-/// Returns `None` if `parse_type_phrase` reports `TargetFilter::Any` or leaves
+/// Returns `None` if `parse_type_phrase_folding` reports `TargetFilter::Any` or leaves
 /// residual text — both indicate the phrase was not a pure type qualifier.
 fn type_only_filter(qualifier: &str) -> Option<TargetFilter> {
     // CR 105.2b: bare color-quality qualifiers ("multicolored", "monocolored",
@@ -18130,7 +18130,7 @@ fn type_only_filter(qualifier: &str) -> Option<TargetFilter> {
             TypedFilter::card().properties(vec![FilterProp::WasKicked]),
         ));
     }
-    let (filter, remainder) = parse_type_phrase(qualifier);
+    let (filter, remainder) = parse_type_phrase_folding(qualifier);
     if remainder.trim().is_empty() && !matches!(filter, TargetFilter::Any) {
         Some(filter)
     } else {
@@ -18325,7 +18325,7 @@ pub(crate) fn parse_post_spell_modifier(modifier: &str) -> Option<TargetFilter> 
     // or a creature card in your graveyard" (Volo, Guide to Monsters). Reuse the
     // shared-quality clause combinator so the disjunctive reference ("creature
     // you control or a creature card in your graveyard") is not mis-split as a
-    // type-phrase `Or` inside `parse_type_phrase`.
+    // type-phrase `Or` inside `parse_type_phrase_folding`.
     if let Ok((rest, prop)) =
         super::oracle_target::parse_shared_quality_clause(modifier, &ParseContext::default())
     {
@@ -19355,7 +19355,7 @@ fn try_parse_one_or_more_put_into_graveyard(
         let base_filter = if subject_text == "cards" {
             None
         } else if let Some(type_text) = subject_text.strip_suffix(" cards") {
-            let (f, remainder) = parse_type_phrase(type_text);
+            let (f, remainder) = parse_type_phrase_folding(type_text);
             if !remainder.trim().is_empty() {
                 continue;
             }
@@ -19506,7 +19506,7 @@ fn try_parse_discard_trigger(
                 .is_ok()
         }
 
-        let (filter, rest) = parse_type_phrase(after_verb);
+        let (filter, rest) = parse_type_phrase_folding(after_verb);
         if !discard_filter_tail_is_complete(rest)
             && tag::<_, _, OracleError<'_>>("or ")
                 .parse(rest.trim_start())
@@ -20046,14 +20046,14 @@ fn parse_land_play_trigger_subject(
     .parse(after_prefix)
     .ok()?;
     // CR 305.1: Decompose verb ("play"/"plays") from the land object phrase.
-    // The object phrase itself goes through `parse_type_phrase`, the shared
+    // The object phrase itself goes through `parse_type_phrase_folding`, the shared
     // typed-filter grammar for supertypes, subtypes, "another", and zone
     // suffixes. That keeps "a legendary land", "another land", "an Island",
     // and "a land from exile" on one parser seam.
     let (after_verb, _) = alt((tag::<_, _, OracleError<'_>>("plays "), tag("play ")))
         .parse(after_subject)
         .ok()?;
-    let (filter, rest) = parse_type_phrase(after_verb);
+    let (filter, rest) = parse_type_phrase_folding(after_verb);
     if rest.len() == after_verb.len() {
         return None;
     }
@@ -20311,7 +20311,7 @@ fn parse_control_none_filter(text: &str) -> Option<TargetFilter> {
         };
 
     // Try parsing as a type phrase first (handles "creatures", "artifacts", "lands", etc.)
-    let (filter, rest) = parse_type_phrase(remainder);
+    let (filter, rest) = parse_type_phrase_folding(remainder);
     if !rest.trim().is_empty() {
         return None;
     }

--- a/crates/engine/src/parser/oracle_trigger_tests.rs
+++ b/crates/engine/src/parser/oracle_trigger_tests.rs
@@ -10140,7 +10140,7 @@ fn trigger_you_cast_oxford_comma_subtype_list_spell() {
 /// the earlier subtype-list-only approach mis-typed the core-type legs as
 /// bogus `Subtype("instant")`/`Subtype("sorcery")` filters that matched no
 /// spell, so instant/sorcery casts silently stopped triggering. The list must
-/// route through `parse_type_phrase` (which types each leg), NOT a
+/// route through `parse_type_phrase_folding` (which types each leg), NOT a
 /// subtype-only list parser.
 #[test]
 fn trigger_you_cast_oxford_comma_mixed_type_list_spell() {
@@ -10384,7 +10384,7 @@ fn trigger_you_cast_another_spell_keeps_another_filter() {
 
 /// CR 702.8a + CR 603.2 (issue #4754): Slitherwisp — "Whenever you cast another
 /// spell that has flash" must scope the trigger to flash spells. The "that has
-/// flash" keyword clause was dropped by `parse_type_phrase`, leaving only the
+/// flash" keyword clause was dropped by `parse_type_phrase_folding`, leaving only the
 /// `Another` prop, so the trigger over-fired on every non-first spell (a
 /// counterspell without flash wrongly triggered it). The spell filter must now
 /// carry BOTH `WithKeyword(Flash)` and `Another`.
@@ -11128,7 +11128,7 @@ fn trigger_intervening_if_that_creature_was_dealt_excess_damage_this_turn() {
 
 /// CR 120.10 + CR 603.4: Rith, Liberated Primeval's phase trigger with an
 /// opponent-scoped excess-damage intervening-if must set `channel: Excess`
-/// and produce a non-trivial target filter. `parse_type_phrase` emits
+/// and produce a non-trivial target filter. `parse_type_phrase_folding` emits
 /// `TargetFilter::Or` for compound types, so we check the channel and
 /// that the condition is a QuantityComparison with DamageDealtThisTurn.
 #[test]
@@ -13646,7 +13646,7 @@ fn trigger_nth_spell_opponent_noncreature() {
         "Esper Sentinel",
     );
     assert_eq!(def.mode, TriggerMode::SpellCast);
-    // parse_type_phrase("noncreature") produces [Non(Creature)] without a redundant
+    // parse_type_phrase_folding("noncreature") produces [Non(Creature)] without a redundant
     // Card base type — Non(Creature) alone is sufficient for spell-history filtering.
     assert_eq!(
         def.constraint,
@@ -25840,7 +25840,7 @@ fn trigger_if_it_wasnt_cast() {
 #[test]
 fn trigger_subject_extracts_opponent_as_player() {
     // CR 608.2k: "an opponent" should be recognized as a player-type subject,
-    // not fall through to parse_type_phrase returning Any.
+    // not fall through to parse_type_phrase_folding returning Any.
     let (filter, rest) =
         parse_single_subject("an opponent draws a card", &mut ParseContext::default());
     assert!(
@@ -26688,7 +26688,7 @@ fn you_attack_with_one_or_more_gods_populates_filter() {
 }
 
 /// Issue #610 (Anim Pakal class) — negated subtype head noun. "non-Gnome
-/// creatures" must yield a negated-Gnome filter on `valid_card`. `parse_type_phrase`
+/// creatures" must yield a negated-Gnome filter on `valid_card`. `parse_type_phrase_folding`
 /// already emits the negation; verify it survives onto `valid_card`.
 #[test]
 fn you_attack_with_one_or_more_non_gnome_creatures() {
@@ -28802,7 +28802,7 @@ fn high_tide_runtime_bonus_mana_routes_to_triggering_player_and_expires_at_eot()
 
 /// CR 614.12: Summoner's Grimoire's granted ability — the leading
 /// "if that card is an enchantment card" must materialize an
-/// `enters_modified_if` gate on the absorbed ChangeZone (via `parse_type_phrase`),
+/// `enters_modified_if` gate on the absorbed ChangeZone (via `parse_type_phrase_folding`),
 /// not be silently dropped while applying the riders unconditionally.
 #[test]
 fn grimoire_granted_trigger_gates_enters_on_moved_object_type() {

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -17858,9 +17858,9 @@ fn default_distinct_names() -> Vec<SharedQuality> {
 /// the current reading first, that collision can only ever mis-read a LEGACY
 /// payload, and no legacy writer emitted either shape here. The two legacy
 /// producers were `parse_number_of_distinct_colors_among_permanents_tail`
-/// (craft materials → `And { [ExiledBySource, Typed] }`, or a `parse_type_phrase`
+/// (craft materials → `And { [ExiledBySource, Typed] }`, or a `parse_type_phrase_folding`
 /// object filter) and `parse_for_each_distinct_colors_among_permanents`
-/// (`parse_type_phrase` only) — neither can yield a BARE `ExiledBySource` /
+/// (`parse_type_phrase_folding` only) — neither can yield a BARE `ExiledBySource` /
 /// `TrackedSet` filter.
 fn deserialize_distinct_colors_population<'de, D>(
     deserializer: D,

--- a/crates/engine/tests/integration/chosen_color_object_filter.rs
+++ b/crates/engine/tests/integration/chosen_color_object_filter.rs
@@ -1,7 +1,7 @@
 //! Runtime cast-pipeline coverage for the PRINTED chosen-colour object-filter
 //! qualifier — `<type-phrase> of the color of your choice` (CR 105.4).
 //!
-//! Before the fix, `parse_type_phrase_with_ctx` had a trailing chosen-TYPE
+//! Before the fix, `parse_type_phrase_folding_with_ctx` had a trailing chosen-TYPE
 //! qualifier arm but no chosen-COLOUR sibling, so the colour restriction was
 //! silently dropped: Wash Out returned EVERY permanent and Root Greevil
 //! destroyed EVERY enchantment. The fix adds the arm (gated on

--- a/crates/engine/tests/integration/copy_gy_creature_mana_value_x.rs
+++ b/crates/engine/tests/integration/copy_gy_creature_mana_value_x.rs
@@ -1,7 +1,7 @@
 //! dq-f: "becomes a copy of target creature card in your graveyard with mana
 //! value X" (Lazav, the Multifarious; Likeness Looter). The copy target's
 //! mana-value clause TRAILS its zone clause ("… in your graveyard with mana value
-//! X"). Before the zone-then-mana-value second pass in `parse_type_phrase_with_ctx`,
+//! X"). Before the zone-then-mana-value second pass in `parse_type_phrase_folding_with_ctx`,
 //! the trailing "with mana value X" clause was dropped, so (a) the target filter
 //! carried no `FilterProp::Cmc` bound to the announced X, and (b) the leftover
 //! "with mana value X" fragment sat in front of the ", except …" body and blocked

--- a/crates/engine/tests/integration/gimbal_gremlin_prodigy.rs
+++ b/crates/engine/tests/integration/gimbal_gremlin_prodigy.rs
@@ -4,7 +4,7 @@
 //!
 //! Bug (pre-fix): the quantity phrase fell through to the
 //! `oracle_quantity::parse_quantity_ref_with_context` fallback, which calls
-//! `parse_type_phrase_with_ctx` and silently discards the unconsumed
+//! `parse_type_phrase_folding_with_ctx` and silently discards the unconsumed
 //! remainder. "differently named" was unrecognized, so the result was
 //! `QuantityRef::ObjectCount { filter: <empty Typed> }` — a filter that
 //! matches every battlefield permanent. With even a handful of permanents in

--- a/crates/engine/tests/integration/issue_2943_kayas_wrath.rs
+++ b/crates/engine/tests/integration/issue_2943_kayas_wrath.rs
@@ -5,7 +5,7 @@
 //!    you controlled that were destroyed this way."
 //!
 //! Before the fix the lifegain clause lowered to `Effect::Unimplemented` because
-//! `parse_quantity_ref` let `parse_type_phrase` consume "creatures you controlled"
+//! `parse_quantity_ref` let `parse_type_phrase_folding` consume "creatures you controlled"
 //! and leave an unresolved "that were destroyed this way" tail. The fix routes
 //! "the number of … destroyed/sacrificed this way" through
 //! `FilteredTrackedSetSize` before the generic object-count fall-through.

--- a/crates/engine/tests/integration/issue_4772_too_evil_to_stay_dead.rs
+++ b/crates/engine/tests/integration/issue_4772_too_evil_to_stay_dead.rs
@@ -224,7 +224,7 @@ fn too_evil_to_stay_dead_with_teamwork_still_reanimates() {
 // dq-f: the NARROW (no-teamwork) branch's "mana value 4 or less" clause TRAILS
 // its zone clause ("target creature card in your graveyard with mana value 4 or
 // less"). Before the zone-then-mana-value second pass in
-// `parse_type_phrase_with_ctx`, that clause was dropped, so the narrow branch
+// `parse_type_phrase_folding_with_ctx`, that clause was dropped, so the narrow branch
 // behaved identically to the broad (teamwork-paid) branch — any creature card in
 // the graveyard was a legal target regardless of mana value. This test pins that
 // dq-f now correctly restricts the no-teamwork target slot.

--- a/crates/engine/tests/integration/issue_8183_static_gate_fail_open.rs
+++ b/crates/engine/tests/integration/issue_8183_static_gate_fail_open.rs
@@ -78,7 +78,7 @@
 //!     share a creature type", CR 603.4) and **Synchronized Eviction** ("costs
 //!     {2} less to cast if you control at least two creatures that share a
 //!     creature type") both parsed, both reported as supported, and both were
-//!     WRONG: `parse_type_phrase` consumes the relative clause into a
+//!     WRONG: `parse_type_phrase_folding` consumes the relative clause into a
 //!     `FilterProp::SharesQuality { reference: None }`, which is a
 //!     group-SELECTION marker that `filter::evaluate_shares_quality` answers
 //!     TRUE for every object. Inside a `QuantityRef::ObjectCount` that silently

--- a/crates/engine/tests/integration/l02_bb6_conditional_enters_with_counter.rs
+++ b/crates/engine/tests/integration/l02_bb6_conditional_enters_with_counter.rs
@@ -283,7 +283,7 @@ fn enters_with_counter_subject_covers_this_creature_and_that_artifact() {
 /// creature died this turn" → filtered gate; (b) the bare "a creature died this
 /// turn" still yields the UNFILTERED ref (no Morbid regression); (c) a
 /// name-negation ("a creature not named Ebondeath, Dracolich died this turn") is
-/// NOT claimed by the arm (parse_type_phrase leaves "not named …" leftover → the
+/// NOT claimed by the arm (parse_type_phrase_folding leaves "not named …" leftover → the
 /// arm rejects → clean gap). Revert-probe: remove the filtered arm → (a) errors.
 #[test]
 fn filtered_died_this_turn_arm_and_clean_gaps() {

--- a/crates/engine/tests/integration/mutable_pupa_perpetual_keyword_mirror.rs
+++ b/crates/engine/tests/integration/mutable_pupa_perpetual_keyword_mirror.rs
@@ -175,7 +175,7 @@ fn mutable_pupa_accumulates_every_matching_keyword() {
 // `resolve_chain_body` disjunct. CR 608.2c. Oracle text verbatim from
 // data/card-data.json. The counter recipient, "any creature you control", now
 // parses to a real `TargetFilter::Typed{Creature, controller: You}` (see the
-// `parse_type_phrase_with_ctx` "any " quantifier fix) instead of falling back
+// `parse_type_phrase_folding_with_ctx` "any " quantifier fix) instead of falling back
 // to the degenerate `TargetFilter::Any`.
 //
 // CR 608.2d: an untargeted "any creature you control" choice (no literal

--- a/crates/engine/tests/integration/namor_attacking_that_player.rs
+++ b/crates/engine/tests/integration/namor_attacking_that_player.rs
@@ -17,7 +17,7 @@
 //! discriminate it.
 //!
 //! **Defect B — the pump was board-wide.** With "attacking that player"
-//! unconsumed by `parse_type_phrase`, the clause fell through to the numeric
+//! unconsumed by `parse_type_phrase_folding`, the clause fell through to the numeric
 //! imperative path, which emits the documented
 //! `Effect::Pump { target: TargetFilter::Any }` sentinel. `TargetFilter::Any`
 //! matches unconditionally, so +2/+0 landed on every permanent on the

--- a/crates/engine/tests/integration/oversimplify_per_player_fractal.rs
+++ b/crates/engine/tests/integration/oversimplify_per_player_fractal.rs
@@ -14,7 +14,7 @@
 //!      third-person `puts ` verb AND the `"a number of <type> counters on it
 //!      equal to <quantity>"` body (delegating to the shared
 //!      `parse_dynamic_counter_suffix_body`).
-//!   2. Parser — `parse_type_phrase_with_ctx` lowers
+//!   2. Parser — `parse_type_phrase_folding_with_ctx` lowers
 //!      `"creatures they controlled that were exiled this way"` into a
 //!      composite `And{Typed{Creature,ScopedPlayer}, ExiledBySource}` filter.
 //!   3. Engine — `QuantityRef::Aggregate{Power|Toughness}` falls back to the

--- a/crates/engine/tests/integration/squirming_emergence_mana_value_target.rs
+++ b/crates/engine/tests/integration/squirming_emergence_mana_value_target.rs
@@ -1,7 +1,7 @@
 //! dq-f: Squirming Emergence — the target's mana-value clause TRAILS its zone
 //! clause ("target nonland permanent card in your graveyard with mana value less
 //! than or equal to the number of permanent cards in your graveyard"). Before the
-//! zone-then-mana-value second pass in `parse_type_phrase_with_ctx`, the trailing
+//! zone-then-mana-value second pass in `parse_type_phrase_folding_with_ctx`, the trailing
 //! "with mana value …" clause was dropped, so every nonland permanent card in the
 //! graveyard was a legal target regardless of its mana value.
 //!

--- a/crates/engine/tests/integration/statecraft_damage_prevention.rs
+++ b/crates/engine/tests/integration/statecraft_damage_prevention.rs
@@ -77,7 +77,7 @@ fn free_cost() -> ManaCost {
 }
 
 /// "Creatures you control" / "enchanted creature" both resolve to
-/// `TargetFilter::Typed` populated by `parse_type_phrase` /
+/// `TargetFilter::Typed` populated by `parse_type_phrase_folding` /
 /// `parse_attached_host_subject`. `creatures_you_control()` is the shape
 /// Statecraft's subject parses to; used by the parser-shape reach-guards
 /// below to prove the shield actually exists before asserting a negative.

--- a/crates/engine/tests/integration/teysa_wojek_investigate_per_opponent.rs
+++ b/crates/engine/tests/integration/teysa_wojek_investigate_per_opponent.rs
@@ -390,7 +390,7 @@ fn teysa_runtime_no_clue_when_no_opponent_lost_life() {
 // ("for each goaded creature you control") and Sophina ("for each nontoken attacking
 // creature"). The parameterized gate-widen + Gap A (`FilterProp::Goaded`) now lift
 // Serene Sleuth to an `ObjectCount` repeat_for; Sophina stays a bare Investigate
-// (Gap B deferred — parse_type_phrase leading-adjective order-dependence). Both
+// (Gap B deferred — parse_type_phrase_folding leading-adjective order-dependence). Both
 // branches drive the real seam and pair their `repeat_for` assertion with a positive
 // `Effect::Investigate` reach-guard so neither is vacuous.
 const SERENE_SLEUTH: &str = "When this creature enters, investigate. (Create a Clue token. It's \
@@ -558,7 +558,7 @@ fn object_for_each_investigate_is_lifted() {
     );
 
     // Sophina's attack trigger: object for-each ("nontoken attacking creature") —
-    // Gap B (DEFERRED). parse_type_phrase's leading-adjective order-dependence means
+    // Gap B (DEFERRED). parse_type_phrase_folding's leading-adjective order-dependence means
     // this for-each does NOT yet parse to a member-count, so the seam leaves it a bare
     // Investigate. Deferred-gap tripwire: paired with a positive `Effect::Investigate`
     // reach-guard (non-vacuous), it asserts the CURRENT bare-Investigate state and
@@ -576,7 +576,7 @@ fn object_for_each_investigate_is_lifted() {
     );
     assert!(
         attack.repeat_for.is_none(),
-        "Gap B deferred (parse_type_phrase leading-adjective order-dependence): \
+        "Gap B deferred (parse_type_phrase_folding leading-adjective order-dependence): \
          'nontoken attacking creature' does not yet lift — flip this guard when Gap B lands: {:?}",
         attack.repeat_for
     );

--- a/crates/engine/tests/integration/ultimate_spider_man_mass_counter_double.rs
+++ b/crates/engine/tests/integration/ultimate_spider_man_mass_counter_double.rs
@@ -11,7 +11,7 @@
 //!      form to an honest `Effect::Unimplemented`, so the trigger did nothing;
 //!   2. `Effect::Double { DoubleTarget::Counters }` had no battlefield-population
 //!      tier at all, so even a lowered effect would have doubled nothing; and
-//!   3. `parse_type_phrase_with_ctx`'s bare "and"/"or" branch rejected a
+//!   3. `parse_type_phrase_folding_with_ctx`'s bare "and"/"or" branch rejected a
 //!      supertype-led right conjunct, collapsing the population to
 //!      `Typed{[Subtype("Spider")]}` with NO controller — which both misses the
 //!      controller's legendary creatures and reaches across the table.

--- a/scripts/check-skill-doc.sh
+++ b/scripts/check-skill-doc.sh
@@ -154,7 +154,8 @@ fn parse_animation_spec	crates/engine/src/parser/oracle_effect/animation.rs
 fn try_parse_put_counter	crates/engine/src/parser/oracle_effect/counter.rs
 fn try_parse_add_mana_effect	crates/engine/src/parser/oracle_effect/mana.rs
 fn parse_target	crates/engine/src/parser/oracle_target.rs
-fn parse_type_phrase	crates/engine/src/parser/oracle_target.rs
+fn parse_type_phrase_folding(	crates/engine/src/parser/oracle_target.rs
+fn parse_type_phrase(	crates/engine/src/parser/oracle_nom/target.rs
 fn parse_number	crates/engine/src/parser/oracle_util.rs
 fn contains_possessive	crates/engine/src/parser/oracle_util.rs
 fn contains_object_pronoun	crates/engine/src/parser/oracle_util.rs


### PR DESCRIPTION
## Summary

Follow-up to #8600, implementing the rename recommended in review there:

> Two readers, four spellings, one file, and the shortest spelling is the one that silently picks Legacy. That is a naming collision, and this repo's rule is to make a hazard unrepresentable rather than annotate it.

Renames `oracle_target::parse_type_phrase` → **`parse_type_phrase_folding`** (and its delegate → `parse_type_phrase_folding_with_ctx`), leaving the nom reader as `parse_type_phrase`. The name now records the grammar: the folding reader folds a type list across all of `TYPE_SEPARATORS`, where the nom reader joins on `" or "` alone.

Behavior-preserving — renames only, no logic changes.

### Before / after in the file the review measured

`oracle_effect/mod.rs`, where the token resolved four ways:

| spelling | reader | before | after |
|---|---|---|---|
| `parse_type_phrase(..)` bare, via `use` | folding | 11 | **0** |
| `super::oracle_target::parse_type_phrase(..)` | folding | 5 | **0** |
| `parse_type_phrase_folding(..)` (bare + qualified) | folding | — | 43 |
| `super::oracle_nom::target::parse_type_phrase(..)` | nom | 4 | 4 |
| `nom_target::parse_type_phrase(..)` | nom | 1 | 1 |

The bare token `parse_type_phrase(` now appears **only** on explicitly nom-qualified lines. The shortest spelling no longer silently selects the folding reader.

## Sites deliberately NOT renamed

The nom reader keeps its name, so every site resolving to it had to be excluded. Three needed care beyond a token match:

- **`oracle_trigger.rs:39`** — `use super::oracle_nom::target::parse_type_phrase as parse_type_phrase_nom;`, in the one file that imports **both** readers (lines 41-44 import the folding one). A token-level rewrite would have re-pointed that alias at the folding reader; its 3 call sites would then have failed only because the return types happen to differ.
- **Value positions in `oracle_effect/mod.rs`** — `parse_type_phrase.parse(i)?` (`:13539`) and `preceded(space1, …parse_type_phrase)` (`:14926`) pass the nom reader as a combinator rather than calling it.
- **`oracle_nom/target.rs`** — refers to its own function unqualified throughout, so the whole module is excluded. (My first pass renamed the nom declaration itself; caught and reverted before commit.)

Also handled: `oracle_static/mod.rs:39` re-exports the name through a `prelude` that ~11 submodules consume via glob, so those call sites carry no local `use`; and `\bparse_type_phrase\b(?!_)` protects the prefix-sharing `parse_type_phrase_with_ctx` (81 occurrences), `parse_type_phrase_nom`, `parse_type_phrase_nonempty`, and ~50 `#[test] fn parse_type_phrase_*` names.

## Verification

`oracle_target` is `pub(crate)` (`parser/mod.rs:23`) and nothing outside `crates/engine` references this function, so the compiler is a **complete** oracle here — a missed or mis-flipped site cannot fail silently in a downstream crate.

- `cargo check -p phase-engine --all-targets` — **clean, exit 0** (covers the lib, inline `#[cfg(test)]` modules, and the integration test binary).
- `cargo fmt --all` — clean.
- Residual-reference sweep: zero unqualified `parse_type_phrase` outside the nom module and nom-qualified paths.

54 files, +1023/-959. Most of the churn is call sites and prose comments that name the reader.

## Noted, not fixed

`parse_type_phrase_nonempty` (`oracle_nom/condition.rs`) guards its result with `matches!(filter, TargetFilter::Any)`, but the folding reader never returns `Any` — its no-match shape is an empty `TypedFilter` plus the whole input, which is exactly the hazard #8600 documents. So that guard does not fire on the case it names. Pre-existing on `main` (verified against the merge-base), and a behavior change, so it is left for a separate PR rather than smuggled into a rename.

## Ordering

Independent of #8600 — they touch the same two declarations, so whichever lands second will need a trivial rebase. #8600's doc comments are carried forward here in their post-rename form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved parsing of compound card and object descriptions, including disjunctions, qualifiers, and suffixes.
  * Fixed cases where portions of type-based phrases were left unparsed or incorrectly reported as unrecognized.
  * Added stricter handling for incomplete filters and trailing punctuation in parsed conditions.
* **Tests**
  * Updated regression coverage and documentation to reflect the improved parsing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->