### PR TITLE
Ship a Flatpak for the Linux desktop shell (#8614)

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,8 +133,10 @@ cd client && pnpm install && pnpm dev # Start frontend
 WebKitGTK has no audio stack of its own — the desktop app's sound effects and
 music are GStreamer pipelines it assembles at runtime. The **AppImage bundles
 that runtime itself** (`bundle.linux.appimage.bundleMediaFramework`), so it
-needs nothing installed. The **`.deb` declares it** and apt pulls it in. Running
-from source, or repackaging for another distribution, needs these installed:
+needs nothing installed. The **`.deb` declares it** and apt pulls it in. The
+**Flatpak inherits it from `org.gnome.Platform`** (see [Flatpak](#flatpak)).
+Running from source, or repackaging for another distribution, needs these
+installed:
 
 ```bash
 sudo apt-get install gstreamer1.0-plugins-base gstreamer1.0-plugins-good gstreamer1.0-libav
@@ -150,6 +152,72 @@ Release-time verification that the shipped AppImage's bundled plugin set really
 resolves those elements is tracked separately, in
 [#8357](https://github.com/phase-rs/phase/issues/8357) — it lives in the release
 workflow, which is maintainer-owned.
+
+### Flatpak
+
+`packaging/flatpak/` holds a Flatpak manifest for the desktop shell and a
+`build-local.sh` that builds it from an already-released `.deb` or `.AppImage`:
+
+```bash
+./packaging/flatpak/build-local.sh --appimage ~/Downloads/Phase-Desktop-Linux-x86_64.AppImage --install
+```
+
+That needs a release whose shell already carries the update guard described
+below; the script refuses older artifacts rather than package them. Run
+`--help` for the full options.
+
+**Why a third Linux artifact.** The two existing ones each leave users out. The
+AppImage pegs a CPU core at idle on the NVIDIA proprietary driver, and the
+`.deb` installs cleanly only on Debian-family distributions — everyone else
+needs the AppImage or a conversion workaround. A Flatpak covers both gaps at
+once: it installs the same way on any distribution that has `flatpak`, and it
+inherits a working WebKitGTK and GStreamer stack from the runtime.
+
+It compiles nothing. Every library `phase-tauri` links against is already in
+`org.gnome.Platform//50`, so the script stages the exact binary from a release
+artifact — the packaged binary stays identical to the one `.deb`/`.AppImage`
+users run — and the package inherits the runtime's WebKitGTK and GStreamer
+plugin set instead of vendoring its own. Concretely, that buys three things —
+the first from the packaging format, the other two from that inheritance:
+
+- **Distribution coverage.** The `.deb` is Debian-family only. A Flatpak is the
+  one artifact that installs identically on Fedora, openSUSE, Arch, the
+  immutable/atomic desktops, and Debian/Ubuntu alike, without asking the user
+  to convert a package or fall back to the AppImage.
+- **NVIDIA idle CPU ([#8614](https://github.com/phase-rs/phase/issues/8614)).**
+  The AppImage's bundled, Ubuntu-built WebKitGTK burns close to a full core at
+  idle on the NVIDIA proprietary driver. Measured on the reporter's machine, the
+  Flatpak idles in the same range as a healthy host-WebKit build, while still
+  rendering on the NVIDIA driver rather than falling back to software. The root
+  cause is still unknown — this routes around the bug rather than fixing it, and
+  the measurement covers one machine, one driver version, and one distribution.
+  The AppImage is unaffected on other GPU stacks, so this is not a deprecation —
+  but **NVIDIA users are the ones to point here.**
+- **Audio ([#8615](https://github.com/phase-rs/phase/issues/8615)).** The
+  runtime supplies every element the section above lists, `avdec_aac` included,
+  from the base runtime rather than the optional
+  `org.freedesktop.Platform.codecs-extra` extension. (That is the decoder whose
+  absence makes the AppImage silent; end-to-end playback in the Flatpak has not
+  been verified. The AppImage-side fix is tracked separately.)
+
+A packaged shell must not self-update: `/app` is read-only and `flatpak update`
+owns upgrades. `client/src-tauri/src/update_authority.rs` detects the sandbox
+and declines every release the updater offers. That guard is compiled **into the
+shell binary**, so it only holds for artifacts built from a release that
+contains it — `build-local.sh` refuses to stage an older binary rather than
+produce a package that tries to rewrite its own read-only `/app`. Most releases
+do not touch the package at all: the shell is a thin bootstrap that loads the
+current web channel over the network, so web-app releases arrive without any
+package update.
+
+The package is X11-only — it pins `GDK_BACKEND=x11` and grants no Wayland
+socket, so a Wayland session needs Xwayland (the default nearly everywhere).
+
+CI does not build this package today, so there is no prebuilt Flatpak for users
+to install yet — the manifest and script are for local and manual builds. Adding
+a build step to the release workflow, which is maintainer-owned, is what would
+attach a `.flatpak` to each release and make this an artifact users can actually
+get.
 
 ### Android APKs
 

--- a/client/src-tauri/src/lib.rs
+++ b/client/src-tauri/src/lib.rs
@@ -12,6 +12,8 @@ mod native_bridge;
 #[cfg(desktop)]
 mod native_engine;
 mod native_engine_contract;
+#[cfg(desktop)]
+mod update_authority;
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     // WebKitGTK's dmabuf renderer renders blank frames when the GPU import
@@ -48,7 +50,20 @@ pub fn run() {
                 let _ = window.set_focus();
             }
         }))
-        .plugin(tauri_plugin_updater::Builder::new().build())
+        // The plugin stays registered everywhere so the `check()` command the
+        // web app calls always exists — an unregistered plugin rejects the
+        // call, and client/src/pwa/tauriUpdater.ts surfaces that rejection as a
+        // visible update error. Refusing the release instead resolves to "no
+        // update available", which that same lifecycle already treats as the
+        // quiet, healthy outcome.
+        .plugin(
+            tauri_plugin_updater::Builder::new()
+                .default_version_comparator(|current, candidate| {
+                    update_authority::UpdateAuthority::detect()
+                        .should_install(&current, &candidate.version)
+                })
+                .build(),
+        )
         .plugin(tauri_plugin_process::init())
         .invoke_handler(tauri::generate_handler![
             audio_probe::audio_boot_health,
@@ -268,6 +283,76 @@ mod tests {
         assert_eq!(window.height, 800.0);
         assert!(window.resizable);
         assert!(window.maximized);
+    }
+
+    /// `update_authority` reaches the running app through exactly one call: the
+    /// updater plugin's version comparator. Drop that call and the module still
+    /// compiles, its own unit tests still pass, and self-update is silently
+    /// restored inside the Flatpak sandbox, where `/app` is read-only. No test
+    /// of the module can observe that, so pin the wiring here — the same reason
+    /// the generated Android Gradle invariants are pinned below.
+    #[test]
+    fn updater_plugin_defers_to_the_update_authority() {
+        // Only the production half of this file, because the needles below are
+        // themselves string literals in this module: matching the whole file
+        // would match the test's own array and pass with the wiring deleted.
+        let source = include_str!("lib.rs")
+            .split("mod tests")
+            .next()
+            .expect("split always yields a first element");
+        for required in [
+            "tauri_plugin_updater::Builder::new()",
+            ".default_version_comparator(",
+            "update_authority::UpdateAuthority::detect()",
+            ".should_install(",
+        ] {
+            assert!(
+                source.contains(required),
+                "updater registration lost required invariant: {required}"
+            );
+        }
+    }
+
+    /// Flatpak keys the desktop entry, the icons and the AppStream component on
+    /// the app-id, and Tauri names the window's WM class from the identifier.
+    /// If the two drift the package still builds and installs, but launches
+    /// into an unmatched window with no icon, so pin them together.
+    #[test]
+    fn flatpak_manifest_app_id_matches_the_tauri_identifier() {
+        let identifier = serde_json::from_str::<tauri::Config>(include_str!("../tauri.conf.json"))
+            .unwrap()
+            .identifier;
+        let manifest = include_str!("../../../packaging/flatpak/rs.phase.app.yml");
+        assert!(
+            manifest
+                .lines()
+                .any(|line| line.trim() == format!("app-id: {identifier}")),
+            "packaging/flatpak/rs.phase.app.yml must declare app-id: {identifier}"
+        );
+        for asset in [
+            include_str!("../../../packaging/flatpak/rs.phase.app.desktop"),
+            include_str!("../../../packaging/flatpak/rs.phase.app.metainfo.xml"),
+        ] {
+            assert!(
+                asset.contains(&identifier),
+                "flatpak asset must reference the {identifier} app-id"
+            );
+        }
+        // Flatpak exports a desktop entry, an icon and a metainfo component only
+        // when each is installed under the app-id name, so the install
+        // destinations are the part that actually decides whether the launcher
+        // works. Declaring the right app-id while installing to the old file
+        // names silently exports nothing.
+        for destination in [
+            format!("{identifier}.desktop"),
+            format!("{identifier}.metainfo.xml"),
+            format!("{identifier}.png"),
+        ] {
+            assert!(
+                manifest.contains(&destination),
+                "rs.phase.app.yml must install {destination} for flatpak to export it"
+            );
+        }
     }
 
     #[test]

--- a/client/src-tauri/src/update_authority.rs
+++ b/client/src-tauri/src/update_authority.rs
@@ -1,0 +1,139 @@
+//! Which system is responsible for replacing this installation's files.
+//!
+//! The shell ships in two shapes. Self-managed bundles — `.AppImage`, `.deb`,
+//! `.dmg`, `.exe` — are installed by the user and `tauri_plugin_updater`
+//! downloads and swaps them in place. A Flatpak is the other shape: `/app` is
+//! mounted read-only and `flatpak update` performs upgrades out of band, so the
+//! shell replacing its own binaries is both impossible and wrong to attempt.
+//!
+//! This distinction cannot be expressed in `tauri.conf.json`. `tauri.conf.json`
+//! sets `createUpdaterArtifacts`, which only decides whether the *build*
+//! produces updater signatures; it has no bearing on whether a running binary
+//! checks for updates. The Flatpak also reuses the binary the Linux release job
+//! already built, so no Flatpak-specific build config is consulted at all. And
+//! the check is driven from the web app — `client/src/pwa/tauriUpdater.ts`,
+//! served remotely and shared with every other desktop package — so the
+//! frontend cannot gate it either. The shell is the only layer that knows how
+//! it was installed, which makes this the seam that owns the policy.
+//!
+//! Known limit: this is enforced as the plugin's *default* comparator, and
+//! `check({ allowDowngrades: true })` replaces it outright with
+//! `update.version != current` rather than composing with it (see the plugin's
+//! `commands.rs`). No caller passes that option today —
+//! `client/src/pwa/tauriUpdater.ts` calls a bare `check()` — but the web app is
+//! versioned independently of this binary, so a future frontend could reach
+//! past this guard. Closing that would mean withholding the updater's install
+//! permission from sandboxed builds rather than answering "no" to every
+//! release; it is deliberately not attempted here.
+
+use semver::Version;
+use std::path::Path;
+
+/// The canonical marker for "running inside a Flatpak sandbox". `flatpak-run`
+/// writes this file into every sandbox, and it is what GLib's own
+/// containerisation check looks for. Preferred over the `FLATPAK_ID`
+/// environment variable, which child processes inherit and anything can set.
+const FLATPAK_INFO: &str = "/.flatpak-info";
+
+/// Who owns replacing this installation's files.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum UpdateAuthority {
+    /// A self-managed bundle: the shell may replace its own installation.
+    Shell,
+    /// A Flatpak: the sandbox owns a read-only `/app`, and `flatpak update`
+    /// performs upgrades.
+    Flatpak,
+}
+
+impl UpdateAuthority {
+    /// Resolves the authority for the running process.
+    pub fn detect() -> Self {
+        Self::detect_at(Path::new(FLATPAK_INFO))
+    }
+
+    /// Test seam for [`detect`](Self::detect); the marker path is a parameter
+    /// so both arms are reachable without a sandbox to run under.
+    fn detect_at(flatpak_info: &Path) -> Self {
+        if flatpak_info.exists() {
+            Self::Flatpak
+        } else {
+            Self::Shell
+        }
+    }
+
+    /// Whether an available release should be installed by the shell itself.
+    ///
+    /// This is the whole of `tauri_plugin_updater`'s decision: supplying a
+    /// comparator *replaces* the plugin's built-in `candidate > current` test
+    /// rather than running alongside it, so the `Shell` arm has to restate it.
+    /// Dropping that comparison would make every self-managed install offer
+    /// whatever version the manifest happens to name, downgrades included.
+    pub fn should_install(self, current: &Version, candidate: &Version) -> bool {
+        match self {
+            Self::Shell => candidate > current,
+            Self::Flatpak => false,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn v(raw: &str) -> Version {
+        Version::parse(raw).unwrap()
+    }
+
+    /// Both arms, driven off paths whose existence is already guaranteed by the
+    /// crate layout, so the test needs no temporary files or dev-dependency.
+    #[test]
+    fn detect_reads_the_flatpak_sandbox_marker() {
+        let root = Path::new(env!("CARGO_MANIFEST_DIR"));
+        let present = root.join("Cargo.toml");
+        let absent = root.join("this-crate-is-not-a-flatpak-sandbox");
+
+        assert!(present.exists(), "fixture path must exist");
+        assert!(!absent.exists(), "fixture path must not exist");
+        assert_eq!(
+            UpdateAuthority::detect_at(&present),
+            UpdateAuthority::Flatpak
+        );
+        assert_eq!(UpdateAuthority::detect_at(&absent), UpdateAuthority::Shell);
+    }
+
+    /// The marker is an absolute path deliberately: resolving it relative to the
+    /// working directory would make the verdict depend on where the shell was
+    /// launched from. Pin the exact constant — an equality against `detect()`
+    /// would restate that function's definition and hold even if it regressed
+    /// to returning one arm unconditionally.
+    #[test]
+    fn sandbox_marker_is_the_absolute_flatpak_run_path() {
+        assert_eq!(FLATPAK_INFO, "/.flatpak-info");
+        assert!(Path::new(FLATPAK_INFO).is_absolute());
+    }
+
+    /// A self-managed bundle keeps the plugin's stock semantics exactly.
+    #[test]
+    fn shell_installs_only_strictly_newer_releases() {
+        let current = v("1.0.12");
+        assert!(UpdateAuthority::Shell.should_install(&current, &v("1.0.13")));
+        assert!(UpdateAuthority::Shell.should_install(&current, &v("2.0.0")));
+        assert!(!UpdateAuthority::Shell.should_install(&current, &current));
+        assert!(!UpdateAuthority::Shell.should_install(&current, &v("1.0.11")));
+    }
+
+    /// The guard itself: a Flatpak refuses every release, including the newer
+    /// one a self-managed bundle would take, so `check()` resolves to "no
+    /// update" instead of trying to write to a read-only `/app`.
+    #[test]
+    fn flatpak_refuses_every_release_the_shell_would_take() {
+        let current = v("1.0.12");
+        for candidate in ["1.0.13", "2.0.0", "1.0.12", "1.0.11"] {
+            assert!(
+                !UpdateAuthority::Flatpak.should_install(&current, &v(candidate)),
+                "flatpak must not self-install {candidate}"
+            );
+        }
+        assert!(UpdateAuthority::Shell.should_install(&current, &v("1.0.13")));
+    }
+}

--- a/client/src/pwa/__tests__/tauriUpdater.test.ts
+++ b/client/src/pwa/__tests__/tauriUpdater.test.ts
@@ -105,6 +105,21 @@ describe("registerTauriUpdater connectivity lifecycle", () => {
     await vi.waitFor(() => expect(mocks.check).toHaveBeenCalledTimes(1));
   });
 
+  // The shell refuses updates inside a Flatpak sandbox by supplying the updater
+  // plugin's *default* version comparator (client/src-tauri/src/update_authority.rs).
+  // `check({ allowDowngrades: true })` replaces that default outright rather than
+  // composing with it, so passing any options here would reach past the guard and
+  // let a sandboxed install try to rewrite its read-only /app. This shell binary
+  // and this web app ship on separate schedules, so the constraint is pinned here
+  // rather than left as a comment.
+  it("checks for updates with no options so the sandbox update guard is not bypassed", async () => {
+    const updater = await import("../tauriUpdater");
+    updater.registerTauriUpdater();
+
+    await vi.waitFor(() => expect(mocks.check).toHaveBeenCalledTimes(1));
+    expect(mocks.check).toHaveBeenCalledWith();
+  });
+
   it("does not self-update a dev build or non-desktop host", async () => {
     vi.stubEnv("DEV", true);
     const updater = await import("../tauriUpdater");

--- a/packaging/flatpak/.gitignore
+++ b/packaging/flatpak/.gitignore
@@ -1,0 +1,7 @@
+# Staged release binary and flatpak-builder working trees; all reproducible
+# from a released artifact via ./build-local.sh.
+build/
+.flatpak-builder-out/
+.flatpak-repo/
+.flatpak-builder/
+*.flatpak

--- a/packaging/flatpak/build-local.sh
+++ b/packaging/flatpak/build-local.sh
@@ -1,0 +1,212 @@
+#!/usr/bin/env bash
+# Build the phase.rs Flatpak locally from an already-released Linux artifact.
+#
+# The Flatpak deliberately compiles nothing. org.gnome.Platform//50 supplies
+# every library `phase-tauri` links against, so this script stages the exact
+# binary the release job already produced and hands it to flatpak-builder. That
+# keeps the packaged binary byte-identical to the one .deb/.AppImage users run,
+# and keeps this script honest: if it built its own binary, a green build here
+# would say nothing about the artifact people actually download.
+#
+#   ./build-local.sh --appimage ~/Downloads/Phase-Desktop-Linux-x86_64.AppImage
+#   ./build-local.sh --deb ~/Downloads/Phase-Desktop-Linux-x86_64.deb --install
+#
+# Requires `flatpak`, `flatpak-builder` and `objdump`. See --help.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly HERE
+readonly MANIFEST="$HERE/rs.phase.app.yml"
+readonly STAGE="$HERE/build"
+readonly BUILDDIR="$HERE/.flatpak-builder-out"
+readonly REPO="$HERE/.flatpak-repo"
+
+source_artifact=""
+source_kind=""
+do_install=0
+do_run=0
+do_bundle=0
+allow_unguarded=0
+built_unguarded=0
+
+die() { printf '\033[31merror:\033[0m %s\n' "$*" >&2; exit 1; }
+note() { printf '\033[36m==>\033[0m %s\n' "$*"; }
+
+# Read both from the manifest rather than restating them. A second copy here
+# would keep validating the old runtime after a manifest bump, while
+# flatpak-builder built against the new one.
+manifest_value() {
+  local key="$1" value
+  value="$(sed -n "s/^${key}:[[:space:]]*['\"]\{0,1\}\([^'\"[:space:]]\{1,\}\)['\"]\{0,1\}[[:space:]]*\$/\1/p" "$MANIFEST")"
+  [ -n "$value" ] || die "could not read '$key' from $MANIFEST"
+  printf '%s' "$value"
+}
+
+usage() {
+  cat <<'EOF'
+Usage: build-local.sh (--appimage PATH | --deb PATH | --binary PATH) [options]
+
+Source (exactly one required):
+  --appimage PATH   Extract phase-tauri from a released .AppImage
+  --deb PATH        Extract phase-tauri from a released .deb
+  --binary PATH     Use an already-extracted phase-tauri binary
+
+Options:
+  --install         flatpak install the built app into the user installation
+  --run             Launch the app after building (implies --install)
+  --bundle          Also write <app-id>.flatpak, a single-file bundle
+  --allow-unguarded-updater
+                    Build even if the staged binary predates the sandbox
+                    update guard. For packaging experiments only — the
+                    resulting package will try to self-update. Do not ship it.
+  -h, --help        Show this help
+
+Prerequisites:
+  flatpak, flatpak-builder, objdump (binutils), and the GNOME runtime + SDK
+  at the version rs.phase.app.yml names. If a runtime is missing, this script
+  exits with the exact `flatpak install` command for it.
+EOF
+}
+
+set_source() {
+  [ -z "$source_artifact" ] || die "pass only one of --appimage/--deb/--binary"
+  source_kind="$1"
+  [ -n "${2:-}" ] || die "--$1 needs a path"
+  [ -f "$2" ] || die "no such file: $2"
+  source_artifact="$(cd "$(dirname "$2")" && pwd)/$(basename "$2")"
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --appimage) set_source appimage "${2:-}"; shift 2 ;;
+    --deb)      set_source deb "${2:-}"; shift 2 ;;
+    --binary)   set_source binary "${2:-}"; shift 2 ;;
+    --install)  do_install=1; shift ;;
+    --run)      do_run=1; do_install=1; shift ;;
+    --bundle)   do_bundle=1; shift ;;
+    --allow-unguarded-updater) allow_unguarded=1; shift ;;
+    -h|--help)  usage; exit 0 ;;
+    *)          usage >&2; die "unknown argument: $1" ;;
+  esac
+done
+
+[ -n "$source_artifact" ] || { usage >&2; die "a source artifact is required"; }
+
+# Derived only now: --help and argument errors must work even when the manifest
+# is missing or malformed.
+[ -f "$MANIFEST" ] || die "manifest not found: $MANIFEST"
+APP_ID="$(manifest_value app-id)"
+RUNTIME_VERSION="$(manifest_value runtime-version)"
+readonly APP_ID RUNTIME_VERSION
+
+command -v flatpak >/dev/null || die "flatpak is not installed"
+command -v flatpak-builder >/dev/null \
+  || die "flatpak-builder is not installed (try: flatpak install --user flathub org.flatpak.Builder, then use 'flatpak run org.flatpak.Builder')"
+# Checked up front because the NEEDED preflight below reads objdump through a
+# process substitution, where a missing binary would go unnoticed by `set -e`
+# and turn that check into a silent pass.
+command -v objdump >/dev/null || die "objdump is not installed (install binutils)"
+
+for ref in "org.gnome.Platform//$RUNTIME_VERSION" "org.gnome.Sdk//$RUNTIME_VERSION"; do
+  flatpak info "$ref" >/dev/null 2>&1 \
+    || die "missing $ref — install it with: flatpak install --user flathub $ref"
+done
+
+note "staging phase-tauri from $(basename "$source_artifact")"
+rm -rf "$STAGE"
+mkdir -p "$STAGE"
+scratch="$(mktemp -d)"
+trap 'rm -rf "$scratch"' EXIT
+
+case "$source_kind" in
+  binary)
+    cp "$source_artifact" "$STAGE/phase-tauri"
+    ;;
+  appimage)
+    # Release downloads arrive without the bit set, and the extract below runs
+    # the artifact directly, so say why rather than dying on "Permission denied".
+    [ -x "$source_artifact" ] \
+      || die "AppImage is not executable — chmod +x '$source_artifact' first"
+    # --appimage-extract always unpacks into ./squashfs-root of the cwd.
+    (cd "$scratch" && "$source_artifact" --appimage-extract >/dev/null)
+    [ -f "$scratch/squashfs-root/usr/bin/phase-tauri" ] \
+      || die "no usr/bin/phase-tauri inside that AppImage"
+    # Copy the binary OUT of the AppDir rather than pointing the build at it in
+    # place. phase-tauri carries RUNPATH '$ORIGIN/../lib', so a copy that stays
+    # next to the AppDir's bundled libraries keeps resolving against them — the
+    # exact Ubuntu-built WebKitGTK this package exists to stop using.
+    cp "$scratch/squashfs-root/usr/bin/phase-tauri" "$STAGE/phase-tauri"
+    ;;
+  deb)
+    if command -v dpkg-deb >/dev/null; then
+      dpkg-deb -x "$source_artifact" "$scratch/deb"
+    else
+      # Fedora and friends usually lack dpkg; ar + tar is in binutils/coreutils.
+      (cd "$scratch" && ar x "$source_artifact")
+      mkdir -p "$scratch/deb"
+      data="$(find "$scratch" -maxdepth 1 -name 'data.tar.*' -print -quit)"
+      [ -n "$data" ] || die "no data.tar.* member inside that .deb"
+      tar -xf "$data" -C "$scratch/deb"
+    fi
+    binary="$(find "$scratch/deb" -type f -name phase-tauri -print -quit)"
+    [ -n "$binary" ] || die "no phase-tauri inside that .deb"
+    cp "$binary" "$STAGE/phase-tauri"
+    ;;
+esac
+
+chmod 755 "$STAGE/phase-tauri"
+
+# The guard that stops the shell replacing its own binaries lives *inside* the
+# staged binary (client/src-tauri/src/update_authority.rs), not in this package.
+# Staging a release that predates it produces a Flatpak with self-update fully
+# live, which then tries to rewrite a read-only /app on every check and leaves a
+# permanent update error in the UI. Refuse to build that by default.
+#
+# Heuristic on purpose: the guard's marker path is a string literal in the
+# binary, so its presence is evidence the guard was compiled in.
+note "checking the staged binary carries the sandbox update guard"
+if ! grep -qa -- '/.flatpak-info' "$STAGE/phase-tauri"; then
+  [ "$allow_unguarded" -eq 1 ] || die \
+    "this artifact predates the Flatpak update guard, so the package would try to self-update inside the sandbox; stage a release built from update_authority.rs, or pass --allow-unguarded-updater to build it anyway"
+  printf '\033[33mwarning:\033[0m staged binary has no sandbox update guard; this package will attempt to self-update. Do not distribute it.\n' >&2
+  built_unguarded=1
+fi
+
+# Fail loudly here rather than at runtime inside the sandbox: if the binary ever
+# grows a dependency the runtime does not carry, this is the check that says so.
+note "checking the runtime satisfies every NEEDED library"
+runtime_files="$(flatpak info --show-location "org.gnome.Platform//$RUNTIME_VERSION")/files"
+missing=""
+while read -r lib; do
+  [ -n "$lib" ] || continue
+  find "$runtime_files/lib" -name "$lib" -print -quit 2>/dev/null | grep -q . \
+    || missing="$missing $lib"
+done < <(objdump -p "$STAGE/phase-tauri" | awk '/NEEDED/{print $2}')
+[ -z "$missing" ] || die "org.gnome.Platform//$RUNTIME_VERSION is missing:$missing"
+
+note "building $APP_ID"
+rm -rf "$BUILDDIR"
+flatpak-builder --force-clean --repo="$REPO" "$BUILDDIR" "$MANIFEST"
+
+if [ "$do_install" -eq 1 ]; then
+  note "installing into the user installation"
+  flatpak remote-add --user --no-gpg-verify --if-not-exists phase-local "$REPO"
+  flatpak install --user --noninteractive --reinstall phase-local "$APP_ID"
+fi
+
+if [ "$do_bundle" -eq 1 ]; then
+  note "writing $HERE/$APP_ID.flatpak"
+  flatpak build-bundle "$REPO" "$HERE/$APP_ID.flatpak" "$APP_ID"
+fi
+
+if [ "$do_run" -eq 1 ]; then
+  note "launching"
+  flatpak run "$APP_ID"
+fi
+
+note "done"
+
+# flatpak-builder floods the terminal, so the warning above has long scrolled
+# away by now. Say it again where it is the last thing on screen.
+[ "$built_unguarded" -eq 0 ] || printf \
+  '\033[33mwarning:\033[0m built WITHOUT the sandbox update guard — for local experiments only, do not distribute.\n' >&2

--- a/packaging/flatpak/rs.phase.app.desktop
+++ b/packaging/flatpak/rs.phase.app.desktop
@@ -1,0 +1,13 @@
+[Desktop Entry]
+Type=Application
+Name=Phase
+Comment=Play Magic: The Gathering against AI opponents and other players
+Exec=phase-tauri
+Icon=rs.phase.app
+Terminal=false
+Categories=Game;CardGame;
+Keywords=magic;mtg;cards;tcg;
+# The Tauri window reports WM_CLASS "phase-tauri"; without this the shell shows
+# up as an unmatched window rather than under its own launcher icon. The
+# AppImage's generated .desktop pins the same value.
+StartupWMClass=phase-tauri

--- a/packaging/flatpak/rs.phase.app.metainfo.xml
+++ b/packaging/flatpak/rs.phase.app.metainfo.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  AppStream metadata for the phase.rs desktop shell.
+
+  Without this file the package still installs and runs, but software centres
+  render it as an unnamed entry with no icon or description, so it is part of
+  the package rather than an extra.
+
+  Deliberately absent: <screenshots/> and a reviewed OARS content rating.
+  Both are Flathub listing requirements rather than build requirements, and
+  both need assets and a judgement call that belong to the maintainer — see
+  the distribution-channel question in the pull request.
+-->
+<component type="desktop-application">
+  <id>rs.phase.app</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>MIT OR Apache-2.0</project_license>
+
+  <name>Phase</name>
+  <summary>Play Magic: The Gathering against AI opponents and other players</summary>
+
+  <description>
+    <p>
+      phase.rs is a Magic: The Gathering game engine with an in-browser client.
+      The desktop shell loads the current release channel, so the application
+      itself stays current without reinstalling the package.
+    </p>
+    <p>Features:</p>
+    <ul>
+      <li>Play against AI opponents or other players online</li>
+      <li>Draft, sealed, and constructed formats</li>
+      <li>Deck building with the full card catalogue</li>
+    </ul>
+  </description>
+
+  <launchable type="desktop-id">rs.phase.app.desktop</launchable>
+
+  <url type="homepage">https://phase-rs.dev</url>
+  <url type="bugtracker">https://github.com/phase-rs/phase/issues</url>
+
+  <content_rating type="oars-1.1" />
+</component>

--- a/packaging/flatpak/rs.phase.app.yml
+++ b/packaging/flatpak/rs.phase.app.yml
@@ -1,0 +1,77 @@
+# Flatpak manifest for the phase.rs desktop shell.
+#
+# What this manifest deliberately does NOT contain is the point of it: no
+# WebKitGTK, no GTK, no GLib, no GStreamer. `org.gnome.Platform//50` supplies
+# every one of them. `objdump -p phase-tauri` lists 14 shared libraries plus the
+# dynamic loader; all 15 resolve inside the runtime, and the runtime's glibc
+# (2.42) clears the binary's GLIBC_2.39 floor, so the same `phase-tauri` the
+# Linux release job already builds runs here unmodified.
+#
+# That is also why this package behaves differently from the AppImage on the
+# defects tracked in #8614 and #8615: it inherits the runtime's WebKitGTK and
+# the runtime's GStreamer plugin set instead of vendoring its own.
+#
+# Build it with ./build-local.sh, which stages `phase-tauri` out of a released
+# .deb or .AppImage and then drives flatpak-builder with this file.
+app-id: rs.phase.app
+runtime: org.gnome.Platform
+runtime-version: '50'
+sdk: org.gnome.Sdk
+command: phase-tauri
+
+finish-args:
+  # The shell is a thin bootstrap: it navigates the webview to the remote
+  # channel origin (client/bootstrap/bootstrap.ts), so the app is inert
+  # without network.
+  - --share=network
+  # X11 shared-memory transport; GTK needs it alongside --socket=x11.
+  - --share=ipc
+  # Plain x11, NOT fallback-x11. fallback-x11 withholds X11 only when
+  # --socket=wayland is granted *as well* and a Wayland socket exists, so with
+  # no wayland grant here the two are equivalent today. Plain x11 is the one
+  # that stays correct the moment someone adds --socket=wayland: fallback-x11
+  # would then resolve to no X11 on a Wayland session, leaving DISPLAY unset
+  # and aborting gtk_init() while GDK_BACKEND below still pins the x11 backend.
+  # Xwayland serves the Wayland case.
+  - --socket=x11
+  # Audio. WebKitGTK has no audio stack of its own — every AudioContext is a
+  # GStreamer pipeline — and the runtime supplies the plugins (see README).
+  - --socket=pulseaudio
+  # Hardware acceleration. Without it WebKit falls back to software rendering,
+  # which is exactly the outcome the #8614 investigation was avoiding.
+  - --device=dri
+  # tao/tauri crash on the GDK Wayland backend (tauri-apps/tauri#8541), which
+  # is why the AppImage's AppRun exports the same variable. Because the backend
+  # is pinned to x11 here, --socket=wayland would grant an access this app can
+  # never use; drop this env and add that socket together, not separately.
+  - --env=GDK_BACKEND=x11
+
+modules:
+  - name: phase
+    buildsystem: simple
+    build-commands:
+      - install -Dm755 phase-tauri /app/bin/phase-tauri
+      - install -Dm644 rs.phase.app.desktop /app/share/applications/rs.phase.app.desktop
+      - install -Dm644 rs.phase.app.metainfo.xml /app/share/metainfo/rs.phase.app.metainfo.xml
+      - install -Dm644 32x32.png /app/share/icons/hicolor/32x32/apps/rs.phase.app.png
+      - install -Dm644 128x128.png /app/share/icons/hicolor/128x128/apps/rs.phase.app.png
+      - install -Dm644 128x128@2x.png /app/share/icons/hicolor/256x256/apps/rs.phase.app.png
+    sources:
+      # Staged by build-local.sh out of a released .deb or .AppImage so the
+      # package ships the exact binary users already get, rather than a
+      # separately-compiled one.
+      - type: file
+        path: build/phase-tauri
+      - type: file
+        path: rs.phase.app.desktop
+      - type: file
+        path: rs.phase.app.metainfo.xml
+      # Icons are reused from the Tauri bundle's own icon set rather than
+      # duplicated into this directory. Flatpak keys icons by app-id, so each
+      # is renamed to rs.phase.app.png at install time above.
+      - type: file
+        path: ../../client/src-tauri/icons/32x32.png
+      - type: file
+        path: ../../client/src-tauri/icons/128x128.png
+      - type: file
+        path: ../../client/src-tauri/icons/128x128@2x.png


### PR DESCRIPTION
## Summary

Adds a Flatpak package for the Linux desktop shell: a manifest, a local build script, and the shell-side guard a sandboxed package needs.

**The motivation is coverage, not just #8614.** The two Linux artifacts we ship each leave users out: the AppImage is pathological on the NVIDIA proprietary driver, and the `.deb` installs cleanly only on Debian-family distributions — a Fedora user on an NVIDIA card is served by neither. A Flatpak is the one artifact that installs identically wherever `flatpak` exists, and it inherits WebKitGTK and GStreamer from `org.gnome.Platform//50` instead of vendoring them, which is what changes its behaviour on [#8614](https://github.com/phase-rs/phase/issues/8614) and [#8615](https://github.com/phase-rs/phase/issues/8615).

**Read the first open decision before merging.** This PR deliberately does not touch the release workflow, so on its own it ships **no artifact to users** — it gives you a manifest, a verified build script, and the guard, but no prebuilt `.flatpak`. Wiring the release step is what turns this into something a user can install, and that file is yours; the proposed diff is at the bottom.

Refs #8614, refs #8615 — deliberately **not** `Closes`. This adds an artifact that routes around both defects; it does not fix the AppImage, which remains what most users download, and the #8614 root cause is still unknown. #8615's AppImage-side fix is already in flight in #8630. Closing either issue is your call, not this PR's.

## Files changed

- `packaging/flatpak/rs.phase.app.yml`
- `packaging/flatpak/build-local.sh`
- `packaging/flatpak/rs.phase.app.desktop`
- `packaging/flatpak/rs.phase.app.metainfo.xml`
- `packaging/flatpak/.gitignore`
- `client/src-tauri/src/update_authority.rs`
- `client/src-tauri/src/lib.rs`
- `client/src/pwa/__tests__/tauriUpdater.test.ts`
- `README.md`

## Track

Developer

## LLM

Model: claude-opus-5
Tier: Frontier
Thinking: high

## Implementation method (required)

Method: not-applicable — packaging and desktop-shell change. Nothing under `crates/engine/` is touched: no parser, effect, resolver, targeting, or card logic, and no `card-data.json` input.

## CR references

None. No MTG game-rules logic is added or modified.

## Verification

- [x] Required checks ran clean, or the exact CI-owned alternative is stated below.
- [x] Gate A output below is for the current committed head.
- [x] Final review-impl below is clean for the current committed head.
- [x] Both anchors cite existing analogous code at the same seam.

- `cargo fmt --all -- --check` (repo root and `client/src-tauri`) — clean, exit 0
- `cargo test --locked --manifest-path client/src-tauri/Cargo.toml` — **84 passed, 0 failed**, exit 0 (this is the exact command `ci.yml:796` runs for this crate)
- `pnpm exec vitest run src/pwa/__tests__/tauriUpdater.test.ts` — **15 passed**, exit 0
- `shellcheck packaging/flatpak/build-local.sh` — clean; `bash -n` — clean
- `desktop-file-validate packaging/flatpak/rs.phase.app.desktop` — valid
- `appstreamcli validate packaging/flatpak/rs.phase.app.metainfo.xml` — successful (2 infos, 1 pedantic: `developer-info-missing`, a Flathub listing requirement scoped out in the file's own comment)
- `pnpm tauri build --bundles deb` — `.deb` bundled (then exits 1 on updater signing; see below)
- `./packaging/flatpak/build-local.sh --deb … --install --bundle` with `flatpak-builder 1.4.10` — exit 0, zero warnings, package installed and the app verified loading the live web client (details below)
- `./scripts/check-parser-combinators.sh` — see Gate A
- `git push` pre-push hook — **"All pre-push checks passed"**, exit 0. It ran, in order: `cargo fmt --check`, workspace `cargo clippy`, card-data-validate release check, parser combinator gate, engine parser tests, phase-ai lib tests, oracle-gen, card-data-validate, coverage-report, coverage regression check, `pnpm lint` (50 warnings, **0 errors**, all pre-existing), `pnpm type-check`. `--no-verify` was not used.

Clippy note: `cargo clippy --all-targets -- -D warnings` on `phase-tauri` reports 5 warnings, all in files this PR does not touch (`native_engine.rs` ×3 `too_many_arguments`, `mobile_compat.rs` ×2 `let_unit_value`) and **zero** in the changed files. `ci.yml:67` excludes this crate from the workspace clippy run (`--workspace --exclude phase-tauri`), so these are pre-existing and not enforced for it; I have not touched them.

**Verified against the real runtime, not assumed:**

- All 15 `NEEDED` entries of the shipped `phase-tauri` (14 shared libraries + the dynamic loader) resolve inside the installed `org.gnome.Platform//50`; runtime glibc is 2.42, clearing the binary's `GLIBC_2.39` floor.
- `avdec_aac` resolves from the **base runtime's** `/usr/lib/x86_64-linux-gnu/gstreamer-1.0/libgstlibav.so`, not from `org.freedesktop.Platform.codecs-extra` — checked with `gst-inspect-1.0` inside the sandbox, and confirmed by the plugin's `Filename`. The extension is installed on this machine, so ruling it out mattered. Every element the README's Linux audio section names (`appsrc`, `appsink`, `decodebin`, `giostreamsrc`, `autoaudiosink`, `qtdemux`, `avdec_aac`) resolves.
- The package was built, installed, and launched: it renders, and its `WebKitWebProcess` maps `libEGL_nvidia.so.595.91.07` and `libnvidia-eglcore`, so it is on the NVIDIA driver rather than a software-rendering fallback. The loaded `libwebkit2gtk-4.1.so.0.21.9` hashes identically to the runtime's copy.
- `/.flatpak-info` — the marker `update_authority` keys on — is present inside the sandbox and absent on the host.

**The full build was executed end-to-end** with `flatpak-builder 1.4.10` against `org.gnome.Sdk//50`, through the script's *documented* `--deb` path and its *primary* guard path — not the `--allow-unguarded-updater` override:

- Built a real `.deb` from this branch with `pnpm tauri build --bundles deb` (the same CLI path `tauri-action` drives in CI), so the binary is production-mode and carries the guard, then ran `./packaging/flatpak/build-local.sh --deb … --install --bundle` → exit 0, **zero warnings**, confirming the trailing unguarded-build warning cannot fire on a guarded binary.
- `flatpak-builder` consumed `rs.phase.app.yml` directly: all six `install -D` commands ran, the app exported and installed, and a single-file `rs.phase.app.flatpak` bundle was written.
- The installed app's permissions match the manifest exactly — `shared=ipc;network`, `sockets=pulseaudio;x11`, `devices=dri`, `GDK_BACKEND=x11` — with no Wayland socket and no pipewire filesystem hole.
- Flatpak exported the desktop entry and all three icons under the app-id (`rs.phase.app.desktop`, `rs.phase.app.png` at 32/128/256), which is the export behaviour `flatpak_manifest_app_id_matches_the_tauri_identifier` pins.
- **The app loads.** Not just "a window appeared" — the home screen renders the live web app from `https://phase-rs.dev` (nav rail, Play vs AI / Play Online / Draft, coverage dashboard, `v0.76.0`), screenshot-verified. On the running app process: `FLATPAK_ID=rs.phase.app`, `GDK_BACKEND=x11`, the guard marker present in the running executable, `/.flatpak-info` visible in its mount namespace — so `UpdateAuthority::detect()` resolves `Flatpak` and `should_install()` returns false for every release — WebKit is the runtime's `libwebkit2gtk-4.1.so.0.21.9`, the PulseAudio socket is present, `libEGL_nvidia.so.595.91.07` is mapped, and nothing is logged to stderr.

Worth knowing if you build locally: `pnpm tauri build` **exits 1 after bundling** without `TAURI_SIGNING_PRIVATE_KEY`, because `tauri.conf.json` sets `createUpdaterArtifacts: true`. The `.deb` is complete before that point, so `build-local.sh` can consume it, but the CLI does not exit clean without the release secret.

**Limitations, stated rather than implied:**

- **Audible playback was not verified** — only that the decoder whose absence #8615 describes is present and resolvable.
- **The CPU measurements are the reporter's, not re-run here.** One machine, one NVIDIA driver (595.91.07), one distribution. Intel and other driver versions are untested. I independently reproduced the identity evidence (the runtime WebKit hash and the NVIDIA mapping), not the timings.

## Gate A

Gate A PASS head=ce574c4ad64a834f138baa3e66678870afd1481e base=5dad6ede25aaab0bafc050b35471591627d31306

## Anchored on

- `client/src-tauri/src/host_platform.rs:6` — existing typed `HostPlatform` enum answering a "how is this running" question with an enum rather than a bool; `UpdateAuthority` follows the same shape and placement (a small dedicated module beside it, `#[cfg]`-gated like `media_stack` at `client/src-tauri/src/lib.rs:6-7`).
- `client/src-tauri/src/lib.rs:405` — existing `generated_android_gradle_keeps_release_invariants`, which pins invariants by `include_str!`-ing a file and asserting required fragments; `updater_plugin_defers_to_the_update_authority` follows that pattern for the updater wiring (scanning only the pre-`mod tests` half, so it cannot match its own needles).
- `client/src-tauri/src/lib.rs:268` — existing `desktop_config_is_typed_and_preserves_the_base_authority`, which pins desktop shell config shape so drift fails loudly; `flatpak_manifest_app_id_matches_the_tauri_identifier` extends that habit to the packaging app-id.

Mechanism considered and rejected: the `tauri.android.conf.json` overlay pinned at `client/src-tauri/src/lib.rs:190` (`verify_android_config`). It cannot express this. `createUpdaterArtifacts` only controls whether a *build* emits updater signatures, this package consumes an already-built binary so no Flatpak config is ever read, and the update check is driven from `client/src/pwa/tauriUpdater.ts`, which is served remotely and shared with every desktop package. The shell is the only layer that knows how it was installed.

## Final review-impl

Final review-impl PASS head=ce574c4ad64a834f138baa3e66678870afd1481e

Five rounds, independent reviewer, fresh context, given only the diff plus `CLAUDE.md`. Round 1 returned 4 defects and 6 nits; round 2 returned 0 defects and 5 nits; rounds 3, 4 and 5 returned CLEAN. The two that mattered:

- The first version of `updater_plugin_defers_to_the_update_authority` was **self-satisfying** — `include_str!("lib.rs")` matched the needles in the test's own array, so it passed with the production wiring deleted. It now scans only the pre-`mod tests` half, verified to fail on both a deleted `.plugin(...)` block and a dropped `.default_version_comparator(...)`.
- The guard is compiled **into the binary**, so a Flatpak staged from a release predating it has no guard at all — and the README asserted otherwise. Confirmed empirically that the shipped v1.0.12 binary lacks the marker (with a positive control proving `grep -a` finds a known string in that same binary). `build-local.sh` now refuses such an artifact by default, with an explicit `--allow-unguarded-updater` override for packaging experiments.

## Claimed parse impact

None.

## Scope Expansion

Two items go beyond "add a manifest", both load-bearing for a correct package:

1. `client/src-tauri/src/update_authority.rs` + its `lib.rs` wiring. Without it a Flatpak would try to rewrite its own read-only `/app` on every update check. The change is inert outside a sandbox: the `Shell` arm restates the plugin's built-in `candidate > current` exactly, so AppImage/`.deb`/`.dmg`/`.exe` behaviour is unchanged.
2. One test added to `client/src/pwa/__tests__/tauriUpdater.test.ts`. The guard is installed as the plugin's *default* comparator, and `check({ allowDowngrades: true })` would replace it wholesale. No caller passes that today, but the web app ships independently of this binary, so the assertion pins the premise rather than leaving it a comment that expires.

## Validation Failures

None.

## CI Failures

None.

---

## Open decisions for you — deliberately not presumed

1. **Release-workflow wiring is yours — and it is the load-bearing one.** `README.md` says the release workflow is maintainer-owned and `.github/CODEOWNERS` puts `*` under @matthewevans, so this PR **ships no artifact to users by itself**. Everything else here is inert until that step exists: the manifest and script only serve local and manual builds. The proposed diff is below, and it was deliberately kept out of the commit rather than pushed into your file uninvited. Collision risk with #8630 is low — it edits the Linux apt step at `@@ -229,11 @@`, while this inserts after "Stage shell artifacts" around line 288.
2. **Distribution channel.** A `.flatpak` bundle attached to the release (matches how `.deb`/`.AppImage` ship today, and `build-local.sh --bundle` already produces one) versus a real OSTree repo or Flathub, which gets delta updates — the prior investigation measured ~1.4 MB per shell update versus ~90 MB for a full AppImage — but needs a repo and a maintainer identity.
3. **How prominently to recommend it.** Two separate audiences: **NVIDIA users**, where the AppImage is measurably bad and the README points here explicitly; and **non-Debian distributions**, where the `.deb` simply does not apply and the AppImage is today's only option. The README presents the Flatpak as the artifact covering both, without deprecating the AppImage — which stays correct on other GPU stacks. `update.json` and the updater plumbing are untouched, so nothing changes for existing users. Say if you want it promoted further (the download badge and release body are the levers) or pulled back.
4. **Runtime version pin.** `org.gnome.Platform//50` needs a bump policy. The build script now reads the version from the manifest so the two cannot drift, but nothing decides *when* to move it.
5. **Flathub listing gaps, if you go that way.** The metainfo intentionally omits `<screenshots>` and a reviewed OARS content rating — both need assets and a judgement call that are yours.

### Proposed `shell-release.yml` diff (NOT included in this PR)

Insert after the existing **Stage shell artifacts** step, which is what produces the renamed `.deb` this consumes:

```yaml
      - name: Build Flatpak (Linux)
        if: matrix.os == 'linux'
        shell: bash
        run: |
          set -euo pipefail
          sudo apt-get install -y --no-install-recommends flatpak flatpak-builder
          flatpak remote-add --user --if-not-exists flathub \
            https://dl.flathub.org/repo/flathub.flatpakrepo
          flatpak install --user -y flathub org.gnome.Platform//50 org.gnome.Sdk//50
          ./packaging/flatpak/build-local.sh \
            --deb staging/Phase-Desktop-Linux-x86_64.deb --bundle
          mv packaging/flatpak/rs.phase.app.flatpak \
            staging/Phase-Desktop-Linux-x86_64.flatpak
```

And one line added to **Validate release assets**:

```yaml
            artifacts/shell-tauri-linux/Phase-Desktop-Linux-x86_64.flatpak \
```

Notes:

- **Nothing to SHA-pin** — this adds no new Action, only shell, so it does not interact with `action-pin-audit.yml`.
- **The auto-updater stays out of it by construction.** The `update.json` platform-key assertion (`= 'darwin-aarch64,linux-x86_64,windows-x86_64'`) is untouched, so a Flatpak cannot enter the updater manifest. That is correct — `flatpak update` owns upgrades.
- **Ordering matters:** it must run after staging, because reusing the released `.deb` is what keeps the packaged binary byte-identical to what `.deb` users get.
- **Cost:** `org.gnome.Sdk//50` is a ~1.5 GB download per release run. `org.flatpak.Builder` bundles its own SDK if that is unwelcome, or the step can move to a cached job.
- **Timing:** the guard check in `build-local.sh` means this step only produces a correct package once a release containing `update_authority.rs` exists. Until then it fails closed rather than shipping a self-updating sandbox package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Flatpak packaging for the Linux desktop application, including launcher integration, application metadata, and required desktop runtime support.
  * Flatpak installations now receive updates through the package distribution mechanism, while self-managed installations continue accepting newer releases.
  * Added a local build workflow for creating, installing, bundling, or launching the Flatpak from released Linux artifacts.

* **Documentation**
  * Expanded Linux desktop and Quick Start documentation with Flatpak installation and packaging guidance, including current X11 and CI limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->