### PR TITLE
fix(client): scope the connection switch to Host Game, not the lobby

### DIFF
--- a/client/src/components/lobby/ConnectionModeSwitch.tsx
+++ b/client/src/components/lobby/ConnectionModeSwitch.tsx
@@ -5,8 +5,8 @@ import type { ConnectionMode } from "../../stores/multiplayerStore";
 /**
  * Selected-segment styling per mode. This is the app's EXISTING colour
  * language for the two connection modes — emerald for the official server,
- * cyan for P2P (`LobbyView`'s host button tones, `HostSetup`'s `accentTone`) —
- * which until now was only ever shown and never explained.
+ * cyan for P2P (`HostSetup`'s `accentTone`, which the rest of this form
+ * follows) — which until now was only ever shown and never explained.
  */
 const SELECTED_TONE: Record<ConnectionMode, string> = {
   server:
@@ -18,16 +18,12 @@ const SELECTED_TONE: Record<ConnectionMode, string> = {
  *  only because it is the auto-assigned default. */
 const MODES: readonly ConnectionMode[] = ["server", "p2p"];
 
-const SEGMENT_SIZE = {
-  sm: "px-2.5 py-1 text-[11px]",
-  md: "px-2 py-2 text-xs",
-} as const;
-
 /**
- * The authority on which transport a session uses: a dedicated server or a
- * direct peer-to-peer connection. Rendered in the lobby header and at the top
- * of Host Game, so the choice is visible and one click to reverse from either
- * screen.
+ * The authority on which transport a HOSTED session uses: a dedicated server
+ * or a direct peer-to-peer connection. Rendered at the top of Host Game and
+ * nowhere else — it configures a game being created, alongside the room name,
+ * password and lobby listing. Browsing and joining are deliberately not
+ * governed by it: `MultiplayerPage` routes a join on the shape of the code.
  *
  * Buttons with `aria-pressed`, matching the incumbent button-based segmented
  * control (`components/draft/BotDifficultySelector`). `role="radio"` is
@@ -39,11 +35,9 @@ const SEGMENT_SIZE = {
 export function ConnectionModeSwitch({
   value,
   onChange,
-  size = "md",
 }: {
   value: ConnectionMode;
   onChange: (mode: ConnectionMode) => void;
-  size?: keyof typeof SEGMENT_SIZE;
 }) {
   const { t } = useTranslation("multiplayer");
 
@@ -61,7 +55,7 @@ export function ConnectionModeSwitch({
             type="button"
             onClick={() => onChange(mode)}
             aria-pressed={selected}
-            className={`flex-1 cursor-pointer whitespace-nowrap rounded-lg font-medium transition-colors ${SEGMENT_SIZE[size]} ${
+            className={`min-h-11 flex-1 cursor-pointer whitespace-nowrap rounded-lg px-2 py-2 text-xs font-medium transition-colors ${
               selected
                 ? SELECTED_TONE[mode]
                 : "text-white/45 hover:bg-white/[0.05] hover:text-white/70"

--- a/client/src/components/lobby/HostSetup.tsx
+++ b/client/src/components/lobby/HostSetup.tsx
@@ -545,6 +545,28 @@ export function HostSetup({
     setAiSeats((prev) => prev.filter((s) => s.seatIndex < count));
   };
 
+  // A format whose MINIMUM exceeds the P2P ceiling cannot be clamped into
+  // range — only replaced. The mount path above screens the REMEMBERED config
+  // for this, but not the store `formatConfig` it falls back to, and it cannot
+  // see a switch made while this form stays mounted — so this effect covers
+  // both a store-seeded mount and the live flip. Without it the seat clamp
+  // below drives `playerCount` under
+  // `formatConfig.min_players`: the seat picker renders an empty range
+  // (`Array.from` coerces the negative length to 0) and Host submits a
+  // configuration the format itself rejects. Only a custom format can reach
+  // this — every built-in one seats at most `P2P_MAX_PEERS` — so the fallback
+  // is the same default the mount path uses, applied through
+  // `applyResolvedFormat` so every dependent field resets with it. Both effects
+  // run in the SAME commit, so the clamp below would otherwise read this
+  // render's stale `playerCount` and overwrite the seat count set here —
+  // landing on the ceiling rather than the replacement format's own minimum.
+  // It yields to this guard instead; see its own comment.
+  useEffect(() => {
+    if (!isP2P || formatConfig.min_players <= P2P_MAX_PEERS) return;
+    applyResolvedFormat("Commander", FORMAT_DEFAULTS.Commander, null);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isP2P, formatConfig.min_players]);
+
   // The mode switch above this form can lower the seat ceiling while the form
   // is mounted (P2P seats at most `P2P_MAX_PEERS`), and this component is not
   // remounted on a mode change — so the mount-time clamp on `playerCount`
@@ -553,14 +575,19 @@ export function HostSetup({
   // `handlePlayerCountChange` so the AI seats past the new count are pruned
   // with it rather than being submitted from `effectiveAiSeats`.
   //
-  // Guarded on the comparison and depending on `[playerCount, maxPlayers]`
-  // deliberately: `handlePlayerCountChange` is a component-body function whose
-  // identity changes every render, so depending on it would re-render forever.
+  // Guarded on the comparison and depending on the VALUES it reads, never on
+  // `handlePlayerCountChange`: that is a component-body function whose identity
+  // changes every render, so depending on it would re-render forever.
   useEffect(() => {
     if (playerCount <= maxPlayers) return;
+    // Yield to the format guard above when it is firing in this same commit:
+    // it replaces the whole format and seats it at the replacement's own
+    // minimum, and clamping to the ceiling here would overwrite that. The next
+    // render re-evaluates both against the format that actually landed.
+    if (isP2P && formatConfig.min_players > P2P_MAX_PEERS) return;
     handlePlayerCountChange(maxPlayers);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [playerCount, maxPlayers]);
+  }, [playerCount, maxPlayers, isP2P, formatConfig.min_players]);
 
   const handleDeckSizeChange = (deckSize: number) => {
     // Variant-preserving: the engine is the authority for whether the format's
@@ -1123,15 +1150,22 @@ export function HostSetup({
             </Field>
           )}
 
-          {/* Privacy / timing options — iOS-toggle rows (design mockup). */}
-          {!isP2P && (
-            <OptionRow
-              label={t("hostSetup.listInLobby")}
-              on={isPublic}
-              onChange={setIsPublic}
-              accent={accentTone}
-            />
-          )}
+          {/* Privacy / timing options — iOS-toggle rows (design mockup).
+              "List in lobby" is offered in BOTH modes. Listing and transport
+              are independent: a P2P room hosted against a `LobbyOnly` broker —
+              which the official default anchor is — is registered through
+              `broker.registerHost({ public })` and appears in the public list
+              exactly as a server-run game does. Hiding this in P2P never
+              stopped that; it only removed the OPT-OUT, because `isPublic`
+              defaults to true. `startP2PHostingSession` still ANDs it with
+              `useBroker`, so against a `Full` anchor — which has no broker to
+              register with — the room is unlisted whatever this says. */}
+          <OptionRow
+            label={t("hostSetup.listInLobby")}
+            on={isPublic}
+            onChange={setIsPublic}
+            accent={accentTone}
+          />
           <OptionRow label={t("hostSetup.startWhenFull")} on={startWhenFull} onChange={setStartWhenFull} accent={accentTone} />
           {/* Sandbox mode — capability flag, orthogonal to format; lets the host
               submit debug actions. Off by default; immutable for the session. */}

--- a/client/src/components/lobby/LobbyView.tsx
+++ b/client/src/components/lobby/LobbyView.tsx
@@ -14,14 +14,12 @@ import {
   isLobbyEntryCompatible,
   lobbySources,
   useMultiplayerStore,
-  type ConnectionMode,
   type LobbyGameEntry,
   type LobbySource,
 } from "../../stores/multiplayerStore";
 import { assertNever } from "../../utils/assertNever";
 import { MenuPanel } from "../menu/MenuShell";
 import { menuButtonClass } from "../menu/buttonStyles";
-import { ConnectionModeSwitch } from "./ConnectionModeSwitch";
 import { GameListItem } from "./GameListItem";
 import type { LobbyGame } from "./GameListItem";
 import { ServerFlag } from "./ServerFlag";
@@ -29,8 +27,10 @@ import { ServerPicker } from "./ServerPicker";
 import { MenuSelect } from "../ui/MenuSelect";
 
 interface LobbyViewProps {
+  /** Open Host Game. The P2P / Official Server choice is made there, not here:
+   *  it configures a game being created, while this view only browses and
+   *  joins — both of which work identically under either transport. */
   onHostGame: () => void;
-  onHostP2P: () => void;
   onHostDraft?: () => void;
   /**
    * Called when the user elects to join a game. `origin` is the authority
@@ -50,11 +50,6 @@ interface LobbyViewProps {
   ) => void;
   /** Watch a live server game or draft without joining as a player. */
   onSpectate?: (code: string, origin: LobbySource | null, context?: LobbyGame) => void;
-  connectionMode?: ConnectionMode;
-  /** The page-level mode handler. Required, because an unwired switch would be
-   * a control that lies about what it does; the page owns the write so the
-   * anchor repair it performs is not duplicated per surface. */
-  onConnectionModeChange: (mode: ConnectionMode) => void;
   onServerOffline?: () => void;
 }
 
@@ -88,17 +83,12 @@ const ROOM_TYPE_FILTERS: { value: RoomTypeFilter; labelKey: string }[] = [
 
 export function LobbyView({
   onHostGame,
-  onHostP2P,
   onHostDraft,
   onJoinGame,
   onSpectate,
-  connectionMode,
-  onConnectionModeChange,
   onServerOffline,
 }: LobbyViewProps) {
   const { t } = useTranslation("multiplayer");
-  const isServer = connectionMode !== "p2p";
-  const isP2P = connectionMode === "p2p";
   const hostingServer = useMultiplayerStore((s) => s.hostingServer);
   const userLobbySources = useMultiplayerStore((s) => s.userLobbySources);
   const sourceStatus = useMultiplayerStore((s) => s.sourceStatus);
@@ -173,9 +163,6 @@ export function LobbyView({
   }, [formatFilter, setFormatConfig, onHostGame]);
 
   useEffect(() => {
-    // P2P mode uses a direct PeerJS code and has no lobby to subscribe to.
-    if (isP2P) return;
-
     let cancelled = false;
     let lobbyDetach: (() => void) | null = null;
 
@@ -252,16 +239,15 @@ export function LobbyView({
     };
     // Depends on the dialed set's MEMBERSHIP (`dialedSourceKey`), never on
     // `sourceStatus` — a status flap must not churn subscriptions.
-  }, [isP2P, dialedSourceKey, subscribeLobby, subscribeAmbientLobby, onServerOffline]);
+  }, [dialedSourceKey, subscribeLobby, subscribeAmbientLobby, onServerOffline]);
 
   useEffect(() => {
     // Not at app boot, for the same reason the subscription sockets are not: a
     // player who never opens multiplayer pays for nothing. Failures are silent
     // by contract — the lobby simply lists presets and hand-added sources. The
     // TTL in `serverDirectory.ts` is what makes a remount cheap.
-    if (isP2P) return;
     void refreshServerDirectory();
-  }, [isP2P]);
+  }, []);
 
   useEffect(() => {
     // A lobby left open in a background tab goes stale: the listing and each
@@ -270,7 +256,6 @@ export function LobbyView({
     // endpoint, because `refreshServerDirectory` self-guards on both its TTL
     // and its in-flight promise. A timer would fire in a backgrounded tab and
     // buy nothing this does not.
-    if (isP2P) return;
     const onVisibilityChange = () => {
       if (document.visibilityState === "visible") void refreshServerDirectory();
     };
@@ -278,7 +263,7 @@ export function LobbyView({
     return () => {
       document.removeEventListener("visibilitychange", onVisibilityChange);
     };
-  }, [isP2P]);
+  }, []);
 
   /**
    * Each browsed source's raw score components, keyed by the CLIENT url a row
@@ -472,42 +457,29 @@ export function LobbyView({
     <MenuPanel className="relative z-10 flex w-full max-w-3xl flex-col gap-6 px-5 py-6">
       <div className="flex w-full flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
         <div className="text-[0.68rem] uppercase tracking-[0.22em] text-slate-500">
-          {isP2P ? t("lobbyView.directConnection") : t("lobbyView.onlineLobby")}
+          {t("lobbyView.onlineLobby")}
         </div>
         <div className="flex min-w-0 flex-wrap items-center gap-2 sm:justify-end">
-          {/* The mode switch sits with the server chip, not with the room-type
-              filter below: it governs which transport this client uses, not
-              which rows the list shows. */}
-          <span className="text-[0.62rem] font-semibold uppercase tracking-[0.18em] text-slate-500">
-            {t("connectionMode.label")}
-          </span>
-          <ConnectionModeSwitch
-            value={isP2P ? "p2p" : "server"}
-            onChange={onConnectionModeChange}
-            size="sm"
-          />
-          {isServer && (
-            <button
-              type="button"
-              onClick={() => setServerPickerOpen(true)}
-              title={hostingServer ?? ""}
-              className="flex min-w-0 max-w-full items-center gap-1.5 rounded-[7px] border border-white/10 bg-black/25 px-2.5 py-0.5 font-mono text-[10px] text-slate-300 backdrop-blur-sm transition-colors hover:border-white/20 hover:bg-white/5"
-            >
-              {serverFlag && (
-                <ServerFlag
-                  flag={serverFlag}
-                  className="h-2.5 w-auto shrink-0 rounded-[1px] ring-1 ring-black/20"
-                />
-              )}
-              <span className="truncate whitespace-nowrap">{serverHost}</span>
-            </button>
-          )}
-          {isServer && playerCount > 0 && (
+          <button
+            type="button"
+            onClick={() => setServerPickerOpen(true)}
+            title={hostingServer ?? ""}
+            className="flex min-w-0 max-w-full items-center gap-1.5 rounded-[7px] border border-white/10 bg-black/25 px-2.5 py-0.5 font-mono text-[10px] text-slate-300 backdrop-blur-sm transition-colors hover:border-white/20 hover:bg-white/5"
+          >
+            {serverFlag && (
+              <ServerFlag
+                flag={serverFlag}
+                className="h-2.5 w-auto shrink-0 rounded-[1px] ring-1 ring-black/20"
+              />
+            )}
+            <span className="truncate whitespace-nowrap">{serverHost}</span>
+          </button>
+          {playerCount > 0 && (
             <span className="rounded-[7px] border border-emerald-300/20 bg-emerald-500/15 px-2.5 py-0.5 text-xs font-medium text-emerald-200">
               {t("lobbyView.online", { count: playerCount })}
             </span>
           )}
-          {isServer && anyDegraded && (
+          {anyDegraded && (
             <button
               type="button"
               onClick={() => setServerPickerOpen(true)}
@@ -523,29 +495,27 @@ export function LobbyView({
           bar width) so the long format roster never covers the lobby form.
           Desktop keeps the anchored dropdown. min-h-44px + text-base meet the
           44/48px touch-target rule and prevent iOS focus-zoom. */}
-      {isServer && (
-        <div className="flex min-h-[44px] w-full items-center gap-2 self-stretch rounded-[10px] border border-white/10 bg-black/25 px-3 py-1 shadow-[0_8px_22px_rgba(0,0,0,0.18)] backdrop-blur-sm sm:w-auto sm:self-start">
-          <span className="shrink-0 text-[0.62rem] font-medium uppercase tracking-[0.18em] text-gray-500">
-            {t("lobbyView.format")}
-          </span>
-          <MenuSelect
-            ariaLabel={t("lobbyView.format")}
-            label={formatMenuLabel}
-            selectedValue={formatFilter ?? FILTER_ALL_SENTINEL}
-            items={[{ value: FILTER_ALL_SENTINEL, label: t("lobbyView.allFormats") }]}
-            groups={formatMenuGroups}
-            onSelect={(value) =>
-              setFormatFilter(
-                value === FILTER_ALL_SENTINEL ? null : (value as GameFormat),
-              )
-            }
-            wrapperClassName="min-w-0 flex-1 sm:min-w-[10rem]"
-            className="min-h-[44px] rounded-none border-0 bg-transparent px-0 py-1.5 text-base font-medium text-white shadow-none hover:bg-transparent focus-visible:ring-white/20"
-          />
-        </div>
-      )}
+      <div className="flex min-h-[44px] w-full items-center gap-2 self-stretch rounded-[10px] border border-white/10 bg-black/25 px-3 py-1 shadow-[0_8px_22px_rgba(0,0,0,0.18)] backdrop-blur-sm sm:w-auto sm:self-start">
+        <span className="shrink-0 text-[0.62rem] font-medium uppercase tracking-[0.18em] text-gray-500">
+          {t("lobbyView.format")}
+        </span>
+        <MenuSelect
+          ariaLabel={t("lobbyView.format")}
+          label={formatMenuLabel}
+          selectedValue={formatFilter ?? FILTER_ALL_SENTINEL}
+          items={[{ value: FILTER_ALL_SENTINEL, label: t("lobbyView.allFormats") }]}
+          groups={formatMenuGroups}
+          onSelect={(value) =>
+            setFormatFilter(
+              value === FILTER_ALL_SENTINEL ? null : (value as GameFormat),
+            )
+          }
+          wrapperClassName="min-w-0 flex-1 sm:min-w-[10rem]"
+          className="min-h-[44px] rounded-none border-0 bg-transparent px-0 py-1.5 text-base font-medium text-white shadow-none hover:bg-transparent focus-visible:ring-white/20"
+        />
+      </div>
 
-      {isServer && showRoomTypeFilter && (
+      {showRoomTypeFilter && (
         <div className="flex rounded-[10px] border border-white/10 bg-black/25 p-1 shadow-[0_8px_22px_rgba(0,0,0,0.18)] backdrop-blur-sm">
           {ROOM_TYPE_FILTERS.map((opt) => (
             <button
@@ -563,54 +533,46 @@ export function LobbyView({
         </div>
       )}
 
-      {isServer && (
-        <div className="w-full space-y-3">
-          <div className="text-[0.68rem] uppercase tracking-[0.22em] text-slate-500">{t("lobbyView.openTables")}</div>
-          {filteredEntries.length === 0 ? (
-            <div className="flex flex-col items-center gap-3 rounded-[10px] border border-dashed border-white/10 bg-black/12 px-4 py-6 text-center backdrop-blur-sm">
-              <p className="text-sm text-gray-400">
-                {formatFilter
-                  ? t("lobbyView.noFormatGames", { format: formatFilter })
-                  : t("lobbyView.noOpenGames")}
-              </p>
-              {formatFilter && (
-                <button
-                  type="button"
-                  onClick={() => setFormatFilter(null)}
-                  className={menuButtonClass({ tone: "neutral", size: "sm" })}
-                >
-                  {t("lobbyView.showAllFormats")}
-                </button>
-              )}
-            </div>
-          ) : (
-            <div className="flex max-h-64 flex-col gap-2 overflow-y-auto">
-              {filteredEntries.map((entry) => (
-                <GameListItem
-                  // Keyed by source too: `game_code` is unique per authority,
-                  // not across the merged multi-source list.
-                  key={`${entry.source.url}:${entry.game.game_code}`}
-                  entry={entry}
-                  onJoin={handleJoinFromList}
-                  compatible={isLobbyEntryCompatible(entry.game.host_build_commit)}
-                  hostGameCode={hostGameCode}
-                  healthHint={hintByUrl.get(entry.source.url) ?? null}
-                />
-              ))}
-            </div>
-          )}
-        </div>
-      )}
-
-      {isP2P && (
-        <div className="w-full rounded-[10px] border border-cyan-400/20 bg-cyan-500/[0.07] px-4 py-3 text-sm leading-6 text-cyan-100 shadow-[0_8px_22px_rgba(0,0,0,0.18)] backdrop-blur-sm">
-          {t("lobbyView.p2pNotice")}
-        </div>
-      )}
+      <div className="w-full space-y-3">
+        <div className="text-[0.68rem] uppercase tracking-[0.22em] text-slate-500">{t("lobbyView.openTables")}</div>
+        {filteredEntries.length === 0 ? (
+          <div className="flex flex-col items-center gap-3 rounded-[10px] border border-dashed border-white/10 bg-black/12 px-4 py-6 text-center backdrop-blur-sm">
+            <p className="text-sm text-gray-400">
+              {formatFilter
+                ? t("lobbyView.noFormatGames", { format: formatFilter })
+                : t("lobbyView.noOpenGames")}
+            </p>
+            {formatFilter && (
+              <button
+                type="button"
+                onClick={() => setFormatFilter(null)}
+                className={menuButtonClass({ tone: "neutral", size: "sm" })}
+              >
+                {t("lobbyView.showAllFormats")}
+              </button>
+            )}
+          </div>
+        ) : (
+          <div className="flex max-h-64 flex-col gap-2 overflow-y-auto">
+            {filteredEntries.map((entry) => (
+              <GameListItem
+                // Keyed by source too: `game_code` is unique per authority,
+                // not across the merged multi-source list.
+                key={`${entry.source.url}:${entry.game.game_code}`}
+                entry={entry}
+                onJoin={handleJoinFromList}
+                compatible={isLobbyEntryCompatible(entry.game.host_build_commit)}
+                hostGameCode={hostGameCode}
+                healthHint={hintByUrl.get(entry.source.url) ?? null}
+              />
+            ))}
+          </div>
+        )}
+      </div>
 
       <div className="w-full space-y-3">
         <div className="text-[0.68rem] uppercase tracking-[0.22em] text-slate-500">
-          {isP2P ? t("lobbyView.joinByCode") : t("lobbyView.joinATable")}
+          {t("lobbyView.joinATable")}
         </div>
         <div className="flex w-full flex-col gap-2 sm:flex-row sm:items-center">
           <input
@@ -618,8 +580,8 @@ export function LobbyView({
             value={joinCode}
             onChange={(e) => setJoinCode(e.target.value)}
             onKeyDown={(e) => e.key === "Enter" && handleJoinByCode()}
-            placeholder={isP2P ? t("lobbyView.p2pCodePlaceholder") : t("lobbyView.serverCodePlaceholder")}
-            maxLength={isP2P ? 5 : 50}
+            placeholder={t("lobbyView.serverCodePlaceholder")}
+            maxLength={50}
             className="min-w-0 flex-1 rounded-[8px] border border-white/10 bg-black/25 px-4 py-2 font-mono text-sm tracking-wider text-white placeholder-gray-500 outline-none backdrop-blur-sm focus:border-white/20"
           />
           <div className="flex w-full shrink-0 items-center gap-2 sm:w-auto">
@@ -635,7 +597,7 @@ export function LobbyView({
             >
               {t("lobbyView.join")}
             </button>
-            {isServer && onSpectate && (
+            {onSpectate && (
               <button
                 type="button"
                 onClick={handleSpectateByCode}
@@ -658,7 +620,7 @@ export function LobbyView({
         <div className="min-w-0">
           <div className="text-[0.68rem] uppercase tracking-[0.22em] text-slate-500">{t("lobbyView.host")}</div>
           <div className="mt-1 text-sm text-slate-400">
-            {isP2P ? t("lobbyView.hostP2PDescription") : t("lobbyView.hostServerDescription")}
+            {t("lobbyView.hostServerDescription")}
           </div>
         </div>
         <div className="flex items-center gap-2">
@@ -670,13 +632,12 @@ export function LobbyView({
               {t("lobbyView.hostDraft")}
             </button>
           )}
-          {/* One button; the mode switch above says which transport it opens,
-              and its tone follows that mode's accent. Each mode keeps its own
-              entry point: the server one seeds host-setup with the lobby's
-              active format filter, the P2P one does not. */}
+          {/* One entry point into Host Game, which is where the P2P /
+              Official Server choice is made. Seeds host-setup with the lobby's
+              active format filter on the way. */}
           <button
-            onClick={isP2P ? onHostP2P : handleHost}
-            className={menuButtonClass({ tone: isP2P ? "cyan" : "emerald", size: "md" })}
+            onClick={handleHost}
+            className={menuButtonClass({ tone: "emerald", size: "md" })}
           >
             {t("lobbyView.hostGame")}
           </button>

--- a/client/src/components/lobby/__tests__/HostSetup.test.tsx
+++ b/client/src/components/lobby/__tests__/HostSetup.test.tsx
@@ -462,7 +462,7 @@ describe("HostSetup", () => {
     await i18n.changeLanguage("en");
   });
 
-  it("uses P2P labeling/theme and hides server-only lobby listing in p2p mode", () => {
+  it("uses P2P labeling/theme and still offers the lobby listing in p2p mode", () => {
     render(
       <HostSetup
         onHost={vi.fn()}
@@ -475,7 +475,9 @@ describe("HostSetup", () => {
     // The screen heading now lives on the page shell (MultiplayerPage); the
     // form itself is distinguished by its P2P submit-button labeling.
     expect(screen.getByRole("button", { name: "Host P2P Game" })).toBeInTheDocument();
-    expect(screen.queryByText("List in lobby")).not.toBeInTheDocument();
+    // Listing is NOT server-only: a brokered P2P room is advertised in the
+    // public lobby, so the control that governs that has to be here too.
+    expect(screen.getByRole("switch", { name: "List in lobby" })).toBeInTheDocument();
     expect(screen.queryByText("P2P currently supports 2-player Standard.")).not.toBeInTheDocument();
   });
 
@@ -499,8 +501,15 @@ describe("HostSetup", () => {
     it("names every visible switch and associates only the sandbox help", () => {
       render(<HostSetup onHost={vi.fn()} onBack={vi.fn()} connectionMode={connectionMode} onConnectionModeChange={vi.fn()} />);
 
-      const names = ["Start when full", "Sandbox Mode — allow debug actions", "Set password"];
-      if (connectionMode === "server") names.unshift("List in lobby");
+      // "List in lobby" is present in BOTH modes: a P2P room brokered by a
+      // `LobbyOnly` anchor is listed exactly as a server-run game is, so the
+      // opt-out has to be reachable from either transport.
+      const names = [
+        "List in lobby",
+        "Start when full",
+        "Sandbox Mode — allow debug actions",
+        "Set password",
+      ];
 
       expect(screen.getAllByRole("switch")).toHaveLength(names.length);
       for (const name of names) {
@@ -511,9 +520,6 @@ describe("HostSetup", () => {
           expect(control).not.toHaveAttribute("aria-describedby");
           expect(control).not.toHaveAccessibleDescription();
         }
-      }
-      if (connectionMode === "p2p") {
-        expect(screen.queryByRole("switch", { name: "List in lobby" })).not.toBeInTheDocument();
       }
     });
 
@@ -545,12 +551,12 @@ describe("HostSetup", () => {
       const onHost = vi.fn();
       render(<HostSetup onHost={onHost} onBack={vi.fn()} connectionMode={connectionMode} onConnectionModeChange={vi.fn()} />);
 
-      if (connectionMode === "server") {
-        const publicSwitch = screen.getByRole("switch", { name: "List in lobby" });
-        expect(publicSwitch).toBeChecked();
-        await user.click(publicSwitch);
-        expect(publicSwitch).not.toBeChecked();
-      }
+      // Checked by default in both modes — which is what the hidden P2P
+      // toggle used to submit with no way to change it.
+      const publicSwitch = screen.getByRole("switch", { name: "List in lobby" });
+      expect(publicSwitch).toBeChecked();
+      await user.click(publicSwitch);
+      expect(publicSwitch).not.toBeChecked();
 
       const startSwitch = screen.getByRole("switch", { name: "Start when full" });
       expect(startSwitch).toBeChecked();
@@ -579,7 +585,7 @@ describe("HostSetup", () => {
       }));
       expect(onHost).toHaveBeenCalledTimes(1);
       expect(onHost).toHaveBeenCalledWith(expect.objectContaining({
-        public: connectionMode === "p2p",
+        public: false,
         startWhenFull: false,
         password: "test-password",
         formatConfig: expect.objectContaining({ allow_debug_actions: true }),
@@ -1041,6 +1047,69 @@ describe("HostSetup", () => {
     expect(screen.queryByRole("button", { name: "Use" })).not.toBeInTheDocument();
   });
 
+  /**
+   * Hiding such a format from the PICKER is not enough: one already selected in
+   * server mode survives a flip to P2P, and a minimum above the ceiling cannot
+   * be clamped into range — only replaced. Without the guard, `maxPlayers` (6)
+   * falls below `formatConfig.min_players` (7), `Array.from` coerces the
+   * negative length to 0, and the seat picker renders EMPTY while Host submits
+   * a configuration the format itself rejects.
+   */
+  it("replaces a selected over-ceiling format when the mode flips to P2P", async () => {
+    const user = userEvent.setup();
+    const onHostSpy = vi.fn();
+    // Seeded through the store because the module-level `formatConfigForCustomRules`
+    // mock answers every saved format with a 2-player config — the "Use" flow
+    // therefore cannot produce an over-ceiling selection, while the store's
+    // `formatConfig` is exactly how a real one survives into this form.
+    useMultiplayerStore.setState({
+      formatConfig: {
+        ...FORMAT_DEFAULTS.Commander,
+        format: "Custom:0",
+        min_players: 7,
+        max_players: 8,
+      },
+    });
+
+    const { rerender } = render(
+      <HostSetup
+        onHost={onHostSpy}
+        onBack={vi.fn()}
+        connectionMode="server"
+        onConnectionModeChange={vi.fn()}
+      />,
+    );
+
+    // Reach-guard: the over-ceiling format really is in force, so the seats
+    // below are the guard's doing and not a form that never left its defaults.
+    expect(screen.getByRole("button", { name: "8" })).toBeInTheDocument();
+
+    rerender(
+      <HostSetup
+        onHost={onHostSpy}
+        onBack={vi.fn()}
+        connectionMode="p2p"
+        onConnectionModeChange={vi.fn()}
+      />,
+    );
+
+    // Replaced, not clamped: the seat range is Commander's 2–6. Without the
+    // guard this range is empty (6 − 7 + 1 = 0) and NO seat button renders.
+    expect(screen.getByRole("button", { name: "2" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "6" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "7" })).not.toBeInTheDocument();
+
+    // Seated at the REPLACEMENT's own minimum, not at the P2P ceiling: the
+    // seat clamp yields to the guard rather than overwriting what it set.
+    await user.click(screen.getByRole("button", { name: "Host P2P Game" }));
+    expect(onHostSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        formatConfig: expect.objectContaining({ format: "Commander", max_players: 2 }),
+      }),
+      null,
+    );
+  });
+
   // ── Connection mode switch ──────────────────────────────────────────────
 
   it("mirrors the connection switch and reports a change to the page", async () => {
@@ -1059,7 +1128,7 @@ describe("HostSetup", () => {
     expect(
       within(group).getByRole("button", { name: "Official Server" }),
     ).toHaveAttribute("aria-pressed", "true");
-    // The server-only control is what the mode is currently buying.
+    // Listing is offered under both transports, so it must survive the flip.
     expect(screen.getByText("List in lobby")).toBeInTheDocument();
 
     await user.click(within(group).getByRole("button", { name: "P2P" }));

--- a/client/src/components/lobby/__tests__/LobbyView.test.tsx
+++ b/client/src/components/lobby/__tests__/LobbyView.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { act, cleanup, render, screen, waitFor, within } from "@testing-library/react";
+import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import type { LobbyGame } from "../../../adapter/types";
@@ -126,8 +126,6 @@ function renderLobby(props: {
   return render(
     <LobbyView
       onHostGame={vi.fn()}
-      onHostP2P={vi.fn()}
-      onConnectionModeChange={vi.fn()}
       onJoinGame={props.onJoinGame ?? vi.fn()}
       onSpectate={props.onSpectate ?? vi.fn()}
       onServerOffline={vi.fn()}
@@ -204,8 +202,6 @@ describe("LobbyView", () => {
     render(
       <LobbyView
         onHostGame={vi.fn()}
-        onHostP2P={vi.fn()}
-        onConnectionModeChange={vi.fn()}
         onJoinGame={vi.fn()}
         onServerOffline={onServerOffline}
       />,
@@ -235,8 +231,6 @@ describe("LobbyView", () => {
     const { unmount } = render(
       <LobbyView
         onHostGame={vi.fn()}
-        onHostP2P={vi.fn()}
-        onConnectionModeChange={vi.fn()}
         onJoinGame={vi.fn()}
         onServerOffline={onServerOffline}
       />,
@@ -247,23 +241,6 @@ describe("LobbyView", () => {
     await Promise.resolve();
 
     expect(onServerOffline).not.toHaveBeenCalled();
-  });
-
-  it("does not subscribe in p2p mode", () => {
-    const subscribeLobby = vi.fn();
-    useMultiplayerStore.setState({ subscribeLobby });
-    render(
-      <LobbyView
-        onHostGame={vi.fn()}
-        onHostP2P={vi.fn()}
-        onConnectionModeChange={vi.fn()}
-        onJoinGame={vi.fn()}
-        connectionMode="p2p"
-        onServerOffline={vi.fn()}
-      />,
-    );
-
-    expect(subscribeLobby).not.toHaveBeenCalled();
   });
 
   // Renamed from "fires offline fallback when the stored server address is
@@ -282,8 +259,6 @@ describe("LobbyView", () => {
     render(
       <LobbyView
         onHostGame={vi.fn()}
-        onHostP2P={vi.fn()}
-        onConnectionModeChange={vi.fn()}
         onJoinGame={vi.fn()}
         onServerOffline={onServerOffline}
       />,
@@ -627,27 +602,13 @@ describe("LobbyView", () => {
   });
 
   // V-U11j
-  it("refreshes the server directory on mount, in server mode only", async () => {
+  it("refreshes the server directory on mount", async () => {
     useMultiplayerStore.setState({
       subscribeLobby: vi.fn().mockResolvedValue(() => {}),
       subscribeAmbientLobby: vi.fn(() => () => {}),
     });
     renderLobby({});
     expect(directoryMocks.refreshServerDirectory).toHaveBeenCalledTimes(1);
-
-    cleanup();
-    directoryMocks.refreshServerDirectory.mockClear();
-    // Paired negative: P2P has no lobby to browse and no directory to read.
-    render(
-      <LobbyView
-        onHostGame={vi.fn()}
-        onHostP2P={vi.fn()}
-        onConnectionModeChange={vi.fn()}
-        onJoinGame={vi.fn()}
-        connectionMode="p2p"
-      />,
-    );
-    expect(directoryMocks.refreshServerDirectory).toHaveBeenCalledTimes(0);
   });
 
   // V-U11k
@@ -713,31 +674,11 @@ describe("LobbyView", () => {
   });
 
   // V-U12rb
-  it("installs no visibility refresh in p2p mode and removes it on unmount", () => {
+  it("refreshes on tab visibility and removes the listener on unmount", () => {
     const visibility = vi.spyOn(document, "visibilityState", "get");
     try {
       visibility.mockReturnValue("visible");
 
-      // (i) P2P has no lobby to browse and no directory to read.
-      render(
-        <LobbyView
-          onHostGame={vi.fn()}
-          onHostP2P={vi.fn()}
-          onConnectionModeChange={vi.fn()}
-          onJoinGame={vi.fn()}
-          onSpectate={vi.fn()}
-          onServerOffline={vi.fn()}
-          connectionMode="p2p"
-        />,
-      );
-      // Reach-guard: a p2p-ONLY element, so the zero below is the effect's
-      // guard and not a render that never happened.
-      expect(screen.getByText(/Peer-to-peer mode\./)).toBeInTheDocument();
-      document.dispatchEvent(new Event("visibilitychange"));
-      expect(directoryMocks.refreshServerDirectory).toHaveBeenCalledTimes(0);
-
-      // (ii) Server mode: the listener works, and is gone after unmount.
-      cleanup();
       const { unmount } = renderLobby({});
       document.dispatchEvent(new Event("visibilitychange"));
       const beforeUnmount = directoryMocks.refreshServerDirectory.mock.calls.length;
@@ -797,89 +738,76 @@ describe("LobbyView", () => {
     expect(presetRow.textContent).not.toContain("SLOW");
   });
 
-  // ── Connection mode switch ──────────────────────────────────────────────
+  // ── The lobby is transport-agnostic ─────────────────────────────────────
 
-  /** Mode is a PROP: the view reports a change and never applies one to
-   *  itself, which is what keeps the page the single authority. */
-  function renderWithMode(props: {
-    connectionMode: "server" | "p2p";
-    onHostGame?: () => void;
-    onHostP2P?: () => void;
-    onConnectionModeChange?: (mode: "server" | "p2p") => void;
-  }) {
-    return render(
-      <LobbyView
-        onHostGame={props.onHostGame ?? vi.fn()}
-        onHostP2P={props.onHostP2P ?? vi.fn()}
-        onConnectionModeChange={props.onConnectionModeChange ?? vi.fn()}
-        onJoinGame={vi.fn()}
-        onSpectate={vi.fn()}
-        onServerOffline={vi.fn()}
-        connectionMode={props.connectionMode}
-      />,
-    );
-  }
+  /** The P2P / Official Server choice lives on Host Game, because it
+   *  configures a game being CREATED. This view only browses, joins and
+   *  spectates — all of which behave identically under either transport — so
+   *  it takes no mode prop at all. */
+  it("renders no connection switch: the transport is a Host Game choice", () => {
+    renderLobby({});
 
-  it("reports a mode change instead of applying one", async () => {
-    const user = userEvent.setup();
-    const onConnectionModeChange = vi.fn();
-    renderWithMode({ connectionMode: "server", onConnectionModeChange });
-
-    const group = screen.getByRole("group", { name: "Connection" });
     expect(
-      within(group).getByRole("button", { name: "Official Server" }),
-    ).toHaveAttribute("aria-pressed", "true");
-
-    await user.click(within(group).getByRole("button", { name: "P2P" }));
-
-    expect(onConnectionModeChange).toHaveBeenCalledWith("p2p");
-    // Nothing local moved: the view still renders the mode it was given.
-    expect(
-      within(group).getByRole("button", { name: "Official Server" }),
-    ).toHaveAttribute("aria-pressed", "true");
-  });
-
-  it("offers one host button whose action follows the active mode", async () => {
-    const user = userEvent.setup();
-    const server = { onHostGame: vi.fn(), onHostP2P: vi.fn() };
-    renderWithMode({ connectionMode: "server", ...server });
-
-    // One button, not two mutually-exclusive ones.
-    expect(screen.getAllByRole("button", { name: "Host Game" })).toHaveLength(1);
-    await user.click(screen.getByRole("button", { name: "Host Game" }));
-    expect(server.onHostGame).toHaveBeenCalledTimes(1);
-    expect(server.onHostP2P).not.toHaveBeenCalled();
-
-    // Same button in P2P, dispatching to the entry point that does NOT seed
-    // host-setup from the lobby's format filter.
-    cleanup();
-    const p2p = { onHostGame: vi.fn(), onHostP2P: vi.fn() };
-    renderWithMode({ connectionMode: "p2p", ...p2p });
-
-    await user.click(screen.getByRole("button", { name: "Host Game" }));
-    expect(p2p.onHostP2P).toHaveBeenCalledTimes(1);
-    expect(p2p.onHostGame).not.toHaveBeenCalled();
-  });
-
-  it("replaces the P2P-only server shortcut with the switch", () => {
-    renderWithMode({ connectionMode: "p2p" });
-
-    expect(screen.getByRole("group", { name: "Connection" })).toBeInTheDocument();
+      screen.queryByRole("group", { name: "Connection" }),
+    ).not.toBeInTheDocument();
+    // The switch replaced this shortcut, and removing the switch must not
+    // bring it back.
     expect(
       screen.queryByRole("button", { name: "Pick server" }),
     ).not.toBeInTheDocument();
   });
 
-  it("keeps the room-type filter applied when the connection switch is used", async () => {
+  it("accepts a full-length server code in the join field", async () => {
+    const user = userEvent.setup();
+    renderLobby({});
+
+    const input = screen.getByPlaceholderText("Enter code or CODE@IP:PORT");
+    // Regression guard. `MultiplayerPage` routes a join on the SHAPE of the
+    // code, never on a connection mode — but the field used to cap itself at
+    // the 5-character P2P length whenever the lobby was in P2P mode, which
+    // silently truncated exactly this string as the user typed it.
+    const scoped = "ABC12@play.example.com:8443";
+    await user.type(input, scoped);
+    expect(input).toHaveValue(scoped);
+  });
+
+  it("offers one host button, which opens Host Game", async () => {
+    const user = userEvent.setup();
+    const onHostGame = vi.fn();
+    render(
+      <LobbyView
+        onHostGame={onHostGame}
+        onJoinGame={vi.fn()}
+        onSpectate={vi.fn()}
+        onServerOffline={vi.fn()}
+      />,
+    );
+
+    // One button, not a server one and a P2P one.
+    expect(screen.getAllByRole("button", { name: "Host Game" })).toHaveLength(1);
+    await user.click(screen.getByRole("button", { name: "Host Game" }));
+    expect(onHostGame).toHaveBeenCalledTimes(1);
+  });
+
+  it("filters the browsed list by room type, P2P rows included", async () => {
     const user = userEvent.setup();
     const source: LobbySource = {
       url: SERVER_PRESETS[0].url,
       name: "lobby.phase-rs.dev",
       origin: "official",
     };
+    // Two rows of opposite transports, so each filter has something to KEEP as
+    // well as something to hide — a single-row fixture would let every
+    // assertion below pass on the first filter click alone.
     const subscribeLobby = vi.fn(
       async (onUpdate: (games: LobbyGame[], source: LobbySource) => void) => {
-        onUpdate([lobbyGame("SRV01", "Server table", 100)], source);
+        onUpdate(
+          [
+            lobbyGame("SRV01", "Server table", 100),
+            { ...lobbyGame("P2P01", "Direct table", 200), is_p2p: true },
+          ],
+          source,
+        );
         return () => {};
       },
     );
@@ -887,25 +815,20 @@ describe("LobbyView", () => {
       subscribeLobby,
       subscribeAmbientLobby: vi.fn(() => () => {}),
     });
-    renderWithMode({ connectionMode: "server" });
+    renderLobby({});
 
     await screen.findByRole("button", { name: /Server table/ });
-    // "Draft", not "P2P": the room-type filter and the connection switch both
-    // carry a "P2P" label, and only the switch is inside the named group.
-    await user.click(screen.getByRole("button", { name: "Draft" }));
+    expect(screen.getByRole("button", { name: /Direct table/ })).toBeInTheDocument();
+
+    // The room-type filter is what scopes the list, and it is available
+    // unconditionally: a player browses P2P tables without changing anything
+    // about how they would host.
+    await user.click(screen.getByRole("button", { name: "P2P" }));
+    expect(screen.getByRole("button", { name: /Direct table/ })).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /Server table/ })).not.toBeInTheDocument();
 
-    await user.click(
-      within(screen.getByRole("group", { name: "Connection" })).getByRole(
-        "button",
-        { name: "P2P" },
-      ),
-    );
-
-    // The filter the user set still hides the non-draft row. Deliberately NOT
-    // asserting "no re-subscribe": `connectionMode` is a fixed prop here and
-    // `onConnectionModeChange` is a spy, so the mode cannot actually change and
-    // a re-subscribe count would hold no matter what the switch did.
-    expect(screen.queryByRole("button", { name: /Server table/ })).not.toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Server" }));
+    expect(screen.getByRole("button", { name: /Server table/ })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Direct table/ })).not.toBeInTheDocument();
   });
 });

--- a/client/src/i18n/locales/de/multiplayer.json
+++ b/client/src/i18n/locales/de/multiplayer.json
@@ -180,7 +180,6 @@
     "createDraft": "Draft erstellen"
   },
   "lobbyView": {
-    "directConnection": "Direktverbindung",
     "onlineLobby": "Online-Lobby",
     "online": "{{count}} online",
     "format": "Format",
@@ -193,14 +192,10 @@
     "noFormatGames": "Derzeit keine {{format}}-Spiele.",
     "noOpenGames": "Derzeit keine offenen Spiele.",
     "showAllFormats": "Alle Formate anzeigen",
-    "p2pNotice": "Peer-to-Peer-Modus. Hoste oder tritt direkt mit einem 5-stelligen Raumcode bei.",
-    "joinByCode": "Per Code beitreten",
     "joinATable": "Einem Tisch beitreten",
-    "p2pCodePlaceholder": "5-stelligen P2P-Code eingeben",
     "serverCodePlaceholder": "Code oder CODE@IP:PORT eingeben",
     "join": "Beitreten",
     "host": "Hosten",
-    "hostP2PDescription": "Erstelle einen direkten Raum für einen Gegner.",
     "hostServerDescription": "Öffne einen Raum und warte auf Spieler.",
     "hostDraft": "Draft hosten",
     "hostGame": "Spiel hosten",

--- a/client/src/i18n/locales/en/multiplayer.json
+++ b/client/src/i18n/locales/en/multiplayer.json
@@ -180,7 +180,6 @@
     "createDraft": "Create Draft"
   },
   "lobbyView": {
-    "directConnection": "Direct Connection",
     "onlineLobby": "Online Lobby",
     "online": "{{count}} online",
     "format": "Format",
@@ -193,15 +192,11 @@
     "noFormatGames": "No {{format}} games right now.",
     "noOpenGames": "No open games right now.",
     "showAllFormats": "Show all formats",
-    "p2pNotice": "Peer-to-peer mode. Host or join directly with a 5-character room code.",
-    "joinByCode": "Join by Code",
     "joinATable": "Join a Table",
-    "p2pCodePlaceholder": "Enter 5-character P2P code",
     "serverCodePlaceholder": "Enter code or CODE@IP:PORT",
     "join": "Join",
     "watch": "Watch",
     "host": "Host",
-    "hostP2PDescription": "Create a direct room for one opponent.",
     "hostServerDescription": "Open a room and wait for players.",
     "hostDraft": "Host Draft",
     "hostGame": "Host Game",

--- a/client/src/i18n/locales/es/multiplayer.json
+++ b/client/src/i18n/locales/es/multiplayer.json
@@ -180,7 +180,6 @@
     "createDraft": "Crear draft"
   },
   "lobbyView": {
-    "directConnection": "Conexión directa",
     "onlineLobby": "Sala de espera en línea",
     "online": "{{count}} en línea",
     "format": "Formato",
@@ -193,14 +192,10 @@
     "noFormatGames": "No hay partidas de {{format}} ahora mismo.",
     "noOpenGames": "No hay partidas abiertas ahora mismo.",
     "showAllFormats": "Mostrar todos los formatos",
-    "p2pNotice": "Modo peer-to-peer. Hospeda o únete directamente con un código de sala de 5 caracteres.",
-    "joinByCode": "Unirse por código",
     "joinATable": "Unirse a una mesa",
-    "p2pCodePlaceholder": "Introduce el código P2P de 5 caracteres",
     "serverCodePlaceholder": "Introduce el código o CÓDIGO@IP:PUERTO",
     "join": "Unirse",
     "host": "Hospedar",
-    "hostP2PDescription": "Crea una sala directa para un oponente.",
     "hostServerDescription": "Abre una sala y espera a los jugadores.",
     "hostDraft": "Hospedar draft",
     "hostGame": "Hospedar partida",

--- a/client/src/i18n/locales/fr/multiplayer.json
+++ b/client/src/i18n/locales/fr/multiplayer.json
@@ -180,7 +180,6 @@
     "createDraft": "Créer le draft"
   },
   "lobbyView": {
-    "directConnection": "Connexion directe",
     "onlineLobby": "Salon en ligne",
     "online": "{{count}} en ligne",
     "format": "Format",
@@ -193,14 +192,10 @@
     "noFormatGames": "Aucune partie {{format}} pour le moment.",
     "noOpenGames": "Aucune partie ouverte pour le moment.",
     "showAllFormats": "Afficher tous les formats",
-    "p2pNotice": "Mode pair-à-pair. Hébergez ou rejoignez directement avec un code de salle à 5 caractères.",
-    "joinByCode": "Rejoindre par code",
     "joinATable": "Rejoindre une table",
-    "p2pCodePlaceholder": "Saisissez un code P2P à 5 caractères",
     "serverCodePlaceholder": "Saisissez un code ou CODE@IP:PORT",
     "join": "Rejoindre",
     "host": "Héberger",
-    "hostP2PDescription": "Créez une salle directe pour un adversaire.",
     "hostServerDescription": "Ouvrez une salle et attendez des joueurs.",
     "hostDraft": "Héberger un draft",
     "hostGame": "Héberger une partie",

--- a/client/src/i18n/locales/it/multiplayer.json
+++ b/client/src/i18n/locales/it/multiplayer.json
@@ -180,7 +180,6 @@
     "createDraft": "Crea draft"
   },
   "lobbyView": {
-    "directConnection": "Connessione diretta",
     "onlineLobby": "Lobby online",
     "online": "{{count}} online",
     "format": "Formato",
@@ -193,14 +192,10 @@
     "noFormatGames": "Nessuna partita {{format}} al momento.",
     "noOpenGames": "Nessuna partita aperta al momento.",
     "showAllFormats": "Mostra tutti i formati",
-    "p2pNotice": "Modalità peer-to-peer. Ospita o unisciti direttamente con un codice stanza di 5 caratteri.",
-    "joinByCode": "Unisciti tramite codice",
     "joinATable": "Unisciti a un tavolo",
-    "p2pCodePlaceholder": "Inserisci codice P2P di 5 caratteri",
     "serverCodePlaceholder": "Inserisci codice o CODICE@IP:PORTA",
     "join": "Unisciti",
     "host": "Ospita",
-    "hostP2PDescription": "Crea una stanza diretta per un avversario.",
     "hostServerDescription": "Apri una stanza e attendi i giocatori.",
     "hostDraft": "Ospita draft",
     "hostGame": "Ospita partita",

--- a/client/src/i18n/locales/pl/multiplayer.json
+++ b/client/src/i18n/locales/pl/multiplayer.json
@@ -180,7 +180,6 @@
     "createDraft": "Utwórz draft"
   },
   "lobbyView": {
-    "directConnection": "Połączenie bezpośrednie",
     "onlineLobby": "Poczekalnia online",
     "online": "{{count}} online",
     "format": "Format",
@@ -193,14 +192,10 @@
     "noFormatGames": "Brak gier {{format}} w tej chwili.",
     "noOpenGames": "Brak otwartych gier w tej chwili.",
     "showAllFormats": "Pokaż wszystkie formaty",
-    "p2pNotice": "Tryb peer-to-peer. Hostuj lub dołącz bezpośrednio za pomocą 5-znakowego kodu pokoju.",
-    "joinByCode": "Dołącz za pomocą kodu",
     "joinATable": "Dołącz do stołu",
-    "p2pCodePlaceholder": "Wpisz 5-znakowy kod P2P",
     "serverCodePlaceholder": "Wpisz kod lub KOD@IP:PORT",
     "join": "Dołącz",
     "host": "Hostuj",
-    "hostP2PDescription": "Utwórz bezpośredni pokój dla jednego przeciwnika.",
     "hostServerDescription": "Otwórz pokój i czekaj na graczy.",
     "hostDraft": "Hostuj draft",
     "hostGame": "Hostuj grę",

--- a/client/src/i18n/locales/pt/multiplayer.json
+++ b/client/src/i18n/locales/pt/multiplayer.json
@@ -180,7 +180,6 @@
     "createDraft": "Criar Draft"
   },
   "lobbyView": {
-    "directConnection": "Conexão Direta",
     "onlineLobby": "Lobby Online",
     "online": "{{count}} online",
     "format": "Formato",
@@ -193,14 +192,10 @@
     "noFormatGames": "Nenhum jogo de {{format}} no momento.",
     "noOpenGames": "Nenhum jogo aberto no momento.",
     "showAllFormats": "Mostrar todos os formatos",
-    "p2pNotice": "Modo peer-to-peer. Hospede ou entre diretamente com um código de sala de 5 caracteres.",
-    "joinByCode": "Entrar por Código",
     "joinATable": "Entrar em uma Mesa",
-    "p2pCodePlaceholder": "Insira o código P2P de 5 caracteres",
     "serverCodePlaceholder": "Insira o código ou CÓDIGO@IP:PORTA",
     "join": "Entrar",
     "host": "Hospedar",
-    "hostP2PDescription": "Crie uma sala direta para um oponente.",
     "hostServerDescription": "Abra uma sala e aguarde os jogadores.",
     "hostDraft": "Hospedar Draft",
     "hostGame": "Hospedar Jogo",

--- a/client/src/pages/MultiplayerPage.tsx
+++ b/client/src/pages/MultiplayerPage.tsx
@@ -229,23 +229,33 @@ function MultiplayerPageContent({
     navigate(location.pathname, { replace: true, state: null });
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
-  // The single owner of a mode change, called by BOTH surfaces that render
-  // the switch (the lobby header and Host Game) so the anchor repair below
-  // lives in exactly one place.
-  const handleConnectionModeChange = useCallback(
-    (mode: ConnectionMode) => {
-      setConnectionMode(mode);
-      // Server mode needs an anchor to browse and host through, and the
-      // server chip — now the only route back to `ServerPicker` — renders
-      // empty without one. The only way to still hold a `null` anchor is a
-      // blob persisted before the picker's "None" row was removed. This
-      // ensures an anchor exists; it never clears one.
-      if (mode === "server" && useMultiplayerStore.getState().hostingServer === null) {
-        setHostingServer(DEFAULT_MULTIPLAYER_SERVER_URL);
-      }
-    },
-    [setConnectionMode, setHostingServer],
-  );
+  // Guarantee a lobby anchor. The lobby browses, joins and spectates through
+  // it under BOTH transports, and the server chip — the only route back to
+  // `ServerPicker` — renders empty without one. The sole way to still hold a
+  // `null` anchor is a blob persisted before the picker's "None (P2P only)"
+  // row was removed, so this is a one-shot migration on arrival: it ensures an
+  // anchor exists and never clears one.
+  useEffect(() => {
+    const state = useMultiplayerStore.getState();
+    if (state.hostingServer !== null) return;
+    // That "None" pick was a TRANSPORT choice as much as an anchor one, and
+    // the derivation above reads the anchor when nothing is stored. Record the
+    // choice first, or seeding the anchor would silently move a deliberate
+    // P2P-only player onto the official server.
+    if (state.connectionMode === null) {
+      setConnectionMode("p2p");
+    }
+    setHostingServer(DEFAULT_MULTIPLAYER_SERVER_URL);
+  }, [setConnectionMode, setHostingServer]);
+
+  // Stable identity is load-bearing, not a micro-optimisation: `LobbyView`
+  // lists this callback in its subscription effect's dependency array, so an
+  // inline arrow re-runs that effect on EVERY render of this page — tearing
+  // down and re-dialling every lobby source each time, and, while they are
+  // down, re-opening the prompt on the very re-render its own dismissal
+  // causes. Until the switch moved to Host Game, P2P mode hid that by
+  // short-circuiting the effect and suppressing this callback outright.
+  const handleServerOffline = useCallback(() => setServerOfflinePrompt(true), []);
 
   // Live legality check: whenever the user is on host-setup with an active
   // deck and a chosen format, re-run the engine's compatibility check after
@@ -632,8 +642,8 @@ function MultiplayerPageContent({
 
   const handleSpectate = useCallback(
     async (code: string, origin: LobbySource | null, context?: LobbyGame) => {
-      // Boundary guard: `onSpectate` is only passed in server mode, so a
-      // null origin here means the lobby has no authority to watch through.
+      // Boundary guard: spectating needs an authority to watch through, so a
+      // null origin here is nothing this page can open a socket on.
       if (origin === null) {
         showToast(t("page.joinNeedsServer"));
         return;
@@ -650,18 +660,18 @@ function MultiplayerPageContent({
         navigate(`/draft-spectator?${spectatorParams.toString()}`);
         return;
       }
-      // Typed codes skip lobby-row context; drafts not in the public lobby
-      // still resolve via SpectateDraft when lookup reports not_found.
-      if (!resolved?.draft_metadata && connectionMode === "server") {
-        const lookup = await lookupJoinTargetFromStore(code, origin);
-        if (!lookup.ok && lookup.reason === "not_found") {
-          navigate(`/draft-spectator?${spectatorParams.toString()}`);
-          return;
-        }
-        if (!lookup.ok) {
-          showToast(lookup.message);
-          return;
-        }
+      // Past the branch above, `resolved` carries no draft metadata. Typed
+      // codes skip lobby-row context entirely, and a draft that is not in the
+      // public lobby still resolves via SpectateDraft when lookup reports
+      // not_found.
+      const lookup = await lookupJoinTargetFromStore(code, origin);
+      if (!lookup.ok && lookup.reason === "not_found") {
+        navigate(`/draft-spectator?${spectatorParams.toString()}`);
+        return;
+      }
+      if (!lookup.ok) {
+        showToast(lookup.message);
+        return;
       }
       const gameId = crypto.randomUUID();
       useGameStore.setState({ gameId });
@@ -669,7 +679,7 @@ function MultiplayerPageContent({
         `/game/${gameId}?mode=spectate&code=${encodeURIComponent(code)}&server=${encodeURIComponent(origin.url)}`,
       );
     },
-    [navigate, connectionMode, lookupJoinTargetFromStore, showToast, t],
+    [navigate, lookupJoinTargetFromStore, showToast, t],
   );
 
   // Join from lobby → execute immediately if deck exists, otherwise prompt
@@ -908,21 +918,14 @@ function MultiplayerPageContent({
             // left the previous region's PlayerCount on screen. lobbyRetryKey
             // still drives the "Keep waiting" offline retry.
             key={`${hostingServer ?? "direct"}:${lobbyRetryKey}`}
-            onHostGame={() => { setConnectionMode("server"); setView("host-setup"); }}
-            onHostP2P={() => { setConnectionMode("p2p"); setView("host-setup"); }}
+            // Deliberately does NOT set a mode: the transport is chosen on
+            // Host Game itself, so arriving there keeps whatever the player
+            // last chose rather than silently overriding it.
+            onHostGame={() => setView("host-setup")}
             onHostDraft={handleHostDraft}
             onJoinGame={handleJoinGame}
-            onSpectate={connectionMode === "server" ? handleSpectate : undefined}
-            connectionMode={connectionMode}
-            onConnectionModeChange={handleConnectionModeChange}
-            onServerOffline={() => {
-              // Only prompt when we're actually trying to use the server; if
-              // the user already flipped to P2P the "unreachable" state is
-              // expected and not worth interrupting.
-              if (connectionMode === "server") {
-                setServerOfflinePrompt(true);
-              }
-            }}
+            onSpectate={handleSpectate}
+            onServerOffline={handleServerOffline}
           />
         )}
 
@@ -931,7 +934,7 @@ function MultiplayerPageContent({
             onHost={handleHostSetupComplete}
             onBack={() => setView("lobby")}
             connectionMode={connectionMode}
-            onConnectionModeChange={handleConnectionModeChange}
+            onConnectionModeChange={setConnectionMode}
             hostDisabled={liveCheck.status === "illegal" || liveCheck.status === "checking"}
             hostDisabledReason={
               liveCheck.status === "illegal"

--- a/client/src/pages/__tests__/MultiplayerPage.connectionMode.test.tsx
+++ b/client/src/pages/__tests__/MultiplayerPage.connectionMode.test.tsx
@@ -9,16 +9,21 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
  *
  * Three claims live here: a stored choice OUTRANKS the `hostingServer`-derived
  * fallback across a remount; the server-offline prompt flips the same switch
- * the user sees rather than routing around it; and entering server mode with
- * no anchor repairs the anchor instead of leaving the lobby pointed at
- * nothing. Harness shape follows `MultiplayerPage.hostServer.test.tsx`: render
- * the real page, stub the children, keep the real store module.
+ * the user sees rather than routing around it; and arriving with no anchor
+ * repairs it instead of leaving the lobby pointed at nothing. Harness shape
+ * follows `MultiplayerPage.hostServer.test.tsx`: render the real page, stub
+ * the children, keep the real store module.
+ *
+ * The switch is read off HOST SETUP, not the lobby: the transport configures a
+ * game being created, so that is the only surface that renders it.
  */
 const harness = vi.hoisted(() => ({
   navigate: vi.fn(),
-  /** Live props of the stubbed lobby, so a test reads the mode the page
-   * actually handed the switch — not the store field behind it. */
+  /** Live props of the stubbed lobby — the route into host setup. */
   lobby: null as Record<string, unknown> | null,
+  /** Live props of the stubbed host setup, so a test reads the mode the page
+   * actually handed the switch — not the store field behind it. */
+  hostSetup: null as Record<string, unknown> | null,
 }));
 
 /**
@@ -45,7 +50,12 @@ vi.mock("../../components/lobby/LobbyView", () => ({
   },
 }));
 
-vi.mock("../../components/lobby/HostSetup", () => ({ HostSetup: () => null }));
+vi.mock("../../components/lobby/HostSetup", () => ({
+  HostSetup: (props: Record<string, unknown>) => {
+    harness.hostSetup = props;
+    return <div data-testid="host-setup" />;
+  },
+}));
 vi.mock("../../components/chrome/ScreenChrome", () => ({ ScreenChrome: () => null }));
 vi.mock("../../components/chrome/ShellContext", () => ({ useInShell: () => false }));
 vi.mock("../../components/menu/MenuParticles", () => ({ MenuParticles: () => null }));
@@ -99,10 +109,26 @@ function renderPage() {
   );
 }
 
+/** Walk the production route to the switch: lobby → Host Game. */
+async function openHostSetup() {
+  await screen.findByTestId("lobby");
+  act(() => {
+    (harness.lobby!.onHostGame as () => void)();
+  });
+  await screen.findByTestId("host-setup");
+}
+
+function switchMode(mode: string) {
+  act(() => {
+    (harness.hostSetup!.onConnectionModeChange as (m: string) => void)(mode);
+  });
+}
+
 describe("MultiplayerPage connection mode", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     harness.lobby = null;
+    harness.hostSetup = null;
     useMultiplayerStore.setState({
       hostingServer: ANCHOR_URL,
       connectionMode: null,
@@ -121,15 +147,13 @@ describe("MultiplayerPage connection mode", () => {
     // so the assertion after the choice measures the precedence and not a
     // page that is always in P2P.
     renderPage();
-    await screen.findByTestId("lobby");
-    expect(harness.lobby!.connectionMode).toBe("server");
+    await openHostSetup();
+    expect(harness.hostSetup!.connectionMode).toBe("server");
 
-    act(() => {
-      (harness.lobby!.onConnectionModeChange as (mode: string) => void)("p2p");
-    });
-    expect(harness.lobby!.connectionMode).toBe("p2p");
-    // The anchor is untouched: it is also the P2P broker target, so the switch
-    // must never clear it.
+    switchMode("p2p");
+    expect(harness.hostSetup!.connectionMode).toBe("p2p");
+    // The anchor is untouched: it is also the P2P broker target, and the lobby
+    // browses through it in either mode, so the switch must never clear it.
     expect(useMultiplayerStore.getState().hostingServer).toBe(ANCHOR_URL);
     // The choice reaches storage. Without this the whole design is inert on a
     // reload, and the in-memory remount below would pass on a value that only
@@ -141,35 +165,40 @@ describe("MultiplayerPage connection mode", () => {
 
     cleanup();
     renderPage();
-    await screen.findByTestId("lobby");
+    await openHostSetup();
 
-    expect(harness.lobby!.connectionMode).toBe("p2p");
+    expect(harness.hostSetup!.connectionMode).toBe("p2p");
   });
 
-  it("repairs a missing anchor when the user picks server mode", async () => {
+  it("repairs a missing anchor on arrival, in either mode", async () => {
     // The legacy state: a blob persisted while the picker still offered its
-    // "None" row. Nothing else can produce it any more.
-    useMultiplayerStore.setState({ hostingServer: null });
+    // "None" row. Nothing else can produce it any more. The repair is no
+    // longer tied to picking server mode — the lobby browses, joins and
+    // spectates through the anchor whatever the hosting choice is, so an
+    // anchorless page is not a reachable state at all.
+    // `connectionMode` is null too: these blobs predate the switch entirely,
+    // so "None" is the only record of the transport this player wanted.
+    useMultiplayerStore.setState({ hostingServer: null, connectionMode: null });
+    expect(useMultiplayerStore.getState().hostingServer).toBeNull();
 
     renderPage();
     await screen.findByTestId("lobby");
-    expect(harness.lobby!.connectionMode).toBe("p2p");
 
-    act(() => {
-      (harness.lobby!.onConnectionModeChange as (mode: string) => void)("server");
-    });
-
-    expect(harness.lobby!.connectionMode).toBe("server");
     expect(useMultiplayerStore.getState().hostingServer).toBe(
       DEFAULT_MULTIPLAYER_SERVER_URL,
     );
+    // The anchor repair must not read as a transport change: seeding it while
+    // the mode derived from it would move a deliberate P2P-only player onto
+    // the official server without them touching anything.
+    expect(useMultiplayerStore.getState().connectionMode).toBe("p2p");
+    await openHostSetup();
+    expect(harness.hostSetup!.connectionMode).toBe("p2p");
   });
 
   it("flips the switch when the offline prompt offers direct codes", async () => {
     const user = userEvent.setup();
     renderPage();
     await screen.findByTestId("lobby");
-    expect(harness.lobby!.connectionMode).toBe("server");
 
     act(() => {
       (harness.lobby!.onServerOffline as () => void)();
@@ -177,11 +206,46 @@ describe("MultiplayerPage connection mode", () => {
 
     await user.click(screen.getByRole("button", { name: "Use direct code" }));
 
-    // The prompt must not route AROUND the control: after it, the switch the
-    // user is looking at reports P2P, and the choice is stored like any other.
-    expect(harness.lobby!.connectionMode).toBe("p2p");
     expect(useMultiplayerStore.getState().connectionMode).toBe("p2p");
     // It chooses a mode, not a server.
     expect(useMultiplayerStore.getState().hostingServer).toBe(ANCHOR_URL);
+
+    // The prompt must not route AROUND the control: the switch the user next
+    // sees on Host Game reports the mode the prompt chose for them.
+    await openHostSetup();
+    expect(harness.hostSetup!.connectionMode).toBe("p2p");
+  });
+
+  /**
+   * Regression. The lobby is no longer gated by the connection mode, so the two
+   * guards that used to make "Use direct code" an escape hatch are gone:
+   * `LobbyView` short-circuited its subscription effect in P2P, and this page
+   * suppressed `onServerOffline` in P2P. What replaces them is identity
+   * stability. `LobbyView` lists this callback in its subscription effect's
+   * dependency array, so an inline arrow re-ran that effect on every render of
+   * this page — re-dialling sources that were still down and re-opening the
+   * modal on the very re-render its own dismissal caused. Neither button could
+   * close it.
+   */
+  it("hands the lobby an offline callback that survives answering the prompt", async () => {
+    const user = userEvent.setup();
+    renderPage();
+    await screen.findByTestId("lobby");
+    const first = harness.lobby!.onServerOffline;
+
+    act(() => {
+      (harness.lobby!.onServerOffline as () => void)();
+    });
+    // Opening the prompt is a page state change, so the lobby has re-rendered.
+    expect(screen.getByRole("button", { name: "Use direct code" })).toBeInTheDocument();
+    expect(harness.lobby!.onServerOffline).toBe(first);
+
+    await user.click(screen.getByRole("button", { name: "Use direct code" }));
+    expect(
+      screen.queryByRole("button", { name: "Use direct code" }),
+    ).not.toBeInTheDocument();
+    // Unchanged across the answer's own re-render too — which is precisely what
+    // stops `LobbyView`'s effect re-running and re-arming what was just closed.
+    expect(harness.lobby!.onServerOffline).toBe(first);
   });
 });

--- a/client/src/pages/__tests__/MultiplayerPage.hostServer.test.tsx
+++ b/client/src/pages/__tests__/MultiplayerPage.hostServer.test.tsx
@@ -226,13 +226,16 @@ describe("MultiplayerPage host server", () => {
     renderPage();
     await screen.findByTestId("lobby");
 
-    // The production route into P2P host-setup with a NON-NULL anchor: the
-    // lobby's own "host a direct-code game" affordance, which flips the mode
-    // without touching `hostingServer`.
+    // The production route into P2P host-setup with a NON-NULL anchor: open
+    // Host Game from the lobby, then choose P2P on the screen that owns that
+    // choice. Neither step touches `hostingServer`.
     act(() => {
-      (harness.lobby!.onHostP2P as () => void)();
+      (harness.lobby!.onHostGame as () => void)();
     });
     await screen.findByTestId("host-setup");
+    act(() => {
+      (harness.hostSetup!.onConnectionModeChange as (m: string) => void)("p2p");
+    });
 
     await submitHostSetup(null);
 

--- a/client/src/pages/__tests__/MultiplayerPage.joinOrigin.test.tsx
+++ b/client/src/pages/__tests__/MultiplayerPage.joinOrigin.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { cleanup, render, waitFor } from "@testing-library/react";
 import { useEffect } from "react";
 import { MemoryRouter } from "react-router";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -16,7 +16,6 @@ import type { LobbyGame } from "../../adapter/types";
 const harness = vi.hoisted(() => ({
   navigate: vi.fn(),
   lobbyAction: null as null | ((props: Record<string, unknown>) => void),
-  connectionMode: undefined as string | undefined,
 }));
 
 /**
@@ -38,7 +37,6 @@ vi.mock("react-router", async (importOriginal) => ({
 
 vi.mock("../../components/lobby/LobbyView", () => ({
   LobbyView: (props: Record<string, unknown>) => {
-    harness.connectionMode = props.connectionMode as string | undefined;
     useEffect(() => {
       harness.lobbyAction?.(props);
       // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -159,7 +157,6 @@ describe("MultiplayerPage join origin", () => {
     // `clearAllMocks` drops calls but keeps queued implementations.
     storeMocks.findLobbyGameByCode.mockReset();
     harness.lobbyAction = null;
-    harness.connectionMode = undefined;
     localStorage.setItem("active-deck", "Test Deck");
     lookupJoinTarget.mockResolvedValue({
       ok: true,
@@ -372,15 +369,6 @@ describe("MultiplayerPage join origin", () => {
     expect(
       harness.navigate.mock.calls.filter(([target]) => target !== "/multiplayer"),
     ).toHaveLength(0);
-  });
-
-  it("mounts in P2P mode when the hosting server is None", async () => {
-    useMultiplayerStore.setState({ hostingServer: null });
-
-    renderPage();
-
-    await screen.findByTestId("lobby");
-    expect(harness.connectionMode).toBe("p2p");
   });
 
   it("navigates a direct P2P code with no origin and no server param", async () => {

--- a/client/src/stores/multiplayerStore.ts
+++ b/client/src/stores/multiplayerStore.ts
@@ -124,10 +124,12 @@ type ConnectionStatus = "disconnected" | "connecting" | "connected";
 type HostingStatus = "idle" | "connecting" | "waiting";
 
 /**
- * The transport a multiplayer session runs over: a dedicated server, or a
- * direct peer-to-peer mesh. The player picks it explicitly in the lobby's
- * connection switch, so it lives here rather than being derived from
- * {@link MultiplayerState.hostingServer}.
+ * The transport a HOSTED multiplayer session runs over: a dedicated server, or
+ * a direct peer-to-peer mesh. The player picks it explicitly on Host Game, so
+ * it lives here rather than being derived from
+ * {@link MultiplayerState.hostingServer}. Browsing and joining are NOT scoped
+ * by it — the lobby serves both transports and a join is routed by the shape
+ * of the code.
  */
 export type ConnectionMode = "server" | "p2p";
 
@@ -1162,15 +1164,17 @@ interface MultiplayerState {
    */
   hostingServer: string | null;
   /**
-   * The connection mode the player chose in the lobby's connection switch, or
-   * `null` when they have never chosen one. PERSISTED, so the choice survives
-   * a reload and the ordinary lobby → game → lobby round trip.
+   * The connection mode the player chose on Host Game, or `null` when they
+   * have never chosen one. PERSISTED, so the choice survives a reload and the
+   * ordinary lobby → game → lobby round trip.
    *
    * `null` is the load-bearing "absent" sentinel: `MultiplayerPage` falls back
    * to deriving the mode from {@link MultiplayerState.hostingServer} only
-   * while this is `null`, which is what lets a legacy blob with a `null`
-   * anchor still boot into P2P. A non-null initial would make "never chosen"
-   * indistinguishable from "chose server" and destroy that preference.
+   * while this is `null`. A non-null initial would make "never chosen"
+   * indistinguishable from "chose server" and destroy that preference. The
+   * page also converts a legacy `null` anchor — the old "None (P2P only)"
+   * pick — into an explicit `"p2p"` here as it seeds an anchor, so that
+   * preference outlives the derivation it used to depend on.
    */
   connectionMode: ConnectionMode | null;
   /** Hand-added lobby authorities. Persisted; built-in presets are derived


### PR DESCRIPTION
The P2P / Official Server switch shipped in both the lobby header and Host
Game. The lobby placement gated things the mode does not actually control.

`MultiplayerPage` routes a join on the SHAPE of the code (a 5-character room
code, or a row's `is_p2p`), never on `connectionMode` — but `LobbyView` set
`maxLength={isP2P ? 5 : 50}`, so P2P mode physically prevented typing a server
code. It also skipped the lobby subscription entirely, so flipping the header
switch blanked the game list, and it hid Watch. A control that turns off the
lobby is not a transport picker.

So the switch now lives only on Host Game, beside the room name, password and
lobby listing it actually belongs with. The lobby always subscribes, always
lists, accepts any code, and always offers Watch; its one Host Game button
opens the screen where the transport is chosen. The room-type filter — already
content-driven — is what scopes the list to P2P or server rooms.

"List in lobby" is now offered in P2P too. It was hidden behind `!isP2P`, but a
P2P room hosted against a `LobbyOnly` broker (which the official default anchor
is) already registers through `broker.registerHost({ public })` and appears in
the public list. Hiding the toggle never stopped that — it only removed the
opt-out, since `isPublic` defaults to true.

Also from review of the previous change:

- The segmented control met neither the 44px touch-target floor in its `sm`
  nor its `md` size. The lobby was the only `sm` caller, so the variant map
  goes with it and the remaining size gets `min-h-11`.
- A custom format whose minimum exceeds the P2P seat ceiling cannot be clamped
  into range, only replaced: the mount path screens a remembered one, but a
  switch made while the form is mounted drove `playerCount` under
  `formatConfig.min_players`, rendering an empty seat range and submitting a
  configuration the format rejects. The seat clamp now yields to the guard so
  the replacement lands on its own minimum rather than the ceiling.

`onServerOffline` is memoised because `LobbyView` lists it in its subscription
effect's dependencies: an inline arrow re-ran that effect on every page render,
which the old P2P short-circuit had masked — and while the sources were down it
re-opened the offline modal on the very re-render its own dismissal caused,
leaving no way to close it.

A legacy `null` hosting anchor (the removed "None (P2P only)" pick) is migrated
on arrival, recording it as an explicit `"p2p"` choice first so seeding the
anchor does not silently move that player onto the official server.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Connection mode selection is now available in Host Game setup rather than the lobby.
  - Lobby browsing, joining, spectating, filtering, and hosting now use a unified experience across connection types.
  - “List in lobby” is available for both hosting modes.
  - Host setup automatically switches to a compatible format when a selected format exceeds connection limits.
  - Connection preferences persist across navigation and reloads.

- **UI Updates**
  - Removed P2P-specific lobby notices, join-by-code options, and descriptions across supported languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->