### PR TITLE
fix(engine): key the action boundary's owner slots to the controlled seat at every entrypoint

### DIFF
--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -1392,7 +1392,8 @@ fn apply_action_boundary_core(
     stack_resolution_limit: Option<u32>,
 ) -> Result<RawActionApplication, EngineError> {
     let lifecycle = super::lifecycle::enter_action_frame();
-    if let Err(error) = mana_sources::preflight_tap_land_action(state, semantic_owner, &action) {
+    if let Err(error) = mana_sources::preflight_tap_land_action(state, authenticated_actor, &action)
+    {
         lifecycle.discard();
         return Err(error);
     }
@@ -7404,14 +7405,7 @@ fn check_actor_authorization(
     actor: PlayerId,
     action: &GameAction,
 ) -> Result<(), EngineError> {
-    if action.is_actor_scoped_preference()
-        || matches!(
-            action,
-            GameAction::Debug(_)
-                | GameAction::GrantDebugPermission { .. }
-                | GameAction::RevokeDebugPermission { .. }
-        )
-    {
+    if action.is_submitter_scoped() {
         return Ok(());
     }
     if let GameAction::RevokeResolveAllConsent {
@@ -7447,14 +7441,21 @@ fn check_actor_authorization(
     Ok(())
 }
 
-/// Engine-internal convenience: apply `action` as the player the engine is
-/// currently waiting on. Intended for simulation (AI search, legal-action
+/// Engine-internal convenience: apply `action` on behalf of the player the
+/// engine is currently waiting on, submitted by whoever is authorized to
+/// submit for that player. Intended for simulation (AI search, legal-action
 /// probing) and tests — *not* for transport adapters, which must pass a
 /// transport-authenticated `actor` to [`apply`] directly.
 ///
-/// For [`GameAction::Concede`] the concede payload's `player_id` is used as
-/// the actor, so tests can concede any player without first maneuvering the
-/// `WaitingFor` state onto that player.
+/// CR 723.3 + CR 723.5: under a player-control effect those are two different
+/// players, so both halves of the action boundary are derived here from one
+/// authority instead of being collapsed onto the submitter. [`apply`] and
+/// [`apply_for_simulation`] remain the collapsed forms, for callers that hold
+/// a trusted actor and no owner information to split from.
+///
+/// For [`GameAction::Concede`] the concede payload's `player_id` fills both
+/// halves (CR 723.6), so tests can concede any player without first
+/// maneuvering the `WaitingFor` state onto that player.
 pub fn apply_as_current(
     state: &mut GameState,
     action: GameAction,
@@ -7487,21 +7488,40 @@ fn apply_as_current_with_mode(
     action: GameAction,
     mode: PublicFinalizeMode,
 ) -> Result<ActionResult, EngineError> {
-    let actor = match &action {
-        GameAction::Concede { player_id } => *player_id,
-        // CR 103.5: For simultaneous-decision states, pick the first pending
-        // player as the simulation representative. `authorized_submitters`
-        // returns the full set; `first()` is deterministic (seat-ordered).
+    let (authenticated_actor, semantic_owner) = match &action {
+        // CR 723.6: the controller of another player can't make that player
+        // concede, so a concession is its own submitter and its own owner.
+        GameAction::Concede { player_id } => (*player_id, *player_id),
         _ => {
-            let submitters = turn_control::authorized_submitters(state);
-            submitters.first().copied().ok_or_else(|| {
+            // CR 103.5: For simultaneous-decision states, pick the first
+            // pending player as the simulation representative. `acting_players`
+            // returns the full set; `first()` is deterministic (seat-ordered).
+            let acting = state.waiting_for.acting_players();
+            let owner = *acting.first().ok_or_else(|| {
                 EngineError::InvalidAction(
                     "apply_as_current: no authorized submitter (game over?)".to_string(),
                 )
-            })?
+            })?;
+            // CR 723.3 + CR 723.5: the controller makes the controlled player's
+            // choices, but only control of the player changes — the decision
+            // seat the reducer keys stays the controlled player.
+            let submitter = turn_control::authorized_submitter_for_player(state, owner);
+            if action.is_submitter_scoped() {
+                // CR 723.5b: an action naming the submitting seat rather than a
+                // decision slot is not a choice control redirects.
+                (submitter, submitter)
+            } else {
+                (submitter, owner)
+            }
         }
     };
-    apply_action_boundary(state, actor, action, mode)
+    apply_action_boundary_for_semantic_owner(
+        state,
+        authenticated_actor,
+        semantic_owner,
+        action,
+        mode,
+    )
 }
 
 /// The action boundary at which a typed cost-move root is allowed to resume.
@@ -10066,7 +10086,9 @@ fn apply_action(
             {
                 return Err(EngineError::NotYourPriority);
             }
-            handle_untap_land_for_mana(state, state.priority_player, object_id, &mut events)?;
+            // CR 723.5a: the tap booked to the seat, so the undo must look it up
+            // there rather than under its authorized submitter.
+            handle_untap_land_for_mana(state, *player, object_id, &mut events)?;
             WaitingFor::Priority { player: *player }
         }
         (
@@ -10143,13 +10165,16 @@ fn apply_action(
                 // allows undo — painlands (damage on resolution), pay-life
                 // sources, and sacrifice sources all commit irreversible
                 // state atomically with CR 605.3b resolution.
+                // CR 723.5a: a controller spends only the controlled player's
+                // resources, so the tap books to the seat holding priority, not
+                // to the player authorized to submit for it.
                 if is_land
                     && mana_sources::object_mana_ability_penalty(state, source_id, &ability_def)
                         .is_undoable()
                 {
                     state
                         .lands_tapped_for_mana
-                        .entry(state.priority_player)
+                        .entry(*player)
                         .or_default()
                         .push(source_id);
                 }
@@ -12290,7 +12315,9 @@ fn apply_action(
             },
             GameAction::UntapLandForMana { object_id },
         ) => {
-            handle_untap_land_for_mana(state, state.priority_player, object_id, &mut events)?;
+            // CR 723.5a: this arm's paired tap keys the seat, so its undo must
+            // too — the submitter may be a different player under turn control.
+            handle_untap_land_for_mana(state, *player, object_id, &mut events)?;
             WaitingFor::ManaPayment {
                 player: *player,
                 convoke_mode: *convoke_mode,

--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -7450,8 +7450,8 @@ fn check_actor_authorization(
 /// CR 723.3 + CR 723.5: under a player-control effect those are two different
 /// players, so both halves of the action boundary are derived here from one
 /// authority instead of being collapsed onto the submitter. [`apply`] and
-/// [`apply_for_simulation`] remain the collapsed forms, for callers that hold
-/// a trusted actor and no owner information to split from.
+/// [`apply_for_simulation`] remain the collapsed forms because a transport has
+/// no *trusted* owner to pass, not because none exists.
 ///
 /// For [`GameAction::Concede`] the concede payload's `player_id` fills both
 /// halves (CR 723.6), so tests can concede any player without first
@@ -9846,9 +9846,10 @@ fn apply_action(
         state.loop_answer_journal = None;
     }
 
-    // Keep the semantic owner of the prompt before reducing it. Under turn
-    // control this can differ from the authenticated submitter; a successful
-    // action discharges a shortened shortcut only for that owner.
+    // The prompt's semantic owner: the seat `state.waiting_for` names, or the
+    // authenticated submitter where it names no single seat. Under turn control
+    // the two can differ. The simultaneous mulligan arms below do not read it —
+    // they resolve their per-player state from the `actor` parameter.
     let semantic_actor = state.waiting_for.acting_player().unwrap_or(actor);
     let action_for_divergence = action.clone();
 
@@ -9857,9 +9858,11 @@ fn apply_action(
     // seat, not necessarily to its authenticated submitter. In
     // particular, a turn controller can act for P0; tearing down P2's
     // representative instead would leave P0's frozen cohort live and let the
-    // boundary runner resolve an entry after P0 deliberately acted. Outside a
-    // Priority window retain the authenticated actor: simultaneous mulligan
-    // variants have no single semantic priority seat.
+    // boundary runner resolve an entry after P0 deliberately acted.
+    // CR 723.3 + CR 723.5: outside a Priority window the prompt's own seat owns
+    // the preference, which is what `semantic_actor` names; its
+    // `unwrap_or(actor)` fallback keeps the authenticated actor wherever
+    // `state.waiting_for` names no single seat.
     // CR 117.6 + CR 805.5b: Canonicalize that seat before consulting a
     // session, because a shared team's representative owns its priority pass.
     let session_preference_owner = match (&state.waiting_for, &action) {
@@ -9870,7 +9873,7 @@ fn apply_action(
         (WaitingFor::Priority { player }, _) => {
             super::topology::priority_pass_representative(state, *player)
         }
-        _ => actor,
+        _ => semantic_actor,
     };
     match &action {
         GameAction::SetAutoPass { .. }
@@ -9909,6 +9912,8 @@ fn apply_action(
 
     // Clear manual mana-tap tracking when the player commits to a non-mana action.
     // ActivateAbility is handled per-arm (only non-mana abilities clear tracking).
+    // CR 723.5a: the tracking records whose resources were spent, so it is keyed
+    // to the seat that spent them, as the insert side already is.
     match &action {
         GameAction::PassPriority
         | GameAction::PlayLand { .. }
@@ -9924,7 +9929,7 @@ fn apply_action(
         | GameAction::RollPlanarDie
         | GameAction::PayUnlessCost { .. }
         | GameAction::PayCombatTax { .. } => {
-            state.lands_tapped_for_mana.remove(&actor);
+            state.lands_tapped_for_mana.remove(&semantic_actor);
         }
         _ => {}
     }
@@ -11588,7 +11593,7 @@ fn apply_action(
             WaitingFor::PrecastCopyShortcutOffer { .. }
             | WaitingFor::RespondToPrecastCopyShortcut { .. },
             GameAction::PrecastCopyShortcut { epoch, response },
-        ) => super::precast_copy_shortcut::handle(state, actor, epoch, response, &mut events)?,
+        ) => super::precast_copy_shortcut::handle(state, epoch, response, &mut events)?,
         // CR 732.2b/c: an opponent answers the loop-shortcut offer.
         (
             WaitingFor::RespondToShortcut {

--- a/crates/engine/src/game/interaction.rs
+++ b/crates/engine/src/game/interaction.rs
@@ -861,6 +861,11 @@ pub(crate) fn semantic_owner_for_actor(state: &GameState, actor: PlayerId) -> Op
         .find(|owner| interaction_submitter_for_owner(state, *owner) == actor)
 }
 
+/// Whether this action leaves an open interaction standing.
+///
+/// Not [`GameAction::is_submitter_scoped`], whose near-identical list answers a
+/// different question — whether an action may skip the seat check. The two
+/// lists may diverge.
 pub(crate) fn action_preserves_interaction(action: &GameAction) -> bool {
     matches!(
         action,

--- a/crates/engine/src/game/mana_sources.rs
+++ b/crates/engine/src/game/mana_sources.rs
@@ -837,9 +837,13 @@ fn live_mana_output_units(
 /// Pure action-boundary validation for semantic land-mana submissions. It is
 /// deliberately called before interaction rebinding or transient-state cleanup
 /// so a hostile stale/ambiguous payload leaves the complete game state intact.
+/// `authenticated_actor` is the submitting connection, not the seat whose mana
+/// sources are being activated: CR 723.5a lets a controller spend only the
+/// controlled player's resources, so the seat comes from `state.waiting_for`
+/// and only the right to submit for it is checked here.
 pub(crate) fn preflight_tap_land_action(
     state: &GameState,
-    player: PlayerId,
+    authenticated_actor: PlayerId,
     action: &GameAction,
 ) -> Result<(), EngineError> {
     if !matches!(action, GameAction::TapLandForMana { .. }) {
@@ -858,7 +862,7 @@ pub(crate) fn preflight_tap_land_action(
     // CR 723.5 + CR 723.5a: a turn controller makes the waiting player's
     // choices, but activates that player's mana sources and spends only that
     // player's resources.
-    if turn_control::authorized_submitter_for_player(state, waiting_player) != player {
+    if turn_control::authorized_submitter_for_player(state, waiting_player) != authenticated_actor {
         return Err(EngineError::WrongPlayer);
     }
     let matches = activatable_mana_actions_for_player(state, waiting_player)

--- a/crates/engine/src/game/precast_copy_shortcut.rs
+++ b/crates/engine/src/game/precast_copy_shortcut.rs
@@ -20,7 +20,7 @@ use crate::types::identifiers::ObjectId;
 use crate::types::player::PlayerId;
 use crate::types::triggers::TriggerMode;
 
-use super::{engine::EngineError, turn_control};
+use super::engine::EngineError;
 
 /// Bounded proof length for the finite clone route, keeping shortcut replay
 /// nonlethal and below the engine's per-action work limit.
@@ -93,9 +93,12 @@ pub(super) fn maybe_offer_after_cast_triggers(
 /// Handles all pre-cast protocol actions. The public state carries only opaque
 /// epoch/breakpoint ids; route validation and replay data are read solely from
 /// the private sidecar.
+///
+/// CR 723.5: submitter authorization is settled at the action boundary before
+/// this runs, so the response dispatches on the open prompt and the live offer
+/// alone.
 pub(super) fn handle(
     state: &mut GameState,
-    actor: PlayerId,
     epoch: u64,
     response: PrecastCopyShortcutResponse,
     events: &mut Vec<GameEvent>,
@@ -112,19 +115,14 @@ pub(super) fn handle(
     }
 
     match (&state.waiting_for, response) {
-        (
-            WaitingFor::PrecastCopyShortcutOffer { proposer, .. },
-            PrecastCopyShortcutResponse::Decline,
-        ) if actor == turn_control::authorized_submitter_for_player(state, *proposer) => {
+        (WaitingFor::PrecastCopyShortcutOffer { .. }, PrecastCopyShortcutResponse::Decline) => {
             suppress_current_offer(state, &offer);
             Ok(priority_for(offer.caster))
         }
         (
-            WaitingFor::PrecastCopyShortcutOffer { proposer, .. },
+            WaitingFor::PrecastCopyShortcutOffer { .. },
             PrecastCopyShortcutResponse::Propose { route_id },
-        ) if actor == turn_control::authorized_submitter_for_player(state, *proposer)
-            && route_id == offer.route_id =>
-        {
+        ) if route_id == offer.route_id => {
             if let Some((&next, rest)) = offer.responders.split_first() {
                 Ok(responder_wait(next, offer.epoch, rest, &offer.breakpoints))
             } else {
@@ -133,12 +131,10 @@ pub(super) fn handle(
         }
         (
             WaitingFor::RespondToPrecastCopyShortcut {
-                player,
-                remaining_players,
-                ..
+                remaining_players, ..
             },
             PrecastCopyShortcutResponse::Accept,
-        ) if actor == turn_control::authorized_submitter_for_player(state, *player) => {
+        ) => {
             if let Some((&next, rest)) = remaining_players.split_first() {
                 Ok(responder_wait(next, offer.epoch, rest, &offer.breakpoints))
             } else {
@@ -152,7 +148,7 @@ pub(super) fn handle(
                 ..
             },
             PrecastCopyShortcutResponse::Shorten { breakpoint_id },
-        ) if actor == turn_control::authorized_submitter_for_player(state, *player) => {
+        ) => {
             let Some(breakpoint) = offer
                 .breakpoints
                 .iter()

--- a/crates/engine/src/game/triggers_devour_runtime_tests.rs
+++ b/crates/engine/src/game/triggers_devour_runtime_tests.rs
@@ -977,10 +977,11 @@ fn b2_devour_producer_path_leaves_no_dispatching_drain() {
 /// installed a drain.
 ///
 /// **H7 — guard, the non-interference witness for the ENTRY call site.** The
-/// submission below routes `apply_as_current -> apply_as_current_with_mode ->
-/// apply_action_boundary -> apply_action_boundary_with_stack_limit ->
-/// apply_action_boundary_core`, so the entry-side sweep added at that function
-/// runs on THIS state — a healthy one, parked mid-prompt with a live owner.
+/// submission below routes `apply_as_current -> apply_as_current_with_mode
+/// -> apply_action_boundary_for_semantic_owner
+/// -> apply_action_boundary_with_stack_limit -> apply_action_boundary_core`,
+/// so the entry-side sweep added at that function runs on THIS state — a
+/// healthy one, parked mid-prompt with a live owner.
 /// This row is therefore also the row that ESTABLISHES the premise §5.4's
 /// safety rests on: parked-awaiting-input work carries `Paused`, never
 /// `Dispatching` (CR 614.12a — the as-enters choice is still being made, so the
@@ -999,7 +1000,8 @@ fn h1_devour_empty_sacrifice_retires_its_drain_and_frame() {
 
     // NON-INTERFERENCE WITNESS for the entry-side sweep added at
     // `engine::apply_action_boundary_core`. The submission below routes
-    // `apply_as_current -> apply_as_current_with_mode -> apply_action_boundary
+    // `apply_as_current -> apply_as_current_with_mode
+    //  -> apply_action_boundary_for_semantic_owner
     //  -> apply_action_boundary_with_stack_limit -> apply_action_boundary_core`,
     // so the entry sweep runs on THIS state — a healthy one, parked mid-prompt
     // with a live owner. CR 614.12a: the as-enters choice is still being made,

--- a/crates/engine/src/types/actions.rs
+++ b/crates/engine/src/types/actions.rs
@@ -1813,6 +1813,24 @@ impl GameAction {
         )
     }
 
+    /// Whether this action names the submitting seat itself rather than a
+    /// decision slot the engine is waiting on.
+    ///
+    /// CR 723.5b: the controller of another player can't make choices or
+    /// decisions for that player that aren't called for by the rules or by any
+    /// objects. A UI preference mutates the submitter's own slot and a debug
+    /// capability grant authorizes the submitting connection — neither is such
+    /// a choice, so controlling a player must not redirect either one.
+    pub fn is_submitter_scoped(&self) -> bool {
+        self.is_actor_scoped_preference()
+            || matches!(
+                self,
+                GameAction::Debug(_)
+                    | GameAction::GrantDebugPermission { .. }
+                    | GameAction::RevokeDebugPermission { .. }
+            )
+    }
+
     /// Issue #4878: allocation-free total order over `GameAction`, used for
     /// deterministic AI candidate / legal-action sorting. Orders by the
     /// `GameActionKind` discriminant first, then by payload fields, so equal

--- a/crates/engine/src/types/actions.rs
+++ b/crates/engine/src/types/actions.rs
@@ -1821,6 +1821,11 @@ impl GameAction {
     /// objects. A UI preference mutates the submitter's own slot and a debug
     /// capability grant authorizes the submitting connection — neither is such
     /// a choice, so controlling a player must not redirect either one.
+    ///
+    /// Not `game::interaction::action_preserves_interaction`, whose
+    /// near-identical list answers a different question: this one decides
+    /// whether an action may skip the seat check, that one whether an action
+    /// leaves an open interaction standing. The two lists may diverge.
     pub fn is_submitter_scoped(&self) -> bool {
         self.is_actor_scoped_preference()
             || matches!(

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -1188,6 +1188,7 @@ mod trk_compound_short_names;
 mod true_conviction_double_keyword_grant;
 mod turn_based_draw_step_miracle_offer;
 mod turn_control_priority_softlock;
+mod turn_control_semantic_owner;
 mod twice_instead_repeat_for;
 mod twilight_prophet_upkeep_drain_1375;
 mod typhoon_per_opponent_island_count;

--- a/crates/engine/tests/integration/precast_copy_shortcut.rs
+++ b/crates/engine/tests/integration/precast_copy_shortcut.rs
@@ -5,11 +5,12 @@ use std::path::Path;
 use std::sync::OnceLock;
 
 use engine::database::card_db::CardDatabase;
-use engine::game::engine::apply;
+use engine::game::engine::{apply, apply_as_current};
 use engine::game::game_object::GameObject;
 use engine::game::scenario::{GameRunner, GameScenario, P0, P1};
 use engine::game::scenario_db::GameScenarioDbExt;
 use engine::game::zones::{add_to_zone, create_object, remove_from_zone};
+use engine::game::EngineError;
 use engine::game::{filter_state_for_viewer, normalize_untrusted_restore};
 use engine::types::ability::{
     CardSelectionMode, ContinuousModification, CopyRetargetPermission, Effect, QuantityExpr,
@@ -387,6 +388,114 @@ fn precast_controlled_caster_uses_authorized_submitter_for_protocol_actions() {
         WaitingFor::Priority { player } if player == P0
     ));
     assert_eq!(declined.state().priority_player, P1);
+}
+
+/// A controlled board at the pre-cast offer, with `turn_decision_controller`
+/// latched onto P1 and P0 the offer's proposer.
+fn controlled_offer(controller: Option<PlayerId>) -> (GameRunner, u64) {
+    let (mut runner, chain, _) = setup_shortcut(2);
+    {
+        let state = runner.state_mut();
+        state.turn_decision_controller = controller;
+        engine::game::public_state::sync_waiting_for(state, &WaitingFor::Priority { player: P0 });
+    }
+    let epoch = cast_to_offer(&mut runner, chain);
+    (runner, epoch)
+}
+
+fn protocol_action(epoch: u64, response: PrecastCopyShortcutResponse) -> GameAction {
+    GameAction::PrecastCopyShortcut { epoch, response }
+}
+
+/// CR 723.5: submitter authorization is settled at the action boundary, so the
+/// protocol handler resolves the response against the prompt it answers and the
+/// owner-derived boundary form reaches it under control.
+#[test]
+fn a_controlled_offer_is_proposed_and_declined_through_the_owner_derived_boundary() {
+    for controller in [Some(P1), None] {
+        let (mut proposed, epoch) = controlled_offer(controller);
+        apply_as_current(
+            proposed.state_mut(),
+            protocol_action(
+                epoch,
+                PrecastCopyShortcutResponse::Propose { route_id: epoch },
+            ),
+        )
+        .expect("the proposal reaches the handler through the owner-derived boundary");
+        assert!(
+            matches!(
+                proposed.state().waiting_for,
+                WaitingFor::RespondToPrecastCopyShortcut { .. }
+            ),
+            "controller={controller:?} must advance to the responder wait, got {:?}",
+            proposed.state().waiting_for
+        );
+
+        let (mut declined, epoch) = controlled_offer(controller);
+        apply_as_current(
+            declined.state_mut(),
+            protocol_action(epoch, PrecastCopyShortcutResponse::Decline),
+        )
+        .expect("the decline reaches the handler through the owner-derived boundary");
+        assert!(
+            matches!(
+                declined.state().waiting_for,
+                WaitingFor::Priority { player } if player == P0
+            ),
+            "controller={controller:?} must return priority to the caster, got {:?}",
+            declined.state().waiting_for
+        );
+    }
+}
+
+/// The deletion moved no authorization: the controlled proposer still cannot
+/// submit its own response, and a proposal that does not name the live offer's
+/// route is still refused by the conjunct that survives.
+#[test]
+fn a_controlled_offer_still_refuses_an_unauthorized_submitter_and_a_stale_route() {
+    let (mut runner, epoch) = controlled_offer(Some(P1));
+    assert!(
+        matches!(
+            apply(
+                runner.state_mut(),
+                P0,
+                protocol_action(epoch, PrecastCopyShortcutResponse::Decline)
+            ),
+            Err(EngineError::WrongPlayer)
+        ),
+        "the controlled semantic owner is not an authorized submitter"
+    );
+    assert!(
+        apply(
+            runner.state_mut(),
+            P1,
+            protocol_action(
+                epoch,
+                PrecastCopyShortcutResponse::Propose {
+                    route_id: epoch ^ 1
+                }
+            )
+        )
+        .is_err(),
+        "a proposal must still name the live offer's route"
+    );
+    assert!(
+        matches!(
+            runner.state().waiting_for,
+            WaitingFor::PrecastCopyShortcutOffer { .. }
+        ),
+        "both refusals leave the offer standing"
+    );
+
+    apply(
+        runner.state_mut(),
+        P1,
+        protocol_action(
+            epoch,
+            PrecastCopyShortcutResponse::Propose { route_id: epoch },
+        ),
+    )
+    .expect("the same board accepts the authorized submitter's live-route proposal");
 }
 
 /// CR 732.2b-c: every responder answers after a shorten and the selected

--- a/crates/engine/tests/integration/turn_control_semantic_owner.rs
+++ b/crates/engine/tests/integration/turn_control_semantic_owner.rs
@@ -1,0 +1,642 @@
+//! CR 723: the action boundary authorizes the player allowed to submit an
+//! action while keying player-scoped state to the seat whose decision it is.
+//!
+//! CR 723.5 sends the controlled player's choices to the controller, CR 723.3
+//! leaves the decision seat its own, and CR 723.5a lets the controller spend
+//! only that seat's resources. `apply_as_current` derived one player and used
+//! it for both, and under control the `state.priority_player` sites wrote the
+//! controller's key while their paired sites wrote the seat's. CR 723.5b
+//! bounds the redirect: an action that names the submitting seat is not a
+//! choice control redirects.
+
+use engine::game::engine::{apply_as_current, apply_interaction_for_simulation};
+use engine::game::mana_sources::activatable_mana_actions_for_player;
+use engine::game::public_state::sync_waiting_for;
+use engine::game::scenario::{GameRunner, GameScenario, P0, P1};
+use engine::game::turn_control::authorized_submitter_for_player;
+use engine::game::EngineError;
+use engine::types::ability::{AbilityCost, Effect, ResolvedAbility};
+use engine::types::actions::{DebugAction, GameAction};
+use engine::types::game_state::{AutoPassMode, TurnBoundary, WaitingFor};
+use engine::types::identifiers::ObjectId;
+use engine::types::mana::{ManaColor, ManaCost, ManaCostShard};
+use engine::types::phase::{Phase, PhaseStop, PhaseStopScope};
+use engine::types::player::PlayerId;
+use engine::types::zones::Zone;
+
+const P2: PlayerId = PlayerId(2);
+const P3: PlayerId = PlayerId(3);
+
+const OPPOSITION_AGENT: &str = "Flash\n\
+You control your opponents while they're searching their libraries.\n\
+While an opponent is searching their library, they exile each card they find. You may play those cards for as long as they remain exiled, and you may spend mana as though it were mana of any color to cast them.";
+const TEST_TUTOR: &str =
+    "Search your library for a card, put that card into your hand, then shuffle.";
+
+/// Put `seat` on a priority window, optionally under `controller`'s CR 723
+/// player control, re-deriving `priority_player` the way the engine does.
+fn install_priority(runner: &mut GameRunner, seat: PlayerId, controller: Option<PlayerId>) {
+    let state = runner.state_mut();
+    state.active_player = seat;
+    state.turn_decision_controller = controller;
+    state.priority_passes.clear();
+    sync_waiting_for(state, &WaitingFor::Priority { player: seat });
+}
+
+/// Non-vacuity guard: a row exercises the split only while the seat's decisions
+/// are submittable by a different player.
+fn assert_seat_submits_through(runner: &GameRunner, seat: PlayerId, submitter: PlayerId) {
+    assert_eq!(
+        authorized_submitter_for_player(runner.state(), seat),
+        submitter,
+        "the seat's authorized submitter decides whether this row discriminates"
+    );
+}
+
+fn tracked_seats(runner: &GameRunner) -> Vec<PlayerId> {
+    let mut seats: Vec<PlayerId> = runner
+        .state()
+        .lands_tapped_for_mana
+        .keys()
+        .copied()
+        .collect();
+    seats.sort_by_key(|player| player.0);
+    seats
+}
+
+fn tracked_lands(runner: &GameRunner, seat: PlayerId) -> Vec<ObjectId> {
+    runner
+        .state()
+        .lands_tapped_for_mana
+        .get(&seat)
+        .cloned()
+        .unwrap_or_default()
+}
+
+/// Four seats, each with one Forest already booked as manually tapped for mana.
+fn four_player_board_with_every_seat_tracked(controller: Option<PlayerId>) -> GameRunner {
+    let mut scenario = GameScenario::new_n_player(4, 42);
+    scenario.at_phase(Phase::PreCombatMain);
+    let lands: Vec<(PlayerId, ObjectId)> = [P0, P1, P2, P3]
+        .into_iter()
+        .map(|seat| (seat, scenario.add_basic_land(seat, ManaColor::Green)))
+        .collect();
+    let mut runner = scenario.build();
+    install_priority(&mut runner, P1, controller);
+    for (seat, land) in lands {
+        runner
+            .state_mut()
+            .lands_tapped_for_mana
+            .insert(seat, vec![land]);
+    }
+    runner
+}
+
+/// One Forest on the acting seat's battlefield, at that seat's priority window.
+fn land_board(seats: u8, controller: Option<PlayerId>) -> (GameRunner, ObjectId) {
+    let mut scenario = GameScenario::new_n_player(seats, 42);
+    scenario.at_phase(Phase::PreCombatMain);
+    let forest = scenario.add_basic_land(P1, ManaColor::Green);
+    let mut runner = scenario.build();
+    install_priority(&mut runner, P1, controller);
+    (runner, forest)
+}
+
+/// The tap action the engine itself enumerates for `seat` — never hand-built.
+fn engine_authored_tap(runner: &GameRunner, seat: PlayerId, land: ObjectId) -> GameAction {
+    activatable_mana_actions_for_player(runner.state(), seat)
+        .into_iter()
+        .find(|action| {
+            matches!(
+                action,
+                GameAction::TapLandForMana { selection } if selection.source.object_id == land
+            )
+        })
+        .expect("the engine enumerates a land tap for the seat")
+}
+
+/// CR 723.5a: a `PassPriority` clears the manual mana tracking of the seat that
+/// passed, not of the player authorized to submit that pass.
+#[test]
+fn a_pass_clears_the_controlled_seats_mana_tracking() {
+    let mut runner = four_player_board_with_every_seat_tracked(Some(P0));
+    assert_seat_submits_through(&runner, P1, P0);
+    assert_eq!(tracked_seats(&runner), vec![P0, P1, P2, P3]);
+
+    apply_as_current(runner.state_mut(), GameAction::PassPriority)
+        .expect("the controller passes the controlled seat's priority");
+
+    assert_eq!(
+        tracked_seats(&runner),
+        vec![P0, P2, P3],
+        "only the passing seat's tracking clears"
+    );
+}
+
+/// Reach guard for the row above: with no control effect the same board, the
+/// same call and the same expected set must hold.
+#[test]
+fn a_pass_clears_its_own_seats_mana_tracking_without_control() {
+    let mut runner = four_player_board_with_every_seat_tracked(None);
+    assert_seat_submits_through(&runner, P1, P1);
+
+    apply_as_current(runner.state_mut(), GameAction::PassPriority)
+        .expect("the seat passes its own priority");
+
+    assert_eq!(tracked_seats(&runner), vec![P0, P2, P3]);
+}
+
+/// CR 723.9: an effect may give a player control of themselves, and that player
+/// then makes their own decisions — indistinguishable from no control at all.
+#[test]
+fn self_control_clears_the_same_seat_as_no_control() {
+    let mut runner = four_player_board_with_every_seat_tracked(Some(P1));
+    assert_seat_submits_through(&runner, P1, P1);
+
+    apply_as_current(runner.state_mut(), GameAction::PassPriority)
+        .expect("a self-controlling seat passes its own priority");
+
+    assert_eq!(tracked_seats(&runner), vec![P0, P2, P3]);
+}
+
+/// CR 723.5 + CR 723.5a: the controller may submit the controlled seat's land
+/// tap through either boundary form, and the mana books to that seat.
+#[test]
+fn the_controllers_land_tap_is_accepted_and_books_to_the_controlled_seat() {
+    let (mut runner, forest) = land_board(2, Some(P0));
+    assert_seat_submits_through(&runner, P1, P0);
+    let tap = engine_authored_tap(&runner, P1, forest);
+    apply_as_current(runner.state_mut(), tap).expect("the controller taps the seat's land");
+    assert_eq!(tracked_lands(&runner, P1), vec![forest]);
+    assert_eq!(tracked_seats(&runner), vec![P1]);
+
+    let (mut runner, forest) = land_board(2, Some(P0));
+    let tap = engine_authored_tap(&runner, P1, forest);
+    apply_interaction_for_simulation(runner.state_mut(), P0, P1, tap)
+        .expect("the split boundary accepts the same tap");
+    assert_eq!(tracked_lands(&runner, P1), vec![forest]);
+}
+
+/// CR 723.5: while controlled, the seat itself is not an authorized submitter,
+/// so its own tap must be refused.
+#[test]
+fn the_controlled_seat_may_not_submit_its_own_land_tap() {
+    let (mut runner, forest) = land_board(2, Some(P0));
+    let tap = engine_authored_tap(&runner, P1, forest);
+
+    assert!(
+        matches!(
+            apply_interaction_for_simulation(runner.state_mut(), P1, P1, tap),
+            Err(EngineError::WrongPlayer)
+        ),
+        "the controlled seat is not its own authorized submitter"
+    );
+    assert!(runner.state().lands_tapped_for_mana.is_empty());
+}
+
+/// Reach guard: uncontrolled, the seat's own tap is accepted through both forms
+/// and books to the seat.
+#[test]
+fn an_uncontrolled_seat_taps_its_own_land_through_both_boundary_forms() {
+    let (mut runner, forest) = land_board(2, None);
+    assert_seat_submits_through(&runner, P1, P1);
+    let tap = engine_authored_tap(&runner, P1, forest);
+    apply_as_current(runner.state_mut(), tap).expect("the seat taps its own land");
+    assert_eq!(tracked_lands(&runner, P1), vec![forest]);
+
+    let (mut runner, forest) = land_board(2, None);
+    let tap = engine_authored_tap(&runner, P1, forest);
+    apply_interaction_for_simulation(runner.state_mut(), P1, P1, tap)
+        .expect("the split boundary accepts the seat's own tap");
+    assert_eq!(tracked_lands(&runner, P1), vec![forest]);
+}
+
+/// CR 723.5a: an undoable land mana ability activated through `ActivateAbility`
+/// books to the seat holding priority, never to its submitter or a bystander.
+#[test]
+fn a_controlled_seats_mana_ability_books_its_land_to_the_seat() {
+    let (mut runner, forest) = land_board(4, Some(P0));
+    assert_seat_submits_through(&runner, P1, P0);
+
+    apply_as_current(
+        runner.state_mut(),
+        GameAction::ActivateAbility {
+            source_id: forest,
+            ability_index: 0,
+        },
+    )
+    .expect("the controller activates the seat's land mana ability");
+
+    assert_eq!(tracked_seats(&runner), vec![P1]);
+    assert_eq!(tracked_lands(&runner, P1), vec![forest]);
+}
+
+/// Reach guard for the row above.
+#[test]
+fn an_uncontrolled_seats_mana_ability_books_its_land_to_the_seat() {
+    let (mut runner, forest) = land_board(4, None);
+    assert_seat_submits_through(&runner, P1, P1);
+
+    apply_as_current(
+        runner.state_mut(),
+        GameAction::ActivateAbility {
+            source_id: forest,
+            ability_index: 0,
+        },
+    )
+    .expect("the seat activates its own land mana ability");
+
+    assert_eq!(tracked_seats(&runner), vec![P1]);
+}
+
+/// CR 723.5a + CR 605.3b: the undo of a manual land tap looks the tap up under
+/// the seat it booked to, so the round trip closes at a priority window.
+#[test]
+fn a_controlled_seats_land_tap_undoes_at_priority() {
+    let (mut runner, forest) = land_board(2, Some(P0));
+    assert_seat_submits_through(&runner, P1, P0);
+    let tap = engine_authored_tap(&runner, P1, forest);
+    apply_as_current(runner.state_mut(), tap).expect("the controller taps the seat's land");
+    assert_eq!(tracked_lands(&runner, P1), vec![forest]);
+
+    apply_as_current(
+        runner.state_mut(),
+        GameAction::UntapLandForMana { object_id: forest },
+    )
+    .expect("the controller undoes the seat's own tap");
+
+    assert!(runner.state().lands_tapped_for_mana.is_empty());
+    assert!(!runner.state().objects[&forest].tapped);
+}
+
+/// The same round trip at a mana-payment window, whose tap arm already keyed
+/// the seat while its undo arm did not.
+#[test]
+fn a_controlled_seats_land_tap_undoes_during_mana_payment() {
+    let (mut runner, forest) = land_board(2, Some(P0));
+    runner.enter_mana_payment(P1, None);
+    assert_seat_submits_through(&runner, P1, P0);
+    let tap = engine_authored_tap(&runner, P1, forest);
+    apply_as_current(runner.state_mut(), tap).expect("the controller taps the seat's land");
+    assert_eq!(tracked_lands(&runner, P1), vec![forest]);
+
+    apply_as_current(
+        runner.state_mut(),
+        GameAction::UntapLandForMana { object_id: forest },
+    )
+    .expect("the controller undoes the seat's own tap mid-payment");
+
+    assert!(runner.state().lands_tapped_for_mana.is_empty());
+    assert!(!runner.state().objects[&forest].tapped);
+}
+
+/// The already-correct end of the same key class: an unless-payment window
+/// destructures its own seat, so its round trip closes under control with no
+/// source line changed for it.
+#[test]
+fn a_controlled_seats_land_tap_undoes_during_an_unless_payment() {
+    let (mut runner, forest) = land_board(2, Some(P0));
+    let pending_effect = ResolvedAbility::new(
+        Effect::Unimplemented {
+            name: "Unless Payment Witness".to_string(),
+            description: None,
+        },
+        vec![],
+        forest,
+        P1,
+    );
+    runner.state_mut().waiting_for = WaitingFor::UnlessPayment {
+        player: P1,
+        cost: AbilityCost::Mana {
+            cost: ManaCost::Cost {
+                shards: vec![ManaCostShard::Green],
+                generic: 0,
+            },
+        },
+        pending_effect: Box::new(pending_effect),
+        trigger_event: None,
+        effect_description: Some("unless payment witness".to_string()),
+        remaining: vec![],
+    };
+    assert_seat_submits_through(&runner, P1, P0);
+
+    let tap = engine_authored_tap(&runner, P1, forest);
+    apply_as_current(runner.state_mut(), tap).expect("the controller taps the seat's land");
+    assert_eq!(tracked_lands(&runner, P1), vec![forest]);
+
+    apply_as_current(
+        runner.state_mut(),
+        GameAction::UntapLandForMana { object_id: forest },
+    )
+    .expect("the controller undoes the seat's own tap during the unless payment");
+
+    assert!(runner.state().lands_tapped_for_mana.is_empty());
+}
+
+/// A land the seat never tapped for mana stays untrackable, so the undo guard
+/// still refuses it after the key moved to the seat.
+#[test]
+fn an_untapped_second_land_is_still_refused_by_the_undo_guard() {
+    let mut scenario = GameScenario::new_n_player(2, 42);
+    scenario.at_phase(Phase::PreCombatMain);
+    let tapped = scenario.add_basic_land(P1, ManaColor::Green);
+    let untouched = scenario.add_basic_land(P1, ManaColor::Green);
+    let mut runner = scenario.build();
+    install_priority(&mut runner, P1, Some(P0));
+    let tap = engine_authored_tap(&runner, P1, tapped);
+    apply_as_current(runner.state_mut(), tap).expect("the controller taps one of the seat's lands");
+
+    assert!(matches!(
+        apply_as_current(
+            runner.state_mut(),
+            GameAction::UntapLandForMana {
+                object_id: untouched
+            },
+        ),
+        Err(EngineError::InvalidAction(_))
+    ));
+    assert_eq!(tracked_lands(&runner, P1), vec![tapped]);
+    assert!(!runner.state().objects[&untouched].tapped);
+}
+
+/// Build the Opposition Agent latch: an opponent's own-library search that
+/// CR 723.2 hands to the agent's controller, with no `turn_decision_controller`.
+fn opposition_agent_search(with_agent: bool) -> (GameRunner, ObjectId) {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    if with_agent {
+        scenario.add_creature_from_oracle(P0, "Opposition Agent", 3, 2, OPPOSITION_AGENT);
+    }
+    let tutor = scenario
+        .add_spell_to_hand_from_oracle(P1, "Test Tutor", false, TEST_TUTOR)
+        .with_mana_cost(ManaCost::zero())
+        .id();
+    let found = scenario
+        .add_spell_to_library_top(P1, "Found Card", true)
+        .id();
+    scenario.add_card_to_library_top(P1, "Library Filler");
+    let mut runner = scenario.build();
+    {
+        let state = runner.state_mut();
+        state.active_player = P1;
+        state.priority_player = P1;
+        state.waiting_for = WaitingFor::Priority { player: P1 };
+    }
+    let outcome = runner.cast(tutor).resolve();
+    assert!(
+        matches!(
+            outcome.final_waiting_for(),
+            WaitingFor::SearchChoice { player: P1, .. }
+        ),
+        "the tutor must halt on the searcher's own search choice, got {:?}",
+        outcome.final_waiting_for()
+    );
+    (runner, found)
+}
+
+fn seed_auto_pass(runner: &mut GameRunner) {
+    for seat in [P0, P1] {
+        runner.state_mut().auto_pass.insert(
+            seat,
+            AutoPassMode::UntilTurnBoundary {
+                until: TurnBoundary::EndOfCurrentTurn,
+            },
+        );
+    }
+    assert!(runner.state().auto_pass.contains_key(&P0));
+    assert!(runner.state().auto_pass.contains_key(&P1));
+}
+
+/// CR 723.2 + CR 723.5: the search latch redirects the submitter with no
+/// `turn_decision_controller` set at all, and the searcher's own preference is
+/// what the search choice discharges.
+#[test]
+fn a_latched_search_choice_discharges_the_searchers_preference() {
+    let (mut runner, found) = opposition_agent_search(true);
+    assert!(
+        runner.state().turn_decision_controller.is_none(),
+        "the latch must redirect with no turn-control field set"
+    );
+    assert_seat_submits_through(&runner, P1, P0);
+    seed_auto_pass(&mut runner);
+
+    runner
+        .act(GameAction::SelectCards { cards: vec![found] })
+        .expect("the agent's controller submits the searcher's choice");
+
+    assert!(
+        !runner.state().auto_pass.contains_key(&P1),
+        "the searcher's own preference is the one the choice discharges"
+    );
+    assert!(
+        runner.state().auto_pass.contains_key(&P0),
+        "the submitting controller's preference is untouched"
+    );
+}
+
+/// Reach guard: the same tutor with no agent on the battlefield discharges the
+/// same seat's preference, so the row above pins the latch, not the tutor.
+#[test]
+fn an_unlatched_search_choice_discharges_the_searchers_preference() {
+    let (mut runner, found) = opposition_agent_search(false);
+    assert_seat_submits_through(&runner, P1, P1);
+    seed_auto_pass(&mut runner);
+
+    runner
+        .act(GameAction::SelectCards { cards: vec![found] })
+        .expect("the searcher submits its own choice");
+
+    assert!(!runner.state().auto_pass.contains_key(&P1));
+    assert!(runner.state().auto_pass.contains_key(&P0));
+}
+
+fn one_phase_stop() -> Vec<PhaseStop> {
+    vec![PhaseStop {
+        phase: Phase::End,
+        scope: PhaseStopScope::AllTurns,
+    }]
+}
+
+/// CR 723.5b: a phase-stop preference is not a choice called for by the rules
+/// or by an object, so it writes the submitting seat's slot and never the
+/// controlled seat's.
+#[test]
+fn a_phase_stop_preference_writes_the_submitters_slot_under_control() {
+    let mut runner = four_player_board_with_every_seat_tracked(Some(P0));
+    assert_seat_submits_through(&runner, P1, P0);
+
+    apply_as_current(
+        runner.state_mut(),
+        GameAction::SetPhaseStops {
+            stops: one_phase_stop(),
+        },
+    )
+    .expect("a preference is legal in every state");
+
+    assert_eq!(
+        runner.state().phase_stops.get(&P0),
+        Some(&one_phase_stop()),
+        "the submitting connection owns the preference"
+    );
+    assert!(
+        !runner.state().phase_stops.contains_key(&P1),
+        "the controlled seat has no preference of its own to gain"
+    );
+}
+
+/// Reach guard: uncontrolled, the same call reaches the same live handler and
+/// writes the acting seat's own slot.
+#[test]
+fn a_phase_stop_preference_writes_the_acting_seats_slot_without_control() {
+    let mut runner = four_player_board_with_every_seat_tracked(None);
+    assert_seat_submits_through(&runner, P1, P1);
+
+    apply_as_current(
+        runner.state_mut(),
+        GameAction::SetPhaseStops {
+            stops: one_phase_stop(),
+        },
+    )
+    .expect("a preference is legal in every state");
+
+    assert_eq!(runner.state().phase_stops.get(&P1), Some(&one_phase_stop()));
+}
+
+/// CR 723.5b bounds the exemption: `SetAutoPass` stores a mode for the priority
+/// seat and immediately passes that priority, so it stays a rules choice and
+/// the controlled seat may not submit it.
+#[test]
+fn the_controlled_seat_may_not_submit_an_auto_pass_request() {
+    let mut runner = four_player_board_with_every_seat_tracked(Some(P0));
+    assert_seat_submits_through(&runner, P1, P0);
+
+    assert!(
+        matches!(
+            apply_interaction_for_simulation(
+                runner.state_mut(),
+                P1,
+                P1,
+                GameAction::SetAutoPass {
+                    mode: engine::types::game_state::AutoPassRequest::UntilStackEmpty,
+                },
+            ),
+            Err(EngineError::WrongPlayer)
+        ),
+        "an auto-pass request is not exempt from submitter authorization"
+    );
+}
+
+/// Live positive control for the refusal above: the same unauthorized actor
+/// submitting an actually-exempt action is accepted, so the exemption decides
+/// the verdict rather than the board.
+#[test]
+fn the_controlled_seat_may_submit_its_own_phase_stop_preference() {
+    let mut runner = four_player_board_with_every_seat_tracked(Some(P0));
+
+    apply_interaction_for_simulation(
+        runner.state_mut(),
+        P1,
+        P1,
+        GameAction::SetPhaseStops {
+            stops: one_phase_stop(),
+        },
+    )
+    .expect("a preference names its own submitter, so any seat may set its own");
+
+    assert_eq!(runner.state().phase_stops.get(&P1), Some(&one_phase_stop()));
+}
+
+/// A sandbox-enabled controlled board. Both preconditions are load-bearing:
+/// `debug_mode` gates every debug action, and `allow_debug_actions` gates the
+/// host grant/revoke guard ahead of its host check.
+fn sandbox_board(permitted: PlayerId) -> GameRunner {
+    let mut runner = four_player_board_with_every_seat_tracked(Some(P0));
+    let state = runner.state_mut();
+    state.debug_mode = true;
+    state.format_config.allow_debug_actions = true;
+    state.debug_permitted.clear();
+    state.debug_permitted.insert(permitted);
+    runner
+}
+
+fn zero_count_create() -> GameAction {
+    GameAction::Debug(DebugAction::CreateCard {
+        card_name: "Forest".to_string(),
+        owner: P1,
+        zone: Zone::Hand,
+        count: 0,
+        attach_to: None,
+        run_etb: false,
+        nonlegendary: false,
+    })
+}
+
+/// CR 723.5b: a sandbox capability authorizes the submitting connection, so the
+/// gate reads the submitter even while that submitter controls another player.
+#[test]
+fn a_debug_action_is_gated_on_the_submitting_connection() {
+    let mut runner = sandbox_board(P0);
+    assert_seat_submits_through(&runner, P1, P0);
+
+    apply_as_current(
+        runner.state_mut(),
+        GameAction::Debug(DebugAction::SetLife {
+            player_id: P1,
+            life: 15,
+        }),
+    )
+    .expect("the permitted submitter's debug action is accepted");
+
+    assert_eq!(runner.state().players[P1.0 as usize].life, 15);
+}
+
+/// Hostile fixture for the row above: permitting the controlled seat instead of
+/// the submitter must refuse the same call, proving the gate is live.
+#[test]
+fn a_debug_action_is_refused_when_only_the_controlled_seat_is_permitted() {
+    let mut runner = sandbox_board(P1);
+    let life_before = runner.state().players[P1.0 as usize].life;
+
+    assert!(matches!(
+        apply_as_current(
+            runner.state_mut(),
+            GameAction::Debug(DebugAction::SetLife {
+                player_id: P1,
+                life: 15,
+            }),
+        ),
+        Err(EngineError::InvalidAction(_))
+    ));
+    assert_eq!(runner.state().players[P1.0 as usize].life, life_before);
+}
+
+/// The zero-count debug no-op takes the boundary's own early return, so its
+/// preflight call site is covered against both permission sets.
+#[test]
+fn a_zero_count_debug_action_is_gated_on_the_submitting_connection() {
+    let mut runner = sandbox_board(P0);
+    apply_as_current(runner.state_mut(), zero_count_create())
+        .expect("the permitted submitter's zero-count debug no-op is accepted");
+
+    let mut runner = sandbox_board(P1);
+    assert!(matches!(
+        apply_as_current(runner.state_mut(), zero_count_create()),
+        Err(EngineError::InvalidAction(_))
+    ));
+}
+
+/// CR 723.5b: the host-only grant guard compares the submitting connection, so
+/// controlling another player must not move the comparison onto that player.
+#[test]
+fn a_debug_permission_grant_is_authorized_against_the_submitting_host() {
+    let mut runner = sandbox_board(P0);
+    assert_seat_submits_through(&runner, P1, P0);
+
+    apply_as_current(
+        runner.state_mut(),
+        GameAction::GrantDebugPermission { player_id: P1 },
+    )
+    .expect("the host grants debug permission while controlling another player");
+
+    assert!(runner.state().debug_permitted.contains(&P1));
+}

--- a/crates/engine/tests/integration/turn_control_semantic_owner.rs
+++ b/crates/engine/tests/integration/turn_control_semantic_owner.rs
@@ -9,7 +9,9 @@
 //! bounds the redirect: an action that names the submitting seat is not a
 //! choice control redirects.
 
-use engine::game::engine::{apply_as_current, apply_interaction_for_simulation};
+use engine::game::engine::{
+    apply, apply_as_current, apply_for_simulation, apply_interaction_for_simulation,
+};
 use engine::game::mana_sources::activatable_mana_actions_for_player;
 use engine::game::public_state::sync_waiting_for;
 use engine::game::scenario::{GameRunner, GameScenario, P0, P1};
@@ -17,7 +19,10 @@ use engine::game::turn_control::authorized_submitter_for_player;
 use engine::game::EngineError;
 use engine::types::ability::{AbilityCost, Effect, ResolvedAbility};
 use engine::types::actions::{DebugAction, GameAction};
-use engine::types::game_state::{AutoPassMode, TurnBoundary, WaitingFor};
+use engine::types::game_state::{
+    ActionResult, AutoPassMode, AutoPassRequest, CastPaymentMode, GameState,
+    StackResolutionSession, TurnBoundary, WaitingFor,
+};
 use engine::types::identifiers::ObjectId;
 use engine::types::mana::{ManaColor, ManaCost, ManaCostShard};
 use engine::types::phase::{Phase, PhaseStop, PhaseStopScope};
@@ -102,6 +107,16 @@ fn land_board(seats: u8, controller: Option<PlayerId>) -> (GameRunner, ObjectId)
     (runner, forest)
 }
 
+type CollapsedApply = fn(&mut GameState, PlayerId, GameAction) -> Result<ActionResult, EngineError>;
+
+/// The two entrypoints that fill the reducer's owner slot with the
+/// authenticated submitter, so a reduction keyed to that slot answers them
+/// differently from the split forms.
+const COLLAPSED_FORMS: [(&str, CollapsedApply); 2] = [
+    ("apply", apply),
+    ("apply_for_simulation", apply_for_simulation),
+];
+
 /// The tap action the engine itself enumerates for `seat` — never hand-built.
 fn engine_authored_tap(runner: &GameRunner, seat: PlayerId, land: ObjectId) -> GameAction {
     activatable_mana_actions_for_player(runner.state(), seat)
@@ -156,6 +171,66 @@ fn self_control_clears_the_same_seat_as_no_control() {
     apply_as_current(runner.state_mut(), GameAction::PassPriority)
         .expect("a self-controlling seat passes its own priority");
 
+    assert_eq!(tracked_seats(&runner), vec![P0, P2, P3]);
+}
+
+/// CR 723.5a: the collapsed entrypoints clear the manual mana tracking of the
+/// seat whose priority was passed, not of the player who submitted the pass.
+#[test]
+fn a_collapsed_pass_clears_the_controlled_seats_mana_tracking() {
+    for (form, collapsed) in COLLAPSED_FORMS {
+        let mut runner = four_player_board_with_every_seat_tracked(Some(P0));
+        assert_seat_submits_through(&runner, P1, P0);
+        assert_eq!(tracked_seats(&runner), vec![P0, P1, P2, P3]);
+
+        collapsed(runner.state_mut(), P0, GameAction::PassPriority)
+            .expect("the controller passes the controlled seat's priority");
+
+        assert_eq!(
+            tracked_seats(&runner),
+            vec![P0, P2, P3],
+            "{form} must clear the passing seat's tracking and only that seat's"
+        );
+    }
+}
+
+/// Reach guard: with no control effect the same board and the same call through
+/// each collapsed form clear the same seat, so the row above pins the redirect.
+#[test]
+fn a_collapsed_pass_clears_its_own_seats_mana_tracking_without_control() {
+    for (form, collapsed) in COLLAPSED_FORMS {
+        let mut runner = four_player_board_with_every_seat_tracked(None);
+        assert_seat_submits_through(&runner, P1, P1);
+
+        collapsed(runner.state_mut(), P1, GameAction::PassPriority)
+            .expect("the seat passes its own priority");
+
+        assert_eq!(tracked_seats(&runner), vec![P0, P2, P3], "{form}");
+    }
+}
+
+/// CR 723.5: the controlled seat is not its own authorized submitter, so a
+/// collapsed form refuses its pass before any tracking is cleared.
+#[test]
+fn the_controlled_seat_may_not_submit_its_own_pass_through_a_collapsed_form() {
+    let mut runner = four_player_board_with_every_seat_tracked(Some(P0));
+    assert_seat_submits_through(&runner, P1, P0);
+
+    assert!(
+        matches!(
+            apply(runner.state_mut(), P1, GameAction::PassPriority),
+            Err(EngineError::WrongPlayer)
+        ),
+        "the controlled seat is not its own authorized submitter"
+    );
+    assert_eq!(
+        tracked_seats(&runner),
+        vec![P0, P1, P2, P3],
+        "a refused pass clears nothing"
+    );
+
+    apply(runner.state_mut(), P0, GameAction::PassPriority)
+        .expect("the same board accepts the authorized submitter's pass");
     assert_eq!(tracked_seats(&runner), vec![P0, P2, P3]);
 }
 
@@ -450,6 +525,96 @@ fn an_unlatched_search_choice_discharges_the_searchers_preference() {
     assert!(runner.state().auto_pass.contains_key(&P0));
 }
 
+/// CR 723.2 + CR 723.5: the collapsed entrypoint discharges the preference of
+/// the searcher whose prompt it is, not of the agent's controller who submitted
+/// the choice.
+#[test]
+fn a_collapsed_latched_search_choice_discharges_the_searchers_preference() {
+    let (mut runner, found) = opposition_agent_search(true);
+    assert!(
+        runner.state().turn_decision_controller.is_none(),
+        "the latch must redirect with no turn-control field set"
+    );
+    assert_seat_submits_through(&runner, P1, P0);
+    seed_auto_pass(&mut runner);
+
+    apply(
+        runner.state_mut(),
+        P0,
+        GameAction::SelectCards { cards: vec![found] },
+    )
+    .expect("the agent's controller submits the searcher's choice");
+
+    assert!(
+        !runner.state().auto_pass.contains_key(&P1),
+        "the searcher's own preference is the one the choice discharges"
+    );
+    assert!(
+        runner.state().auto_pass.contains_key(&P0),
+        "the submitting controller's preference is untouched"
+    );
+}
+
+/// Reach guard: the same tutor with no agent discharges the same seat through
+/// the same entrypoint, so the row above pins the latch and not the tutor.
+#[test]
+fn a_collapsed_unlatched_search_choice_discharges_the_searchers_preference() {
+    let (mut runner, found) = opposition_agent_search(false);
+    assert_seat_submits_through(&runner, P1, P1);
+    seed_auto_pass(&mut runner);
+
+    apply(
+        runner.state_mut(),
+        P1,
+        GameAction::SelectCards { cards: vec![found] },
+    )
+    .expect("the searcher submits its own choice");
+
+    assert!(!runner.state().auto_pass.contains_key(&P1));
+    assert!(runner.state().auto_pass.contains_key(&P0));
+}
+
+/// CR 723.5b: a preference names its submitting seat, so it returns from the
+/// reducer ahead of the prompt-keyed discharge even while the latch redirects.
+#[test]
+fn a_collapsed_preference_leaves_both_seats_modes_standing_under_a_latch() {
+    let (mut runner, found) = opposition_agent_search(true);
+    assert_seat_submits_through(&runner, P1, P0);
+    seed_auto_pass(&mut runner);
+
+    apply(
+        runner.state_mut(),
+        P0,
+        GameAction::SetPhaseStops {
+            stops: one_phase_stop(),
+        },
+    )
+    .expect("a preference is legal in every state");
+
+    assert!(
+        runner.state().auto_pass.contains_key(&P0),
+        "a preference discharges no auto-pass mode at all"
+    );
+    assert!(runner.state().auto_pass.contains_key(&P1));
+    assert_eq!(
+        runner.state().phase_stops.get(&P0),
+        Some(&one_phase_stop()),
+        "the submitting connection owns the preference"
+    );
+    assert!(!runner.state().phase_stops.contains_key(&P1));
+
+    // Positive control on this exact board: a prompt-keyed action does reach
+    // the discharge, so the modes left standing above are not an inert board.
+    apply(
+        runner.state_mut(),
+        P0,
+        GameAction::SelectCards { cards: vec![found] },
+    )
+    .expect("the agent's controller submits the searcher's choice");
+    assert!(!runner.state().auto_pass.contains_key(&P1));
+    assert!(runner.state().auto_pass.contains_key(&P0));
+}
+
 fn one_phase_stop() -> Vec<PhaseStop> {
     vec![PhaseStop {
         phase: Phase::End,
@@ -639,4 +804,251 @@ fn a_debug_permission_grant_is_authorized_against_the_submitting_host() {
     .expect("the host grants debug permission while controlling another player");
 
     assert!(runner.state().debug_permitted.contains(&P1));
+}
+
+const TEST_LIFE_GAIN: &str = "You gain 1 life.";
+
+/// Latch CR 723 control at the window the drive already opened.
+/// `install_priority` would replace it with a fresh `Priority` window, which is
+/// the state the stack-resolution-session rows exist to avoid.
+fn latch_control(runner: &mut GameRunner, controller: Option<PlayerId>) {
+    let state = runner.state_mut();
+    state.turn_decision_controller = controller;
+    let standing = state.waiting_for.clone();
+    sync_waiting_for(state, &standing);
+}
+
+fn live_session(runner: &GameRunner) -> &StackResolutionSession {
+    runner
+        .state()
+        .stack_resolution_session
+        .as_ref()
+        .expect("the row needs a live stack-resolution session")
+}
+
+/// Drive to `ManaPayment { player: P1 }` over a two-entry stack with a live
+/// stack-resolution session armed by `arming_seat` and a standing auto-pass mode
+/// held by P0, then latch `controller`. Returns the tap the engine itself
+/// enumerates for P1 at that window.
+///
+/// The arming seat selects which reader of the session key the row moves. When
+/// P0 arms, it is a representative and the session's own mode is its standing
+/// mode, so the membership branch decides. When another seat arms, P0 takes a
+/// turn-boundary mode first because the session's restore baseline snapshots
+/// `state.auto_pass` as it installs, so only a mode already standing is carried;
+/// neither key is then a representative.
+fn stack_session_at_mana_payment(
+    arming_seat: PlayerId,
+    controller: Option<PlayerId>,
+) -> (GameRunner, GameAction) {
+    let mut scenario = GameScenario::new_n_player(3, 42);
+    scenario.at_phase(Phase::PreCombatMain);
+    let forest = scenario.add_basic_land(P1, ManaColor::Green);
+    let spell = scenario
+        .add_spell_to_hand_from_oracle(P1, "Test Lifegain", true, TEST_LIFE_GAIN)
+        .with_mana_cost(ManaCost::Cost {
+            shards: vec![ManaCostShard::Green],
+            generic: 0,
+        })
+        .id();
+    let filler_a = scenario.add_bolt_to_hand(P0);
+    let filler_b = scenario.add_bolt_to_hand(P0);
+    let mut runner = scenario.build();
+    runner.state_mut().active_player = P1;
+    runner.cast(filler_a).target_player(P1).commit();
+    runner.cast(filler_b).target_player(P1).commit();
+
+    if arming_seat != P0 {
+        apply(
+            runner.state_mut(),
+            P0,
+            GameAction::SetAutoPass {
+                mode: AutoPassRequest::UntilTurnBoundary {
+                    until: TurnBoundary::EndOfCurrentTurn,
+                },
+            },
+        )
+        .expect("P0 takes a standing mode ahead of the session");
+    }
+    for _ in 0..4 {
+        match runner.state().waiting_for {
+            WaitingFor::Priority { player } if player == arming_seat => break,
+            WaitingFor::Priority { player } => {
+                apply(runner.state_mut(), player, GameAction::PassPriority)
+                    .expect("a seat passes its own priority");
+            }
+            ref other => panic!("expected a priority window, got {other:?}"),
+        }
+    }
+    apply(
+        runner.state_mut(),
+        arming_seat,
+        GameAction::SetAutoPass {
+            mode: AutoPassRequest::UntilStackEmpty,
+        },
+    )
+    .expect("the arming seat opens a stack-resolution session");
+    assert_eq!(
+        live_session(&runner).representatives,
+        [arming_seat].into_iter().collect(),
+        "the arming seat is the session's sole representative"
+    );
+    assert!(
+        matches!(runner.state().waiting_for, WaitingFor::Priority { player } if player == P1),
+        "the arming pass must land on the casting seat's window, got {:?}",
+        runner.state().waiting_for
+    );
+
+    let card_id = runner.state().objects[&spell].card_id;
+    apply(
+        runner.state_mut(),
+        P1,
+        GameAction::CastSpell {
+            object_id: spell,
+            card_id,
+            targets: vec![],
+            payment_mode: CastPaymentMode::Manual,
+        },
+    )
+    .expect("the casting seat opens a manual payment window");
+    assert!(
+        matches!(runner.state().waiting_for, WaitingFor::ManaPayment { player, .. } if player == P1),
+        "the row needs a non-Priority window, got {:?}",
+        runner.state().waiting_for
+    );
+    assert!(
+        runner.state().stack_resolution_session.is_some(),
+        "the session must still be live at the payment window"
+    );
+    assert!(
+        runner.state().auto_pass.contains_key(&P0),
+        "P0 must hold the standing mode this row watches"
+    );
+
+    latch_control(&mut runner, controller);
+    let tap = engine_authored_tap(&runner, P1, forest);
+    (runner, tap)
+}
+
+/// CR 723.3 + CR 723.5: the controlled seat's payment is that seat's action, so
+/// it revokes no frozen authorization belonging to the player who submitted it.
+#[test]
+fn a_controlled_payment_leaves_the_submitters_own_session_standing() {
+    let (mut runner, tap) = stack_session_at_mana_payment(P0, Some(P0));
+    assert_seat_submits_through(&runner, P1, P0);
+    assert!(
+        live_session(&runner).representatives.contains(&P0),
+        "the submitter is a representative, so the membership branch decides this row"
+    );
+
+    let mut hostile = runner.state().clone();
+    assert!(
+        matches!(
+            apply(&mut hostile, P1, tap.clone()),
+            Err(EngineError::WrongPlayer)
+        ),
+        "the controlled seat is not its own authorized submitter"
+    );
+
+    apply(runner.state_mut(), P0, tap).expect("the controller pays for the controlled seat");
+
+    assert!(
+        runner.state().stack_resolution_session.is_some(),
+        "the seat's payment must not tear down the submitter's session"
+    );
+    assert!(
+        matches!(
+            runner.state().auto_pass.get(&P0),
+            Some(AutoPassMode::UntilStackEmpty { .. })
+        ),
+        "the submitter keeps the mode it armed, got {:?}",
+        runner.state().auto_pass.get(&P0)
+    );
+}
+
+/// Reach guard: uncontrolled, the same route and the same tap leave the same
+/// session and mode standing, so the row above pins the redirect.
+#[test]
+fn an_uncontrolled_payment_leaves_the_representatives_session_standing() {
+    let (mut runner, tap) = stack_session_at_mana_payment(P0, None);
+    assert_seat_submits_through(&runner, P1, P1);
+
+    apply(runner.state_mut(), P1, tap).expect("the seat pays its own cost");
+
+    assert!(runner.state().stack_resolution_session.is_some());
+    assert!(matches!(
+        runner.state().auto_pass.get(&P0),
+        Some(AutoPassMode::UntilStackEmpty { .. })
+    ));
+}
+
+/// CR 723.3 + CR 723.5: with both keys outside the session's representatives
+/// only the key itself can move, and the controlled seat's payment strips
+/// neither the submitter's standing mode nor the baseline entry a later
+/// teardown must give back.
+#[test]
+fn a_controlled_payment_leaves_a_nonrepresentative_submitters_mode_and_baseline() {
+    let (mut runner, tap) = stack_session_at_mana_payment(P2, Some(P0));
+    assert_seat_submits_through(&runner, P1, P0);
+    let representatives = &live_session(&runner).representatives;
+    assert!(
+        !representatives.contains(&P0) && !representatives.contains(&P1),
+        "neither key is a representative, so the membership branch is held still"
+    );
+    assert!(
+        live_session(&runner)
+            .auto_pass_overlay
+            .baseline
+            .contains_key(&P0),
+        "the baseline must carry P0's pre-session mode for this row to watch it"
+    );
+
+    let mut hostile = runner.state().clone();
+    assert!(
+        matches!(
+            apply(&mut hostile, P1, tap.clone()),
+            Err(EngineError::WrongPlayer)
+        ),
+        "the controlled seat is not its own authorized submitter"
+    );
+
+    apply(runner.state_mut(), P0, tap).expect("the controller pays for the controlled seat");
+
+    assert!(
+        matches!(
+            runner.state().auto_pass.get(&P0),
+            Some(AutoPassMode::UntilTurnBoundary { .. })
+        ),
+        "the submitter's standing mode is not the paying seat's to revoke"
+    );
+    assert!(
+        live_session(&runner)
+            .auto_pass_overlay
+            .baseline
+            .contains_key(&P0),
+        "stripping the baseline would leave a mode no teardown could restore"
+    );
+    assert!(
+        !live_session(&runner).representatives.contains(&P0),
+        "the session stays live with its representatives unchanged"
+    );
+}
+
+/// Reach guard: uncontrolled, the same route leaves the same mode and baseline
+/// entry standing, so the row above pins the redirect and not the route.
+#[test]
+fn an_uncontrolled_payment_leaves_a_nonrepresentatives_mode_and_baseline() {
+    let (mut runner, tap) = stack_session_at_mana_payment(P2, None);
+    assert_seat_submits_through(&runner, P1, P1);
+
+    apply(runner.state_mut(), P1, tap).expect("the seat pays its own cost");
+
+    assert!(matches!(
+        runner.state().auto_pass.get(&P0),
+        Some(AutoPassMode::UntilTurnBoundary { .. })
+    ));
+    assert!(live_session(&runner)
+        .auto_pass_overlay
+        .baseline
+        .contains_key(&P0));
 }

--- a/crates/phase-ai/tests/projection_turn_control_submitter.rs
+++ b/crates/phase-ai/tests/projection_turn_control_submitter.rs
@@ -10,11 +10,19 @@
 //! the seat's objects its own, so the seat must stay the semantic owner rather
 //! than be remapped. CR 723.9 (self-control) must remain a no-op.
 
+use engine::game::engine::apply_for_simulation;
 use engine::game::public_state::sync_waiting_for;
+use engine::game::scenario::GameScenario;
 use engine::game::turn_control::authorized_submitter_for_player;
-use engine::types::game_state::GameState;
+use engine::game::EngineError;
+use engine::types::ability::{CastingPermission, ManaSpendPermission};
+use engine::types::actions::GameAction;
+use engine::types::game_state::{GameState, WaitingFor};
+use engine::types::identifiers::ObjectId;
+use engine::types::mana::ManaCost;
 use engine::types::phase::Phase;
 use engine::types::player::PlayerId;
+use engine::types::zones::Zone;
 use engine::util::Deadline;
 use phase_ai::projection::{project_to, ProjectionHorizon};
 use phase_ai::saved_state::load_saved_game_state;
@@ -215,4 +223,146 @@ fn self_control_leaves_the_seat_as_its_own_submitter() {
     );
 
     assert_projected_past_the_turn_boundary(&base, &controlled, "self-controlled");
+}
+
+const OPPOSITION_AGENT: &str = "Flash\n\
+You control your opponents while they're searching their libraries.\n\
+While an opponent is searching their library, they exile each card they find. You may play those cards for as long as they remain exiled, and you may spend mana as though it were mana of any color to cast them.";
+const TEST_TUTOR: &str =
+    "Search your library for a card, put that card into your hand, then shuffle.";
+
+/// A board halted on the searcher's own library search, optionally under an
+/// Opposition Agent. CR 723.2 latches the search decision onto the agent's
+/// controller without ever setting `turn_decision_controller`.
+fn opposition_agent_search_state(with_agent: bool) -> (GameState, ObjectId) {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    if with_agent {
+        scenario.add_creature_from_oracle(CONTROLLER, "Opposition Agent", 3, 2, OPPOSITION_AGENT);
+    }
+    let tutor = scenario
+        .add_spell_to_hand_from_oracle(SEAT, "Test Tutor", false, TEST_TUTOR)
+        .with_mana_cost(ManaCost::zero())
+        .id();
+    let found = scenario
+        .add_spell_to_library_top(SEAT, "Found Card", true)
+        .id();
+    scenario.add_card_to_library_top(SEAT, "Library Filler");
+    let mut runner = scenario.build();
+    {
+        let state = runner.state_mut();
+        state.active_player = SEAT;
+        state.priority_player = SEAT;
+        state.waiting_for = WaitingFor::Priority { player: SEAT };
+    }
+    let outcome = runner.cast(tutor).resolve();
+    assert!(
+        matches!(
+            outcome.final_waiting_for(),
+            WaitingFor::SearchChoice { player, .. } if *player == SEAT
+        ),
+        "the tutor must halt on the searcher's own search choice, got {:?}",
+        outcome.final_waiting_for()
+    );
+    (runner.state().clone(), found)
+}
+
+fn agent_permission_granted_to(state: &GameState, found: ObjectId, grantee: PlayerId) -> bool {
+    state.objects[&found]
+        .casting_permissions
+        .iter()
+        .any(|permission| {
+            matches!(
+                permission,
+                CastingPermission::PlayFromExile {
+                    granted_to,
+                    mana_spend_permission: Some(ManaSpendPermission::AnyColor),
+                    ..
+                } if *granted_to == grantee
+            )
+        })
+}
+
+/// Row 4. The second CR 723 redirect source. `turn_decision_controller` is
+/// unset here, so a projection that only handled that field would dispatch the
+/// searcher as its own submitter and be refused.
+#[test]
+fn projection_advances_over_a_search_control_latch() {
+    let (latched, found) = opposition_agent_search_state(true);
+    assert!(
+        latched.turn_decision_controller.is_none(),
+        "the latch must redirect with no turn-control field set"
+    );
+    assert_eq!(
+        authorized_submitter_for_player(&latched, SEAT),
+        CONTROLLER,
+        "the searcher's decisions are submittable only by the agent's controller"
+    );
+
+    let projection = project_to(
+        &latched,
+        CONTROLLER,
+        SEAT,
+        ProjectionHorizon::OpponentBeginCombat,
+        Deadline::none(),
+    )
+    .unwrap_or_else(|bail| panic!("latched: projection bailed with {bail:?}"));
+
+    // The split is what carries this row: the collapsed dispatch is refused on
+    // this same board, which is the bail a re-collapsed `project_to` would hit.
+    let mut collapsed = latched.clone();
+    assert!(
+        matches!(
+            apply_for_simulation(
+                &mut collapsed,
+                SEAT,
+                GameAction::SelectCards { cards: vec![found] }
+            ),
+            Err(EngineError::WrongPlayer)
+        ),
+        "the searcher is not its own authorized submitter under the latch"
+    );
+
+    assert_eq!(
+        projection.state.objects[&found].zone,
+        Zone::Exile,
+        "CR 723.3: the found card follows the searcher's own replaced destination"
+    );
+    assert!(
+        agent_permission_granted_to(&projection.state, found, CONTROLLER),
+        "the agent grants its controller permission to play the exiled card"
+    );
+}
+
+/// Paired reach-guard: the same tutor with no agent reaches the same horizon,
+/// so the row above pins the latch rather than the projection's ability to
+/// traverse a search at all.
+#[test]
+fn projection_reaches_the_same_horizon_without_a_search_control_latch() {
+    let (unlatched, found) = opposition_agent_search_state(false);
+    assert_eq!(
+        authorized_submitter_for_player(&unlatched, SEAT),
+        SEAT,
+        "with no agent the searcher submits its own search choice"
+    );
+
+    let projection = project_to(
+        &unlatched,
+        CONTROLLER,
+        SEAT,
+        ProjectionHorizon::OpponentBeginCombat,
+        Deadline::none(),
+    )
+    .unwrap_or_else(|bail| panic!("unlatched: projection bailed with {bail:?}"));
+
+    assert_eq!(
+        projection.state.objects[&found].zone,
+        Zone::Hand,
+        "with no agent the found card reaches the tutor's own destination"
+    );
+    assert!(!agent_permission_granted_to(
+        &projection.state,
+        found,
+        CONTROLLER
+    ));
 }


### PR DESCRIPTION
## Summary

The engine's action boundary carries two player slots: `authenticated_actor`, the trusted submitting
connection, and `semantic_owner`, the player whose decision slot the action names. Under a
player-control effect (CR 723.5) those are two different players. This pull request keys the
owner-scoped state to the controlled seat at every entrypoint that reads it, and repairs the two
places where reading one slot as the other was observable.

**The first revision fixed this at one caller and that was not enough.** `apply_as_current_with_mode`
stopped collapsing the two slots, but `apply_action` read its own boundary *parameter* at the two
owner-keyed consumers that matter — the `lands_tapped_for_mana` clear and the
`session_preference_owner` fallback arm — so `apply` and `apply_for_simulation`, which the client,
the server and the AI's simulated world submit through, kept keying the controller. That left two
entrypoints disagreeing about one rule, which is worse than the uniform bug it replaced. Both
consumers now read the `semantic_actor` binding `apply_action` already computes from
`state.waiting_for`; it is entrypoint-independent because it reads state rather than the parameter.
The `Priority` arm keeps its shared-team canonicalization (CR 117.6, CR 805.5b) and the `Concede`
block returns before the binding, so neither moves, and the `unwrap_or(actor)` fallback keeps the
authenticated actor wherever `waiting_for` names no single seat — which is where the simultaneous
mulligan arms go on resolving their per-player state from the parameter, deliberately.

The seam split itself is unchanged and still carries its own justification. Because
`authorized_submitters` is defined as
`acting_players().into_iter().map(authorized_submitter_for_player).collect()`, and `map` preserves
order and length, taking `acting_players().first()` as the owner and mapping it for the submitter
yields an authenticated actor **bit-identical to the one computed before**.
`check_actor_authorization` reads only that slot, so it cannot change verdict for any state. That
property is what bounds the change against 1754 call sites, **none of which is edited**.

Repairs that fall out of the split:

- `preflight_tap_land_action` was reading the `semantic_owner` slot as if it held the submitter. On
  the interaction path that already rejected a controller's land tap with `WrongPlayer`.
- Three sites keyed `state.priority_player` — the `ActivateAbility` undoable-land insert and both
  `UntapLandForMana` arms — while the paired inserts and clears around them key the seat.
- Actions naming the submitting seat rather than a decision slot must not be redirected at all
  (CR 723.5b). `is_submitter_scoped` replaces the identical disjunction `check_actor_authorization`
  already carried inline, so one named predicate serves both readers.
- **`precast_copy_shortcut::handle` was regressed by the split itself and is repaired here.** It
  guarded on `actor == authorized_submitter_for_player(state, *proposer)`, reading the parameter as
  the submitter, while the caller now passes the owner — so a controller's own pre-cast response was
  refused. Measured on an otherwise identical board: `apply(P1, Propose)` returned `Ok` while
  `apply_as_current` returned `InvalidAction`, with the no-control leg `Ok`. `Decline` regressed the
  same way. The argument is deleted rather than re-keyed: the action boundary settles submitter
  authorization before the handler runs, and each of the four guards it fed duplicated that check.

## Files changed

- `crates/engine/src/game/engine.rs` — the seam split, the preflight argument, the three re-keyed
  `state.priority_player` sites, `check_actor_authorization` consuming the new predicate, and the two
  reducer owner slots re-keyed to `semantic_actor`
- `crates/engine/src/game/precast_copy_shortcut.rs` — `handle` loses its `actor` parameter and the
  four conjuncts that duplicated the boundary's authorization check
- `crates/engine/src/game/mana_sources.rs` — `preflight_tap_land_action` takes the authenticated
  actor, and its parameter now says so
- `crates/engine/src/types/actions.rs` — `GameAction::is_submitter_scoped`, plus a cross-reference
  to its near-identical neighbour
- `crates/engine/src/game/interaction.rs` — the mirror cross-reference on
  `action_preserves_interaction`; doc-only
- `crates/engine/tests/integration/turn_control_semantic_owner.rs` — 32 tests, 10 of them new in
  this revision
- `crates/engine/tests/integration/precast_copy_shortcut.rs` — 17 tests, 2 of them new for the
  repaired handler
- `crates/engine/tests/integration/main.rs` — one `mod` line
- `crates/phase-ai/tests/projection_turn_control_submitter.rs` — a projection row; see Coverage below
- `crates/engine/src/game/triggers_devour_runtime_tests.rs` — comment only; see Scope Expansion

## Track

Developer

## LLM

Model: claude-opus-5
Tier: Frontier
Thinking: high

## Implementation method (required)

Method: /engine-implementer

Pipeline-reviewed head: dfe3f45fef4b273305bce05d7a0313a3e11ec9e4
Current branch head: 58d42b66365986c53fb0540e6b0625fd01a12f4d
Pipeline status: historical — the reviewed candidate's findings were all false prose. The two in the
tree were corrected in a comment-only delta (0 non-comment changed lines, against a live control of
457 on the candidate diff) and the two in the commit message by amending the then-unpublished
candidate.
Current-head review: none

## CR references

Each verified against `docs/MagicCompRules.txt` with its subject checked against the claim it
annotates, not merely its existence confirmed, with negative controls run:

- `CR 723.3` — "Only control of the player changes. All objects are controlled by their normal
  controllers." The decision seat stays the controlled player.
- `CR 723.5` — "While controlling another player, a player makes all choices and decisions the
  controlled player is allowed to make." The submitter is the controller.
- `CR 723.5a` — "The controller of another player can use only that player's resources (cards, mana,
  and so on) to pay costs for that player." The rule for the `lands_tapped_for_mana` key, not
  CR 605.3b, whose subject is why the tracking exists at all.
- `CR 723.5b` — "The controller of another player can't make choices or decisions for that player
  that aren't called for by the rules or by any objects." The subject of the submitter-scoped
  collapse.
- `CR 723.6` — the controller can't make that player concede; `Concede` stays unredirected.
- `CR 723.9` — an effect may give a player control of themselves; the self-control no-op row.
- `CR 723.2` — names Opposition Agent, which is why the search-latch rows cite it rather than 723.1.
- `CR 117.6` + `CR 805.5b` — a shared team's representative owns its priority pass; why the
  `Priority` arm keeps its canonicalization instead of taking the raw seat.
- `CR 103.5` — simultaneous mulligans; kept and rescoped to `acting_players`.
- `CR 605.3b` — a mana ability doesn't use the stack; left in place beside the new annotation.
- `CR 723` — the section, on the test module.

## Verification

- [x] Required checks ran clean at the current committed head.
- [x] Gate A output below is for the current committed head.
- [x] Both anchors cite existing analogous code at the same seam.

At `58d42b66365986c53fb0540e6b0625fd01a12f4d`, in a clean worktree checked out at that commit:

- `cargo fmt --check -- <the 6 changed paths>` — clean (exit 0)
- `cargo clippy --workspace --all-targets -- -D warnings` — clean (exit 0), zero warning lines
- `cargo nextest run --workspace --no-fail-fast` — **31099 run, 31099 passed**, 47 skipped
- `./scripts/check-cr-citation-anchors.sh` — PASS (exit 0), its own self-check leg firing
- `./scripts/check-parser-combinators.sh` — PASS, **and vacuous for this change**: no file under
  `crates/engine/src/parser/` is in scope, so the PASS says the gate ran, not that it examined
  anything from here

The `phase-ai` `self_destruct_target_selection_prefers_lethal_over_nonlethal_body` test that failed
under parallel load on the previous head passes here, in the same full-workspace run. It is recorded
as load-sensitive rather than fixed by this change; nothing in this change reaches it.

## Gate A

Gate A PASS head=58d42b66365986c53fb0540e6b0625fd01a12f4d base=d6d28370c09242182488cac72e16e5a84941885f

## Anchored on

- `crates/phase-ai/src/projection.rs` — the projection dispatch landed in #8605 performs this exact
  derivation at this exact seam: resolve the seat from `waiting_for`, map it through
  `turn_control::authorized_submitter_for_player`, and pass both halves to
  `apply_interaction_for_simulation`.
- `crates/engine/src/game/engine.rs` — `apply_action`'s own `semantic_actor` binding, which already
  derived the prompt's owner from `state.waiting_for` with a comment naming this rule. The reducer
  fix extends that existing authority rather than adding one. **The previous revision of this
  description claimed `apply` and `apply_for_simulation` had "no owner information to split from";
  that was false and it is what made the entrypoint gap look principled.** `apply` has the owner, in
  `state.waiting_for` — the only place the split reads it from. What `apply` lacks is a *trusted*
  owner, which is a different thing and not what the reducer needs.

## Claimed parse impact

None. No parser file is touched; `git diff --name-only` over `crates/engine/src/parser/` returns
nothing, with a live positive control over `crates/engine/src/` returning the changed source files.

## Scope Expansion

Two, disclosed rather than folded in silently.

1. Renaming the boundary hop staled a documented call chain in
   `crates/engine/src/game/triggers_devour_runtime_tests.rs`, which spelled
   `apply_as_current_with_mode -> apply_action_boundary` at two comment sites. Two comment lines; the
   file's tests are unmoved. The site set was regenerated by grep rather than guessed.
2. `precast_copy_shortcut.rs` and its test module are new to this pull request's scope. The defect
   there was **created by this pull request's own first revision**, so it is repaired here rather
   than exported as a follow-up.

## Coverage: what the rows establish, and what they cannot

The first revision's rows all went through `GameRunner::act`, which is `apply_as_current` — the one
entrypoint that had been fixed. That is why its suite was green while the live path kept the defect,
and it is the single most important thing to know about this change's tests.

Every row that exercises the reducer now submits through `apply` or `apply_for_simulation`, driven
from one table of the collapsed forms, so a fix that reached only the convenience form fails them.
Redness was measured, not asserted: with the new test files projected onto **base source** in a
clean worktree at the previous head, **7 of the 12 new rows fail**. The other 5 are meant to pass
there — four no-control guards plus one refusal row — and each was shown to fail under a mutant
of the line it actually guards (the mana clear deleted; the `auto_pass` removal deleted; the
membership branch broadened; `baseline.remove` widened to `.clear()`; and for the refusal row, two
separate builds adding `PrecastCopyShortcut` to `is_submitter_scoped` and dropping the `route_id`
conjunct). A control that cannot be made to fail is not a control.

The deleted authorization guards were attacked adversarially rather than argued away: a driven sweep
over 5 boards × both pre-cast prompts × 4 responses × every submitter × every (auth, owner) pair ×
5 entrypoints returned **zero admitted-but-unauthorized**, on a live instrument that returned a
nonzero count under a mutant. One bound is disclosed: `Shorten`'s admit direction was not reachable
because breakpoint id 0 is never issued, so only its refusal direction was exercised.

`crates/phase-ai/tests/projection_turn_control_submitter.rs` is genuine added coverage for the #8605
projection dispatch, **not evidence for this change** — it passes at base, because `project_to`
already routed through a two-slot form. It is listed under Files changed for what it is.

## AI gate

Not run locally, stated rather than silently skipped, and the reason was re-derived for this
revision rather than inherited.

The previous revision justified the drop with "the duel suite's decks are inline… 119 distinct card
names". **That was wrong**: 15 of 32 matchups draw both seats from `crates/phase-ai/duel_decks/**`.
Across the 17 deck files actually walked — 319 distinct names, with a live positive control — no card
grants control of a player. The split and the reducer re-key are provably no-ops wherever
`authorized_submitter_for_player(seat) == seat`, which `check_actor_authorization` guarantees absent
a redirect, so a suite that cannot construct a control redirect cannot construct the condition under
which any line of this change behaves differently.

The check is not skipped in CI. `.github/workflows/ai-gate.yml` filters on `crates/phase-ai/**`, and
this change touches `crates/phase-ai/tests/`, so **Paired-seed AI gate** runs here as an independent
check. No production line under `crates/phase-ai/src/` is modified.

## Carried forward

`state.priority_player` is written directly at sites that bypass `authorized_submitter_for_player`,
which every `Priority` guard in `apply_action` compares against. Under the predicate "production-path
writes while `waiting_for` is a `Priority` window, non-test modules only", the class has **27**
members — the `PairWith` arm the review named is one of them. It is a floor rather than a total: the
proximity window used both under-counts (three named production sites fall outside it) and
over-counts (one member compiles only under a feature, another writes a throwaway probe state).
Neither direction changes the disposition, which needed only "more than one": this is a sweep of its
own and is booked as follow-up work rather than widened into this pull request.

## Validation Failures

None.

## CI Failures

None.
