### PR TITLE
Fix Cartographer's Hawk

### DIFF
--- a/crates/engine/src/analysis/resource.rs
+++ b/crates/engine/src/analysis/resource.rs
@@ -27680,7 +27680,7 @@ mod tests {
             comparator: Comparator::GE,
             count: Box::new(QuantityExpr::Fixed { value: 1 }),
         };
-        // The other payload `parse_attacked_player_relative_clause` builds ("attacks a player
+        // The other payload `parse_player_relative_clause` builds ("attacks a player
         // who has more life than you"): `player_filter_contains` treats it as a LEAF, so the
         // walk is handed NOTHING below the crossing and no extension of that walk could reach
         // the dependence — the verdict has to be taken at the node.

--- a/crates/engine/src/game/trigger_matchers.rs
+++ b/crates/engine/src/game/trigger_matchers.rs
@@ -781,8 +781,8 @@ fn is_player_scope_damage_filter(filter: &TargetFilter) -> bool {
         // predicate ("deals damage to a player who has more life than you") is a
         // player recipient, never an object one. Decided, not defaulted: the
         // `_ => false` tail below would silently misclassify it as an object
-        // filter. Unreachable today — no printed card produces this shape — but
-        // pinned by a unit test so a future flip is deliberate.
+        // filter. Cartographer's Hawk exercises this event-time player-relative
+        // damage-recipient shape; the unit test keeps future changes deliberate.
         TargetFilter::PlayerMatching { .. } => true,
         _ => false,
     }
@@ -5411,8 +5411,8 @@ mod tests {
     /// predicate as a PLAYER recipient. Decided, not defaulted: the match ends
     /// in `_ => false`, so nothing but this pin records the decision.
     ///
-    /// Unreachable today (no printed card produces a `PlayerMatching` damage
-    /// recipient), which is precisely why it is pinned — a future flip must be
+    /// Cartographer's Hawk produces a `PlayerMatching` damage recipient for its
+    /// event-time player-relative trigger; this pin keeps future changes
     /// deliberate.
     #[test]
     fn player_matching_is_a_player_scope_damage_recipient() {

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -8427,7 +8427,7 @@ pub(crate) fn parse_opponent_most_life_restriction(input: &str) -> OracleResult<
 /// CR 119.1 + CR 109.5 + CR 810.9a: "who has more life than you" as a
 /// per-candidate player predicate. Consumes its OWN `who ` prefix, matching the
 /// convention of [`lower::parse_controls_permanent_object`] so that every arm of
-/// [`parse_attacked_player_relative_clause`] starts from the same input
+/// [`parse_player_relative_clause`] starts from the same input
 /// position.
 ///
 /// `attr` is read PER CANDIDATE by `effects::candidate_player_scalar_with_state`
@@ -8569,24 +8569,24 @@ fn controls_clause_player_filter<'a>(
 }
 
 /// CR 508.1b + CR 603.2 + CR 102.1: the `who`-headed relative clause narrowing
-/// an ATTACKED player ("attacks a player who has more life than you"). Composed
-/// by axis — one arm per predicate family — so a new predicate costs one arm,
-/// never a full-sentence `tag`.
+/// a trigger-event player ("attacks a player who has more life than you" /
+/// "deals combat damage to a player who controls more lands than you").
+/// Composed by axis — one arm per predicate family — so a new predicate costs
+/// one arm, never a full-sentence `tag`.
 ///
 /// The `who ` token is consumed by the ARMS, exactly once each, never by this
 /// dispatcher: `parse_has_more_life_than_you` opens with `tag("who ")`, and
 /// `controls_clause_player_filter`'s delegate opens all of its branches with
 /// `tag("who ")`. Stripping `who ` here would break the delegate.
 ///
-/// `input` MUST be the caller's post-noun slice — the text after the single
-/// space that follows the attacked-player noun. Every `parse_attack_target` tag
-/// carries a LEADING space, so the raw remainder begins with that space and no
-/// arm here would match it.
+/// `input` MUST be the caller's post-noun slice, with the relative-clause head
+/// (`who `) unconsumed. Callers normalize their own noun remainder before
+/// entering this shared predicate grammar.
 ///
-/// `relation` is supplied by the caller from the base attacked-player noun
+/// `relation` is supplied by the caller from the base player noun
 /// ("a player" -> All, "one of your opponents" -> Opponent), so the base-scope
 /// and predicate axes compose rather than multiply.
-pub(crate) fn parse_attacked_player_relative_clause<'a>(
+pub(crate) fn parse_player_relative_clause<'a>(
     input: &'a str,
     relation: PlayerRelation,
     ctx: &mut ParseContext,

--- a/crates/engine/src/parser/oracle_tests.rs
+++ b/crates/engine/src/parser/oracle_tests.rs
@@ -7,8 +7,8 @@ use crate::parser::oracle_ir::doc::{
 use crate::parser::oracle_ir::static_ir::StaticIr;
 use crate::parser::oracle_util::GRANTING_SELF_PLACEHOLDER;
 use crate::types::ability::{
-    AdditionalCostOrigin, AdditionalCostPaymentSource, CountScope, CounterAdjustment, DoorLockOp,
-    PlayerRelation, SpellStackToGraveyardReplacement,
+    AdditionalCostOrigin, AdditionalCostPaymentSource, CountScope, CounterAdjustment,
+    DamageKindFilter, DoorLockOp, PlayerRelation, SpellStackToGraveyardReplacement,
 };
 use crate::types::counter::{CounterMatch, CounterType};
 use crate::types::triggers::AttackTargetFilter;
@@ -27163,6 +27163,194 @@ fn owlbear_cub_attacked_player_land_threshold_predicate_is_bound() {
     };
     assert!(typed.type_filters.contains(&TypeFilter::Land));
     assert_eq!(attack.condition, None);
+}
+
+/// Issue #8391 — Cartographer's Hawk's recipient-relative land comparison is
+/// part of the combat-damage event, not an intervening-if condition. The
+/// complete, verbatim Oracle text also pins the existing bounce/search chain.
+#[test]
+fn cartographers_hawk_damage_recipient_predicate_is_bound_to_the_event() {
+    let parsed = parse(
+        "Flying\nWhen this creature deals combat damage to a player who controls more lands than you, return it to its owner's hand. If you do, you may search your library for a Plains card, put it onto the battlefield tapped, then shuffle.",
+        "Cartographer's Hawk",
+        &[Keyword::Flying],
+        &["Creature"],
+        &["Bird"],
+    );
+    assert!(
+        !parsed_has_unimplemented(&parsed),
+        "Cartographer's Hawk must parse without an Unimplemented effect: {parsed:#?}"
+    );
+
+    let trigger = parsed
+        .triggers
+        .iter()
+        .find(|trigger| trigger.mode == TriggerMode::DamageDone)
+        .expect("Cartographer's Hawk must retain its combat-damage trigger");
+    assert_eq!(trigger.damage_kind, DamageKindFilter::CombatOnly);
+    assert_eq!(trigger.valid_source, Some(TargetFilter::SelfRef));
+    assert_eq!(
+        trigger.condition, None,
+        "the event predicate is not CR 603.4"
+    );
+    assert_eq!(
+        trigger.valid_target,
+        Some(TargetFilter::PlayerMatching {
+            player: Box::new(PlayerFilter::ControlsCount {
+                relation: PlayerRelation::All,
+                filter: TargetFilter::Typed(TypedFilter::new(TypeFilter::Land)),
+                comparator: Comparator::GT,
+                count: Box::new(QuantityExpr::Ref {
+                    qty: QuantityRef::ObjectCount {
+                        filter: TargetFilter::Typed(
+                            TypedFilter::new(TypeFilter::Land).controller(ControllerRef::You),
+                        ),
+                    },
+                }),
+            }),
+        }),
+        "the damaged player must be compared with the trigger controller"
+    );
+
+    let bounce = trigger
+        .execute
+        .as_deref()
+        .expect("the trigger must retain its effect chain");
+    assert!(
+        matches!(
+            bounce.effect.as_ref(),
+            Effect::Bounce {
+                target: TargetFilter::ParentTarget,
+                ..
+            }
+        ),
+        "Cartographer's Hawk must begin by returning itself: {bounce:#?}"
+    );
+    let search = bounce
+        .sub_ability
+        .as_deref()
+        .expect("the successful bounce must continue to the optional Plains search");
+    assert!(search.optional, "\"you may search\" must remain optional");
+    assert!(matches!(
+        search.effect.as_ref(),
+        Effect::SearchLibrary { .. }
+    ));
+    let put_plains = search
+        .sub_ability
+        .as_deref()
+        .expect("the search must continue to putting the chosen Plains onto the battlefield");
+    assert!(matches!(
+        put_plains.effect.as_ref(),
+        Effect::ChangeZone {
+            enter_tapped: crate::types::zones::EtbTapState::Tapped,
+            ..
+        }
+    ));
+    assert!(matches!(
+        put_plains
+            .sub_ability
+            .as_deref()
+            .map(|definition| definition.effect.as_ref()),
+        Some(Effect::Shuffle { .. })
+    ));
+}
+
+/// The generic subject-led and article/source-led production routes must emit
+/// the same relative-recipient filter. The negative rows ensure neither route
+/// silently degrades an unmodelled `who` clause to its broad player noun.
+#[test]
+fn damage_recipient_relative_predicates_have_route_parity_and_fail_closed() {
+    let expected = TargetFilter::PlayerMatching {
+        player: Box::new(PlayerFilter::ControlsCount {
+            relation: PlayerRelation::All,
+            filter: TargetFilter::Typed(TypedFilter::new(TypeFilter::Land)),
+            comparator: Comparator::GT,
+            count: Box::new(QuantityExpr::Ref {
+                qty: QuantityRef::ObjectCount {
+                    filter: TargetFilter::Typed(
+                        TypedFilter::new(TypeFilter::Land).controller(ControllerRef::You),
+                    ),
+                },
+            }),
+        }),
+    };
+    for (name, text) in [
+        (
+            "Generic Damage Recipient",
+            "Whenever ~ deals combat damage to a player who controls more lands than you, draw a card.",
+        ),
+        (
+            "Article Damage Recipient",
+            "Whenever a creature deals combat damage to a player who controls more lands than you, draw a card.",
+        ),
+    ] {
+        let parsed = parse(text, name, &[], &["Creature"], &[]);
+        let trigger = parsed
+            .triggers
+            .iter()
+            .find(|trigger| trigger.mode == TriggerMode::DamageDone)
+            .unwrap_or_else(|| panic!("{name} must parse as DamageDone: {parsed:#?}"));
+        assert_eq!(trigger.valid_target, Some(expected.clone()));
+        assert_eq!(trigger.condition, None);
+        assert!(
+            !parsed_has_unimplemented(&parsed),
+            "{name}: supported recipient predicate must not leave an Unimplemented effect: {parsed:#?}"
+        );
+    }
+
+    for (name, text) in [
+        (
+            "Unsupported generic recipient predicate",
+            "Whenever ~ deals combat damage to a player who has drawn three cards this turn, draw a card.",
+        ),
+        (
+            "Partial generic recipient predicate",
+            "Whenever ~ deals combat damage to a player who controls more lands than you and controls a Forest, draw a card.",
+        ),
+        (
+            "Opponent recipient predicate",
+            "Whenever a creature deals combat damage to an opponent who controls more lands than you, draw a card.",
+        ),
+    ] {
+        let parsed = parse(text, name, &[], &["Creature"], &[]);
+        assert!(
+            parsed
+                .triggers
+                .iter()
+                .all(|trigger| matches!(trigger.mode, TriggerMode::Unknown(_))),
+            "{name}: an unmodelled recipient predicate must be terminally Unknown: {parsed:#?}"
+        );
+        assert!(
+            !parsed.triggers.iter().any(|trigger| {
+                trigger.mode == TriggerMode::DamageDone
+                    && matches!(
+                        trigger.valid_target,
+                        None | Some(TargetFilter::Player) | Some(TargetFilter::Typed(_))
+                    )
+            }),
+            "{name}: must not retain a broad damage-recipient filter: {parsed:#?}"
+        );
+    }
+
+    for (name, text) in [
+        (
+            "Plain player recipient",
+            "Whenever ~ deals combat damage to a player, draw a card.",
+        ),
+        (
+            "Plain opponent recipient",
+            "Whenever a creature deals combat damage to an opponent, draw a card.",
+        ),
+    ] {
+        let parsed = parse(text, name, &[], &["Creature"], &[]);
+        assert!(
+            parsed
+                .triggers
+                .iter()
+                .any(|trigger| trigger.mode == TriggerMode::DamageDone),
+            "{name}: an unqualified recipient must remain supported: {parsed:#?}"
+        );
+    }
 }
 
 /// V11 — consume-on-success: a `who`-headed clause the predicate grammar cannot

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -10,7 +10,7 @@ use nom::Parser;
 use super::oracle_effect::conditions::source_saddled_filter;
 use super::oracle_effect::{
     attach_terminal_die_result_branches_before_finalization, condition_text_is_rehomeable,
-    lower_effect_chain_ir, parse_attacked_player_relative_clause, parse_effect_chain_ir,
+    lower_effect_chain_ir, parse_effect_chain_ir, parse_player_relative_clause,
     try_parse_reanimator_aura_etb_effect_ir, try_parse_reanimator_aura_grant_etb_effect_ir,
 };
 use super::oracle_ir::ast::parsed_clause;
@@ -10315,6 +10315,14 @@ fn make_base() -> TriggerDefinition {
         .trigger_zones(vec![Zone::Battlefield])
 }
 
+fn unknown_trigger_definition(description: &str) -> (TriggerMode, TriggerDefinition) {
+    let mode = TriggerMode::Unknown(description.to_string());
+    let mut def = make_base();
+    def.mode = mode.clone();
+    def.description = Some(description.to_string());
+    (mode, def)
+}
+
 /// CR 202.3 + CR 208.1: Spell-cast quality suffix comparing mana value and/or
 /// power/toughness against the source's chosen number (Talion class).
 fn parse_spell_chosen_number_quality(spell_clause: &str) -> Option<TypedFilter> {
@@ -11672,6 +11680,40 @@ fn parse_damage_to_qualifier_with_rest(after_verb: &str) -> OracleResult<'_, Tar
     .parse(rest)
 }
 
+/// CR 603.1 + CR 603.2: A relative clause in a damage trigger's recipient
+/// ("to a player who …") narrows the event's damaged player. It is evaluated
+/// while matching that event through `valid_target`, rather than installed as
+/// an intervening-if `condition` that CR 603.4 would re-check on resolution.
+fn parse_damage_player_relative_recipient<'a>(
+    after_damage: &'a str,
+    ctx: &mut ParseContext,
+) -> OracleResult<'a, TargetFilter> {
+    let (rest, _) = tag::<_, _, OracleError<'_>>("to ").parse(after_damage.trim_start())?;
+    let (rest, relation) = value(PlayerRelation::All, tag("a player")).parse(rest)?;
+    let (rest, _) = space1.parse(rest)?;
+    let (rest, player) = parse_player_relative_clause(rest, relation, ctx)?;
+    let (rest, ()) = nom_primitives::peek_clause_terminator(rest)?;
+    Ok((
+        rest,
+        TargetFilter::PlayerMatching {
+            player: Box::new(player),
+        },
+    ))
+}
+
+/// Returns whether a recognized ordinary damage-recipient noun leaves a
+/// `who`-headed predicate that this route did not model. The zero-consumption
+/// peek makes that residual a terminal unknown rather than silently retaining
+/// the broad player filter.
+fn has_unmodelled_damage_recipient_predicate(after_damage: &str) -> bool {
+    let Ok((remainder, _)) = parse_damage_to_qualifier_with_rest(after_damage) else {
+        return false;
+    };
+    peek(preceded(space1, tag::<_, _, OracleError<'_>>("who ")))
+        .parse(remainder)
+        .is_ok()
+}
+
 /// CR 120.1 + CR 208.1 + CR 603.4: Parse the full Taii Wakeen recipient shape —
 /// `"to <object> equal to that <object>'s toughness|power"` — atomically. Only
 /// succeeds when an object recipient is immediately followed by the equal-to-P/T
@@ -12472,6 +12514,10 @@ fn try_parse_event(
                 scope: DamageAmountScope::PerSource,
             });
             def.valid_source = Some(subject.clone());
+            if let Ok((_, filter)) = parse_damage_player_relative_recipient(after_damage, ctx) {
+                def.valid_target = Some(filter);
+                return Some((TriggerMode::DamageDone, def));
+            }
             // CR 120.1 + CR 208.1 + CR 603.4: Taii Wakeen's damage==recipient-P/T
             // shape ("to <object> equal to that <object>'s toughness/power") is
             // tried first and atomically — it succeeds only when the object
@@ -12513,6 +12559,9 @@ fn try_parse_event(
                 // Ordinary player recipient ("to a player" / "to an opponent" /
                 // …) — unchanged from the pre-Taii behavior.
                 def.valid_target = Some(filter);
+            }
+            if has_unmodelled_damage_recipient_predicate(after_damage) {
+                return Some(unknown_trigger_definition(full_lower));
             }
             return Some((TriggerMode::DamageDone, def));
         }
@@ -12676,7 +12725,7 @@ fn try_parse_event(
                 // is a real clause boundary, checked with the shared
                 // `peek_clause_terminator` authority; anything else falls into
                 // the SAME declined branch as a total parse failure.
-                let modelled = parse_attacked_player_relative_clause(after_noun, relation, ctx)
+                let modelled = parse_player_relative_clause(after_noun, relation, ctx)
                     .ok()
                     .filter(|(remainder, _)| {
                         nom_primitives::peek_clause_terminator(remainder).is_ok()
@@ -14175,6 +14224,14 @@ fn try_parse_source_deals_damage_trigger(lower: &str) -> Option<(TriggerMode, Tr
     def.mode = TriggerMode::DamageDone;
     def.damage_kind = damage_kind;
     def.valid_source = Some(source_filter);
+    let mut recipient_ctx = ParseContext::default();
+    if let Ok((_, filter)) =
+        parse_damage_player_relative_recipient(after_damage, &mut recipient_ctx)
+    {
+        def.valid_target = Some(filter);
+        def.damage_amount = threshold;
+        return Some((TriggerMode::DamageDone, def));
+    }
     // CR 120.1 + CR 208.1 + CR 603.4: Taii Wakeen's damage==recipient-P/T shape
     // ("to <object> equal to that <object>'s toughness/power"). Tried first and
     // atomically — succeeds only when an object recipient is immediately
@@ -14228,6 +14285,9 @@ fn try_parse_source_deals_damage_trigger(lower: &str) -> Option<(TriggerMode, Tr
     // but is not one of this parser's recipient qualifiers, leave the line for
     // narrower parsers such as "a source deals damage to this creature".
     let valid_target = parse_damage_to_qualifier(after_damage);
+    if has_unmodelled_damage_recipient_predicate(after_damage) {
+        return Some(unknown_trigger_definition(lower));
+    }
     let has_recipient_tail = preceded(opt(space1), tag::<_, _, OracleError<'_>>("to "))
         .parse(after_damage)
         .is_ok();

--- a/crates/engine/tests/integration/cartographers_hawk_relative_damage_recipient.rs
+++ b/crates/engine/tests/integration/cartographers_hawk_relative_damage_recipient.rs
@@ -1,0 +1,175 @@
+//! Issue #8391 — Cartographer's Hawk checks the damaged player's land count
+//! when combat damage is dealt, not while its triggered ability resolves.
+
+use engine::game::effects::resolve_ability_chain;
+use engine::game::scenario::{GameRunner, GameScenario, P0, P1};
+use engine::game::zones::create_object;
+use engine::types::ability::{Effect, ResolvedAbility, TargetFilter, TargetRef};
+use engine::types::actions::GameAction;
+use engine::types::card_type::{CoreType, Supertype};
+use engine::types::events::GameEvent;
+use engine::types::game_state::WaitingFor;
+use engine::types::identifiers::{CardId, ObjectId};
+use engine::types::mana::ManaColor;
+use engine::types::phase::Phase;
+use engine::types::zones::Zone;
+
+use super::rules::run_combat;
+
+const CARTOGRAPHERS_HAWK_ORACLE: &str = "Flying\nWhen this creature deals combat damage to a player who controls more lands than you, return it to its owner's hand. If you do, you may search your library for a Plains card, put it onto the battlefield tapped, then shuffle.";
+
+struct HawkBoard {
+    runner: GameRunner,
+    hawk: ObjectId,
+    defender_lands: Vec<ObjectId>,
+    plains_in_library: ObjectId,
+}
+
+fn add_plains_to_library(runner: &mut GameRunner) -> ObjectId {
+    let state = runner.state_mut();
+    let plains = create_object(
+        state,
+        CardId(state.next_object_id),
+        P0,
+        "Plains".to_string(),
+        Zone::Library,
+    );
+    let object = state
+        .objects
+        .get_mut(&plains)
+        .expect("created library Plains must exist");
+    object.card_types.core_types.push(CoreType::Land);
+    object.card_types.supertypes.push(Supertype::Basic);
+    object.card_types.subtypes.push("Plains".to_string());
+    object.base_card_types = object.card_types.clone();
+    plains
+}
+
+fn board(controller_lands: usize, defender_lands: usize, defender_nonlands: usize) -> HawkBoard {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let hawk = scenario
+        .add_creature(P0, "Cartographer's Hawk", 2, 2)
+        .from_oracle_text(CARTOGRAPHERS_HAWK_ORACLE)
+        .id();
+    for _ in 0..controller_lands {
+        scenario.add_basic_land(P0, ManaColor::White);
+    }
+    let mut defender_land_ids = Vec::new();
+    for _ in 0..defender_lands {
+        defender_land_ids.push(scenario.add_basic_land(P1, ManaColor::Green));
+    }
+    for index in 0..defender_nonlands {
+        scenario.add_creature(P1, &format!("Defender nonland {index}"), 2, 2);
+    }
+
+    let mut runner = scenario.build();
+    let plains_in_library = add_plains_to_library(&mut runner);
+    HawkBoard {
+        runner,
+        hawk,
+        defender_lands: defender_land_ids,
+        plains_in_library,
+    }
+}
+
+/// Resolve the already-created Hawk trigger. The optional search is accepted
+/// and the explicitly supplied Plains is selected, making every continuation
+/// in the printed effect chain reachable.
+fn resolve_hawk_trigger(runner: &mut GameRunner, plains: ObjectId) {
+    for _ in 0..24 {
+        runner.advance_until_stack_empty();
+        match runner.state().waiting_for.clone() {
+            WaitingFor::OptionalEffectChoice { .. } => {
+                runner
+                    .act(GameAction::DecideOptionalEffect { accept: true })
+                    .expect("accepting Cartographer's Hawk's optional search must succeed");
+            }
+            WaitingFor::SearchChoice { cards, .. } => {
+                assert!(
+                    cards.contains(&plains),
+                    "the Plains in the library must be a legal search choice: {cards:?}"
+                );
+                runner
+                    .act(GameAction::SelectCards {
+                        cards: vec![plains],
+                    })
+                    .expect("selecting the searched Plains must succeed");
+            }
+            WaitingFor::Priority { .. } if runner.state().stack.is_empty() => return,
+            other => panic!("unexpected state while resolving Cartographer's Hawk: {other:?}"),
+        }
+    }
+    panic!("Cartographer's Hawk trigger did not finish resolving");
+}
+
+/// CR 603.2: equal land counts do not satisfy the event predicate. The second
+/// board keeps the same equal LAND census while giving the defender extra
+/// nonland permanents, so a broad or all-permanents count cannot pass.
+#[test]
+fn cartographers_hawk_does_not_trigger_for_equal_lands_even_with_extra_nonlands() {
+    for (name, defender_nonlands) in [("equal lands", 0), ("hostile nonland census", 4)] {
+        let HawkBoard {
+            mut runner, hawk, ..
+        } = board(2, 2, defender_nonlands);
+        run_combat(&mut runner, vec![hawk], vec![]);
+        assert!(
+            runner.state().stack.is_empty(),
+            "{name}: equal land counts must not put Hawk's trigger on the stack"
+        );
+        assert_eq!(
+            runner.state().objects[&hawk].zone,
+            Zone::Battlefield,
+            "{name}: Hawk must remain on the battlefield when its event predicate is false"
+        );
+    }
+}
+
+/// CR 603.2 checks this recipient predicate when combat damage happens. The
+/// defender's excess land is then removed before the trigger resolves; Hawk
+/// still returns and its optional Plains search proceeds, proving this is not a
+/// CR 603.4 intervening-if condition rechecked at resolution.
+#[test]
+fn cartographers_hawk_uses_the_damaged_players_land_count_at_event_time() {
+    let HawkBoard {
+        mut runner,
+        hawk,
+        defender_lands,
+        plains_in_library,
+    } = board(1, 2, 0);
+    run_combat(&mut runner, vec![hawk], vec![]);
+    assert!(
+        !runner.state().stack.is_empty(),
+        "strictly more defender lands must create Hawk's combat-damage trigger"
+    );
+
+    let excess_land = defender_lands[0];
+    let destroy = ResolvedAbility::new(
+        Effect::Destroy {
+            target: TargetFilter::Any,
+            cant_regenerate: false,
+        },
+        vec![TargetRef::Object(excess_land)],
+        hawk,
+        P0,
+    );
+    let mut events = Vec::<GameEvent>::new();
+    resolve_ability_chain(runner.state_mut(), &destroy, &mut events, 0)
+        .expect("removing the defender's excess land must resolve");
+    assert_eq!(runner.state().objects[&excess_land].zone, Zone::Graveyard);
+
+    resolve_hawk_trigger(&mut runner, plains_in_library);
+    assert_eq!(
+        runner.state().objects[&hawk].zone,
+        Zone::Hand,
+        "Hawk must still bounce after the defender's count falls before resolution"
+    );
+    assert_eq!(
+        runner.state().objects[&plains_in_library].zone,
+        Zone::Battlefield
+    );
+    assert!(
+        runner.state().objects[&plains_in_library].tapped,
+        "the searched Plains must enter tapped"
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -98,6 +98,7 @@ mod call_forth_tempest_and_rootha;
 mod captain_america_throw;
 mod captain_marvel_apex_avenger;
 mod carmen_cruel_skymarcher_counter_lookback_8160;
+mod cartographers_hawk_relative_damage_recipient;
 mod cascade_intervening_if_pipeline;
 mod case_solve_condition;
 mod cast_during_resolution_pipeline;

--- a/docs/parser-misparse-backlog.md
+++ b/docs/parser-misparse-backlog.md
@@ -148,7 +148,6 @@ This is the prioritized "fix N root causes → unlock M cards" backlog: the top 
 - Cantor of the Refrain
 - Captain America's Shield
 - Captain N'ghathrod
-- Cartographer's Hawk
 - Cathedral Membrane
 - Cemetery Prowler
 - Cephalid Shrine


### PR DESCRIPTION
## Summary

Fixes the damaged-player relative-clause misparse for **Cartographer's Hawk**. The event predicate now remains in the trigger's recipient filter, and the verified backlog entry is removed. Closes #8391.

## Files changed

- `crates/engine/src/analysis/resource.rs`
- `crates/engine/src/game/trigger_matchers.rs`
- `crates/engine/src/parser/oracle_effect/mod.rs`
- `crates/engine/src/parser/oracle_tests.rs`
- `crates/engine/src/parser/oracle_trigger.rs`
- `crates/engine/tests/integration/cartographers_hawk_relative_damage_recipient.rs`
- `crates/engine/tests/integration/main.rs`
- `docs/parser-misparse-backlog.md`

## Track

Developer

## LLM

Model: gpt-5.6-terra
Tier: Frontier
Thinking: high

## Implementation method (required)

Method: /engine-implementer

## CR references

- CR 603.1 + CR 603.2 — the damaged-player predicate is part of the trigger event and is checked when that event occurs.
- CR 603.4 — explicitly distinguished: no intervening-if condition is installed or rechecked at resolution.

## Verification

- [x] Required contribution checks ran clean; the exact base-identical doctest caveat is recorded below.
- [x] Gate A output below is for the current committed head.
- [x] Final review-impl below is clean for the current committed head.
- [x] Both anchors cite existing analogous code at the same seam.

- `cargo fmt --all -- --check` — PASS.
- `./scripts/check-parser-combinators.sh 611c9c5bdf0915d869a91fc692de217f2ae353be` — PASS for current head `916a3ecd9fc583b57b9d06cd58c66de0ea451f8c`.
- `CARGO_INCREMENTAL=0 CARGO_TARGET_DIR=/tmp/phase-issue-8391-completion-target cargo clippy --all-targets -- -D warnings` — PASS.
- `cargo test -p phase-engine --lib cartographers_hawk_damage_recipient_predicate_is_bound_to_the_event -- --nocapture` — PASS.
- `cargo test -p phase-engine --lib damage_recipient_relative_predicates_have_route_parity_and_fail_closed -- --nocapture` — PASS.
- `cargo test -p phase-engine --test integration cartographers_hawk -- --nocapture` — PASS (2 tests).
- `cargo test -p phase-engine` — 20,752 unit tests and 6,485 integration tests passed; see the base-identical doctest caveat below.
- Same-corpus base/candidate `./scripts/gen-card-data.sh` — PASS; targeted semantic audit confirms Hawk's trigger and full effect chain.
- `coverage-parse-diff` — exactly three cards changed: Cartographer's Hawk's recipient filter was corrected; Creepy Crawler and Miss Highwater became explicit unsupported triggers rather than false broad support.

## Gate A

Gate A PASS head=916a3ecd9fc583b57b9d06cd58c66de0ea451f8c base=611c9c5bdf0915d869a91fc692de217f2ae353be

## Anchored on

- `crates/engine/src/parser/oracle_effect/mod.rs:8569` — existing shared player-relative `who` predicate grammar.
- `crates/engine/src/game/trigger_matchers.rs:1340` — existing `DamageDone` matcher evaluates `valid_target` against the concrete damaged player.

## Final review-impl

Final review-impl PASS head=916a3ecd9fc583b57b9d06cd58c66de0ea451f8c

## Claimed parse impact

Cartographer's Hawk; Creepy Crawler; Miss Highwater.

## Scope Expansion

Updated two trigger-matcher comments to reflect the newly reachable `PlayerMatching` damage-recipient shape; no behavior beyond the reviewed parser fix was added.

## Validation Failures

`cargo test -p phase-engine` exits 101 only because the doctest at `crates/engine/src/game/ability_utils.rs:8798` does not compile. The identical command fails at base `611c9c5bdf0915d869a91fc692de217f2ae353be` with the same missing names and return-type errors; it is unrelated to this diff. All unit and integration tests passed.

## CI Failures

None.

## Pipeline handoff

Pipeline-reviewed head: `916a3ecd9fc583b57b9d06cd58c66de0ea451f8c`
Current branch head: `916a3ecd9fc583b57b9d06cd58c66de0ea451f8c`
Pipeline status: current
Current-head review: clean at `916a3ecd9fc583b57b9d06cd58c66de0ea451f8c`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Cartographer’s Hawk triggers to evaluate the damaged player’s land count when damage occurs, rather than when the ability resolves.
  * Improved parsing of damage triggers involving relative player-recipient conditions.
  * Unrecognized recipient conditions now fail safely instead of applying an overly broad player filter.

* **Tests**
  * Added coverage for Cartographer’s Hawk trigger timing and related damage-recipient parsing scenarios.

* **Documentation**
  * Updated parser documentation and removed Cartographer’s Hawk from the known misparse backlog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->