### PR TITLE
fix(coverage): require text evidence before flagging a silent drop

### DIFF
--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -11,8 +11,9 @@ use crate::game::token_presets::{
 use crate::game::triggers::{build_trigger_registry, trigger_registry};
 use crate::parser::oracle::{
     is_commander_permission_sentence, is_deck_construction_copy_limit_sentence,
-    is_draft_matters_sentence,
+    is_draft_matters_sentence, parse_strive_cost_line,
 };
+use crate::parser::oracle_casting::parse_casting_restriction_line;
 use crate::parser::oracle_ir::diagnostic::OracleDiagnostic;
 use crate::parser::oracle_util::normalize_card_name_refs;
 use crate::types::ability::{
@@ -5281,7 +5282,7 @@ pub fn build_parse_details(
     // pitch cost, Snapcaster-style flash, "without paying its mana cost", etc.).
     // Each `SpellCastingOption` corresponds to its own Oracle line, so it must
     // emit exactly one `ParsedItem` to keep `count_effective_parsed_items` in
-    // parity with `count_effective_oracle_lines`. Without this, pitch spells
+    // parity with `effective_oracle_lines`. Without this, pitch spells
     // (Force of Will, Force of Negation, Misdirection, …) are falsely flagged
     // by the silent-drop audit.
     for option in &face.casting_options {
@@ -5666,7 +5667,7 @@ fn build_cost_item(cost: &AbilityCost, items: &mut Vec<ParsedItem>) {
 ///
 /// An additional cost ("As an additional cost to cast this spell, ...") is its
 /// own Oracle line, so it must emit exactly one `ParsedItem` to keep
-/// `count_effective_parsed_items` in parity with `count_effective_oracle_lines`.
+/// `count_effective_parsed_items` in parity with `effective_oracle_lines`.
 /// Without this, cards with a concrete additional cost plus one spell effect
 /// (e.g. Vicious Rivalry, Fix What's Broken) are falsely flagged by the
 /// silent-drop audit: the Oracle line is counted but no parse item is emitted
@@ -5752,7 +5753,7 @@ fn ability_cost_has_unimplemented(cost: &AbilityCost) -> bool {
 /// "without paying its mana cost", "as though it had flash", Adventure half).
 ///
 /// Each casting option corresponds to its own Oracle line; this keeps
-/// `count_effective_parsed_items` aligned with `count_effective_oracle_lines`
+/// `count_effective_parsed_items` aligned with `effective_oracle_lines`
 /// so pitch spells (Force of Will, Force of Negation, Misdirection, …) are
 /// not falsely flagged by the silent-drop audit. The item is unsupported only
 /// when the option carries an `Unimplemented` cost component.
@@ -6452,7 +6453,7 @@ pub fn analyze_coverage(card_db: &CardDatabase) -> CoverageSummary {
 
         // Flag cards where the parser consumed Oracle text without producing
         // a corresponding parse item. Uses the parse tree computed above.
-        check_silent_drops(&face.oracle_text, &parse_details, &mut missing);
+        check_silent_drops(&face.oracle_text, &face.name, &parse_details, &mut missing);
 
         // The public result, summary counters, and warning rollup all derive
         // from this one canonical gap set. `missing` captures analysis-only
@@ -7711,6 +7712,7 @@ fn check_subtype_lexicon(face: &CardFace, valid: &HashSet<String>, missing: &mut
 /// parser accepted text but produced no runtime behavior for it.
 fn check_silent_drops(
     oracle_text: &Option<String>,
+    card_name: &str,
     parse_details: &[ParsedItem],
     missing: &mut Vec<String>,
 ) {
@@ -7718,15 +7720,82 @@ fn check_silent_drops(
         return;
     };
 
-    let effective_oracle = count_effective_oracle_lines(oracle_text);
-    let effective_parsed = count_effective_parsed_items(parse_details);
+    let lines = effective_oracle_lines(oracle_text);
+    let dropped = count_dropped_oracle_lines(&lines, card_name, parse_details);
 
-    if effective_oracle > effective_parsed {
-        let label = format!("SilentDrop:{}_of_{}", effective_parsed, effective_oracle);
+    if dropped > 0 {
+        let label = format!("SilentDrop:{}_of_{}", lines.len() - dropped, lines.len());
         if !missing.contains(&label) {
             missing.push(label);
         }
     }
+}
+
+/// How many effective Oracle lines the parse tree demonstrably fails to represent.
+///
+/// Two independent measures must agree before a printed line is called dropped:
+///
+/// * **Cardinality** — effective lines minus parse roots. A single root can
+///   legitimately cover several printed lines: a `sub_ability` chain ("Scry 1." +
+///   "Draw a card." on Opt), an ability-word branch ("Morbid — That creature gets
+///   -13/-13 … instead" on Tragic Slip), a die-roll outcome table. So this measure
+///   over-reports on its own and is kept only as a ceiling.
+/// * **Text evidence** — a printed line matched by no `source_text` anywhere in the
+///   tree, beyond what the tree's `source_text`-less items can account for.
+///
+/// Taking the minimum means a flag always carries evidence that a specific printed
+/// line went unrepresented, and can never fire on cardinality alone. It also makes
+/// the check monotone: because the ceiling *is* the historical rule, this can only
+/// ever withdraw a flag, never raise a new one.
+fn count_dropped_oracle_lines(
+    lines: &[String],
+    card_name: &str,
+    parse_details: &[ParsedItem],
+) -> usize {
+    let cardinality = lines
+        .len()
+        .saturating_sub(count_effective_parsed_items(parse_details));
+    if cardinality == 0 {
+        return 0;
+    }
+
+    // Only reached for cards the cardinality ceiling already suspects, so the
+    // normalization below stays off the hot path for the rest of the corpus.
+    let card_name_lower = card_name.to_lowercase();
+    let mut source_texts = Vec::new();
+    collect_source_texts(parse_details, &mut source_texts);
+    let sources: Vec<String> = source_texts
+        .iter()
+        .map(|src| normalize_for_matching(&src.to_lowercase(), &card_name_lower))
+        .collect();
+
+    let uncovered = lines
+        .iter()
+        .filter(|line| {
+            let line = normalize_for_matching(&line.to_lowercase(), &card_name_lower);
+            !sources
+                .iter()
+                .any(|src| src.contains(&line) || line.contains(src.as_str()))
+        })
+        .count();
+
+    // An item carrying no `source_text` — a bare keyword, an unlabeled chained
+    // effect — could be the representation of any one uncovered line, so each
+    // offsets one. Without this the check would flag every card whose behavior
+    // parses into items the parser never attached printed text to.
+    let anonymous = count_anonymous_parse_items(parse_details);
+
+    cardinality.min(uncovered.saturating_sub(anonymous))
+}
+
+/// Count parse-tree items, at any depth, that carry no `source_text`.
+fn count_anonymous_parse_items(items: &[ParsedItem]) -> usize {
+    items
+        .iter()
+        .map(|item| {
+            usize::from(item.source_text.is_none()) + count_anonymous_parse_items(&item.children)
+        })
+        .sum()
 }
 
 /// Flag cards whose parsed features aren't handled by any runtime resolver.
@@ -8057,8 +8126,13 @@ fn collect_additional_cost_missing_parts(
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SilentDropResult {
     pub card_name: String,
+    /// Effective printed lines the parse tree is expected to represent.
     pub oracle_lines: usize,
+    /// Of those, how many the tree does represent — `oracle_lines - delta`, and
+    /// the numerator of the card's `SilentDrop:{n}_of_{m}` label. Not a count of
+    /// parse roots: one root can represent several printed lines.
     pub parsed_items: usize,
+    /// Printed lines with no representation anywhere in the parse tree.
     pub delta: usize,
     /// Oracle lines with no corresponding parse item (best-effort match).
     pub missing_lines: Vec<String>,
@@ -8082,16 +8156,16 @@ pub fn audit_silent_drops(summary: &CoverageSummary) -> Vec<SilentDropResult> {
             _ => continue,
         };
 
-        let effective_oracle = count_effective_oracle_lines(oracle_text);
-        let effective_parsed = count_effective_parsed_items(&card.parse_details);
+        let lines = effective_oracle_lines(oracle_text);
+        let dropped = count_dropped_oracle_lines(&lines, &card.card_name, &card.parse_details);
 
-        if effective_oracle > effective_parsed {
+        if dropped > 0 {
             let missing_lines = find_missing_lines(oracle_text, &card.parse_details);
             results.push(SilentDropResult {
                 card_name: card.card_name.clone(),
-                oracle_lines: effective_oracle,
-                parsed_items: effective_parsed,
-                delta: effective_oracle - effective_parsed,
+                oracle_lines: lines.len(),
+                parsed_items: lines.len() - dropped,
+                delta: dropped,
                 missing_lines,
             });
         }
@@ -8100,16 +8174,17 @@ pub fn audit_silent_drops(summary: &CoverageSummary) -> Vec<SilentDropResult> {
     results
 }
 
-/// Count effective Oracle text lines, accounting for modal/choose headers
-/// that cover their following bullet points as a single unit.
-fn count_effective_oracle_lines(oracle_text: &str) -> usize {
+/// The printed Oracle lines a card's parse tree is expected to represent, with
+/// reminder text stripped, modal bullets folded into their header, and lines the
+/// parser consumes as typed card-face metadata excluded.
+fn effective_oracle_lines(oracle_text: &str) -> Vec<String> {
     let lines: Vec<&str> = oracle_text
         .split('\n')
         .map(|l| l.trim())
         .filter(|l| !l.is_empty())
         .collect();
 
-    let mut count = 0;
+    let mut effective = Vec::new();
     let mut in_modal = false;
 
     for line in &lines {
@@ -8136,11 +8211,15 @@ fn count_effective_oracle_lines(oracle_text: &str) -> usize {
             continue;
         }
 
+        if is_typed_card_metadata_line(stripped) {
+            continue;
+        }
+
         // Check if this line contains a modal header ("choose one —", "choose two.", etc.)
         // Handles standalone headers, triggered modals ("when enters, choose one —"),
         // activated modals ("{cost}: choose one —"), and period-terminated ("choose three.")
         if is_modal_header_line(&lower) {
-            count += 1;
+            effective.push(stripped.to_string());
             in_modal = true;
             continue;
         }
@@ -8156,10 +8235,34 @@ fn count_effective_oracle_lines(oracle_text: &str) -> usize {
             in_modal = false;
         }
 
-        count += 1;
+        effective.push(stripped.to_string());
     }
 
-    count
+    effective
+}
+
+/// A printed line the parser consumes into a typed field on the card face —
+/// `casting_restrictions` (CR 601.3) or `strive_cost` (CR 601.2f) — rather than
+/// into a resolvable ability. Like the deck-construction and draft-procedure
+/// sentences above, these lines produce no `ParsedItem` by design, so counting
+/// them on the Oracle side reports a `SilentDrop` against a card that is in fact
+/// fully modeled: Grim Wanderer's "Tragic Backstory — Cast this spell only if a
+/// creature died this turn." becomes a typed `RequiresCondition`, and Setessan
+/// Tactics' "Strive —" line becomes `strive_cost: {G}`, yet each contributed a
+/// phantom dropped line.
+///
+/// Both arms delegate to the parser's own recognizer, so the two cannot drift: a
+/// line the parser does not consume this way returns `None` here too, falls
+/// through to ordinary dispatch, and stays honestly countable — Pie-Eating
+/// Contest's unrecognized "gobble X" cost keeps its gap.
+///
+/// Deliberately absent: `parse_additional_cost_line`. A recognized
+/// `AdditionalCost` already emits its own `ParsedItem` (see
+/// `additional_cost_emits_parsed_item_for_supported_cost`), so excluding its line
+/// would drop the Oracle count while the item stayed — masking a genuine drop
+/// elsewhere on the card for no gain.
+fn is_typed_card_metadata_line(stripped: &str) -> bool {
+    parse_casting_restriction_line(stripped).is_some() || parse_strive_cost_line(stripped).is_some()
 }
 
 /// Check if a line contains a modal header pattern: "choose one", "choose two", etc.
@@ -8332,6 +8435,10 @@ fn strip_parenthesized_reminder(line: &str) -> String {
 /// execute body, an otherwise branch, a token-carried static, or a granted
 /// ability. They must not increase this count, or a supported nested detail
 /// could mask a different Oracle line that the parser silently dropped.
+///
+/// The converse also holds — a child can carry its own printed line (a
+/// `sub_ability` chain, an ability-word branch) — so this count is only the
+/// ceiling in [`count_dropped_oracle_lines`], never a verdict on its own.
 fn count_effective_parsed_items(items: &[ParsedItem]) -> usize {
     items.len()
 }
@@ -14592,6 +14699,122 @@ mod tests {
                  This line was silently dropped."
                     .to_string(),
             ),
+            "Test Card",
+            &parse_details,
+            &mut missing,
+        );
+        assert_eq!(missing, vec!["SilentDrop:1_of_2"]);
+    }
+
+    /// Regression (#8564): a `sub_ability` chain is ONE parse root that covers
+    /// TWO printed lines — Opt ("Scry 1." + "Draw a card."), Bladebrand, Tragic
+    /// Slip, Evasive Maneuvers. Counting roots against printed lines flagged all
+    /// of them as silent drops and flipped them to unsupported, even though the
+    /// root's `source_text` demonstrably spans both lines.
+    #[test]
+    fn chained_sub_ability_spanning_two_printed_lines_is_not_a_silent_drop() {
+        const ORACLE: &str = "Scry 1.\nDraw a card.";
+
+        let mut face = make_face();
+        face.abilities.push(
+            AbilityDefinition::new(
+                AbilityKind::Spell,
+                Effect::Scry {
+                    count: QuantityExpr::Fixed { value: 1 },
+                    target: TargetFilter::Controller,
+                },
+            )
+            .description(ORACLE.to_string())
+            .sub_ability(AbilityDefinition::new(
+                AbilityKind::Spell,
+                Effect::Draw {
+                    count: QuantityExpr::Fixed { value: 1 },
+                    target: TargetFilter::Controller,
+                },
+            )),
+        );
+
+        let parse_details = build_parse_details_for_face(&face);
+        // The cardinality ceiling alone still suspects this card: one root
+        // against two printed lines. Only the text evidence clears it.
+        assert_eq!(count_effective_parsed_items(&parse_details), 1);
+        assert_eq!(effective_oracle_lines(ORACLE).len(), 2);
+
+        let mut missing = Vec::new();
+        check_silent_drops(
+            &Some(ORACLE.to_string()),
+            "Test Card",
+            &parse_details,
+            &mut missing,
+        );
+        assert!(
+            missing.is_empty(),
+            "a chained ability whose source_text spans both printed lines is not a drop: {missing:?}"
+        );
+    }
+
+    /// CR 601.3: a "Cast this spell only ..." line — with or without an ability
+    /// word label — is consumed into `casting_restrictions`, never into a
+    /// `ParsedItem`. Grim Wanderer models its Flash and its "Tragic Backstory"
+    /// restriction completely, yet the restriction line counted as a phantom
+    /// dropped line.
+    #[test]
+    fn casting_restriction_line_is_not_a_silent_drop() {
+        const ORACLE: &str =
+            "Flash\nTragic Backstory — Cast this spell only if a creature died this turn.";
+
+        assert_eq!(
+            effective_oracle_lines(ORACLE).len(),
+            1,
+            "the casting-restriction line is typed metadata, not an expected parse item"
+        );
+
+        let mut face = make_face();
+        face.keywords.push(Keyword::Flash);
+
+        let parse_details = build_parse_details_for_face(&face);
+        let mut missing = Vec::new();
+        check_silent_drops(
+            &Some(ORACLE.to_string()),
+            "Grim Wanderer",
+            &parse_details,
+            &mut missing,
+        );
+        assert!(
+            missing.is_empty(),
+            "a fully modeled casting restriction is not a drop: {missing:?}"
+        );
+    }
+
+    /// The exclusion above must not become a blanket amnesty for anything that
+    /// merely looks like a cost preamble. `parse_casting_restriction_line`
+    /// returns `None` for an unrecognized cost, so Pie-Eating Contest's "gobble
+    /// X" keeps its honest gap.
+    #[test]
+    fn unrecognized_additional_cost_line_is_still_a_silent_drop() {
+        const ORACLE: &str = "As an additional cost to cast this spell, gobble X.\n\
+             X target creatures you control each get +2/+2 until end of turn.";
+
+        let mut face = make_face();
+        face.abilities.push(
+            AbilityDefinition::new(
+                AbilityKind::Spell,
+                Effect::Pump {
+                    power: PtValue::Fixed(2),
+                    toughness: PtValue::Fixed(2),
+                    target: TargetFilter::Any,
+                },
+            )
+            .description(
+                "X target creatures you control each get +2/+2 until end of turn.".to_string(),
+            ),
+        );
+
+        let parse_details = build_parse_details_for_face(&face);
+        let mut missing = Vec::new();
+        check_silent_drops(
+            &Some(ORACLE.to_string()),
+            "Pie-Eating Contest",
             &parse_details,
             &mut missing,
         );
@@ -17374,7 +17597,7 @@ mod tests {
     /// (e.g. Vicious Rivalry, Fix What's Broken) produce exactly one Oracle
     /// line for the "As an additional cost..." preamble. That line must be
     /// represented by a `ParsedItem` so that `count_effective_parsed_items`
-    /// matches `count_effective_oracle_lines` and the silent-drop audit
+    /// matches `effective_oracle_lines` and the silent-drop audit
     /// doesn't falsely flag the card as unsupported.
     #[test]
     fn additional_cost_emits_parsed_item_for_supported_cost() {
@@ -17404,6 +17627,7 @@ mod tests {
                  Destroy all artifacts and creatures with mana value X or less."
                     .to_string(),
             ),
+            "Test Card",
             &parse_details,
             &mut missing,
         );
@@ -17430,16 +17654,16 @@ mod tests {
         );
     }
 
-    /// Regression: `count_effective_oracle_lines` must recognize modal
+    /// Regression: `effective_oracle_lines` must recognize modal
     /// headers with "choose up to four" (and higher cardinals) so spells
     /// like Moment of Reckoning don't inflate their Oracle-line count.
     #[test]
-    fn count_effective_oracle_lines_recognizes_choose_up_to_four() {
+    fn effective_oracle_lines_recognizes_choose_up_to_four() {
         let text = "Choose up to four. You may choose the same mode more than once.\n\
                     \u{2022} Destroy target nonland permanent.\n\
                     \u{2022} Return target nonland permanent card from your graveyard to the battlefield.";
         // 1 modal header; both bullets fold into the header.
-        assert_eq!(count_effective_oracle_lines(text), 1);
+        assert_eq!(effective_oracle_lines(text).len(), 1);
     }
 
     /// CR 700.2 + CR 107.3m: dynamic modal headers ("choose up to X —",
@@ -17450,7 +17674,7 @@ mod tests {
     /// unrecognized — the Ruinous case returns 6 (not 2) and the "that many"
     /// case returns 4 (not 1), failing these assertions.
     #[test]
-    fn count_effective_oracle_lines_folds_dynamic_modal_headers() {
+    fn effective_oracle_lines_folds_dynamic_modal_headers() {
         // Ruinous shape (em-dash "choose up to X —"): enters line + dynamic
         // header + 4 bullets → 2 (enters line + folded header).
         let ruinous = "The Ruinous Wrecking Crew enters with X +1/+1 counters on it.\n\
@@ -17459,7 +17683,7 @@ mod tests {
                        \u{2022} Target opponent loses 2 life.\n\
                        \u{2022} Destroy target token.\n\
                        \u{2022} Each player sacrifices a creature of their choice.";
-        assert_eq!(count_effective_oracle_lines(ruinous), 2);
+        assert_eq!(effective_oracle_lines(ruinous).len(), 2);
 
         // Hawkeye shape (period "choose up to that many."): dynamic header + 3
         // bullets → 1 (folded header).
@@ -17467,19 +17691,19 @@ mod tests {
                          \u{2022} Net \u{2014} Target creature can't block this turn.\n\
                          \u{2022} Explosive \u{2014} Deals 2 damage to target player.\n\
                          \u{2022} Boomerang \u{2014} Discard a card, then draw a card.";
-        assert_eq!(count_effective_oracle_lines(that_many), 1);
+        assert_eq!(effective_oracle_lines(that_many).len(), 1);
 
         // Hostile (A1): a NON-modal "choose up to that many <nouns>" selection
         // clause with 0 bullets is unchanged by the recognizer — there are no
         // bullets to fold (Heroic Feast text, one paragraph).
         let heroic_feast = "Choose up to that many target creatures you control. \
                             Put a +1/+1 counter on each of them.";
-        assert_eq!(count_effective_oracle_lines(heroic_feast), 1);
+        assert_eq!(effective_oracle_lines(heroic_feast).len(), 1);
 
         // Regression guard: a FIXED "choose up to two —" header still folds its
         // own 2 bullets (the existing word-cardinal path is unaffected).
         let fixed = "Choose up to two \u{2014}\n\u{2022} Draw a card.\n\u{2022} You gain 2 life.";
-        assert_eq!(count_effective_oracle_lines(fixed), 1);
+        assert_eq!(effective_oracle_lines(fixed).len(), 1);
     }
 
     #[test]
@@ -17488,13 +17712,14 @@ mod tests {
         let mut missing = Vec::new();
         check_silent_drops(
             &Some("Teferi, Temporal Archmage can be your commander.".to_string()),
+            "Teferi, Temporal Archmage",
             &parse_details,
             &mut missing,
         );
 
         assert!(missing.is_empty());
         assert_eq!(
-            count_effective_oracle_lines("Teferi, Temporal Archmage can be your commander."),
+            effective_oracle_lines("Teferi, Temporal Archmage can be your commander.").len(),
             0
         );
 
@@ -17526,13 +17751,13 @@ mod tests {
             );
 
             let mut missing = Vec::new();
-            check_silent_drops(&Some(oracle.to_string()), &[], &mut missing);
+            check_silent_drops(&Some(oracle.to_string()), "Test Card", &[], &mut missing);
             assert!(
                 missing.is_empty(),
                 "deck-construction line falsely counted as SilentDrop: {oracle} -> {missing:?}"
             );
             assert_eq!(
-                count_effective_oracle_lines(oracle),
+                effective_oracle_lines(oracle).len(),
                 0,
                 "deck-construction line should not count as a runtime oracle line: {oracle}"
             );

--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -4156,7 +4156,7 @@ fn attach_modifier_unsupported_marker(execute: &mut AbilityDefinition, fragment:
 /// directly on the un-stripped line. If a DIFFERENT ability word labels the
 /// line, the labeled branch's `ability_word != "strive"` guard still
 /// correctly returns `None` without ever reaching the bare fallback.
-fn parse_strive_cost_line(line: &str) -> Option<ManaCost> {
+pub(crate) fn parse_strive_cost_line(line: &str) -> Option<ManaCost> {
     let stripped = strip_reminder_text(line.trim());
 
     if let Some((ability_word, effect_text)) = strip_ability_word_with_name(&stripped) {


### PR DESCRIPTION
`check_silent_drops` compared two counts that measure different populations:
printed Oracle lines against parse-tree roots. A single root legitimately
covers several printed lines — a `sub_ability` chain ("Scry 1." + "Draw a
card."), an ability-word branch ("Morbid — That creature gets -13/-13 …
instead"), a die-roll outcome table — so the comparison was a coincidence
detector, not a drop detector.

#8564 tightened the parsed side to `items.len()` (correctly: a token's nested
static is detail for its creation line, not a second line) and removed the
slack that had been masking the mismatch. 644 cards were left unsupported
with `SilentDrop` as their only gap, including Opt, Tragic Slip, Bladebrand
and Shower of Coals. Running the engine's own containment matcher over those
644 found only 60 Oracle lines unmatched by any `source_text` in the tree:
for ~90% of them every printed line was represented and the flag was pure
arithmetic.

A drop now needs two measures to agree:

* cardinality (lines - roots), the historical rule, kept only as a ceiling;
* text evidence — a printed line matched by no `source_text` anywhere in the
  tree, beyond what the tree's `source_text`-less items can account for.

Because the ceiling is the historical rule, the check is monotone: it can only
ever withdraw a flag, never raise a new one.

`effective_oracle_lines` also excludes printed lines the parser consumes into
typed card-face fields — `casting_restrictions` (CR 601.3) and `strive_cost`
(CR 601.2f) — which produce no `ParsedItem` by design, joining the existing
deck-construction and draft-procedure exclusions. Both arms delegate to the
parser's own recognizer, so coverage and the parser cannot drift; Pie-Eating
Contest's unrecognized "gobble X" keeps its gap. `parse_additional_cost_line`
is deliberately not an arm: a recognized `AdditionalCost` already emits its
own `ParsedItem`, so excluding its line would mask a genuine drop elsewhere.

Measured over the full corpus (35,798 cards): unsupported 4,501 -> 3,881,
SilentDrop labels 750 -> 33. The 25 residual SilentDrop-only cards are all
genuinely unmodeled — unparsed `Enchant` filters, `Tiered`, `Hidden agenda`,
`Desertwalk`, unrecognized additional costs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of silently dropped card text, reducing false warnings for chained abilities, casting restrictions, additional costs, and modal headers.
  * Silent-drop results now more accurately reflect the number of represented oracle text lines.

* **Tests**
  * Added coverage for multi-line abilities, typed metadata, unrecognized costs, and modal-header handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->