### PR TITLE
fix(client): unbound the join code, gate P2P listing on a broker anchor

### DIFF
--- a/client/src/components/lobby/HostSetup.tsx
+++ b/client/src/components/lobby/HostSetup.tsx
@@ -425,6 +425,21 @@ export function HostSetup({
     ? Math.min(formatConfig.max_players, P2P_MAX_PEERS)
     : formatConfig.max_players;
   const accentTone = isP2P ? "cyan" : "emerald";
+  // A P2P room reaches the public list only through a `LobbyOnly` broker: that
+  // is the sole path `MultiplayerPage` takes into `startP2PHostingSession` with
+  // `useBroker`, and `openBrokerClient` refuses every other mode. Against a
+  // `Full` anchor there is nothing to register with — `hostIsPublic` is false
+  // whatever this form submits — so offering the toggle there would be a
+  // control with no effect.
+  //
+  // Withheld on POSITIVE knowledge only. `sourceStatus` is not persisted, so a
+  // cold mount knows no mode until the handshake lands; treating that as "no
+  // broker" would make the row appear a beat after the form, and the default
+  // anchor is a broker anyway. Unknown therefore reads as available.
+  const p2pListingUnavailable =
+    isP2P
+    && hostingServer !== null
+    && sourceStatus.get(hostingServer)?.serverInfo?.mode === "Full";
 
   /** Apply a freshly-resolved format config. Shared by the built-in picker and
    *  the saved-custom-format picker so both reset the same dependent state. */
@@ -1159,13 +1174,16 @@ export function HostSetup({
               stopped that; it only removed the OPT-OUT, because `isPublic`
               defaults to true. `startP2PHostingSession` still ANDs it with
               `useBroker`, so against a `Full` anchor — which has no broker to
-              register with — the room is unlisted whatever this says. */}
-          <OptionRow
-            label={t("hostSetup.listInLobby")}
-            on={isPublic}
-            onChange={setIsPublic}
-            accent={accentTone}
-          />
+              register with — the room is unlisted whatever this says, which is
+              also why the row is withheld outright in that case. */}
+          {!p2pListingUnavailable && (
+            <OptionRow
+              label={t("hostSetup.listInLobby")}
+              on={isPublic}
+              onChange={setIsPublic}
+              accent={accentTone}
+            />
+          )}
           <OptionRow label={t("hostSetup.startWhenFull")} on={startWhenFull} onChange={setStartWhenFull} accent={accentTone} />
           {/* Sandbox mode — capability flag, orthogonal to format; lets the host
               submit debug actions. Off by default; immutable for the session. */}

--- a/client/src/components/lobby/LobbyView.tsx
+++ b/client/src/components/lobby/LobbyView.tsx
@@ -464,7 +464,7 @@ export function LobbyView({
             type="button"
             onClick={() => setServerPickerOpen(true)}
             title={hostingServer ?? ""}
-            className="flex min-w-0 max-w-full items-center gap-1.5 rounded-[7px] border border-white/10 bg-black/25 px-2.5 py-0.5 font-mono text-[10px] text-slate-300 backdrop-blur-sm transition-colors hover:border-white/20 hover:bg-white/5"
+            className="flex min-h-11 min-w-0 max-w-full items-center gap-1.5 rounded-[7px] border border-white/10 bg-black/25 px-2.5 py-0.5 font-mono text-[10px] text-slate-300 backdrop-blur-sm transition-colors hover:border-white/20 hover:bg-white/5"
           >
             {serverFlag && (
               <ServerFlag
@@ -483,7 +483,7 @@ export function LobbyView({
             <button
               type="button"
               onClick={() => setServerPickerOpen(true)}
-              className="rounded-[7px] border border-amber-300/20 bg-amber-500/15 px-2.5 py-0.5 text-xs font-medium text-amber-200 transition-colors hover:bg-amber-500/25"
+              className="min-h-11 rounded-[7px] border border-amber-300/20 bg-amber-500/15 px-2.5 py-0.5 text-xs font-medium text-amber-200 transition-colors hover:bg-amber-500/25"
             >
               {t("lobbyView.sourcesDegraded")}
             </button>
@@ -521,7 +521,7 @@ export function LobbyView({
             <button
               key={opt.value}
               onClick={() => setRoomTypeFilter(opt.value)}
-              className={`rounded-[7px] px-3 py-1 text-xs font-medium transition-colors ${
+              className={`min-h-11 rounded-[7px] px-3 py-1 text-xs font-medium transition-colors ${
                 roomTypeFilter === opt.value
                   ? "bg-white/12 text-white"
                   : "text-gray-400 hover:bg-white/5 hover:text-gray-200"
@@ -581,7 +581,6 @@ export function LobbyView({
             onChange={(e) => setJoinCode(e.target.value)}
             onKeyDown={(e) => e.key === "Enter" && handleJoinByCode()}
             placeholder={t("lobbyView.serverCodePlaceholder")}
-            maxLength={50}
             className="min-w-0 flex-1 rounded-[8px] border border-white/10 bg-black/25 px-4 py-2 font-mono text-sm tracking-wider text-white placeholder-gray-500 outline-none backdrop-blur-sm focus:border-white/20"
           />
           <div className="flex w-full shrink-0 items-center gap-2 sm:w-auto">

--- a/client/src/components/lobby/__tests__/HostSetup.test.tsx
+++ b/client/src/components/lobby/__tests__/HostSetup.test.tsx
@@ -1110,6 +1110,80 @@ describe("HostSetup", () => {
     );
   });
 
+  /**
+   * Listing and transport are independent, but not unconditionally: a P2P room
+   * reaches the public list only through a `LobbyOnly` broker. Against a `Full`
+   * anchor `startP2PHostingSession` gets `useBroker: false` and `hostIsPublic`
+   * is false whatever this form submits, so the toggle would do nothing.
+   */
+  it("withholds the lobby listing for P2P only against a known Full anchor", () => {
+    const fullAnchor = {
+      state: "open" as const,
+      serverInfo: {
+        version: "0.71.0",
+        buildCommit: "",
+        protocolVersion: PROTOCOL_VERSION,
+        mode: "Full" as const,
+        lobbyProtocolVersion: LOBBY_PROTOCOL_VERSION,
+      },
+      playerCount: 0,
+    };
+    useMultiplayerStore.setState({
+      hostingServer: OFFICIAL_MULTIPLAYER_SERVER_URL,
+      sourceStatus: new Map([[OFFICIAL_MULTIPLAYER_SERVER_URL, fullAnchor]]),
+    });
+
+    // Server mode is unaffected — the game runs ON that server, so it lists.
+    const { rerender } = render(
+      <HostSetup onHost={vi.fn()} onBack={vi.fn()} connectionMode="server" onConnectionModeChange={vi.fn()} />,
+    );
+    expect(screen.getByRole("switch", { name: "List in lobby" })).toBeInTheDocument();
+
+    rerender(
+      <HostSetup onHost={vi.fn()} onBack={vi.fn()} connectionMode="p2p" onConnectionModeChange={vi.fn()} />,
+    );
+    expect(
+      screen.queryByRole("switch", { name: "List in lobby" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("keeps the lobby listing in P2P when the anchor is a broker or unknown", () => {
+    // Unknown: `sourceStatus` is not persisted, so a cold mount has no mode
+    // yet. The default anchor IS a broker, so unknown must read as available
+    // rather than making the row appear a beat late.
+    useMultiplayerStore.setState({
+      hostingServer: OFFICIAL_MULTIPLAYER_SERVER_URL,
+      sourceStatus: new Map(),
+    });
+    const { rerender } = render(
+      <HostSetup onHost={vi.fn()} onBack={vi.fn()} connectionMode="p2p" onConnectionModeChange={vi.fn()} />,
+    );
+    expect(screen.getByRole("switch", { name: "List in lobby" })).toBeInTheDocument();
+
+    useMultiplayerStore.setState({
+      sourceStatus: new Map([
+        [
+          OFFICIAL_MULTIPLAYER_SERVER_URL,
+          {
+            state: "open" as const,
+            serverInfo: {
+              version: "0.71.0",
+              buildCommit: "",
+              protocolVersion: PROTOCOL_VERSION,
+              mode: "LobbyOnly" as const,
+              lobbyProtocolVersion: LOBBY_PROTOCOL_VERSION,
+            },
+            playerCount: 0,
+          },
+        ],
+      ]),
+    });
+    rerender(
+      <HostSetup onHost={vi.fn()} onBack={vi.fn()} connectionMode="p2p" onConnectionModeChange={vi.fn()} />,
+    );
+    expect(screen.getByRole("switch", { name: "List in lobby" })).toBeInTheDocument();
+  });
+
   // ── Connection mode switch ──────────────────────────────────────────────
 
   it("mirrors the connection switch and reports a change to the page", async () => {

--- a/client/src/components/lobby/__tests__/LobbyView.test.tsx
+++ b/client/src/components/lobby/__tests__/LobbyView.test.tsx
@@ -762,11 +762,14 @@ describe("LobbyView", () => {
     renderLobby({});
 
     const input = screen.getByPlaceholderText("Enter code or CODE@IP:PORT");
-    // Regression guard. `MultiplayerPage` routes a join on the SHAPE of the
-    // code, never on a connection mode — but the field used to cap itself at
-    // the 5-character P2P length whenever the lobby was in P2P mode, which
-    // silently truncated exactly this string as the user typed it.
-    const scoped = "ABC12@play.example.com:8443";
+    // Regression guard, two caps deep. The field used to shrink to the
+    // 5-character P2P length whenever the lobby was in P2P mode, truncating
+    // this string as the user typed it; and the server-mode cap it fell back
+    // to was a flat 50, which this target exceeds. `parseJoinCode` and
+    // `parseWebSocketUrl` bound neither the code nor the host, so nothing
+    // downstream justified either number.
+    const scoped = "ABC12@really-long-regional-hostname.phase-rs.example.com:8443";
+    expect(scoped.length).toBeGreaterThan(50);
     await user.type(input, scoped);
     expect(input).toHaveValue(scoped);
   });


### PR DESCRIPTION
Three findings from review of the connection-switch change.

The join input capped itself at 50 characters. `parseJoinCode` splits a
`CODE@host` target and `parseWebSocketUrl` bounds neither half, so a long
hostname was truncated as the user typed it and the join went to the wrong
authority — or nowhere. The cap predates the switch work (it was the
server-mode arm of `maxLength={isP2P ? 5 : 50}`) and nothing downstream ever
justified the number, so it goes.

"List in lobby" is withheld in P2P when the anchor is KNOWN to be a `Full`
server. A P2P room reaches the public list only through a `LobbyOnly` broker:
that is the sole path into `startP2PHostingSession` with `useBroker`, and
`openBrokerClient` refuses every other mode, so `hostIsPublic` is false there
whatever the form submits. Positive knowledge only — `sourceStatus` is not
persisted, so an unknown mode on a cold mount must read as available rather
than making the row appear a beat after the form, and the default anchor is a
broker.

The server chip, the degraded-sources button and the room-type filter buttons
sat under the 44px touch-target floor. They are unchanged from before the
switch work, but that change made them visible in every mode rather than only
in server mode, so they now carry `min-h-11` like the format filter beside
them.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - The “List in lobby” option is now hidden when hosting through a full-mode P2P server that cannot support lobby registration.
  - Join codes can now include longer server addresses without being cut off.

- **Improvements**
  - Updated lobby controls with consistent minimum touch-target sizing for easier interaction.
  - The listing option remains available when server status is unknown or when a compatible lobby broker is detected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->