### PR TITLE
perf(sba): stop computing world-rule timestamps for every permanent on world-free boards

### DIFF
--- a/crates/engine/src/game/layers.rs
+++ b/crates/engine/src/game/layers.rs
@@ -2279,12 +2279,12 @@ fn record_active_effect_collection() {
 }
 
 #[cfg(test)]
-fn reset_active_effect_collection_count() {
+pub(crate) fn reset_active_effect_collection_count() {
     ACTIVE_EFFECT_COLLECTION_COUNT.with(|count| count.set(0));
 }
 
 #[cfg(test)]
-fn active_effect_collection_count() -> usize {
+pub(crate) fn active_effect_collection_count() -> usize {
     ACTIVE_EFFECT_COLLECTION_COUNT.with(core::cell::Cell::get)
 }
 

--- a/crates/engine/src/game/sba.rs
+++ b/crates/engine/src/game/sba.rs
@@ -1702,7 +1702,7 @@ fn check_world_rule(
             obj.card_types
                 .supertypes
                 .contains(&Supertype::World)
-                .then_some((*id, world_acquisition_timestamp(state, obj)))
+                .then(|| (*id, world_acquisition_timestamp(state, obj)))
         })
         .collect();
 
@@ -3000,6 +3000,83 @@ mod tests {
             crate::game::perf_counters::snapshot().static_full_scans,
             0,
             "absent LegendRuleDoesntApply statics must skip the exact check_static_ability scan"
+        );
+    }
+
+    /// CR 704.5k: the world rule needs `world_acquisition_timestamp` only for
+    /// permanents that actually HAVE the world supertype. On a board with none —
+    /// which is almost every board — its cost must not scale with the board.
+    ///
+    /// `bool::then_some` takes a VALUE, so the eager form evaluated the timestamp
+    /// for every permanent before the `contains(&Supertype::World)` result was
+    /// consulted. For a non-printed-world object that call falls past its fast
+    /// path into `layers::collect_shared_active_continuous_effects`, which walks
+    /// every static-effect source and allocates a fresh Vec of the whole board's
+    /// effects — so a world-free board paid one full effect collection PER
+    /// PERMANENT on every SBA pass. The CR 704.5k arity gate (`worlds.len() < 2`)
+    /// sits after that cost and so could not prevent it.
+    ///
+    /// This matters well beyond the world rule: `check_state_based_actions` runs
+    /// on every priority grant, after every stack resolution, in the combat-damage
+    /// loop, and inside every simulated candidate action.
+    ///
+    /// The assertion is board-size INDEPENDENCE rather than a fixed count: SBA
+    /// legitimately gathers effects a small constant number of times for other
+    /// reasons, and pinning that constant would make this test a tripwire for
+    /// unrelated work. Growth with `n` is the defect.
+    ///
+    /// Revert-failing: restore `.then_some(...)` in place of `.then(|| ...)` and
+    /// each count becomes `board size + k` — 10 and 34 today, for SBA's constant
+    /// `k` of 2 — because the eager form gathers once more per permanent on top
+    /// of that constant. The equality below is what breaks, not the constant.
+    #[test]
+    fn sba_world_rule_cost_is_independent_of_board_size_when_no_world_is_present() {
+        fn collections_for(n: u64) -> (usize, usize) {
+            let mut state = setup();
+            for i in 1..=n {
+                create_creature(&mut state, CardId(i), PlayerId(0), "Rat", 1, 1);
+            }
+            assert!(
+                state
+                    .battlefield
+                    .iter()
+                    .filter_map(|id| state.objects.get(id))
+                    .all(|o| !o.card_types.supertypes.contains(&Supertype::World)),
+                "reach-guard: the fixture must contain no world permanent, or this \
+                 proves nothing about the zero-world path"
+            );
+
+            crate::game::layers::reset_active_effect_collection_count();
+            let mut events = Vec::new();
+            check_state_based_actions(&mut state, &mut events);
+            (
+                state.battlefield.len(),
+                crate::game::layers::active_effect_collection_count(),
+            )
+        }
+
+        let (small_board, small) = collections_for(8);
+        let (large_board, large) = collections_for(32);
+
+        // The board sizes are load-bearing in the PASSING direction too. Without
+        // these, a fixture that silently stopped creating permanents would leave
+        // `0 == 0` and the tripwire would be disarmed rather than failing.
+        assert_eq!(small_board, 8, "fixture must place 8 permanents");
+        assert_eq!(large_board, 32, "fixture must place 32 permanents");
+        // ...and the counter must actually be reaching the code under test. Pins
+        // k >= 1 without pinning k == 2, so this stays independent of how many
+        // times SBA legitimately gathers.
+        assert!(
+            small > 0,
+            "SBA must gather continuous effects at least once, or the counter is \
+             no longer instrumenting the path this test measures"
+        );
+
+        assert_eq!(
+            small, large,
+            "gathering continuous effects during SBA must not scale with the \
+             battlefield on a world-free board: {small_board} permanents gathered \
+             {small}, {large_board} gathered {large}"
         );
     }
 


### PR DESCRIPTION
## Summary

`check_world_rule` computed `world_acquisition_timestamp` for **every permanent on the battlefield**, on **every state-based-action pass**, including boards with zero world permanents. `bool::then_some` takes a value, not a closure, so the expensive call was evaluated before the `contains(&Supertype::World)` result was ever consulted. One token — `.then_some(x)` → `.then(|| x)` — takes a 2,500-permanent board from **363 ms to 1.9 ms per SBA pass**.

Found while investigating a Discord report of a ~2,500-rat board that could not take its turn.

## Files changed

- `crates/engine/src/game/sba.rs`
- `crates/engine/src/game/layers.rs`

## Track

Developer

## LLM

Model: claude-opus-5
Tier: Frontier
Thinking: high

## Implementation method (required)

Method: not-applicable — this is a one-token evaluation-strategy fix to an existing state-based-action check, found by profiling a reported hang rather than by implementing a card. The full `review-impl` checklist was run against the committed head (see below).

## CR references

- `CR 704.5k` — the world rule; the annotated code implements both its supertype predicate and its "two or more" arity gate. Verified against `docs/MagicCompRules.txt`. Unchanged text, cited in the new test's doc.

## Verification

- [x] Required checks ran clean, or the exact CI-owned alternative is stated below.
- [x] Gate A output below is for the current committed head.
- [x] Final review-impl below is clean for the current committed head.
- [x] Both anchors cite existing analogous code at the same seam.

- `cargo test -p phase-engine --lib` — **20783 passed; 0 failed; 7 ignored**
- `cargo test -p phase-engine --test integration` — **6527 passed; 0 failed; 3 ignored**
- `cargo fmt --all -- --check` — clean
- `cargo clippy -p phase-engine --all-targets` — clean
- `scripts/check-parser-combinators.sh` — Gate A PASS, Gate G PASS
- `scripts/check-prelowered-ratchet.sh` — Gate P PASS

**Measured, release build, 2,500 Rats + 5 Rat Colony, timing one `check_state_based_actions`:**

| board | before | after | speedup |
|---|---|---|---|
| n=200 | 569.3 µs | 29.8 µs | 19× |
| n=800 | 3.519 ms | 163.9 µs | 21× |
| n=2500 | **363.459 ms** | **1.859 ms** | **196×** |

The growth *shape* changes, not just the constant: strongly superlinear before, near-linear after.

**Behaviour is unchanged, and that is checked rather than asserted:** all 11 pre-existing `sba_world_rule_*` tests pass under **both** forms. `collect_shared_active_continuous_effects` is a pure builder — no cache write, no memo, no interior mutation — so eager and lazy differ only in timing.

**Revert-failing and revert-isolated:** restoring `.then_some` fails the new test *alone* (`11 passed; 1 failed`), reporting `8 permanents gathered 10, 32 gathered 34`.

## Gate A

Gate A PASS head=d3d2b1254c25c41c3f86ed6a508a381bfc2c3508 base=280d6e1f0b5661ee70876b476b0260aec2fc2887

## Anchored on

- `crates/engine/src/game/sba.rs:2962` — `sba_legend_rule_without_exemption_avoids_static_full_scan`, the same file's existing precedent for pinning "this SBA sub-check must not do a full scan when the board does not need one" via a counter rather than a timing assertion.
- `crates/engine/src/game/layers.rs:2265` — `pub(crate) static FULL_EVALUATE_LAYERS_COUNT`, the in-file precedent for a `#[cfg(test)]` counter shared across modules at `pub(crate)` visibility, which is what the two widened helpers follow.

## Final review-impl

Final review-impl PASS head=d3d2b1254c25c41c3f86ed6a508a381bfc2c3508

Ran twice. The first pass (4 lenses: behaviour-equivalence, test-adequacy, seam-and-siblings, visibility-and-CR) returned **PASS** with three LOW findings against `b7405041d`. A confirmation pass against `715b7cd6a` verified two as resolved and judged the third's deferral defensible, raising one further LOW.

Findings and disposition:
- **[LOW] applied** — the test's "Revert-failing" doc line claimed the reverted counts become the board sizes (8 and 32); they are actually 10 and 34 (board size + SBA's constant 2). Corrected, then re-measured to confirm.
- **[LOW] applied** — the test was vacuously satisfiable: `Iterator::all` is `true` on an empty battlefield and `assert_eq!(small, large)` is satisfied by `0 == 0`, so a fixture that stopped creating permanents would go green instead of failing. Board size is now returned and asserted. Verified by neutering the fixture loop: the test now fails with `fixture must place 8 permanents`, where before it passed.
- **[LOW] applied** — `small == large == 0` could still pass if the counter stopped reaching the instrumented path. Added `assert!(small > 0, ...)`, which pins `k >= 1` without pinning `k == 2` and so does not become a tripwire for unrelated work.
- **[LOW] declined, deliberately** — the CR 704.5k arity gate still runs *after* the timestamps, so a single **granted**-world permanent still buys one gather per SBA pass that the next line discards. This is bounded by the number of world permanents in play (0–2 in real decks), does not scale with `n`, and reordering to `filter → arity gate → map` is a control-flow change to `check_world_rule` needing its own granted-world fixture. Folding it into a one-token fix would have widened the change; disclosed here instead.

Delta since the last reviewed head (`715b7cd6a`) is exactly the third LOW above — a one-line `assert!` that review proposed verbatim — plus a rebase onto current `main`. Gate A and the full suites were re-run against this head after both.

## Claimed parse impact

None. No parser code is touched.

## Scope Expansion

None. Two files: the one-token fix plus its regression test, and a `#[cfg(test)]` visibility widening so the test can read the counter.

## Validation Failures

None.

## CI Failures

None.

---

### Why this is worth more than the world rule

`check_state_based_actions` runs on every priority grant (`engine_priority.rs`), after every stack resolution (`stack.rs`), in the combat-damage loop (`combat_damage.rs`), and **inside every simulated candidate action** on the AI/legal-action path. Every large-board report in the tracker has been paying this `O(n·S)` tax unattributed.

Two notes for whoever picks up the related issues:

**#8101's stated mechanism is measurably wrong.** It attributes the stall to "a full `GameState::clone()` per candidate action". `GameState.objects` is an `im::HashMap` (persistent, structurally shared), and `GameState::clone` measured **flat at 3.5–5.9 µs from n=50 to n=2500**. Work aimed at "avoid the clone" would move nothing. The costly part is the `apply` *after* the clone — and ~87% of that was this SBA sweep.

**This does not by itself fix the reported hang.** On the reporter's board, `legal_actions_for_viewer` at declare-attackers measured **936 s** in a release build. This fix removes the largest single term; a ~6.2 s declare-attackers prompt build (`selectable_targets_by_attacker`, quadratic) and uncapped attacker-candidate enumeration remain. I have measurements for those and can file them separately — I kept this PR to the one finding where root cause, fix, and validation are all complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014iuGVJdap2qKcnS85NLSdQ


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved game-state processing efficiency on battlefields without World permanents, reducing unnecessary calculations as board size increases.
  - Preserved existing World-rule behavior while ensuring related values are calculated only when needed.

- **Tests**
  - Added coverage confirming that World-rule processing remains efficient and does not scale unnecessarily with the number of battlefield objects when no World is present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->