### PR TITLE
fix(probe-pin): narrow P7's census anchor to the line its mutation edits

### DIFF
--- a/crates/engine/tests/integration/loop_shortcut_offer_writer_census.rs
+++ b/crates/engine/tests/integration/loop_shortcut_offer_writer_census.rs
@@ -79,7 +79,7 @@
 // resource, locally, on engine-source edits. It is NOT checked in GitHub CI, and CI
 // enrollment is policy-blocked (`.agents/pr-review-policy.toml` `[hard_stops]` lists
 // `.github/workflows/**`). A green block in a merged commit is not a CI-verified block.
-// PROBE-PIN:BEGIN manifest=probe-pin/engine-census.toml digest=sha256:d4d228a11ec1379c
+// PROBE-PIN:BEGIN manifest=probe-pin/engine-census.toml digest=sha256:35206da1a7fd9d60
 // instrument rustc = rustc 1.97.0-nightly (0febdbab2 2026-04-18)
 // | probe | mutation | expect | verdict | firing assertion (anchor) | provenance |
 // |---|---|---|---|---|---|

--- a/crates/engine/tests/integration/loop_shortcut_offer_writer_census.rs
+++ b/crates/engine/tests/integration/loop_shortcut_offer_writer_census.rs
@@ -79,7 +79,7 @@
 // resource, locally, on engine-source edits. It is NOT checked in GitHub CI, and CI
 // enrollment is policy-blocked (`.agents/pr-review-policy.toml` `[hard_stops]` lists
 // `.github/workflows/**`). A green block in a merged commit is not a CI-verified block.
-// PROBE-PIN:BEGIN manifest=probe-pin/engine-census.toml digest=sha256:35206da1a7fd9d60
+// PROBE-PIN:BEGIN manifest=probe-pin/engine-census.toml digest=sha256:8cf2e0fee5d61110
 // instrument rustc = rustc 1.97.0-nightly (0febdbab2 2026-04-18)
 // | probe | mutation | expect | verdict | firing assertion (anchor) | provenance |
 // |---|---|---|---|---|---|

--- a/probe-pin/engine-census.toml
+++ b/probe-pin/engine-census.toml
@@ -216,8 +216,8 @@ claim = "the one consumer runs the COVERAGE half too -- adjacency is load-bearin
   [[probe.mutation]]
   kind    = "replace"
   file    = "crates/engine/src/analysis/decision_template.rs"
-  find    = "    predictability_gate(template, &required).is_ok()\n        && validate_pins(schema, template, validated_range, state).is_ok()\n"
-  replace = "    predictability_gate(template, &required).is_ok()\n        // probe pad\n        // probe pad\n        // probe pad\n        && validate_pins(schema, template, validated_range, state).is_ok()\n"
+  find    = "    predictability_gate(template, &schema.points).is_ok()\n        && validate_pins(schema, template, validated_range, state).is_ok()\n"
+  replace = "    predictability_gate(template, &schema.points).is_ok()\n        // probe pad\n        // probe pad\n        // probe pad\n        && validate_pins(schema, template, validated_range, state).is_ok()\n"
   [[probe.assert_count]]
   file  = "crates/engine/src/analysis/decision_template.rs"
   text  = "// probe pad"

--- a/probe-pin/engine-census.toml
+++ b/probe-pin/engine-census.toml
@@ -216,8 +216,8 @@ claim = "the one consumer runs the COVERAGE half too -- adjacency is load-bearin
   [[probe.mutation]]
   kind    = "replace"
   file    = "crates/engine/src/analysis/decision_template.rs"
-  find    = "    predictability_gate(template, &schema.points).is_ok()\n        && validate_pins(schema, template, validated_range, state).is_ok()\n"
-  replace = "    predictability_gate(template, &schema.points).is_ok()\n        // probe pad\n        // probe pad\n        // probe pad\n        && validate_pins(schema, template, validated_range, state).is_ok()\n"
+  find    = "        && validate_pins(schema, template, validated_range, state).is_ok()\n"
+  replace = "        // probe pad\n        // probe pad\n        // probe pad\n        && validate_pins(schema, template, validated_range, state).is_ok()\n"
   [[probe.assert_count]]
   file  = "crates/engine/src/analysis/decision_template.rs"
   text  = "// probe pad"


### PR DESCRIPTION
## Summary

Probe `P7_coverage_half_unpaired` in `probe-pin/engine-census.toml` anchored its mutation on `predictability_gate(template, &required)`, but #8349 rewrote `declaration_conforms` to pass `&schema.points` and dropped the `required` local. probe-pin treats a 0-match `find` as a rotted probe and aborts the whole run rather than reporting verdicts it cannot trust, so the local `probe-pin-census` Tilt resource has been in terminal error on every run since.

Two commits: the first re-anchors P7 on the live call; the second narrows the anchor to the one line the mutation actually edits, so the same class of drift cannot rot this probe again. `probe-pin` is not enrolled in GitHub CI, so the verification for both is local and recorded below.

## Files changed

- `probe-pin/engine-census.toml` — P7's `find` and `replace`
- `crates/engine/tests/integration/loop_shortcut_offer_writer_census.rs` — regenerated `PROBE-PIN:BEGIN…END` block; the delta is the digest line only, in both commits

## Track

Developer

## LLM

Model: claude-opus-5
Tier: Frontier
Thinking: high

## Implementation method (required)

Method: /engine-implementer

## CR references

None. No CR annotations added or changed; the diff contains no game logic.

## Verification

- [x] Required checks ran clean, or the exact CI-owned alternative is stated below.
- [x] Gate A output below is for the current committed head.
- [x] Final review-impl below is clean for the current committed head.
- [x] Both anchors cite existing analogous code at the same seam.

- `CARGO_TARGET_DIR=target/probe-pin-census cargo probe-pin check probe-pin/engine-census.toml` — **exit 0** at the current head with a clean tree. All nine verdicts match their `expect`.
- `cargo fmt --all --check` — exit 0, no output.
- `./scripts/check-parser-combinators.sh` — exit 0 (`Gate A PASS`, `Gate G PASS`); see the disclosure under Gate A.
- **Negative control, run once per commit.** A green `probe-pin check` prints nothing, so an exit 0 alone is indistinguishable from the instrument not running. Re-rotting the anchor by edit and re-running the identical command reproduces the reported failure — `probe-pin: P7_coverage_half_unpaired mutation[0] …: 'find' matched 0 times, expected exactly 1. … Aborting.`, exit 2 — then restoring by edit returns it to exit 0. That is the live-instrument leg for the green.
- **Population walk.** Every `[[probe.mutation]]` parsed from the manifest (9 mutations across 9 probes; 5 carry a `find`), counted against the file each names. At the base P7 matched 0 while the other four matched 1; at this head all five match 1. P7 was the only rot, which is why the scope is two files.
- **Byte-identity of the narrowed mutation (second commit).** Both mutations were constructed against the live source and compared: the narrowed `find`/`replace` yields a mutant byte-identical to the wide form's, with the three `// probe pad` lines still landing between the two conjuncts. Control: a deliberately wrong two-pad variant does *not* compare equal, so the equality is discriminating rather than trivially true. `[[probe.assert_count]]` and `[probe.expect].anchor` are unchanged.
- **Rebased and re-verified.** #8616 landed on main touching `crates/engine/src/parser/{oracle_cost,oracle_target}.rs`, which is inside this census's walk root `crates/engine/src`. The digest is a measurement over that tree, so the gate leg does not carry across it; this branch was rebased onto `a983de6ef` and `probe-pin check` re-run — exit 0.
- Not run, with reason: `clippy` / `test-engine` / `card-data`. The diff is a TOML manifest and one Rust comment line — no compiled source changes, and `probe-pin`'s `[target].mode = "runtime-read"` reads mutants as text without compiling them.

## Gate A

Gate A PASS head=f2027276b712742208dca6e46eb5d71dd6590d3f base=d6d28370c09242182488cac72e16e5a84941885f

Disclosure: Gate A's base is fork-relative and it scanned 69 files under `crates/engine/src/parser`. This diff touches zero parser files, so the PASS reports that the instrument is live, not that it examined anything in this change.

## Anchored on

- `probe-pin/engine-census.toml:175` — `P5_relocation_preserves_the_count`'s mutation: the same single-line `find` anchored on a live production string that P7 now uses.
- `probe-pin/engine-census.toml:235` — `P8_authority_call_site_removed`'s mutation anchored on a live call-site string in `game/engine.rs`, the same "anchor on the production call" convention P7 follows.

## Final review-impl

Final review-impl PASS head=f2027276b712742208dca6e46eb5d71dd6590d3f

## Claimed parse impact

None.

## Scope Expansion

None. The second commit stays inside the same probe's `find`/`replace` — it changes no other probe, no assertion, and no engine source.

## Validation Failures

None.

## CI Failures

None. `probe-pin` is not enrolled in GitHub CI — `.agents/pr-review-policy.toml` `[hard_stops]` lists `.github/workflows/**`, which the pinned test file's own header records. The gate for this change is local, and its output is under Verification above.
