### PR TITLE
feat(client): make the P2P / Official Server choice an explicit switch

### DIFF
--- a/client/src/components/lobby/ConnectionModeSwitch.tsx
+++ b/client/src/components/lobby/ConnectionModeSwitch.tsx
@@ -1,0 +1,76 @@
+import { useTranslation } from "react-i18next";
+
+import type { ConnectionMode } from "../../stores/multiplayerStore";
+
+/**
+ * Selected-segment styling per mode. This is the app's EXISTING colour
+ * language for the two connection modes — emerald for the official server,
+ * cyan for P2P (`LobbyView`'s host button tones, `HostSetup`'s `accentTone`) —
+ * which until now was only ever shown and never explained.
+ */
+const SELECTED_TONE: Record<ConnectionMode, string> = {
+  server:
+    "bg-emerald-400/15 text-emerald-100 shadow-[inset_0_0_0_1px] shadow-emerald-300/25",
+  p2p: "bg-cyan-400/15 text-cyan-100 shadow-[inset_0_0_0_1px] shadow-cyan-300/25",
+};
+
+/** Render order. Neither mode is recommended over the other; server is first
+ *  only because it is the auto-assigned default. */
+const MODES: readonly ConnectionMode[] = ["server", "p2p"];
+
+const SEGMENT_SIZE = {
+  sm: "px-2.5 py-1 text-[11px]",
+  md: "px-2 py-2 text-xs",
+} as const;
+
+/**
+ * The authority on which transport a session uses: a dedicated server or a
+ * direct peer-to-peer connection. Rendered in the lobby header and at the top
+ * of Host Game, so the choice is visible and one click to reverse from either
+ * screen.
+ *
+ * Buttons with `aria-pressed`, matching the incumbent button-based segmented
+ * control (`components/draft/BotDifficultySelector`). `role="radio"` is
+ * deliberately NOT used: without roving tabindex and arrow-key handling it
+ * reads worse than a pressed-button group. The group carries its own
+ * `aria-label`, so a surface may render a visible label beside it without
+ * having to associate one.
+ */
+export function ConnectionModeSwitch({
+  value,
+  onChange,
+  size = "md",
+}: {
+  value: ConnectionMode;
+  onChange: (mode: ConnectionMode) => void;
+  size?: keyof typeof SEGMENT_SIZE;
+}) {
+  const { t } = useTranslation("multiplayer");
+
+  return (
+    <div
+      role="group"
+      aria-label={t("connectionMode.label")}
+      className="flex rounded-xl border border-white/10 bg-black/18 p-1 backdrop-blur-md"
+    >
+      {MODES.map((mode) => {
+        const selected = value === mode;
+        return (
+          <button
+            key={mode}
+            type="button"
+            onClick={() => onChange(mode)}
+            aria-pressed={selected}
+            className={`flex-1 cursor-pointer whitespace-nowrap rounded-lg font-medium transition-colors ${SEGMENT_SIZE[size]} ${
+              selected
+                ? SELECTED_TONE[mode]
+                : "text-white/45 hover:bg-white/[0.05] hover:text-white/70"
+            }`}
+          >
+            {t(`connectionMode.${mode}`)}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/client/src/components/lobby/HostSetup.tsx
+++ b/client/src/components/lobby/HostSetup.tsx
@@ -20,6 +20,7 @@ import {
 } from "../../stores/multiplayerStore";
 import type {
   AiSeatConfig,
+  ConnectionMode,
   HostingSettings,
   LobbySource,
 } from "../../stores/multiplayerStore";
@@ -36,6 +37,7 @@ import { getHostAdapter } from "../../adapter/wasm-adapter";
 import { isFormatConfigShape } from "../../adapter/format-config-shape";
 import { expandParsedDeck } from "../../services/deckParser";
 import { menuButtonClass } from "../menu/buttonStyles";
+import { ConnectionModeSwitch } from "./ConnectionModeSwitch";
 import { IntegerField } from "../ui/IntegerField";
 import { MenuSelect, type MenuSelectGroup } from "../ui/MenuSelect";
 
@@ -54,7 +56,10 @@ interface HostSetupProps {
    */
   onHost: (settings: HostSettings, serverUrl: string | null) => void | Promise<boolean>;
   onBack: () => void;
-  connectionMode: "server" | "p2p";
+  connectionMode: ConnectionMode;
+  /** The page-level mode handler, shared with the lobby's switch. Mirrored
+   * here because the mode changes what the controls below it mean. */
+  onConnectionModeChange: (mode: ConnectionMode) => void;
   /** When true, the host-submit button is disabled (e.g. live deck check
    * says the active deck is illegal for the chosen format, or a check is
    * still in flight). The parent surfaces the *reason* via the legality
@@ -285,6 +290,7 @@ export function HostSetup({
   onHost,
   onBack,
   connectionMode,
+  onConnectionModeChange,
   hostDisabled = false,
   hostDisabledReason,
 }: HostSetupProps) {
@@ -539,6 +545,23 @@ export function HostSetup({
     setAiSeats((prev) => prev.filter((s) => s.seatIndex < count));
   };
 
+  // The mode switch above this form can lower the seat ceiling while the form
+  // is mounted (P2P seats at most `P2P_MAX_PEERS`), and this component is not
+  // remounted on a mode change — so the mount-time clamp on `playerCount`
+  // above is not enough. Anchored to the LIVE ceiling (`maxPlayers`, which is
+  // also what the seat buttons render from), and routed through
+  // `handlePlayerCountChange` so the AI seats past the new count are pruned
+  // with it rather than being submitted from `effectiveAiSeats`.
+  //
+  // Guarded on the comparison and depending on `[playerCount, maxPlayers]`
+  // deliberately: `handlePlayerCountChange` is a component-body function whose
+  // identity changes every render, so depending on it would re-render forever.
+  useEffect(() => {
+    if (playerCount <= maxPlayers) return;
+    handlePlayerCountChange(maxPlayers);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [playerCount, maxPlayers]);
+
   const handleDeckSizeChange = (deckSize: number) => {
     // Variant-preserving: the engine is the authority for whether the format's
     // rule is a minimum or an exact count (CR 100.5 / CR 903.5a); this picker
@@ -782,6 +805,17 @@ export function HostSetup({
       onSubmit={(e) => { e.preventDefault(); void handleHost(); }}
       className="relative z-10 flex w-full flex-col gap-5"
     >
+      {/* Mode first: it changes what every control below it means, so it sits
+          above format and seats rather than among the option rows. */}
+      <Field label={t("connectionMode.label")}>
+        <div className="max-w-xs">
+          <ConnectionModeSwitch
+            value={connectionMode}
+            onChange={onConnectionModeChange}
+          />
+        </div>
+      </Field>
+
       {isP2P && (
         <p className="max-w-2xl text-sm leading-6 text-slate-400">
           {t("hostSetup.p2pNotice")}
@@ -909,6 +943,14 @@ export function HostSetup({
               </div>
             </Field>
           </div>
+          {/* The seat ceiling is a live consequence of the mode switch above,
+              so say so rather than letting seats vanish from the picker. The
+              number is `P2P_MAX_PEERS` — never a literal. */}
+          {isP2P && formatConfig.max_players > P2P_MAX_PEERS && (
+            <p role="status" className="-mt-1 text-xs text-fg-meta">
+              {t("hostSetup.p2pSeatCap", { max: P2P_MAX_PEERS })}
+            </p>
+          )}
           {playerCount !== 2 && <p className="-mt-1 text-xs text-fg-meta">{t("hostSetup.bo3Note")}</p>}
 
           {/* Free-for-all deck size (FFA only) */}

--- a/client/src/components/lobby/LobbyView.tsx
+++ b/client/src/components/lobby/LobbyView.tsx
@@ -14,12 +14,14 @@ import {
   isLobbyEntryCompatible,
   lobbySources,
   useMultiplayerStore,
+  type ConnectionMode,
   type LobbyGameEntry,
   type LobbySource,
 } from "../../stores/multiplayerStore";
 import { assertNever } from "../../utils/assertNever";
 import { MenuPanel } from "../menu/MenuShell";
 import { menuButtonClass } from "../menu/buttonStyles";
+import { ConnectionModeSwitch } from "./ConnectionModeSwitch";
 import { GameListItem } from "./GameListItem";
 import type { LobbyGame } from "./GameListItem";
 import { ServerFlag } from "./ServerFlag";
@@ -48,7 +50,11 @@ interface LobbyViewProps {
   ) => void;
   /** Watch a live server game or draft without joining as a player. */
   onSpectate?: (code: string, origin: LobbySource | null, context?: LobbyGame) => void;
-  connectionMode?: "server" | "p2p";
+  connectionMode?: ConnectionMode;
+  /** The page-level mode handler. Required, because an unwired switch would be
+   * a control that lies about what it does; the page owns the write so the
+   * anchor repair it performs is not duplicated per surface. */
+  onConnectionModeChange: (mode: ConnectionMode) => void;
   onServerOffline?: () => void;
 }
 
@@ -87,6 +93,7 @@ export function LobbyView({
   onJoinGame,
   onSpectate,
   connectionMode,
+  onConnectionModeChange,
   onServerOffline,
 }: LobbyViewProps) {
   const { t } = useTranslation("multiplayer");
@@ -468,6 +475,17 @@ export function LobbyView({
           {isP2P ? t("lobbyView.directConnection") : t("lobbyView.onlineLobby")}
         </div>
         <div className="flex min-w-0 flex-wrap items-center gap-2 sm:justify-end">
+          {/* The mode switch sits with the server chip, not with the room-type
+              filter below: it governs which transport this client uses, not
+              which rows the list shows. */}
+          <span className="text-[0.62rem] font-semibold uppercase tracking-[0.18em] text-slate-500">
+            {t("connectionMode.label")}
+          </span>
+          <ConnectionModeSwitch
+            value={isP2P ? "p2p" : "server"}
+            onChange={onConnectionModeChange}
+            size="sm"
+          />
           {isServer && (
             <button
               type="button"
@@ -482,20 +500,6 @@ export function LobbyView({
                 />
               )}
               <span className="truncate whitespace-nowrap">{serverHost}</span>
-            </button>
-          )}
-          {/* In P2P mode the user has no other path back to ServerPicker —
-              the server-address chip above is hidden, and ServerOfflinePrompt
-              only fires when we tried to use a server. Offer an explicit
-              affordance so users who picked "P2P only" aren't trapped. */}
-          {isP2P && (
-            <button
-              type="button"
-              onClick={() => setServerPickerOpen(true)}
-              title={t("lobbyView.pickServerTitle")}
-              className="rounded-[7px] border border-white/10 bg-black/25 px-2.5 py-0.5 text-[10px] text-slate-300 backdrop-blur-sm transition-colors hover:border-white/20 hover:bg-white/5"
-            >
-              {t("lobbyView.pickServer")}
             </button>
           )}
           {isServer && playerCount > 0 && (
@@ -666,22 +670,16 @@ export function LobbyView({
               {t("lobbyView.hostDraft")}
             </button>
           )}
-          {isServer && (
-            <button
-              onClick={handleHost}
-              className={menuButtonClass({ tone: "emerald", size: "md" })}
-            >
-              {t("lobbyView.hostGame")}
-            </button>
-          )}
-          {isP2P && (
-            <button
-              onClick={onHostP2P}
-              className={menuButtonClass({ tone: "cyan", size: "md" })}
-            >
-              {t("lobbyView.hostP2PGame")}
-            </button>
-          )}
+          {/* One button; the mode switch above says which transport it opens,
+              and its tone follows that mode's accent. Each mode keeps its own
+              entry point: the server one seeds host-setup with the lobby's
+              active format filter, the P2P one does not. */}
+          <button
+            onClick={isP2P ? onHostP2P : handleHost}
+            className={menuButtonClass({ tone: isP2P ? "cyan" : "emerald", size: "md" })}
+          >
+            {t("lobbyView.hostGame")}
+          </button>
         </div>
       </div>
 

--- a/client/src/components/lobby/ServerPicker.tsx
+++ b/client/src/components/lobby/ServerPicker.tsx
@@ -208,25 +208,6 @@ export function ServerPicker({ onClose }: ServerPickerProps) {
                 </button>
               );
             })}
-            {/* "None" bypasses the matchmaking broker entirely. `null` is the
-             * direct-codes sentinel: no lobby is browsed and `MultiplayerPage`
-             * forces P2P mode, so the UI lands directly on the direct-code
-             * flow without a round-trip through the offline prompt. */}
-            <button
-              type="button"
-              onClick={() => setHostingServer(null)}
-              className={
-                "flex w-full items-center justify-between rounded-[16px] border px-4 py-2.5 text-left text-sm transition-colors "
-                + (hostingServer === null
-                  ? "border-cyan-400/40 bg-cyan-500/10 text-cyan-100"
-                  : "border-white/10 bg-black/18 text-gray-200 hover:border-white/18 hover:bg-white/6")
-              }
-            >
-              <span className="font-medium">{t("serverPicker.noneLabel")}</span>
-              <span className="shrink-0 pl-2 font-mono text-[10px] text-slate-500">
-                {t("serverPicker.directCodes")}
-              </span>
-            </button>
           </div>
         </div>
 

--- a/client/src/components/lobby/__tests__/ConnectionModeSwitch.test.tsx
+++ b/client/src/components/lobby/__tests__/ConnectionModeSwitch.test.tsx
@@ -1,0 +1,56 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { ConnectionModeSwitch } from "../ConnectionModeSwitch";
+
+describe("ConnectionModeSwitch", () => {
+  afterEach(cleanup);
+
+  it("offers both modes and marks the active one as pressed", () => {
+    render(<ConnectionModeSwitch value="server" onChange={vi.fn()} />);
+
+    expect(
+      screen.getByRole("button", { name: "Official Server" }),
+    ).toHaveAttribute("aria-pressed", "true");
+    expect(screen.getByRole("button", { name: "P2P" })).toHaveAttribute(
+      "aria-pressed",
+      "false",
+    );
+  });
+
+  it("follows `value` rather than any state of its own", () => {
+    const { rerender } = render(
+      <ConnectionModeSwitch value="server" onChange={vi.fn()} />,
+    );
+    rerender(<ConnectionModeSwitch value="p2p" onChange={vi.fn()} />);
+
+    expect(screen.getByRole("button", { name: "P2P" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    expect(
+      screen.getByRole("button", { name: "Official Server" }),
+    ).toHaveAttribute("aria-pressed", "false");
+  });
+
+  it("reports the mode the user picked", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<ConnectionModeSwitch value="server" onChange={onChange} />);
+
+    await user.click(screen.getByRole("button", { name: "P2P" }));
+    expect(onChange).toHaveBeenCalledWith("p2p");
+
+    // Re-picking the active mode still reports it: the parent owns the value,
+    // so the control must not decide a click is a no-op.
+    await user.click(screen.getByRole("button", { name: "Official Server" }));
+    expect(onChange).toHaveBeenLastCalledWith("server");
+  });
+
+  it("names the group so a surface can place it beside its own label", () => {
+    render(<ConnectionModeSwitch value="p2p" onChange={vi.fn()} />);
+
+    expect(screen.getByRole("group", { name: "Connection" })).toBeInTheDocument();
+  });
+});

--- a/client/src/components/lobby/__tests__/HostSetup.test.tsx
+++ b/client/src/components/lobby/__tests__/HostSetup.test.tsx
@@ -196,7 +196,7 @@ describe("HostSetup", () => {
     const user = userEvent.setup();
     seedCandidates();
 
-    render(<HostSetup onHost={vi.fn()} onBack={vi.fn()} connectionMode="server" />);
+    render(<HostSetup onHost={vi.fn()} onBack={vi.fn()} connectionMode="server" onConnectionModeChange={vi.fn()} />);
 
     await user.click(screen.getByRole("button", { name: "Host on" }));
     const options = screen.getAllByRole("option");
@@ -222,7 +222,7 @@ describe("HostSetup", () => {
     const onHost = vi.fn().mockResolvedValue(false);
     seedCandidates();
 
-    render(<HostSetup onHost={onHost} onBack={vi.fn()} connectionMode="server" />);
+    render(<HostSetup onHost={onHost} onBack={vi.fn()} connectionMode="server" onConnectionModeChange={vi.fn()} />);
 
     // Half ONE: the default skips both, so the best-scored USABLE server is
     // what an untouched form submits.
@@ -310,7 +310,7 @@ describe("HostSetup", () => {
       ),
     });
 
-    render(<HostSetup onHost={onHost} onBack={vi.fn()} connectionMode="server" />);
+    render(<HostSetup onHost={onHost} onBack={vi.fn()} connectionMode="server" onConnectionModeChange={vi.fn()} />);
 
     await user.click(screen.getByRole("button", { name: "Host on" }));
     // The preset renders as an ordinary unranked candidate — NOT as
@@ -362,7 +362,7 @@ describe("HostSetup", () => {
       }),
     });
 
-    render(<HostSetup onHost={onHost} onBack={vi.fn()} connectionMode="server" />);
+    render(<HostSetup onHost={onHost} onBack={vi.fn()} connectionMode="server" onConnectionModeChange={vi.fn()} />);
 
     await user.click(screen.getByRole("button", { name: "Host on" }));
     expect(screen.getAllByRole("option").map((option) => option.textContent)).toEqual([
@@ -378,7 +378,7 @@ describe("HostSetup", () => {
   it("renders no host-target picker in p2p mode", () => {
     seedCandidates();
 
-    render(<HostSetup onHost={vi.fn()} onBack={vi.fn()} connectionMode="p2p" />);
+    render(<HostSetup onHost={vi.fn()} onBack={vi.fn()} connectionMode="p2p" onConnectionModeChange={vi.fn()} />);
 
     // Reach-guard FIRST: the form really mounted in p2p mode — its own submit
     // label, which server mode never renders — so the absence below is the
@@ -406,7 +406,7 @@ describe("HostSetup", () => {
       disabledDirectorySources: [],
     });
 
-    render(<HostSetup onHost={onHost} onBack={vi.fn()} connectionMode="server" />);
+    render(<HostSetup onHost={onHost} onBack={vi.fn()} connectionMode="server" onConnectionModeChange={vi.fn()} />);
 
     // Reach-guard: the form mounted with an empty candidate list, which is the
     // state the defect needs.
@@ -442,7 +442,7 @@ describe("HostSetup", () => {
     const onHost = vi.fn().mockResolvedValue(false);
     seedCandidates();
 
-    render(<HostSetup onHost={onHost} onBack={vi.fn()} connectionMode="server" />);
+    render(<HostSetup onHost={onHost} onBack={vi.fn()} connectionMode="server" onConnectionModeChange={vi.fn()} />);
 
     // Paired half ONE: submitting without touching the picker passes the
     // default, so the assertion below is not passing on a constant.
@@ -468,6 +468,7 @@ describe("HostSetup", () => {
         onHost={vi.fn()}
         onBack={vi.fn()}
         connectionMode="p2p"
+        onConnectionModeChange={vi.fn()}
       />,
     );
 
@@ -484,6 +485,7 @@ describe("HostSetup", () => {
         onHost={vi.fn()}
         onBack={vi.fn()}
         connectionMode="server"
+        onConnectionModeChange={vi.fn()}
       />,
     );
 
@@ -495,7 +497,7 @@ describe("HostSetup", () => {
 
   describe.each(["server", "p2p"] as const)("accessible hosting options (%s mode)", (connectionMode) => {
     it("names every visible switch and associates only the sandbox help", () => {
-      render(<HostSetup onHost={vi.fn()} onBack={vi.fn()} connectionMode={connectionMode} />);
+      render(<HostSetup onHost={vi.fn()} onBack={vi.fn()} connectionMode={connectionMode} onConnectionModeChange={vi.fn()} />);
 
       const names = ["Start when full", "Sandbox Mode — allow debug actions", "Set password"];
       if (connectionMode === "server") names.unshift("List in lobby");
@@ -518,7 +520,7 @@ describe("HostSetup", () => {
     it("keeps the compact track inside a non-shrinking touch target", async () => {
       const user = userEvent.setup();
       const onHost = vi.fn();
-      render(<HostSetup onHost={onHost} onBack={vi.fn()} connectionMode={connectionMode} />);
+      render(<HostSetup onHost={onHost} onBack={vi.fn()} connectionMode={connectionMode} onConnectionModeChange={vi.fn()} />);
 
       for (const control of screen.getAllByRole("switch")) {
         // Happy DOM does not lay out CSS. Pin the sizing contract here; check
@@ -541,7 +543,7 @@ describe("HostSetup", () => {
     it("supports native Space and Enter without submitting until Host is activated", async () => {
       const user = userEvent.setup();
       const onHost = vi.fn();
-      render(<HostSetup onHost={onHost} onBack={vi.fn()} connectionMode={connectionMode} />);
+      render(<HostSetup onHost={onHost} onBack={vi.fn()} connectionMode={connectionMode} onConnectionModeChange={vi.fn()} />);
 
       if (connectionMode === "server") {
         const publicSwitch = screen.getByRole("switch", { name: "List in lobby" });
@@ -587,7 +589,7 @@ describe("HostSetup", () => {
     it("clears a password when its named switch is turned off", async () => {
       const user = userEvent.setup();
       const onHost = vi.fn();
-      render(<HostSetup onHost={onHost} onBack={vi.fn()} connectionMode={connectionMode} />);
+      render(<HostSetup onHost={onHost} onBack={vi.fn()} connectionMode={connectionMode} onConnectionModeChange={vi.fn()} />);
 
       const passwordSwitch = screen.getByRole("switch", { name: "Set password" });
       await user.click(passwordSwitch);
@@ -615,7 +617,7 @@ describe("HostSetup", () => {
   it("updates switch names and sandbox help when the active locale changes", async () => {
     const user = userEvent.setup();
     i18n.addResourceBundle("de", "multiplayer", deMultiplayer, true, true);
-    render(<HostSetup onHost={vi.fn()} onBack={vi.fn()} connectionMode="server" />);
+    render(<HostSetup onHost={vi.fn()} onBack={vi.fn()} connectionMode="server" onConnectionModeChange={vi.fn()} />);
 
     const translations = [
       ["List in lobby", "In Lobby listen"],
@@ -643,8 +645,8 @@ describe("HostSetup", () => {
   });
 
   it("keeps sandbox descriptions associated with their own mounted form", () => {
-    const first = render(<HostSetup onHost={vi.fn()} onBack={vi.fn()} connectionMode="server" />);
-    const second = render(<HostSetup onHost={vi.fn()} onBack={vi.fn()} connectionMode="p2p" />);
+    const first = render(<HostSetup onHost={vi.fn()} onBack={vi.fn()} connectionMode="server" onConnectionModeChange={vi.fn()} />);
+    const second = render(<HostSetup onHost={vi.fn()} onBack={vi.fn()} connectionMode="p2p" onConnectionModeChange={vi.fn()} />);
 
     const descriptionIds = [first, second].map(({ container }) => {
       const control = within(container).getByRole("switch", { name: "Sandbox Mode — allow debug actions" });
@@ -666,6 +668,7 @@ describe("HostSetup", () => {
         onHost={onHost}
         onBack={vi.fn()}
         connectionMode="server"
+        onConnectionModeChange={vi.fn()}
       />,
     );
 
@@ -694,6 +697,7 @@ describe("HostSetup", () => {
         onHost={onHost}
         onBack={vi.fn()}
         connectionMode="server"
+        onConnectionModeChange={vi.fn()}
       />,
     );
 
@@ -715,6 +719,7 @@ describe("HostSetup", () => {
         onHost={onHost}
         onBack={vi.fn()}
         connectionMode="server"
+        onConnectionModeChange={vi.fn()}
       />,
     );
 
@@ -763,6 +768,7 @@ describe("HostSetup", () => {
         onHost={onHost}
         onBack={vi.fn()}
         connectionMode="server"
+        onConnectionModeChange={vi.fn()}
       />,
     );
 
@@ -789,6 +795,7 @@ describe("HostSetup", () => {
         onHost={vi.fn()}
         onBack={vi.fn()}
         connectionMode="server"
+        onConnectionModeChange={vi.fn()}
       />,
     );
 
@@ -809,7 +816,7 @@ describe("HostSetup", () => {
     const user = userEvent.setup();
     const onHost = vi.fn();
 
-    render(<HostSetup onHost={onHost} onBack={vi.fn()} connectionMode="server" />);
+    render(<HostSetup onHost={onHost} onBack={vi.fn()} connectionMode="server" onConnectionModeChange={vi.fn()} />);
 
     // Commander's 40 is already in the box, so entering a non-standard value
     // means emptying it first. A per-keystroke clamp used to refill the box
@@ -832,7 +839,7 @@ describe("HostSetup", () => {
     const user = userEvent.setup();
     const onHost = vi.fn();
 
-    render(<HostSetup onHost={onHost} onBack={vi.fn()} connectionMode="server" />);
+    render(<HostSetup onHost={onHost} onBack={vi.fn()} connectionMode="server" onConnectionModeChange={vi.fn()} />);
 
     const life = screen.getByLabelText("Starting Life");
     await user.clear(life);
@@ -899,7 +906,7 @@ describe("HostSetup", () => {
         });
 
         render(
-          <HostSetup onHost={vi.fn()} onBack={vi.fn()} connectionMode={connectionMode} />,
+          <HostSetup onHost={vi.fn()} onBack={vi.fn()} connectionMode={connectionMode} onConnectionModeChange={vi.fn()} />,
         );
 
         // Reached the rendered form at all — i.e. the seat-ceiling lookup did
@@ -957,7 +964,7 @@ describe("HostSetup", () => {
       printing_fidelity: "NotApplicable",
     });
 
-    render(<HostSetup onHost={onHost} onBack={vi.fn()} connectionMode="server" />);
+    render(<HostSetup onHost={onHost} onBack={vi.fn()} connectionMode="server" onConnectionModeChange={vi.fn()} />);
 
     expect(screen.getByRole("button", { name: "Host Game" })).toBeEnabled();
 
@@ -1028,9 +1035,92 @@ describe("HostSetup", () => {
       printing_fidelity: "NotApplicable",
     });
 
-    render(<HostSetup onHost={vi.fn()} onBack={vi.fn()} connectionMode="p2p" />);
+    render(<HostSetup onHost={vi.fn()} onBack={vi.fn()} connectionMode="p2p" onConnectionModeChange={vi.fn()} />);
 
     expect(screen.queryByText(saved.name)).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Use" })).not.toBeInTheDocument();
+  });
+
+  // ── Connection mode switch ──────────────────────────────────────────────
+
+  it("mirrors the connection switch and reports a change to the page", async () => {
+    const user = userEvent.setup();
+    const onConnectionModeChange = vi.fn();
+    render(
+      <HostSetup
+        onHost={vi.fn()}
+        onBack={vi.fn()}
+        connectionMode="server"
+        onConnectionModeChange={onConnectionModeChange}
+      />,
+    );
+
+    const group = screen.getByRole("group", { name: "Connection" });
+    expect(
+      within(group).getByRole("button", { name: "Official Server" }),
+    ).toHaveAttribute("aria-pressed", "true");
+    // The server-only control is what the mode is currently buying.
+    expect(screen.getByText("List in lobby")).toBeInTheDocument();
+
+    await user.click(within(group).getByRole("button", { name: "P2P" }));
+
+    // The page owns the value, so the form reports and does not self-apply.
+    expect(onConnectionModeChange).toHaveBeenCalledWith("p2p");
+    expect(screen.getByText("List in lobby")).toBeInTheDocument();
+  });
+
+  /**
+   * The mode is mutable while this form is mounted and the form is not
+   * remounted on a change, so the mount-time seat clamp is not enough: before
+   * this, a Commander Draft table set to 8 seats in server mode kept
+   * submitting 8 after a flip to P2P while the seat picker rendered 3–6 with
+   * nothing selected — and the AI seat at index 7 rode along with it.
+   */
+  it("clamps seats, and the AI seats past them, when the mode drops the ceiling", async () => {
+    const user = userEvent.setup();
+    const onHost = vi.fn();
+    const { rerender } = render(
+      <HostSetup
+        onHost={onHost}
+        onBack={vi.fn()}
+        connectionMode="server"
+        onConnectionModeChange={vi.fn()}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Format" }));
+    await user.click(screen.getByRole("option", { name: "Commander Draft" }));
+    await user.click(screen.getByRole("button", { name: "8" }));
+    // Seat 8 (index 7) is an AI, so the clamp has to prune it rather than only
+    // lower the count — an unpruned seat is submitted via `effectiveAiSeats`.
+    const humans = screen.getAllByRole("button", { name: "Human" });
+    await user.click(humans[humans.length - 1]);
+
+    rerender(
+      <HostSetup
+        onHost={onHost}
+        onBack={vi.fn()}
+        connectionMode="p2p"
+        onConnectionModeChange={vi.fn()}
+      />,
+    );
+
+    // Said, not silent — and the number comes from `P2P_MAX_PEERS`.
+    expect(
+      screen.getByText(
+        "P2P tables seat at most 6 players, so the seat count is capped.",
+      ),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "8" })).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Host P2P Game" }));
+
+    expect(onHost).toHaveBeenCalledWith(
+      expect.objectContaining({
+        formatConfig: expect.objectContaining({ max_players: 6 }),
+        aiSeats: [],
+      }),
+      null,
+    );
   });
 });

--- a/client/src/components/lobby/__tests__/LobbyView.test.tsx
+++ b/client/src/components/lobby/__tests__/LobbyView.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
+import { act, cleanup, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import type { LobbyGame } from "../../../adapter/types";
@@ -127,6 +127,7 @@ function renderLobby(props: {
     <LobbyView
       onHostGame={vi.fn()}
       onHostP2P={vi.fn()}
+      onConnectionModeChange={vi.fn()}
       onJoinGame={props.onJoinGame ?? vi.fn()}
       onSpectate={props.onSpectate ?? vi.fn()}
       onServerOffline={vi.fn()}
@@ -204,6 +205,7 @@ describe("LobbyView", () => {
       <LobbyView
         onHostGame={vi.fn()}
         onHostP2P={vi.fn()}
+        onConnectionModeChange={vi.fn()}
         onJoinGame={vi.fn()}
         onServerOffline={onServerOffline}
       />,
@@ -234,6 +236,7 @@ describe("LobbyView", () => {
       <LobbyView
         onHostGame={vi.fn()}
         onHostP2P={vi.fn()}
+        onConnectionModeChange={vi.fn()}
         onJoinGame={vi.fn()}
         onServerOffline={onServerOffline}
       />,
@@ -253,6 +256,7 @@ describe("LobbyView", () => {
       <LobbyView
         onHostGame={vi.fn()}
         onHostP2P={vi.fn()}
+        onConnectionModeChange={vi.fn()}
         onJoinGame={vi.fn()}
         connectionMode="p2p"
         onServerOffline={vi.fn()}
@@ -279,6 +283,7 @@ describe("LobbyView", () => {
       <LobbyView
         onHostGame={vi.fn()}
         onHostP2P={vi.fn()}
+        onConnectionModeChange={vi.fn()}
         onJoinGame={vi.fn()}
         onServerOffline={onServerOffline}
       />,
@@ -637,6 +642,7 @@ describe("LobbyView", () => {
       <LobbyView
         onHostGame={vi.fn()}
         onHostP2P={vi.fn()}
+        onConnectionModeChange={vi.fn()}
         onJoinGame={vi.fn()}
         connectionMode="p2p"
       />,
@@ -717,6 +723,7 @@ describe("LobbyView", () => {
         <LobbyView
           onHostGame={vi.fn()}
           onHostP2P={vi.fn()}
+          onConnectionModeChange={vi.fn()}
           onJoinGame={vi.fn()}
           onSpectate={vi.fn()}
           onServerOffline={vi.fn()}
@@ -725,7 +732,7 @@ describe("LobbyView", () => {
       );
       // Reach-guard: a p2p-ONLY element, so the zero below is the effect's
       // guard and not a render that never happened.
-      expect(screen.getByText(/Dedicated server unavailable/)).toBeInTheDocument();
+      expect(screen.getByText(/Peer-to-peer mode\./)).toBeInTheDocument();
       document.dispatchEvent(new Event("visibilitychange"));
       expect(directoryMocks.refreshServerDirectory).toHaveBeenCalledTimes(0);
 
@@ -788,5 +795,117 @@ describe("LobbyView", () => {
     // the join is by source URL and not applied to every row.
     const presetRow = screen.getByRole("button", { name: /Table Preset/ });
     expect(presetRow.textContent).not.toContain("SLOW");
+  });
+
+  // ── Connection mode switch ──────────────────────────────────────────────
+
+  /** Mode is a PROP: the view reports a change and never applies one to
+   *  itself, which is what keeps the page the single authority. */
+  function renderWithMode(props: {
+    connectionMode: "server" | "p2p";
+    onHostGame?: () => void;
+    onHostP2P?: () => void;
+    onConnectionModeChange?: (mode: "server" | "p2p") => void;
+  }) {
+    return render(
+      <LobbyView
+        onHostGame={props.onHostGame ?? vi.fn()}
+        onHostP2P={props.onHostP2P ?? vi.fn()}
+        onConnectionModeChange={props.onConnectionModeChange ?? vi.fn()}
+        onJoinGame={vi.fn()}
+        onSpectate={vi.fn()}
+        onServerOffline={vi.fn()}
+        connectionMode={props.connectionMode}
+      />,
+    );
+  }
+
+  it("reports a mode change instead of applying one", async () => {
+    const user = userEvent.setup();
+    const onConnectionModeChange = vi.fn();
+    renderWithMode({ connectionMode: "server", onConnectionModeChange });
+
+    const group = screen.getByRole("group", { name: "Connection" });
+    expect(
+      within(group).getByRole("button", { name: "Official Server" }),
+    ).toHaveAttribute("aria-pressed", "true");
+
+    await user.click(within(group).getByRole("button", { name: "P2P" }));
+
+    expect(onConnectionModeChange).toHaveBeenCalledWith("p2p");
+    // Nothing local moved: the view still renders the mode it was given.
+    expect(
+      within(group).getByRole("button", { name: "Official Server" }),
+    ).toHaveAttribute("aria-pressed", "true");
+  });
+
+  it("offers one host button whose action follows the active mode", async () => {
+    const user = userEvent.setup();
+    const server = { onHostGame: vi.fn(), onHostP2P: vi.fn() };
+    renderWithMode({ connectionMode: "server", ...server });
+
+    // One button, not two mutually-exclusive ones.
+    expect(screen.getAllByRole("button", { name: "Host Game" })).toHaveLength(1);
+    await user.click(screen.getByRole("button", { name: "Host Game" }));
+    expect(server.onHostGame).toHaveBeenCalledTimes(1);
+    expect(server.onHostP2P).not.toHaveBeenCalled();
+
+    // Same button in P2P, dispatching to the entry point that does NOT seed
+    // host-setup from the lobby's format filter.
+    cleanup();
+    const p2p = { onHostGame: vi.fn(), onHostP2P: vi.fn() };
+    renderWithMode({ connectionMode: "p2p", ...p2p });
+
+    await user.click(screen.getByRole("button", { name: "Host Game" }));
+    expect(p2p.onHostP2P).toHaveBeenCalledTimes(1);
+    expect(p2p.onHostGame).not.toHaveBeenCalled();
+  });
+
+  it("replaces the P2P-only server shortcut with the switch", () => {
+    renderWithMode({ connectionMode: "p2p" });
+
+    expect(screen.getByRole("group", { name: "Connection" })).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Pick server" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("keeps the room-type filter applied when the connection switch is used", async () => {
+    const user = userEvent.setup();
+    const source: LobbySource = {
+      url: SERVER_PRESETS[0].url,
+      name: "lobby.phase-rs.dev",
+      origin: "official",
+    };
+    const subscribeLobby = vi.fn(
+      async (onUpdate: (games: LobbyGame[], source: LobbySource) => void) => {
+        onUpdate([lobbyGame("SRV01", "Server table", 100)], source);
+        return () => {};
+      },
+    );
+    useMultiplayerStore.setState({
+      subscribeLobby,
+      subscribeAmbientLobby: vi.fn(() => () => {}),
+    });
+    renderWithMode({ connectionMode: "server" });
+
+    await screen.findByRole("button", { name: /Server table/ });
+    // "Draft", not "P2P": the room-type filter and the connection switch both
+    // carry a "P2P" label, and only the switch is inside the named group.
+    await user.click(screen.getByRole("button", { name: "Draft" }));
+    expect(screen.queryByRole("button", { name: /Server table/ })).not.toBeInTheDocument();
+
+    await user.click(
+      within(screen.getByRole("group", { name: "Connection" })).getByRole(
+        "button",
+        { name: "P2P" },
+      ),
+    );
+
+    // The filter the user set still hides the non-draft row. Deliberately NOT
+    // asserting "no re-subscribe": `connectionMode` is a fixed prop here and
+    // `onConnectionModeChange` is a spy, so the mode cannot actually change and
+    // a re-subscribe count would hold no matter what the switch did.
+    expect(screen.queryByRole("button", { name: /Server table/ })).not.toBeInTheDocument();
   });
 });

--- a/client/src/components/lobby/__tests__/ServerPicker.test.tsx
+++ b/client/src/components/lobby/__tests__/ServerPicker.test.tsx
@@ -175,20 +175,25 @@ describe("ServerPicker", () => {
     ]);
   });
 
-  it("switches the hosting server and back to direct codes", async () => {
-    useMultiplayerStore.setState({ userLobbySources: [userSource("play.example.com")] });
+  it("picks a server, and offers no way to pick none", async () => {
+    useMultiplayerStore.setState({
+      hostingServer: null,
+      userLobbySources: [userSource("play.example.com")],
+    });
     const user = userEvent.setup();
     render(<ServerPicker onClose={vi.fn()} />);
 
-    await user.click(screen.getByRole("button", { name: /None \(P2P only\)/ }));
-
-    expect(useMultiplayerStore.getState().hostingServer).toBeNull();
-    // Sources are a separate axis: switching to direct codes keeps them.
-    expect(useMultiplayerStore.getState().userLobbySources).toHaveLength(1);
+    // The picker is purely server selection now — connection mode moved to the
+    // lobby's switch, so the old "None (P2P only)" row is gone.
+    expect(
+      screen.queryByRole("button", { name: /None \(P2P only\)/ }),
+    ).not.toBeInTheDocument();
 
     await user.click(screen.getByRole("button", { name: /Official/ }));
 
     expect(useMultiplayerStore.getState().hostingServer).toBe(PRESET_URL);
+    // Sources are a separate axis: choosing a hosting server keeps them.
+    expect(useMultiplayerStore.getState().userLobbySources).toHaveLength(1);
   });
 
   it("uses a user source as the hosting server", async () => {

--- a/client/src/i18n/locales/de/multiplayer.json
+++ b/client/src/i18n/locales/de/multiplayer.json
@@ -127,11 +127,14 @@
     "kindFull": "(Spielserver)",
     "kindLobbyOnly": "(Lobby-Broker)"
   },
+  "connectionMode": {
+    "label": "Verbindung",
+    "server": "Offizieller Server",
+    "p2p": "P2P"
+  },
   "serverPicker": {
     "title": "Server",
     "subtitle": "Wähle, wo du hostest und welche Lobbys du durchsuchst.",
-    "noneLabel": "Keiner (nur P2P)",
-    "directCodes": "direkte Codes",
     "official": "Offiziell",
     "selfHosted": "Selbst gehostet",
     "customUrlPlaceholder": "wss://dein-server.beispiel/ws",
@@ -179,8 +182,6 @@
   "lobbyView": {
     "directConnection": "Direktverbindung",
     "onlineLobby": "Online-Lobby",
-    "pickServerTitle": "Wähle einen Server, um den Online-Lobby-Modus zu nutzen",
-    "pickServer": "Server wählen",
     "online": "{{count}} online",
     "format": "Format",
     "allFormats": "Alle Formate",
@@ -192,7 +193,7 @@
     "noFormatGames": "Derzeit keine {{format}}-Spiele.",
     "noOpenGames": "Derzeit keine offenen Spiele.",
     "showAllFormats": "Alle Formate anzeigen",
-    "p2pNotice": "Dedizierter Server nicht verfügbar. Du kannst trotzdem direkt mit einem 5-stelligen Raumcode hosten oder beitreten.",
+    "p2pNotice": "Peer-to-Peer-Modus. Hoste oder tritt direkt mit einem 5-stelligen Raumcode bei.",
     "joinByCode": "Per Code beitreten",
     "joinATable": "Einem Tisch beitreten",
     "p2pCodePlaceholder": "5-stelligen P2P-Code eingeben",
@@ -203,7 +204,6 @@
     "hostServerDescription": "Öffne einen Raum und warte auf Spieler.",
     "hostDraft": "Draft hosten",
     "hostGame": "Spiel hosten",
-    "hostP2PGame": "P2P-Spiel hosten",
     "passwordRequired": "Passwort erforderlich",
     "passwordPlaceholder": "Passwort eingeben",
     "watch": "Watch",
@@ -213,7 +213,8 @@
   "hostSetup": {
     "hostDirectMatch": "Direkte Partie hosten",
     "hostMatch": "Partie hosten",
-    "p2pNotice": "Der dedizierte Server ist nicht verfügbar, daher nutzt dieser Raum eine Direktverbindung.",
+    "p2pNotice": "Peer-to-Peer-Modus. Dieser Raum verbindet die Spieler direkt, statt auf einem Server zu laufen.",
+    "p2pSeatCap": "P2P-Tische haben höchstens {{max}} Plätze, daher ist die Spielerzahl begrenzt.",
     "roomName": "Raumname",
     "optional": "(optional)",
     "roomNamePlaceholder": "z. B. Freitagabend Commander",

--- a/client/src/i18n/locales/en/multiplayer.json
+++ b/client/src/i18n/locales/en/multiplayer.json
@@ -127,11 +127,14 @@
     "kindFull": "(game server)",
     "kindLobbyOnly": "(lobby broker)"
   },
+  "connectionMode": {
+    "label": "Connection",
+    "server": "Official Server",
+    "p2p": "P2P"
+  },
   "serverPicker": {
     "title": "Server",
     "subtitle": "Choose where you host, and which lobbies you browse.",
-    "noneLabel": "None (P2P only)",
-    "directCodes": "direct codes",
     "official": "Official",
     "selfHosted": "Self-hosted",
     "customUrlPlaceholder": "wss://your-server.example/ws",
@@ -179,8 +182,6 @@
   "lobbyView": {
     "directConnection": "Direct Connection",
     "onlineLobby": "Online Lobby",
-    "pickServerTitle": "Pick a server to use online lobby mode",
-    "pickServer": "Pick server",
     "online": "{{count}} online",
     "format": "Format",
     "allFormats": "All formats",
@@ -192,7 +193,7 @@
     "noFormatGames": "No {{format}} games right now.",
     "noOpenGames": "No open games right now.",
     "showAllFormats": "Show all formats",
-    "p2pNotice": "Dedicated server unavailable. You can still host or join directly with a 5-character room code.",
+    "p2pNotice": "Peer-to-peer mode. Host or join directly with a 5-character room code.",
     "joinByCode": "Join by Code",
     "joinATable": "Join a Table",
     "p2pCodePlaceholder": "Enter 5-character P2P code",
@@ -204,7 +205,6 @@
     "hostServerDescription": "Open a room and wait for players.",
     "hostDraft": "Host Draft",
     "hostGame": "Host Game",
-    "hostP2PGame": "Host P2P Game",
     "passwordRequired": "Password Required",
     "passwordPlaceholder": "Enter password",
     "sourcesDegraded": "Some lobby sources are unreachable",
@@ -213,7 +213,8 @@
   "hostSetup": {
     "hostDirectMatch": "Host Direct Match",
     "hostMatch": "Host Match",
-    "p2pNotice": "Dedicated server is unavailable, so this room will use a direct connection.",
+    "p2pNotice": "Peer-to-peer mode. This room connects players directly instead of running on a server.",
+    "p2pSeatCap": "P2P tables seat at most {{max}} players, so the seat count is capped.",
     "roomName": "Room Name",
     "optional": "(optional)",
     "roomNamePlaceholder": "e.g. Friday Night Commander",

--- a/client/src/i18n/locales/es/multiplayer.json
+++ b/client/src/i18n/locales/es/multiplayer.json
@@ -127,11 +127,14 @@
     "kindFull": "(servidor de juego)",
     "kindLobbyOnly": "(intermediario de sala)"
   },
+  "connectionMode": {
+    "label": "Conexión",
+    "server": "Servidor oficial",
+    "p2p": "P2P"
+  },
   "serverPicker": {
     "title": "Servidor",
     "subtitle": "Elige dónde alojas tus partidas y qué salas exploras.",
-    "noneLabel": "Ninguno (solo P2P)",
-    "directCodes": "códigos directos",
     "official": "Oficial",
     "selfHosted": "Autoalojado",
     "customUrlPlaceholder": "wss://tu-servidor.ejemplo/ws",
@@ -179,8 +182,6 @@
   "lobbyView": {
     "directConnection": "Conexión directa",
     "onlineLobby": "Sala de espera en línea",
-    "pickServerTitle": "Elige un servidor para usar el modo de sala de espera en línea",
-    "pickServer": "Elegir servidor",
     "online": "{{count}} en línea",
     "format": "Formato",
     "allFormats": "Todos los formatos",
@@ -192,7 +193,7 @@
     "noFormatGames": "No hay partidas de {{format}} ahora mismo.",
     "noOpenGames": "No hay partidas abiertas ahora mismo.",
     "showAllFormats": "Mostrar todos los formatos",
-    "p2pNotice": "Servidor dedicado no disponible. Aún puedes hospedar o unirte directamente con un código de sala de 5 caracteres.",
+    "p2pNotice": "Modo peer-to-peer. Hospeda o únete directamente con un código de sala de 5 caracteres.",
     "joinByCode": "Unirse por código",
     "joinATable": "Unirse a una mesa",
     "p2pCodePlaceholder": "Introduce el código P2P de 5 caracteres",
@@ -203,7 +204,6 @@
     "hostServerDescription": "Abre una sala y espera a los jugadores.",
     "hostDraft": "Hospedar draft",
     "hostGame": "Hospedar partida",
-    "hostP2PGame": "Hospedar partida P2P",
     "passwordRequired": "Contraseña requerida",
     "passwordPlaceholder": "Introduce la contraseña",
     "watch": "Watch",
@@ -213,7 +213,8 @@
   "hostSetup": {
     "hostDirectMatch": "Hospedar partida directa",
     "hostMatch": "Hospedar partida",
-    "p2pNotice": "El servidor dedicado no está disponible, así que esta sala usará una conexión directa.",
+    "p2pNotice": "Modo peer-to-peer. Esta sala conecta a los jugadores directamente en lugar de ejecutarse en un servidor.",
+    "p2pSeatCap": "Las mesas P2P admiten como máximo {{max}} jugadores, así que el número de asientos está limitado.",
     "roomName": "Nombre de la sala",
     "optional": "(opcional)",
     "roomNamePlaceholder": "p. ej. Commander del viernes por la noche",

--- a/client/src/i18n/locales/fr/multiplayer.json
+++ b/client/src/i18n/locales/fr/multiplayer.json
@@ -127,11 +127,14 @@
     "kindFull": "(serveur de jeu)",
     "kindLobbyOnly": "(courtier de salon)"
   },
+  "connectionMode": {
+    "label": "Connexion",
+    "server": "Serveur officiel",
+    "p2p": "P2P"
+  },
   "serverPicker": {
     "title": "Serveur",
     "subtitle": "Choisissez où vous hébergez, et quels salons vous parcourez.",
-    "noneLabel": "Aucun (P2P uniquement)",
-    "directCodes": "codes directs",
     "official": "Officiel",
     "selfHosted": "Auto-hébergé",
     "customUrlPlaceholder": "wss://votre-serveur.exemple/ws",
@@ -179,8 +182,6 @@
   "lobbyView": {
     "directConnection": "Connexion directe",
     "onlineLobby": "Salon en ligne",
-    "pickServerTitle": "Choisissez un serveur pour utiliser le mode salon en ligne",
-    "pickServer": "Choisir un serveur",
     "online": "{{count}} en ligne",
     "format": "Format",
     "allFormats": "Tous les formats",
@@ -192,7 +193,7 @@
     "noFormatGames": "Aucune partie {{format}} pour le moment.",
     "noOpenGames": "Aucune partie ouverte pour le moment.",
     "showAllFormats": "Afficher tous les formats",
-    "p2pNotice": "Serveur dédié indisponible. Vous pouvez toujours héberger ou rejoindre directement avec un code de salle à 5 caractères.",
+    "p2pNotice": "Mode pair-à-pair. Hébergez ou rejoignez directement avec un code de salle à 5 caractères.",
     "joinByCode": "Rejoindre par code",
     "joinATable": "Rejoindre une table",
     "p2pCodePlaceholder": "Saisissez un code P2P à 5 caractères",
@@ -203,7 +204,6 @@
     "hostServerDescription": "Ouvrez une salle et attendez des joueurs.",
     "hostDraft": "Héberger un draft",
     "hostGame": "Héberger une partie",
-    "hostP2PGame": "Héberger une partie P2P",
     "passwordRequired": "Mot de passe requis",
     "passwordPlaceholder": "Saisissez le mot de passe",
     "watch": "Watch",
@@ -213,7 +213,8 @@
   "hostSetup": {
     "hostDirectMatch": "Héberger un match direct",
     "hostMatch": "Héberger un match",
-    "p2pNotice": "Le serveur dédié est indisponible, donc cette salle utilisera une connexion directe.",
+    "p2pNotice": "Mode pair-à-pair. Cette salle connecte les joueurs directement au lieu de tourner sur un serveur.",
+    "p2pSeatCap": "Les tables P2P accueillent au plus {{max}} joueurs, le nombre de places est donc plafonné.",
     "roomName": "Nom de la salle",
     "optional": "(facultatif)",
     "roomNamePlaceholder": "ex. Commander du vendredi soir",

--- a/client/src/i18n/locales/it/multiplayer.json
+++ b/client/src/i18n/locales/it/multiplayer.json
@@ -127,11 +127,14 @@
     "kindFull": "(server di gioco)",
     "kindLobbyOnly": "(broker lobby)"
   },
+  "connectionMode": {
+    "label": "Connessione",
+    "server": "Server ufficiale",
+    "p2p": "P2P"
+  },
   "serverPicker": {
     "title": "Server",
     "subtitle": "Scegli dove ospitare e quali lobby sfogliare.",
-    "noneLabel": "Nessuno (solo P2P)",
-    "directCodes": "codici diretti",
     "official": "Ufficiale",
     "selfHosted": "Self-hosted",
     "customUrlPlaceholder": "wss://tuo-server.esempio/ws",
@@ -179,8 +182,6 @@
   "lobbyView": {
     "directConnection": "Connessione diretta",
     "onlineLobby": "Lobby online",
-    "pickServerTitle": "Scegli un server per usare la modalità lobby online",
-    "pickServer": "Scegli server",
     "online": "{{count}} online",
     "format": "Formato",
     "allFormats": "Tutti i formati",
@@ -192,7 +193,7 @@
     "noFormatGames": "Nessuna partita {{format}} al momento.",
     "noOpenGames": "Nessuna partita aperta al momento.",
     "showAllFormats": "Mostra tutti i formati",
-    "p2pNotice": "Server dedicato non disponibile. Puoi comunque ospitare o unirti direttamente con un codice stanza di 5 caratteri.",
+    "p2pNotice": "Modalità peer-to-peer. Ospita o unisciti direttamente con un codice stanza di 5 caratteri.",
     "joinByCode": "Unisciti tramite codice",
     "joinATable": "Unisciti a un tavolo",
     "p2pCodePlaceholder": "Inserisci codice P2P di 5 caratteri",
@@ -203,7 +204,6 @@
     "hostServerDescription": "Apri una stanza e attendi i giocatori.",
     "hostDraft": "Ospita draft",
     "hostGame": "Ospita partita",
-    "hostP2PGame": "Ospita partita P2P",
     "passwordRequired": "Password richiesta",
     "passwordPlaceholder": "Inserisci password",
     "watch": "Watch",
@@ -213,7 +213,8 @@
   "hostSetup": {
     "hostDirectMatch": "Ospita partita diretta",
     "hostMatch": "Ospita partita",
-    "p2pNotice": "Il server dedicato non è disponibile, quindi questa stanza userà una connessione diretta.",
+    "p2pNotice": "Modalità peer-to-peer. Questa stanza collega i giocatori direttamente invece di girare su un server.",
+    "p2pSeatCap": "I tavoli P2P ospitano al massimo {{max}} giocatori, quindi il numero di posti è limitato.",
     "roomName": "Nome stanza",
     "optional": "(facoltativo)",
     "roomNamePlaceholder": "es. Commander del venerdì sera",

--- a/client/src/i18n/locales/pl/multiplayer.json
+++ b/client/src/i18n/locales/pl/multiplayer.json
@@ -127,11 +127,14 @@
     "kindFull": "(serwer gry)",
     "kindLobbyOnly": "(broker poczekalni)"
   },
+  "connectionMode": {
+    "label": "Połączenie",
+    "server": "Oficjalny serwer",
+    "p2p": "P2P"
+  },
   "serverPicker": {
     "title": "Serwer",
     "subtitle": "Wybierz, gdzie hostujesz i które poczekalnie przeglądasz.",
-    "noneLabel": "Brak (tylko P2P)",
-    "directCodes": "bezpośrednie kody",
     "official": "Oficjalny",
     "selfHosted": "Własny hosting",
     "customUrlPlaceholder": "wss://twoj-serwer.example/ws",
@@ -179,8 +182,6 @@
   "lobbyView": {
     "directConnection": "Połączenie bezpośrednie",
     "onlineLobby": "Poczekalnia online",
-    "pickServerTitle": "Wybierz serwer, aby korzystać z trybu poczekalni online",
-    "pickServer": "Wybierz serwer",
     "online": "{{count}} online",
     "format": "Format",
     "allFormats": "Wszystkie formaty",
@@ -192,7 +193,7 @@
     "noFormatGames": "Brak gier {{format}} w tej chwili.",
     "noOpenGames": "Brak otwartych gier w tej chwili.",
     "showAllFormats": "Pokaż wszystkie formaty",
-    "p2pNotice": "Dedykowany serwer niedostępny. Nadal możesz być gospodarzem lub dołączyć bezpośrednio za pomocą 5-znakowego kodu pokoju.",
+    "p2pNotice": "Tryb peer-to-peer. Hostuj lub dołącz bezpośrednio za pomocą 5-znakowego kodu pokoju.",
     "joinByCode": "Dołącz za pomocą kodu",
     "joinATable": "Dołącz do stołu",
     "p2pCodePlaceholder": "Wpisz 5-znakowy kod P2P",
@@ -203,7 +204,6 @@
     "hostServerDescription": "Otwórz pokój i czekaj na graczy.",
     "hostDraft": "Hostuj draft",
     "hostGame": "Hostuj grę",
-    "hostP2PGame": "Hostuj grę P2P",
     "passwordRequired": "Wymagane hasło",
     "passwordPlaceholder": "Wpisz hasło",
     "watch": "Watch",
@@ -213,7 +213,8 @@
   "hostSetup": {
     "hostDirectMatch": "Hostuj mecz bezpośredni",
     "hostMatch": "Hostuj mecz",
-    "p2pNotice": "Dedykowany serwer jest niedostępny, więc ten pokój użyje połączenia bezpośredniego.",
+    "p2pNotice": "Tryb peer-to-peer. Ten pokój łączy graczy bezpośrednio, zamiast działać na serwerze.",
+    "p2pSeatCap": "Stoły P2P mieszczą maksymalnie {{max}} graczy, więc liczba miejsc jest ograniczona.",
     "roomName": "Nazwa pokoju",
     "optional": "(opcjonalnie)",
     "roomNamePlaceholder": "np. Piątkowy wieczór Commander",

--- a/client/src/i18n/locales/pt/multiplayer.json
+++ b/client/src/i18n/locales/pt/multiplayer.json
@@ -127,11 +127,14 @@
     "kindFull": "(servidor de jogo)",
     "kindLobbyOnly": "(intermediário de sala)"
   },
+  "connectionMode": {
+    "label": "Conexão",
+    "server": "Servidor oficial",
+    "p2p": "P2P"
+  },
   "serverPicker": {
     "title": "Servidor",
     "subtitle": "Escolha onde você hospeda e quais salas você navega.",
-    "noneLabel": "Nenhum (apenas P2P)",
-    "directCodes": "códigos diretos",
     "official": "Oficial",
     "selfHosted": "Auto-hospedado",
     "customUrlPlaceholder": "wss://seu-servidor.exemplo/ws",
@@ -179,8 +182,6 @@
   "lobbyView": {
     "directConnection": "Conexão Direta",
     "onlineLobby": "Lobby Online",
-    "pickServerTitle": "Escolha um servidor para usar o modo de lobby online",
-    "pickServer": "Escolher servidor",
     "online": "{{count}} online",
     "format": "Formato",
     "allFormats": "Todos os formatos",
@@ -192,7 +193,7 @@
     "noFormatGames": "Nenhum jogo de {{format}} no momento.",
     "noOpenGames": "Nenhum jogo aberto no momento.",
     "showAllFormats": "Mostrar todos os formatos",
-    "p2pNotice": "Servidor dedicado indisponível. Você ainda pode hospedar ou entrar diretamente com um código de sala de 5 caracteres.",
+    "p2pNotice": "Modo peer-to-peer. Hospede ou entre diretamente com um código de sala de 5 caracteres.",
     "joinByCode": "Entrar por Código",
     "joinATable": "Entrar em uma Mesa",
     "p2pCodePlaceholder": "Insira o código P2P de 5 caracteres",
@@ -203,7 +204,6 @@
     "hostServerDescription": "Abra uma sala e aguarde os jogadores.",
     "hostDraft": "Hospedar Draft",
     "hostGame": "Hospedar Jogo",
-    "hostP2PGame": "Hospedar Jogo P2P",
     "passwordRequired": "Senha Necessária",
     "passwordPlaceholder": "Insira a senha",
     "watch": "Watch",
@@ -213,7 +213,8 @@
   "hostSetup": {
     "hostDirectMatch": "Hospedar Partida Direta",
     "hostMatch": "Hospedar Partida",
-    "p2pNotice": "O servidor dedicado está indisponível, então esta sala usará uma conexão direta.",
+    "p2pNotice": "Modo peer-to-peer. Esta sala conecta os jogadores diretamente em vez de rodar em um servidor.",
+    "p2pSeatCap": "Mesas P2P comportam no máximo {{max}} jogadores, então o número de assentos é limitado.",
     "roomName": "Nome da Sala",
     "optional": "(opcional)",
     "roomNamePlaceholder": "ex.: Commander de Sexta à Noite",

--- a/client/src/pages/MultiplayerPage.tsx
+++ b/client/src/pages/MultiplayerPage.tsx
@@ -32,8 +32,10 @@ import {
   findLobbyGameByCode,
   hostingLobbySource,
   useMultiplayerStore,
+  type ConnectionMode,
   type LobbySource,
 } from "../stores/multiplayerStore";
+import { DEFAULT_MULTIPLAYER_SERVER_URL } from "../config/multiplayerServer";
 import {
   useMultiplayerDraftStore,
   type MultiplayerDraftPhase,
@@ -42,8 +44,6 @@ import { useGameStore, saveActiveGame } from "../stores/gameStore";
 import { useCardDataStore } from "../stores/cardDataStore";
 import { useEffectiveOffline } from "../stores/connectivityStore";
 import type { HostSettings } from "../components/lobby/HostSetup";
-
-type ConnectionMode = "server" | "p2p";
 
 function parseViewParam(value: string | null): MultiplayerView {
   if (value === "host-setup" || value === "deck-select" || value === "draft-lobby") return value;
@@ -143,12 +143,6 @@ function MultiplayerPageContent({
   const leaveDraft = useMultiplayerDraftStore((s) => s.leave);
 
   const [activeDeckName, setActiveDeckName] = useState<string | null>(null);
-  // Initial mode tracks `hostingServer`: if the user has picked "None" in
-  // `ServerPicker` (the `null` direct-codes sentinel), skip straight to P2P
-  // so the lobby doesn't attempt a doomed subscription.
-  const [connectionMode, setConnectionMode] = useState<ConnectionMode>(
-    useMultiplayerStore.getState().hostingServer !== null ? "server" : "p2p",
-  );
   const [showSettings, setShowSettings] = useState(false);
   const [pendingAction, setPendingAction] = useState<PendingAction | null>(null);
   // Shown when `LobbyView` detects the server is unreachable. The user picks
@@ -182,6 +176,16 @@ function MultiplayerPageContent({
   const [deckSelectReturn, setDeckSelectReturn] =
     useState<MultiplayerView>("lobby");
   const hostingServer = useMultiplayerStore((s) => s.hostingServer);
+  const chosenConnectionMode = useMultiplayerStore((s) => s.connectionMode);
+  const setConnectionMode = useMultiplayerStore((s) => s.setConnectionMode);
+  const setHostingServer = useMultiplayerStore((s) => s.setHostingServer);
+  // The mode in force. An explicit choice WINS; the `hostingServer`-derived
+  // expression is the hydration fallback, reached only on a first run or a
+  // blob persisted before the connection switch existed — a user whose anchor
+  // is the `null` direct-codes sentinel must still boot into P2P. It is a
+  // migration default, not a competing writer.
+  const connectionMode: ConnectionMode =
+    chosenConnectionMode ?? (hostingServer !== null ? "server" : "p2p");
   // HostSetup mirrors its in-flight format into the store on every change,
   // so reading it here lets both the deck-picker filter and the live
   // compatibility check react to the user's format choice without any
@@ -225,14 +229,23 @@ function MultiplayerPageContent({
     navigate(location.pathname, { replace: true, state: null });
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
-  // Sync connectionMode when the user changes their hosting server via
-  // ServerPicker. `null` → P2P (no server to talk to). Restored address →
-  // server (selecting a server IS the explicit intent). Only reacts to
-  // `hostingServer` changes — not connectionMode — so an explicit "Use
-  // Direct Code" selection isn't immediately reversed.
-  useEffect(() => {
-    setConnectionMode(hostingServer === null ? "p2p" : "server");
-  }, [hostingServer]);
+  // The single owner of a mode change, called by BOTH surfaces that render
+  // the switch (the lobby header and Host Game) so the anchor repair below
+  // lives in exactly one place.
+  const handleConnectionModeChange = useCallback(
+    (mode: ConnectionMode) => {
+      setConnectionMode(mode);
+      // Server mode needs an anchor to browse and host through, and the
+      // server chip — now the only route back to `ServerPicker` — renders
+      // empty without one. The only way to still hold a `null` anchor is a
+      // blob persisted before the picker's "None" row was removed. This
+      // ensures an anchor exists; it never clears one.
+      if (mode === "server" && useMultiplayerStore.getState().hostingServer === null) {
+        setHostingServer(DEFAULT_MULTIPLAYER_SERVER_URL);
+      }
+    },
+    [setConnectionMode, setHostingServer],
+  );
 
   // Live legality check: whenever the user is on host-setup with an active
   // deck and a chosen format, re-run the engine's compatibility check after
@@ -901,6 +914,7 @@ function MultiplayerPageContent({
             onJoinGame={handleJoinGame}
             onSpectate={connectionMode === "server" ? handleSpectate : undefined}
             connectionMode={connectionMode}
+            onConnectionModeChange={handleConnectionModeChange}
             onServerOffline={() => {
               // Only prompt when we're actually trying to use the server; if
               // the user already flipped to P2P the "unreachable" state is
@@ -917,6 +931,7 @@ function MultiplayerPageContent({
             onHost={handleHostSetupComplete}
             onBack={() => setView("lobby")}
             connectionMode={connectionMode}
+            onConnectionModeChange={handleConnectionModeChange}
             hostDisabled={liveCheck.status === "illegal" || liveCheck.status === "checking"}
             hostDisabledReason={
               liveCheck.status === "illegal"

--- a/client/src/pages/__tests__/MultiplayerPage.connectionMode.test.tsx
+++ b/client/src/pages/__tests__/MultiplayerPage.connectionMode.test.tsx
@@ -1,0 +1,187 @@
+import { act, cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * The connection mode is an explicit, persisted choice — not a shadow of the
+ * hosting server.
+ *
+ * Three claims live here: a stored choice OUTRANKS the `hostingServer`-derived
+ * fallback across a remount; the server-offline prompt flips the same switch
+ * the user sees rather than routing around it; and entering server mode with
+ * no anchor repairs the anchor instead of leaving the lobby pointed at
+ * nothing. Harness shape follows `MultiplayerPage.hostServer.test.tsx`: render
+ * the real page, stub the children, keep the real store module.
+ */
+const harness = vi.hoisted(() => ({
+  navigate: vi.fn(),
+  /** Live props of the stubbed lobby, so a test reads the mode the page
+   * actually handed the switch — not the store field behind it. */
+  lobby: null as Record<string, unknown> | null,
+}));
+
+/**
+ * The page mounts the metrics lifecycle installer. Left unmocked it would
+ * register listeners bound to the REAL official host (`vitest.config.ts`
+ * defines `__OFFICIAL_MULTIPLAYER_SERVER_URL__` as the production URL).
+ */
+vi.mock("../../services/serverMetrics", () => ({
+  reportConnectOutcome: vi.fn(),
+  flushMetricsNow: vi.fn(),
+  installServerMetricsLifecycle: vi.fn(),
+  metricsUrl: vi.fn(() => "https://metrics.test/servers/metrics"),
+}));
+
+vi.mock("react-router", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("react-router")>()),
+  useNavigate: () => harness.navigate,
+}));
+
+vi.mock("../../components/lobby/LobbyView", () => ({
+  LobbyView: (props: Record<string, unknown>) => {
+    harness.lobby = props;
+    return <div data-testid="lobby" />;
+  },
+}));
+
+vi.mock("../../components/lobby/HostSetup", () => ({ HostSetup: () => null }));
+vi.mock("../../components/chrome/ScreenChrome", () => ({ ScreenChrome: () => null }));
+vi.mock("../../components/chrome/ShellContext", () => ({ useInShell: () => false }));
+vi.mock("../../components/menu/MenuParticles", () => ({ MenuParticles: () => null }));
+vi.mock("../../components/menu/MyDecks", () => ({ MyDecks: () => null }));
+vi.mock("../../audio/useAudioContext", () => ({ useAudioContext: () => undefined }));
+
+vi.mock("../../stores/cardDataStore", () => ({
+  useCardDataStore: { getState: () => ({ warm: vi.fn() }) },
+}));
+
+vi.mock("../../stores/multiplayerDraftStore", () => ({
+  useMultiplayerDraftStore: (selector: (state: Record<string, unknown>) => unknown) =>
+    selector({
+      phase: "idle",
+      roomCode: null,
+      seats: [],
+      joined: 0,
+      joinDraft: vi.fn(),
+      leave: vi.fn(),
+    }),
+}));
+
+vi.mock("../../stores/gameStore", () => ({
+  useGameStore: { setState: vi.fn() },
+  saveActiveGame: vi.fn(),
+}));
+
+vi.mock("../../constants/storage", () => ({
+  ACTIVE_DECK_KEY: "active-deck",
+  loadActiveDeck: () => ({ main: ["Island"], sideboard: [] }),
+  touchDeckPlayed: vi.fn(),
+}));
+
+vi.mock("../../services/multiplayerSession", () => ({
+  clearWsSession: vi.fn(),
+  loadWsSession: vi.fn(() => null),
+  saveWsSession: vi.fn(),
+}));
+
+import { MultiplayerPage } from "../MultiplayerPage";
+import { useMultiplayerStore } from "../../stores/multiplayerStore";
+import { DEFAULT_MULTIPLAYER_SERVER_URL } from "../../config/multiplayerServer";
+
+const ANCHOR_URL = "wss://anchor.example/ws";
+
+function renderPage() {
+  return render(
+    <MemoryRouter initialEntries={["/multiplayer"]}>
+      <MultiplayerPage />
+    </MemoryRouter>,
+  );
+}
+
+describe("MultiplayerPage connection mode", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    harness.lobby = null;
+    useMultiplayerStore.setState({
+      hostingServer: ANCHOR_URL,
+      connectionMode: null,
+      userLobbySources: [],
+      sourceStatus: new Map(),
+      directorySources: [],
+      disabledDirectorySources: [],
+      toasts: new Map(),
+    });
+  });
+
+  afterEach(cleanup);
+
+  it("keeps a stored P2P choice across a remount, even with a server anchor", async () => {
+    // Reach-guard: with nothing stored, the anchor-derived fallback applies —
+    // so the assertion after the choice measures the precedence and not a
+    // page that is always in P2P.
+    renderPage();
+    await screen.findByTestId("lobby");
+    expect(harness.lobby!.connectionMode).toBe("server");
+
+    act(() => {
+      (harness.lobby!.onConnectionModeChange as (mode: string) => void)("p2p");
+    });
+    expect(harness.lobby!.connectionMode).toBe("p2p");
+    // The anchor is untouched: it is also the P2P broker target, so the switch
+    // must never clear it.
+    expect(useMultiplayerStore.getState().hostingServer).toBe(ANCHOR_URL);
+    // The choice reaches storage. Without this the whole design is inert on a
+    // reload, and the in-memory remount below would pass on a value that only
+    // survives because the module was never re-evaluated.
+    expect(
+      JSON.parse(localStorage.getItem("phase-multiplayer") ?? "{}").state
+        ?.connectionMode,
+    ).toBe("p2p");
+
+    cleanup();
+    renderPage();
+    await screen.findByTestId("lobby");
+
+    expect(harness.lobby!.connectionMode).toBe("p2p");
+  });
+
+  it("repairs a missing anchor when the user picks server mode", async () => {
+    // The legacy state: a blob persisted while the picker still offered its
+    // "None" row. Nothing else can produce it any more.
+    useMultiplayerStore.setState({ hostingServer: null });
+
+    renderPage();
+    await screen.findByTestId("lobby");
+    expect(harness.lobby!.connectionMode).toBe("p2p");
+
+    act(() => {
+      (harness.lobby!.onConnectionModeChange as (mode: string) => void)("server");
+    });
+
+    expect(harness.lobby!.connectionMode).toBe("server");
+    expect(useMultiplayerStore.getState().hostingServer).toBe(
+      DEFAULT_MULTIPLAYER_SERVER_URL,
+    );
+  });
+
+  it("flips the switch when the offline prompt offers direct codes", async () => {
+    const user = userEvent.setup();
+    renderPage();
+    await screen.findByTestId("lobby");
+    expect(harness.lobby!.connectionMode).toBe("server");
+
+    act(() => {
+      (harness.lobby!.onServerOffline as () => void)();
+    });
+
+    await user.click(screen.getByRole("button", { name: "Use direct code" }));
+
+    // The prompt must not route AROUND the control: after it, the switch the
+    // user is looking at reports P2P, and the choice is stored like any other.
+    expect(harness.lobby!.connectionMode).toBe("p2p");
+    expect(useMultiplayerStore.getState().connectionMode).toBe("p2p");
+    // It chooses a mode, not a server.
+    expect(useMultiplayerStore.getState().hostingServer).toBe(ANCHOR_URL);
+  });
+});

--- a/client/src/pages/__tests__/MultiplayerPage.hostServer.test.tsx
+++ b/client/src/pages/__tests__/MultiplayerPage.hostServer.test.tsx
@@ -181,6 +181,9 @@ describe("MultiplayerPage host server", () => {
     // zustand actions are plain state fields, so `setState` swaps them.
     useMultiplayerStore.setState({
       hostingServer: URL_A,
+      // Reset per case: the mode is persisted store state now, so leg (ii)'s
+      // flip to P2P would otherwise leak into whatever runs after it.
+      connectionMode: null,
       userLobbySources: [],
       sourceStatus: new Map(),
       directorySources: [],

--- a/client/src/pages/__tests__/MultiplayerPage.offline.test.tsx
+++ b/client/src/pages/__tests__/MultiplayerPage.offline.test.tsx
@@ -23,6 +23,11 @@ const mocks = vi.hoisted(() => ({
     closeSubscriptionSocket: vi.fn(),
     clearAllToasts: vi.fn(),
     serverAddress: "wss://example.test/ws",
+    // The page reads both off the store now; without them the mode selector
+    // resolves to `undefined` and the switch's setter is not callable.
+    connectionMode: null as "server" | "p2p" | null,
+    setConnectionMode: vi.fn(),
+    setHostingServer: vi.fn(),
     formatConfig: null,
     compatibilityPlayerCount: null,
     resolveGuest: vi.fn(),

--- a/client/src/stores/__tests__/multiplayerStore.test.ts
+++ b/client/src/stores/__tests__/multiplayerStore.test.ts
@@ -987,6 +987,40 @@ describe("multiplayerStore", () => {
     );
   });
 
+  // `connectionMode` is the one persisted key whose ABSENCE is meaningful: it is
+  // the sentinel that means "never chosen", which is what lets the page fall back
+  // to deriving the mode from `hostingServer`. A junk value must therefore land on
+  // `null` and not merely survive the spread — if it did, a corrupted blob would
+  // read as a deliberate choice and permanently override the fallback.
+  it.each([
+    ["a junk string", "peer-to-peer"],
+    ["a non-string", 7],
+    ["null", null],
+  ])("hydrates %s connection mode as never-chosen", (_label, stored) => {
+    localStorage.setItem(
+      "phase-multiplayer",
+      JSON.stringify({ state: { connectionMode: stored }, version: 6 }),
+    );
+
+    act(() => useMultiplayerStore.persist.rehydrate());
+
+    expect(useMultiplayerStore.getState().connectionMode).toBeNull();
+  });
+
+  it.each(["server", "p2p"] as const)(
+    "hydrates a stored %s connection mode as a real choice",
+    (stored) => {
+      localStorage.setItem(
+        "phase-multiplayer",
+        JSON.stringify({ state: { connectionMode: stored }, version: 6 }),
+      );
+
+      act(() => useMultiplayerStore.persist.rehydrate());
+
+      expect(useMultiplayerStore.getState().connectionMode).toBe(stored);
+    },
+  );
+
   it("strips AI seats from team-based server host settings", async () => {
     useMultiplayerStore.getState().startHosting(
       hostingSettings({

--- a/client/src/stores/multiplayerStore.ts
+++ b/client/src/stores/multiplayerStore.ts
@@ -122,6 +122,14 @@ export type { DeckChoice, PlayerSlot, SeatKind, SeatMutation } from "../multipla
 type ConnectionStatus = "disconnected" | "connecting" | "connected";
 type HostingStatus = "idle" | "connecting" | "waiting";
 
+/**
+ * The transport a multiplayer session runs over: a dedicated server, or a
+ * direct peer-to-peer mesh. The player picks it explicitly in the lobby's
+ * connection switch, so it lives here rather than being derived from
+ * {@link MultiplayerState.hostingServer}.
+ */
+export type ConnectionMode = "server" | "p2p";
+
 // Module-level WebSocket ref (non-serializable, lives outside store)
 let hostWs: PhaseSocketTransport | null = null;
 // Module-level broker client for P2P LobbyOnly hosting. Survives page
@@ -1147,6 +1155,18 @@ interface MultiplayerState {
    * `setHostingServer`, migration and hydration).
    */
   hostingServer: string | null;
+  /**
+   * The connection mode the player chose in the lobby's connection switch, or
+   * `null` when they have never chosen one. PERSISTED, so the choice survives
+   * a reload and the ordinary lobby → game → lobby round trip.
+   *
+   * `null` is the load-bearing "absent" sentinel: `MultiplayerPage` falls back
+   * to deriving the mode from {@link MultiplayerState.hostingServer} only
+   * while this is `null`, which is what lets a legacy blob with a `null`
+   * anchor still boot into P2P. A non-null initial would make "never chosen"
+   * indistinguishable from "chose server" and destroy that preference.
+   */
+  connectionMode: ConnectionMode | null;
   /** Hand-added lobby authorities. Persisted; built-in presets are derived
    * per session by {@link lobbySources} and are never stored here. */
   userLobbySources: LobbySource[];
@@ -1219,6 +1239,10 @@ interface MultiplayerActions {
    * Invalid URLs are ignored. Refreshes the global `serverInfo` from the
    * new target's live socket, if it has one. */
   setHostingServer: (url: string | null) => void;
+  /** Record the player's explicit connection-mode choice. The single writer of
+   * {@link MultiplayerState.connectionMode}; there is deliberately no action
+   * that restores the `null` "never chosen" sentinel. */
+  setConnectionMode: (mode: ConnectionMode) => void;
   /** Add a hand-added lobby source. Refuses malformed URLs, URLs already
    * derived as a source (presets included) and adds past the cap. */
   addUserLobbySource: (url: string) => AddLobbySourceResult;
@@ -2292,6 +2316,7 @@ export const useMultiplayerStore = create<MultiplayerState & MultiplayerActions>
       playerId: crypto.randomUUID(),
       displayName: "",
       hostingServer: DEFAULT_MULTIPLAYER_SERVER_URL as string | null,
+      connectionMode: null as ConnectionMode | null,
       userLobbySources: [] as LobbySource[],
       directorySources: [] as DirectorySource[],
       directoryFetchedAtMs: null as number | null,
@@ -2351,6 +2376,8 @@ export const useMultiplayerStore = create<MultiplayerState & MultiplayerActions>
         set({ hostingServer: url, serverInfo: live?.serverInfo ?? null });
       },
 
+      setConnectionMode: (mode) => set({ connectionMode: mode }),
+
       addUserLobbySource: (url) => {
         const source = userLobbySource(url);
         if (!source) return { ok: false, reason: "invalid_url" };
@@ -2382,7 +2409,7 @@ export const useMultiplayerStore = create<MultiplayerState & MultiplayerActions>
         // Hosting on a source the user no longer browses is unreachable: the
         // removed URL is absent from `lobbySources`, so the player's own
         // hosted game drops off the merged list and the picker's hosting
-        // section (presets + None) shows no active selection to change.
+        // section (the presets) shows no active selection to change.
         // Fall back to this build's official server through `setHostingServer`
         // so `serverInfo` is re-pointed with the choice.
         if (url === get().hostingServer) {
@@ -3404,12 +3431,20 @@ export const useMultiplayerStore = create<MultiplayerState & MultiplayerActions>
               : saved.hostingServer === null
                 ? null
                 : current.hostingServer,
+          // Only the two modes are accepted; anything else (including an
+          // absent key) reads as "never chosen", so the page's
+          // `hostingServer`-derived fallback still applies.
+          connectionMode:
+            saved.connectionMode === "server" || saved.connectionMode === "p2p"
+              ? saved.connectionMode
+              : null,
         };
       },
       partialize: (state) => ({
         playerId: state.playerId,
         displayName: state.displayName,
         hostingServer: state.hostingServer,
+        connectionMode: state.connectionMode,
         userLobbySources: state.userLobbySources,
         // No persist version bump: an absent key hydrates through `merge` to
         // the initial `[]`, and an older build reading a newer blob spreads a


### PR DESCRIPTION
The connection mode was a side effect of server selection, not a choice.
`connectionMode` was derived from `hostingServer !== null`, and the lobby
rendered its two host buttons mutually exclusively — so with a server
auto-assigned the P2P button never appeared at all. The only route to P2P
was a ServerPicker row labelled "None (P2P only)": a mode switch disguised
as a server-list entry, which a player looking for direct play had no
reason to open or to read as a mode.

Make the mode an explicit segmented control, shown in the lobby header and
again on Host Game above format/seats, where it changes what those controls
mean. Both surfaces call one page-level handler, so the two placements
cannot disagree.

Mode becomes persisted state rather than a derivation. The store field is
nullable and initialises to `null`: that sentinel is what keeps "never
chosen" distinguishable from "chose server", so an explicit choice survives
a reload while a legacy user with no stored mode still falls back to the
`hostingServer`-derived answer. Hydration validates the stored value the way
neighbouring keys do — persisted state is external input, and a corrupted
blob must not read as a deliberate choice.

`hostingServer` is left alone. It is the broker target, the direct-codes
sentinel and the browsing anchor at once, so nulling it on a mode flip would
break broker-advertised P2P hosting, remount the lobby (discarding a typed
join code), and stick across reloads. The switch only ever ensures an anchor
exists when entering server mode; it never clears one.

Switching to P2P now clamps seats to the peer ceiling through the existing
count handler, so AI seats past the ceiling are pruned rather than submitted,
and the cap is announced inline from the constant.

Both `p2pNotice` strings asserted a server outage, which was true when P2P
was reachable only as a fallback and false once it is a deliberate choice;
they are now mode-descriptive. The ServerPicker "None" row and its dead keys
are gone.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a connection-mode selector for choosing between Official Server and P2P.
  * Connection mode now persists across sessions and updates lobby and hosting actions.
  * Added P2P seat-limit messaging, with player counts adjusted when limits are exceeded.
  * Updated multiplayer labels and notices across supported languages.

* **Changes**
  * Server selection no longer includes a “None (P2P only)” option.
  * Simplified lobby hosting controls and removed the P2P server-picker shortcut.

* **Tests**
  * Added coverage for mode selection, persistence, seat limits, hosting behavior, and localization-related UI updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->