### PR TITLE
Show offline status outside game layout

### DIFF
--- a/client/src-tauri/tauri.conf.json
+++ b/client/src-tauri/tauri.conf.json
@@ -22,7 +22,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; img-src 'self' data: https://cards.scryfall.io https://backs.scryfall.io https://svgs.scryfall.io; connect-src 'self' https://phase-rs.dev https://app.phase-rs.dev https://preview.phase-rs.dev https://api.scryfall.com https://data.scryfall.io"
+      "csp": "default-src 'self'; img-src 'self' data: https://cards.scryfall.io https://backs.scryfall.io https://svgs.scryfall.io; connect-src 'self' ipc: http://ipc.localhost https://phase-rs.dev https://app.phase-rs.dev https://preview.phase-rs.dev https://api.scryfall.com https://data.scryfall.io"
     }
   },
   "bundle": {

--- a/client/src/components/chrome/AppShell.tsx
+++ b/client/src/components/chrome/AppShell.tsx
@@ -61,7 +61,6 @@ export function AppShell() {
   return (
     <ShellProvider value={true}>
       <DraftShellChromeProvider value={setDraftChromeConfig}>
-        <OfflineModeBadge />
         {/* The scene IS the relative root (matching how each page mounts it). NOTE:
           `.menu-scene` is unlayered CSS, which in Tailwind v4 outranks utilities,
           so it must not share an element with a conflicting position utility —
@@ -162,6 +161,7 @@ export function AppShell() {
                 <SocialBar />
               ) : null}
             </div>
+            <OfflineModeBadge />
             {/* Inner Suspense so a lazy route's load swaps ONLY the content area —
                 the rail/scene persist (true SPA feel). */}
             <main className={`shell-content min-h-0 min-w-0 flex-1 ${responsiveDraftChrome ? "overflow-hidden" : "max-[820px]:pb-[76px]"}`}>

--- a/client/src/components/chrome/AppShell.tsx
+++ b/client/src/components/chrome/AppShell.tsx
@@ -8,6 +8,7 @@ import { DraftSteps } from "../draft/DraftSteps";
 import { WhatsNewModal } from "../modal/WhatsNewModal";
 import { CardDataLoadingBar } from "./CardDataLoadingBar";
 import { ChromeControls } from "./ChromeControls";
+import { OfflineModeBadge } from "./OfflineModeBadge";
 import { Rail } from "./Rail";
 import { DraftShellChromeProvider, ShellProvider, type DraftShellChromeConfig } from "./ShellContext";
 import { SocialBar } from "./SocialBar";
@@ -60,6 +61,7 @@ export function AppShell() {
   return (
     <ShellProvider value={true}>
       <DraftShellChromeProvider value={setDraftChromeConfig}>
+        <OfflineModeBadge />
         {/* The scene IS the relative root (matching how each page mounts it). NOTE:
           `.menu-scene` is unlayered CSS, which in Tailwind v4 outranks utilities,
           so it must not share an element with a conflicting position utility —

--- a/client/src/components/chrome/OfflineModeBadge.tsx
+++ b/client/src/components/chrome/OfflineModeBadge.tsx
@@ -20,7 +20,7 @@ export function OfflineModeBadge() {
       role="status"
       aria-label={`${t("offlineBadge.label")}: ${reason}`}
       title={reason}
-      className="fixed left-1/2 top-[calc(env(safe-area-inset-top)+0.75rem)] z-50 flex -translate-x-1/2 items-center gap-1.5 rounded-full border border-amber-300/40 bg-slate-950/90 px-3 py-1.5 text-[11px] font-semibold text-amber-100 shadow-lg shadow-black/30 backdrop-blur-md"
+      className="pointer-events-none relative z-20 mx-auto mb-2 flex w-fit items-center gap-1.5 rounded-full border border-amber-300/40 bg-slate-950/90 px-3 py-1.5 text-[11px] font-semibold text-amber-100 shadow-lg shadow-black/30 backdrop-blur-md"
     >
       <span className="h-1.5 w-1.5 rounded-full bg-amber-300" aria-hidden />
       <span>{t("offlineBadge.label")}</span>

--- a/client/src/components/chrome/OfflineModeBadge.tsx
+++ b/client/src/components/chrome/OfflineModeBadge.tsx
@@ -1,0 +1,30 @@
+import { useTranslation } from "react-i18next";
+
+import { useConnectivityStore, useEffectiveOffline } from "../../stores/connectivityStore";
+
+/**
+ * Persistent connectivity-policy signal. Local play remains available while
+ * offline, but update and online-service lifecycles are deliberately paused.
+ */
+export function OfflineModeBadge() {
+  const { t } = useTranslation();
+  const effectiveOffline = useEffectiveOffline();
+  const forcedOffline = useConnectivityStore((state) => state.forcedOffline);
+
+  if (!effectiveOffline) return null;
+
+  const reason = t(forcedOffline ? "offlineBadge.forced" : "offlineBadge.connection");
+
+  return (
+    <div
+      role="status"
+      aria-label={`${t("offlineBadge.label")}: ${reason}`}
+      title={reason}
+      className="fixed left-1/2 top-[calc(env(safe-area-inset-top)+0.75rem)] z-50 flex -translate-x-1/2 items-center gap-1.5 rounded-full border border-amber-300/40 bg-slate-950/90 px-3 py-1.5 text-[11px] font-semibold text-amber-100 shadow-lg shadow-black/30 backdrop-blur-md"
+    >
+      <span className="h-1.5 w-1.5 rounded-full bg-amber-300" aria-hidden />
+      <span>{t("offlineBadge.label")}</span>
+      <span className="font-normal text-amber-100/75">{t("offlineBadge.servicesPaused")}</span>
+    </div>
+  );
+}

--- a/client/src/components/chrome/__tests__/AppShell.responsiveDraft.test.tsx
+++ b/client/src/components/chrome/__tests__/AppShell.responsiveDraft.test.tsx
@@ -1,8 +1,9 @@
 import { useMemo, useState } from "react";
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { MemoryRouter, Route, Routes } from "react-router";
 
+import { useConnectivityStore } from "../../../stores/connectivityStore";
 import { AppShell } from "../AppShell";
 import {
   useDraftShellChrome,
@@ -66,6 +67,10 @@ function DraftChromeProbe() {
 }
 
 describe("AppShell responsive draft chrome", () => {
+  beforeEach(() => {
+    useConnectivityStore.setState({ forcedOffline: false, browserOnline: true });
+  });
+
   afterEach(() => {
     cleanup();
     chromeControlProps.length = 0;
@@ -75,6 +80,8 @@ describe("AppShell responsive draft chrome", () => {
   });
 
   it("replaces phone navigation and socials with a top-row Home button", async () => {
+    useConnectivityStore.setState({ forcedOffline: true, browserOnline: true });
+
     render(
       <MemoryRouter initialEntries={["/draft"]}>
         <Routes>
@@ -110,6 +117,10 @@ describe("AppShell responsive draft chrome", () => {
     expect(shellSteps).toHaveTextContent("Draft");
     expect(shellSteps).toHaveClass("absolute", "inset-x-0", "z-0", "justify-center", "pointer-events-none");
     expect(screen.getByRole("link", { name: "Home" })).toHaveClass("relative", "z-10");
+    const offlineStatus = screen.getByRole("status");
+    expect(offlineStatus.previousElementSibling).toBe(phoneChromeRow);
+    expect(offlineStatus).toHaveClass("pointer-events-none", "relative");
+    expect(offlineStatus).not.toHaveClass("fixed");
     expect(screen.getByText("Draft")).toHaveAttribute("aria-current", "step");
     expect(screen.queryByTestId("social-bar")).not.toBeInTheDocument();
     expect(screen.queryByRole("navigation", { name: "Desktop navigation" })).not.toBeInTheDocument();

--- a/client/src/components/chrome/__tests__/OfflineModeBadge.test.tsx
+++ b/client/src/components/chrome/__tests__/OfflineModeBadge.test.tsx
@@ -1,0 +1,37 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { useConnectivityStore } from "../../../stores/connectivityStore";
+import { OfflineModeBadge } from "../OfflineModeBadge";
+
+describe("OfflineModeBadge", () => {
+  beforeEach(() => {
+    useConnectivityStore.setState({ forcedOffline: false, browserOnline: true });
+  });
+
+  afterEach(cleanup);
+
+  it("stays out of the way while online", () => {
+    const { container } = render(<OfflineModeBadge />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("makes an explicit Work Offline choice visible", () => {
+    useConnectivityStore.setState({ forcedOffline: true, browserOnline: true });
+
+    render(<OfflineModeBadge />);
+
+    expect(screen.getByRole("status")).toHaveTextContent("Offline");
+    expect(screen.getByRole("status")).toHaveTextContent("Online updates and services are paused.");
+    expect(screen.getByRole("status")).toHaveAttribute("title", "Work Offline is on.");
+  });
+
+  it("distinguishes a lost connection from the explicit preference", () => {
+    useConnectivityStore.setState({ forcedOffline: false, browserOnline: false });
+
+    render(<OfflineModeBadge />);
+
+    expect(screen.getByRole("status")).toHaveAttribute("title", "No network connection.");
+  });
+});

--- a/client/src/i18n/locales/de/common.json
+++ b/client/src/i18n/locales/de/common.json
@@ -62,6 +62,12 @@
     "updateIssue": "Update-Problem",
     "updated": "aktualisiert"
   },
+  "offlineBadge": {
+    "label": "Offline",
+    "servicesPaused": "Online-Aktualisierungen und Dienste sind pausiert.",
+    "forced": "Offline arbeiten ist aktiviert.",
+    "connection": "Keine Netzwerkverbindung."
+  },
   "comboDetector": {
     "label": "Combo-Detektor (experimentell)",
     "title": "Unendliche Schleifen erkennen: Pflichtschleifen automatisch beenden und ∞-Ressourcen anzeigen (standardmäßig aus)",

--- a/client/src/i18n/locales/en/common.json
+++ b/client/src/i18n/locales/en/common.json
@@ -62,6 +62,12 @@
     "updateIssue": "update issue",
     "updated": "updated"
   },
+  "offlineBadge": {
+    "label": "Offline",
+    "servicesPaused": "Online updates and services are paused.",
+    "forced": "Work Offline is on.",
+    "connection": "No network connection."
+  },
   "comboDetector": {
     "label": "Combo Detector (experimental)",
     "title": "Detect infinite loops: end mandatory loops automatically and show ∞ resources (off by default)",

--- a/client/src/i18n/locales/es/common.json
+++ b/client/src/i18n/locales/es/common.json
@@ -62,6 +62,12 @@
     "updateIssue": "problema de actualización",
     "updated": "actualizado"
   },
+  "offlineBadge": {
+    "label": "Sin conexión",
+    "servicesPaused": "Las actualizaciones y los servicios en línea están en pausa.",
+    "forced": "Trabajar sin conexión está activado.",
+    "connection": "No hay conexión de red."
+  },
   "comboDetector": {
     "label": "Detector de combos (experimental)",
     "title": "Detectar bucles infinitos: terminar bucles obligatorios automáticamente y mostrar recursos ∞ (desactivado por defecto)",

--- a/client/src/i18n/locales/fr/common.json
+++ b/client/src/i18n/locales/fr/common.json
@@ -62,6 +62,12 @@
     "updateIssue": "problème de mise à jour",
     "updated": "à jour"
   },
+  "offlineBadge": {
+    "label": "Hors ligne",
+    "servicesPaused": "Les mises à jour et services en ligne sont suspendus.",
+    "forced": "Travailler hors ligne est activé.",
+    "connection": "Aucune connexion réseau."
+  },
   "comboDetector": {
     "label": "Détecteur de combos (expérimental)",
     "title": "Détecter les boucles infinies : terminer automatiquement les boucles obligatoires et afficher les ressources ∞ (désactivé par défaut)",

--- a/client/src/i18n/locales/it/common.json
+++ b/client/src/i18n/locales/it/common.json
@@ -62,6 +62,12 @@
     "updateIssue": "problema di aggiornamento",
     "updated": "aggiornato"
   },
+  "offlineBadge": {
+    "label": "Offline",
+    "servicesPaused": "Gli aggiornamenti e i servizi online sono in pausa.",
+    "forced": "Lavora offline è attivo.",
+    "connection": "Nessuna connessione di rete."
+  },
   "comboDetector": {
     "label": "Rilevatore di combo (sperimentale)",
     "title": "Rileva i loop infiniti: termina automaticamente i loop obbligatori e mostra le risorse ∞ (disattivato per impostazione predefinita)",

--- a/client/src/i18n/locales/pl/common.json
+++ b/client/src/i18n/locales/pl/common.json
@@ -62,6 +62,12 @@
     "updateIssue": "problem z aktualizacją",
     "updated": "zaktualizowano"
   },
+  "offlineBadge": {
+    "label": "Offline",
+    "servicesPaused": "Aktualizacje i usługi online są wstrzymane.",
+    "forced": "Tryb pracy offline jest włączony.",
+    "connection": "Brak połączenia sieciowego."
+  },
   "comboDetector": {
     "label": "Wykrywacz combosów (eksperymentalne)",
     "title": "Wykrywaj nieskończone pętle: automatycznie kończ obowiązkowe pętle i pokazuj zasoby ∞ (domyślnie wyłączone)",

--- a/client/src/i18n/locales/pt/common.json
+++ b/client/src/i18n/locales/pt/common.json
@@ -62,6 +62,12 @@
     "updateIssue": "problema na atualização",
     "updated": "atualizado"
   },
+  "offlineBadge": {
+    "label": "Offline",
+    "servicesPaused": "As atualizações e os serviços online estão pausados.",
+    "forced": "Trabalhar offline está ativado.",
+    "connection": "Sem conexão de rede."
+  },
   "comboDetector": {
     "label": "Detector de combos (experimental)",
     "title": "Detectar loops infinitos: encerrar loops obrigatórios automaticamente e mostrar recursos ∞ (desativado por padrão)",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a persistent offline status badge to the application shell.
  - The badge explains whether offline mode was enabled manually or caused by a lost network connection.
  - Displays that online services are paused while offline.
  - Added translated offline status messages for supported languages.
  - Enabled required desktop application communication connections.

- **Bug Fixes**
  - Repositioned the offline badge below the top controls to prevent overlap and avoid blocking interactions.

- **Tests**
  - Added coverage for online, forced-offline, and disconnected states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->