### PR TITLE
test(skill-doc): cover the gate, and anchor invariant (4)

### DIFF
--- a/scripts/check-skill-doc.sh
+++ b/scripts/check-skill-doc.sh
@@ -115,6 +115,13 @@ EOF
 #     also matches `parse_target_with_ctx`), so a row keeps passing after the
 #     symbol it names has been renamed away -- the exact drift this invariant
 #     exists to catch.
+#
+#     A row body must contain no unescaped ERE metacharacter. Under the old
+#     substring match a row like `fn peel_clause(` was a valid literal; under
+#     -E it is a regex syntax error, and grep's exit 2 is reported by the `||`
+#     below as documented-symbol-missing -- a regex bug wearing a doc-drift
+#     message. Escape the character, or pin the row with the declaration
+#     keyword instead (`const FOO`, `struct Bar`).
 # ---------------------------------------------------------------------------
 while IFS=$'\t' read -r pat file; do
   grep -qE "$pat" "$file" || err "documented symbol missing: '$pat' in $file"
@@ -226,13 +233,19 @@ done < <(grep -oE '// Priority [^:]+:' "$ORACLE" | sed -E 's#// Priority ##; s#:
 # Each entry is a symbol REMOVED or RENAMED by a landed refactor. If a future
 # rename retires a name the doc cites, add it here in the same commit.
 # ---------------------------------------------------------------------------
+# Both greps anchor the retired name with a trailing \b. Unanchored, a dead
+# name matches its own longer siblings, and both guards then fire on a tree that
+# is not stale: a NEW `parse_keyword_from_oracle_v2()` anywhere under the parser
+# trips the non-vacuity guard, and a SKILL.md citation of
+# `extract_keyword_line_v2()` trips the dead-cite guard. Both fail closed (a
+# spurious red, never a silent green), which is why this trailed invariant (2).
 while IFS= read -r dead; do
   [ -n "$dead" ] || continue
-  if grep -q "$dead" "$SKILL"; then
+  if grep -qE "$dead\b" "$SKILL"; then
     err "SKILL.md cites '$dead', which no longer exists in the parser tree (renamed/removed)"
   fi
   # Non-vacuity: if the symbol came BACK, this list is the stale thing.
-  if grep -rq "fn $dead" crates/engine/src/parser/; then
+  if grep -rqE "fn $dead\b" crates/engine/src/parser/; then
     err "'$dead' is listed as dead but exists in the parser tree — update this list, not the doc"
   fi
 done <<'EOF'

--- a/scripts/check-skill-doc.sh
+++ b/scripts/check-skill-doc.sh
@@ -260,6 +260,25 @@ parse_keyword_from_oracle
 extract_keyword_line
 EOF
 
+# ---------------------------------------------------------------------------
+# (5) This gate's own regression suite, run ahead of the verdict.
+#
+# Every invariant above stands on its patterns discriminating: a row that keeps
+# matching after the symbol it names is renamed away reports green while the doc
+# it guards has rotted. That has shipped twice (an unanchored row absorbing its
+# longer siblings, and a row with no declaration keyword satisfied by a comment),
+# and neither was visible from this script's own output. The suite pins those as
+# properties, so it runs where the gate runs.
+#
+# The guard is also the recursion stop: the throwaway repos the suite builds
+# copy only this script, so the file is absent there and the fixture's own
+# invocation skips this block.
+# ---------------------------------------------------------------------------
+if [ -f "$(dirname "$0")/check_skill_doc_tests.py" ]; then
+  python3 "$(dirname "$0")/check_skill_doc_tests.py" >/dev/null 2>&1 ||
+    err "gate self-tests failed — run: python3 scripts/check_skill_doc_tests.py"
+fi
+
 if [ "$fail" -ne 0 ]; then
   echo "✗ STALE — update .claude/skills/oracle-parser/SKILL.md (see §12)" >&2
   exit 1

--- a/scripts/check-skill-doc.sh
+++ b/scripts/check-skill-doc.sh
@@ -239,6 +239,13 @@ done < <(grep -oE '// Priority [^:]+:' "$ORACLE" | sed -E 's#// Priority ##; s#:
 # trips the non-vacuity guard, and a SKILL.md citation of
 # `extract_keyword_line_v2()` trips the dead-cite guard. Both fail closed (a
 # spurious red, never a silent green), which is why this trailed invariant (2).
+#
+# The anchor is trailing-only, so a live `try_extract_keyword_line` would still
+# trip both guards. That also fails closed, and no such name exists today.
+#
+# As with invariant (2), these are EREs now: an entry below must be a bare
+# identifier with no unescaped ERE metacharacter, or grep exits 2 and the `||`
+# reports a regex bug as doc drift.
 while IFS= read -r dead; do
   [ -n "$dead" ] || continue
   if grep -qE "$dead\b" "$SKILL"; then

--- a/scripts/check_skill_doc_tests.py
+++ b/scripts/check_skill_doc_tests.py
@@ -22,10 +22,10 @@ in it, and asserts the gate's behaviour there.
 
 from __future__ import annotations
 
+import os
 import re
 import shutil
 import subprocess
-import sys
 import tempfile
 import unittest
 from pathlib import Path
@@ -38,17 +38,17 @@ SKILL = Path(".claude/skills/oracle-parser/SKILL.md")
 # honest: the table under test is the real one, not a hand-written stand-in.
 TREE = [Path("crates/engine/src/parser"), SKILL]
 
-# On Windows, `bash` on PATH is often WSL's stub, which has no distro installed
-# and exits non-zero without running anything. Prefer Git Bash there; POSIX
-# hosts (and CI) resolve `bash` normally.
-_WIN_BASH = [
-    "C:\\Program Files\\Git\\bin\\bash.exe",
-    "C:\\Program Files (x86)\\Git\\bin\\bash.exe",
-]
-BASH = next(
-    (c for c in _WIN_BASH if sys.platform == "win32" and Path(c).exists()),
-    "bash",
-)
+# CI and any POSIX host resolve `bash` from PATH. On Windows that name is often
+# WSL's stub, which exits non-zero without running anything, so allow an
+# override rather than hard-coding an install path.
+BASH = os.environ.get("BASH", "bash")
+
+METACHARACTERS = set(".*+?[]{}()|^$")
+
+
+def ere_body(pat: str) -> str:
+    """A row pattern with its trailing `\\b` anchor removed."""
+    return pat[:-2] if pat.endswith("\\b") else pat
 
 
 class Gate:
@@ -67,12 +67,12 @@ class Gate:
             else:
                 shutil.copy2(src, dst)
 
-    def run(self) -> int:
+    def run(self) -> subprocess.CompletedProcess:
         return subprocess.run(
             [BASH, str(self.root / "scripts" / SCRIPT.name)],
             capture_output=True,
             text=True,
-        ).returncode
+        )
 
     def read(self, rel: Path) -> str:
         return (self.root / rel).read_text(encoding="utf-8")
@@ -93,6 +93,15 @@ class Gate:
             if "\t" in line
         ]
 
+    def retired(self) -> list[str]:
+        """Invariant (4)'s retired-symbol list."""
+        body = re.search(
+            r"rename retires a name the doc cites.*?<<'EOF'\n(.*?)\nEOF\n",
+            self.read(Path("scripts") / SCRIPT.name),
+            re.S,
+        ).group(1)
+        return [line for line in body.split("\n") if line.strip()]
+
 
 def gate(fn):
     """Run `fn(g)` against a fresh throwaway repo."""
@@ -108,7 +117,9 @@ class SkillDocGate(unittest.TestCase):
     @gate
     def test_clean_tree_passes(self, g: Gate) -> None:
         """The control. Without this, every refusal below could be vacuous."""
-        self.assertEqual(g.run(), 0, "gate must not red an unmodified tree")
+        self.assertEqual(
+            g.run().returncode, 0, "gate must not red an unmodified tree"
+        )
 
     @gate
     def test_every_anchor_row_is_discriminating(self, g: Gate) -> None:
@@ -125,7 +136,16 @@ class SkillDocGate(unittest.TestCase):
         survivors = []
         for pat, rel in g.rows():
             source = g.read(Path(rel))
-            body = pat[:-2] if pat.endswith("\\b") else pat
+            body = ere_body(pat)
+            # Screened here rather than deferred to
+            # test_row_bodies_carry_no_unescaped_ere_metacharacter: unittest
+            # orders alphabetically, so that test runs AFTER this one, and an
+            # offending row would surface as an opaque `re.error` from the
+            # re.search below instead of its own clean message.
+            self.assertFalse(
+                set(body) & METACHARACTERS,
+                "row " + repr(pat) + " carries an unescaped ERE metacharacter",
+            )
             keywords, _, symbol = body.rpartition(" ")
             decl = re.compile(
                 re.escape(keywords) + r"\s+" + re.escape(symbol) + r"\b"
@@ -134,9 +154,8 @@ class SkillDocGate(unittest.TestCase):
                 source, decl, "row " + repr(pat) + " names no declaration in " + rel
             )
             mutated = decl.sub(keywords + " zzz_renamed_away", source)
-            # Rows carry no ERE metacharacter beyond a trailing `\b`, which means
-            # the same in both dialects (asserted by the next test), so the gate's
-            # pattern can be reused as a Python regex here.
+            # `\b` is the only ERE construct rows use, and it means the same in
+            # both dialects, so the gate's pattern doubles as a Python regex.
             if re.search(pat, mutated):
                 survivors.append(pat + "\t" + rel)
         self.assertEqual(
@@ -148,13 +167,13 @@ class SkillDocGate(unittest.TestCase):
 
     @gate
     def test_row_bodies_carry_no_unescaped_ere_metacharacter(self, g: Gate) -> None:
-        """Rows are EREs. A stray `(` is a regex error reported as doc drift."""
-        meta = set(".*+?[]{}()|^$")
-        offenders = [
-            pat
-            for pat, _ in g.rows()
-            if set(pat[:-2] if pat.endswith("\\b") else pat) & meta
-        ]
+        """Rows are EREs. A stray `(` is a regex error reported as doc drift.
+
+        Covers invariant (4)'s retired list too: it became ERE-interpreted in
+        the same change that anchored it, so it carries the same constraint.
+        """
+        offenders = [pat for pat, _ in g.rows() if set(ere_body(pat)) & METACHARACTERS]
+        offenders += [d for d in g.retired() if set(d) & METACHARACTERS]
         self.assertEqual(
             offenders, [], "unescaped ERE metacharacters: " + repr(offenders)
         )
@@ -164,7 +183,9 @@ class SkillDocGate(unittest.TestCase):
         """Invariant (4)'s non-vacuity guard: a dead name that comes back."""
         f = Path("crates/engine/src/parser/oracle_util.rs")
         g.write(f, g.read(f) + "\npub fn parse_keyword_from_oracle() {}\n")
-        self.assertEqual(g.run(), 1, "a retired symbol returning must be caught")
+        self.assertEqual(
+            g.run().returncode, 1, "a retired symbol returning must be caught"
+        )
 
     @gate
     def test_longer_sibling_does_not_false_fire_retired_list(self, g: Gate) -> None:
@@ -176,28 +197,49 @@ class SkillDocGate(unittest.TestCase):
         f = Path("crates/engine/src/parser/oracle_util.rs")
         g.write(f, g.read(f) + "\npub fn parse_keyword_from_oracle_v2() {}\n")
         self.assertEqual(
-            g.run(), 0, "a longer-named sibling must not fire the retired-list guard"
+            g.run().returncode,
+            0,
+            "a longer-named sibling must not fire the retired-list guard",
         )
 
     @gate
     def test_skill_citing_dead_symbol_is_caught(self, g: Gate) -> None:
         """Invariant (4)'s forward direction: the doc naming a removed symbol."""
         g.write(SKILL, g.read(SKILL) + "\nSee `extract_keyword_line()`.\n")
-        self.assertEqual(g.run(), 1, "a dead citation in SKILL.md must be caught")
+        self.assertEqual(
+            g.run().returncode, 1, "a dead citation in SKILL.md must be caught"
+        )
 
     @gate
     def test_skill_citing_longer_sibling_does_not_false_fire(self, g: Gate) -> None:
         """...but citing a longer name that is not the dead one must not."""
         g.write(SKILL, g.read(SKILL) + "\nSee `extract_keyword_line_v2()`.\n")
         self.assertEqual(
-            g.run(), 0, "a longer-named citation must not fire the dead-cite guard"
+            g.run().returncode,
+            0,
+            "a longer-named citation must not fire the dead-cite guard",
         )
 
     @gate
     def test_missing_documented_path_is_caught(self, g: Gate) -> None:
-        """Invariant (1): a documented file that no longer exists."""
-        (g.root / "crates/engine/src/parser/oracle_target.rs").unlink()
-        self.assertEqual(g.run(), 1, "a missing documented path must be caught")
+        """Invariant (1): a documented file that no longer exists.
+
+        Deletes a path that NO anchor row names. Deleting one that does (say
+        `oracle_target.rs`, which carries two rows) exits 1 via invariant (2)
+        whatever invariant (1) does, so the test would pass with (1) removed
+        entirely. Asserting on stderr pins which invariant fired.
+        """
+        missing = "crates/engine/src/parser/oracle_nom/PATTERNS.md"
+        self.assertNotIn(
+            missing,
+            [rel for _, rel in g.rows()],
+            "fixture assumption broken: this path is now anchored, so the "
+            "assertion below would no longer isolate invariant (1)",
+        )
+        (g.root / missing).unlink()
+        result = g.run()
+        self.assertEqual(result.returncode, 1, "a missing documented path must red")
+        self.assertIn("documented path missing: " + missing, result.stderr)
 
 
 if __name__ == "__main__":

--- a/scripts/check_skill_doc_tests.py
+++ b/scripts/check_skill_doc_tests.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+"""Tests for check-skill-doc.sh.
+
+The script is a drift gate, so what matters is not that it runs but that it
+refuses what it should. Every anchor row is a claim that renaming its symbol
+breaks the build; a row that keeps passing after its symbol is gone is worse
+than no row, because it reports green while the doc it guards has rotted.
+
+That is not hypothetical. Two classes of it have already shipped:
+
+  * An unanchored substring row absorbed its own longer siblings, so
+    `fn parse_type_phrase` kept matching `parse_type_phrase_folding` and ~48
+    `#[test] fn parse_type_phrase_*` names after the symbol it named was
+    renamed away (phase-rs/phase#8613, #8633).
+  * A row carrying no declaration keyword was satisfied by any mention, so
+    `ROUTER_KEYWORD_CASES` matched a doc comment and a string literal and
+    survived a rename of the `const` it documented (#8633 review).
+
+Each case builds a throwaway repository from the real tree, mutates one thing
+in it, and asserts the gate's behaviour there.
+"""
+
+from __future__ import annotations
+
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+SCRIPT = REPO / "scripts" / "check-skill-doc.sh"
+SKILL = Path(".claude/skills/oracle-parser/SKILL.md")
+
+# Files the gate reads. Copying the parser tree wholesale keeps the fixture
+# honest: the table under test is the real one, not a hand-written stand-in.
+TREE = [Path("crates/engine/src/parser"), SKILL]
+
+# On Windows, `bash` on PATH is often WSL's stub, which has no distro installed
+# and exits non-zero without running anything. Prefer Git Bash there; POSIX
+# hosts (and CI) resolve `bash` normally.
+_WIN_BASH = [
+    "C:\\Program Files\\Git\\bin\\bash.exe",
+    "C:\\Program Files (x86)\\Git\\bin\\bash.exe",
+]
+BASH = next(
+    (c for c in _WIN_BASH if sys.platform == "win32" and Path(c).exists()),
+    "bash",
+)
+
+
+class Gate:
+    """A throwaway repo. The script cds to its own parent's parent, so copying
+    it into <root>/scripts makes <root> the repository it inspects."""
+
+    def __init__(self, root: Path) -> None:
+        self.root = root
+        (root / "scripts").mkdir(parents=True)
+        shutil.copy2(SCRIPT, root / "scripts" / SCRIPT.name)
+        for rel in TREE:
+            src, dst = REPO / rel, root / rel
+            dst.parent.mkdir(parents=True, exist_ok=True)
+            if src.is_dir():
+                shutil.copytree(src, dst)
+            else:
+                shutil.copy2(src, dst)
+
+    def run(self) -> int:
+        return subprocess.run(
+            [BASH, str(self.root / "scripts" / SCRIPT.name)],
+            capture_output=True,
+            text=True,
+        ).returncode
+
+    def read(self, rel: Path) -> str:
+        return (self.root / rel).read_text(encoding="utf-8")
+
+    def write(self, rel: Path, text: str) -> None:
+        (self.root / rel).write_text(text, encoding="utf-8", newline="\n")
+
+    def rows(self) -> list[tuple[str, str]]:
+        """Invariant (2)'s anchor table, as (pattern, file) pairs."""
+        body = re.search(
+            r"\(2\) Documented anchor symbols.*?<<'EOF'\n(.*?)\nEOF\n",
+            self.read(Path("scripts") / SCRIPT.name),
+            re.S,
+        ).group(1)
+        return [
+            (line.split("\t", 1)[0], line.split("\t", 1)[1])
+            for line in body.split("\n")
+            if "\t" in line
+        ]
+
+
+def gate(fn):
+    """Run `fn(g)` against a fresh throwaway repo."""
+
+    def wrapper(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            return fn(self, Gate(Path(tmp) / "repo"))
+
+    return wrapper
+
+
+class SkillDocGate(unittest.TestCase):
+    @gate
+    def test_clean_tree_passes(self, g: Gate) -> None:
+        """The control. Without this, every refusal below could be vacuous."""
+        self.assertEqual(g.run(), 0, "gate must not red an unmodified tree")
+
+    @gate
+    def test_every_anchor_row_is_discriminating(self, g: Gate) -> None:
+        """The property the table exists to have.
+
+        For each row, rename the declaration it names and assert the row stops
+        matching. A row that survives documents a prefix, not a symbol -- it
+        would report green after the symbol it guards was renamed away.
+
+        Checked at the row level rather than by re-running the whole gate once
+        per row: the claim is about each pattern's discrimination, and a full
+        invocation per row costs minutes for identical signal.
+        """
+        survivors = []
+        for pat, rel in g.rows():
+            source = g.read(Path(rel))
+            body = pat[:-2] if pat.endswith("\\b") else pat
+            keywords, _, symbol = body.rpartition(" ")
+            decl = re.compile(
+                re.escape(keywords) + r"\s+" + re.escape(symbol) + r"\b"
+            )
+            self.assertRegex(
+                source, decl, "row " + repr(pat) + " names no declaration in " + rel
+            )
+            mutated = decl.sub(keywords + " zzz_renamed_away", source)
+            # Rows carry no ERE metacharacter beyond a trailing `\b`, which means
+            # the same in both dialects (asserted by the next test), so the gate's
+            # pattern can be reused as a Python regex here.
+            if re.search(pat, mutated):
+                survivors.append(pat + "\t" + rel)
+        self.assertEqual(
+            survivors,
+            [],
+            "these rows stayed green after their own symbol was renamed away, "
+            "so they document a prefix rather than a symbol: " + repr(survivors),
+        )
+
+    @gate
+    def test_row_bodies_carry_no_unescaped_ere_metacharacter(self, g: Gate) -> None:
+        """Rows are EREs. A stray `(` is a regex error reported as doc drift."""
+        meta = set(".*+?[]{}()|^$")
+        offenders = [
+            pat
+            for pat, _ in g.rows()
+            if set(pat[:-2] if pat.endswith("\\b") else pat) & meta
+        ]
+        self.assertEqual(
+            offenders, [], "unescaped ERE metacharacters: " + repr(offenders)
+        )
+
+    @gate
+    def test_retired_symbol_returning_is_caught(self, g: Gate) -> None:
+        """Invariant (4)'s non-vacuity guard: a dead name that comes back."""
+        f = Path("crates/engine/src/parser/oracle_util.rs")
+        g.write(f, g.read(f) + "\npub fn parse_keyword_from_oracle() {}\n")
+        self.assertEqual(g.run(), 1, "a retired symbol returning must be caught")
+
+    @gate
+    def test_longer_sibling_does_not_false_fire_retired_list(self, g: Gate) -> None:
+        """...but a DIFFERENT, longer-named function must not trip it.
+
+        Unanchored, `grep -rq "fn $dead"` matched `parse_keyword_from_oracle_v2`
+        and redded a tree that was not stale.
+        """
+        f = Path("crates/engine/src/parser/oracle_util.rs")
+        g.write(f, g.read(f) + "\npub fn parse_keyword_from_oracle_v2() {}\n")
+        self.assertEqual(
+            g.run(), 0, "a longer-named sibling must not fire the retired-list guard"
+        )
+
+    @gate
+    def test_skill_citing_dead_symbol_is_caught(self, g: Gate) -> None:
+        """Invariant (4)'s forward direction: the doc naming a removed symbol."""
+        g.write(SKILL, g.read(SKILL) + "\nSee `extract_keyword_line()`.\n")
+        self.assertEqual(g.run(), 1, "a dead citation in SKILL.md must be caught")
+
+    @gate
+    def test_skill_citing_longer_sibling_does_not_false_fire(self, g: Gate) -> None:
+        """...but citing a longer name that is not the dead one must not."""
+        g.write(SKILL, g.read(SKILL) + "\nSee `extract_keyword_line_v2()`.\n")
+        self.assertEqual(
+            g.run(), 0, "a longer-named citation must not fire the dead-cite guard"
+        )
+
+    @gate
+    def test_missing_documented_path_is_caught(self, g: Gate) -> None:
+        """Invariant (1): a documented file that no longer exists."""
+        (g.root / "crates/engine/src/parser/oracle_target.rs").unlink()
+        self.assertEqual(g.run(), 1, "a missing documented path must be caught")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/scripts/check_skill_doc_tests.py
+++ b/scripts/check_skill_doc_tests.py
@@ -38,10 +38,23 @@ SKILL = Path(".claude/skills/oracle-parser/SKILL.md")
 # honest: the table under test is the real one, not a hand-written stand-in.
 TREE = [Path("crates/engine/src/parser"), SKILL]
 
-# CI and any POSIX host resolve `bash` from PATH. On Windows that name is often
-# WSL's stub, which exits non-zero without running anything, so allow an
-# override rather than hard-coding an install path.
-BASH = os.environ.get("BASH", "bash")
+def _shell() -> str:
+    """The bash to run the gate under.
+
+    `bash` from PATH is correct on CI and any POSIX host. It is not always
+    correct on Windows, where that name often resolves to WSL's stub, which
+    exits non-zero without running anything -- every case then fails for a
+    reason that has nothing to do with the gate. `SKILL_DOC_TEST_BASH`
+    overrides; otherwise fall back to whatever `shutil.which` finds.
+    """
+    override = os.environ.get("SKILL_DOC_TEST_BASH")
+    if override:
+        return override
+    found = shutil.which("bash")
+    return found or "bash"
+
+
+SHELL_BIN = _shell()
 
 METACHARACTERS = set(".*+?[]{}()|^$")
 
@@ -49,6 +62,17 @@ METACHARACTERS = set(".*+?[]{}()|^$")
 def ere_body(pat: str) -> str:
     """A row pattern with its trailing `\\b` anchor removed."""
     return pat[:-2] if pat.endswith("\\b") else pat
+
+
+def unescaped_metacharacters(pat: str) -> set[str]:
+    """The ERE metacharacters a pattern leaves unescaped.
+
+    `check-skill-doc.sh` documents escaping as the supported way to carry one,
+    and the gate does accept `fn peel_clause\\(`, so an escaped pair is not an
+    offender. Dropping every backslash-escaped pair first is what makes this
+    screen agree with the contract rather than overrule it.
+    """
+    return set(re.sub(r"\\.", "", ere_body(pat))) & METACHARACTERS
 
 
 class Gate:
@@ -69,7 +93,7 @@ class Gate:
 
     def run(self) -> subprocess.CompletedProcess:
         return subprocess.run(
-            [BASH, str(self.root / "scripts" / SCRIPT.name)],
+            [SHELL_BIN, str(self.root / "scripts" / SCRIPT.name)],
             capture_output=True,
             text=True,
         )
@@ -94,13 +118,20 @@ class Gate:
         ]
 
     def retired(self) -> list[str]:
-        """Invariant (4)'s retired-symbol list."""
-        body = re.search(
-            r"rename retires a name the doc cites.*?<<'EOF'\n(.*?)\nEOF\n",
-            self.read(Path("scripts") / SCRIPT.name),
-            re.S,
-        ).group(1)
-        return [line for line in body.split("\n") if line.strip()]
+        """Invariant (4)'s retired-symbol list.
+
+        Anchored on the `grep -rqE "fn $dead\\b"` line rather than on prose, so
+        rewording a comment cannot silently reshape what this returns.
+        """
+        script = self.read(Path("scripts") / SCRIPT.name)
+        found = re.search(r'grep -rqE "fn \$dead.*?<<\'EOF\'\n(.*?)\nEOF\n', script, re.S)
+        if found is None:
+            raise AssertionError(
+                "could not locate invariant (4)'s retired-symbol heredoc in "
+                + SCRIPT.name
+                + " -- update Gate.retired() alongside the gate"
+            )
+        return [line for line in found.group(1).split("\n") if line.strip()]
 
 
 def gate(fn):
@@ -143,7 +174,7 @@ class SkillDocGate(unittest.TestCase):
             # offending row would surface as an opaque `re.error` from the
             # re.search below instead of its own clean message.
             self.assertFalse(
-                set(body) & METACHARACTERS,
+                unescaped_metacharacters(pat),
                 "row " + repr(pat) + " carries an unescaped ERE metacharacter",
             )
             keywords, _, symbol = body.rpartition(" ")
@@ -172,8 +203,8 @@ class SkillDocGate(unittest.TestCase):
         Covers invariant (4)'s retired list too: it became ERE-interpreted in
         the same change that anchored it, so it carries the same constraint.
         """
-        offenders = [pat for pat, _ in g.rows() if set(ere_body(pat)) & METACHARACTERS]
-        offenders += [d for d in g.retired() if set(d) & METACHARACTERS]
+        offenders = [pat for pat, _ in g.rows() if unescaped_metacharacters(pat)]
+        offenders += [d for d in g.retired() if unescaped_metacharacters(d)]
         self.assertEqual(
             offenders, [], "unescaped ERE metacharacters: " + repr(offenders)
         )


### PR DESCRIPTION
## Summary

Follow-up to #8633, taking findings **2**, **3** and **5** from @matthewevans's review there. All three were still outstanding on `main` (`f15bd315d`) — verified before writing anything.

Finding **1** was fixed maintainer-side in `99bec3fb3` and is on `main`. Finding **4** (`grep -c` counts lines in invariant (3)) is left alone: it is latent, and it is a different invariant. Finding **6** (whether this script belongs on `[hard_stops]`) is a routing decision, not mine.

## (2) Invariant (4) was unanchored in both directions

Same bug class #8633 generalised, one invariant over. Reproduced against `main` before touching it:

| mutation on an otherwise-clean tree | before | after |
|---|---|---|
| add `pub fn parse_keyword_from_oracle_v2()` under the parser | **exit 1** — `✗ 'parse_keyword_from_oracle' is listed as dead but exists in the parser tree` | exit 0 |
| append a citation of `extract_keyword_line_v2()` to SKILL.md | **exit 1** — `✗ SKILL.md cites 'extract_keyword_line', which no longer exists` | exit 0 |

Both now anchor with a trailing `\b`. As the review noted, these fail *closed* — a spurious red, never a silent green — which is why they correctly trailed the invariant (2) fix rather than blocking it.

## (3) The ERE constraint is now written down

The constraint that makes `-E` safe held when #8633 landed, but only in my verification, not in the file. Now stated at the table: a row body must carry no unescaped ERE metacharacter. Under the old substring match `fn peel_clause(` was a valid literal; under `-E` it is a syntax error, and grep's exit 2 surfaces through `||` as documented-symbol-missing — a regex bug wearing a doc-drift message.

## (5) The gate now has tests

`scripts/check_skill_doc_tests.py`, following the `check_action_pins_tests.py` precedent: build a throwaway repo from the real tree, mutate one thing, assert the gate's behaviour. Eight cases:

- **the control** — a clean tree passes (without it, every refusal below could be vacuous)
- **every anchor row is discriminating** — for each of the 66 rows, rename the declaration it names and assert the row stops matching. *This is the property both shipped bugs violated*, and nothing structural prevented either.
- **no row body carries an unescaped ERE metacharacter** — enforces (3)
- **retired symbol returning is caught** / **a longer-named sibling does not false-fire it**
- **SKILL.md citing a dead symbol is caught** / **citing a longer sibling does not false-fire it**
- **a missing documented path is caught**

**Non-vacuity checked, not assumed.** Against the pre-fix script the two false-fire tests **fail** (`FAILED (failures=2)`); against the fixed script all eight pass. They test the fix, not nothing.

The discriminating test runs at row level rather than invoking the whole gate 66 times — one full invocation costs ~22s locally, so per-row invocation is minutes for identical signal.

## ✅ Wired (this section previously said otherwise)

An earlier revision said this needed a maintainer-owned `ci.yml` step and was inert until then. **That is no longer true, and was never the only option.** The review found a third pattern: `check-engine-authorities.sh:143` runs its own `scripts/*_tests.py` inline, and since `check-skill-doc.sh` is already wired at `ci.yml:94`, calling the suite from the gate gates it immediately with no `.github/workflows/**` edit. That landed in `5d08b252f`.

Do **not** add a separate `ci.yml` step — it would be redundant.

## Verification

- `bash scripts/check-skill-doc.sh` → exit 0 on a clean tree.
- `python3 scripts/check_skill_doc_tests.py` → `Ran 8 tests ... OK`.
- Both changed files are on `scripts/`, which is not a `[hard_stops]` path (only `check_action_pins*.py` are).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified requirements for anchor-symbol patterns, including valid extended regular expressions and escaping special characters.
  * Improved detection of outdated or missing documentation references.

* **Tests**
  * Added comprehensive automated coverage for documentation consistency checks.
  * Validates clean documentation, missing paths, retired symbols, and similarly named symbols without false positives.
  * The documentation consistency check now runs its regression suite before reporting results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
