### PR TITLE
Pin the turn window's source-controller binding (follow-up to #8620)

### DIFF
--- a/crates/engine/src/parser/oracle_classifier.rs
+++ b/crates/engine/src/parser/oracle_classifier.rs
@@ -1304,7 +1304,10 @@ mod tests {
     /// earlier check in `is_static_pattern` claims, and does so as a pure
     /// WIDENING. On the Class route (`oracle_class.rs`), `is_static_pattern` is
     /// the ONLY gate to `parse_static_line` (no ungated leftover-static
-    /// fallback exists there, unlike the normal route's `oracle.rs:7078`), so
+    /// fallback exists there, unlike the normal route's own attempt — the one
+    /// guarded by `oracle.rs`'s "Leftover permanent text can still be a valid
+    /// static even when classifier heuristics miss it" comment, which calls
+    /// `parse_static_line_with_graveyard_keyword_continuation` ungated), so
     /// this terminal peel is what makes a windowed line reachable at all for a
     /// card like Gourmand's Talent.
     #[test]

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -35590,14 +35590,44 @@ fn during_your_turn_composes_onto_subtype_land_and_color_statics() {
     let color_line =
         "During your turn, creatures you control are green in addition to their other colors.";
 
+    // Pin the CONCRETE subtype and the affected filter, not just non-emptiness:
+    // a non-empty check passes even when the parser recovers the wrong subtype
+    // or scopes the grant to the wrong controller, which is most of what could
+    // actually go wrong on these two lines.
     let subtype_def =
         parse_static_line(subtype_line).expect("subtype-granting windowed line must parse");
     assert_eq!(subtype_def.condition, Some(StaticCondition::DuringYourTurn));
-    assert!(!subtype_def.modifications.is_empty(), "{subtype_def:?}");
+    assert_eq!(
+        subtype_def.modifications,
+        vec![ContinuousModification::AddSubtype {
+            subtype: "Zombie".to_string()
+        }],
+        "{subtype_def:?}"
+    );
+    assert_eq!(
+        subtype_def.affected,
+        Some(TargetFilter::Typed(
+            TypedFilter::creature().controller(ControllerRef::You)
+        )),
+        "the grant must be scoped to creatures YOU control: {subtype_def:?}"
+    );
 
     let land_def = parse_static_line(land_line).expect("land-type windowed line must parse");
     assert_eq!(land_def.condition, Some(StaticCondition::DuringYourTurn));
-    assert!(!land_def.modifications.is_empty(), "{land_def:?}");
+    assert_eq!(
+        land_def.modifications,
+        vec![ContinuousModification::AddSubtype {
+            subtype: "Mountain".to_string()
+        }],
+        "{land_def:?}"
+    );
+    assert_eq!(
+        land_def.affected,
+        Some(TargetFilter::Typed(
+            TypedFilter::land().controller(ControllerRef::You)
+        )),
+        "the grant must be scoped to lands YOU control: {land_def:?}"
+    );
 
     let color_def = parse_static_line(color_line).expect("color-granting windowed line must parse");
     assert_eq!(color_def.condition, Some(StaticCondition::DuringYourTurn));

--- a/crates/engine/tests/integration/gourmands_talent_turn_scoped_food_grant.rs
+++ b/crates/engine/tests/integration/gourmands_talent_turn_scoped_food_grant.rs
@@ -67,7 +67,7 @@ Whenever you gain life for the first time each turn, put a +1/+1 counter on each
 /// controls, and a vanilla artifact P1 controls (the owner-vs-controller
 /// hostile row) — all on the battlefield, with mana to cover the granted
 /// ability's `{2}` cost.
-fn setup() -> (GameRunner, ObjectId, ObjectId, ObjectId, ObjectId) {
+fn setup() -> (GameRunner, ObjectId, ObjectId, ObjectId) {
     let mut scenario = GameScenario::new();
     scenario.at_phase(Phase::PreCombatMain);
     scenario.with_mana_pool(
@@ -93,7 +93,7 @@ fn setup() -> (GameRunner, ObjectId, ObjectId, ObjectId, ObjectId) {
         .id();
 
     let runner = scenario.build();
-    (runner, gourmand, p0_artifact, p1_artifact, ObjectId(0))
+    (runner, gourmand, p0_artifact, p1_artifact)
 }
 
 /// V10 + V12 + the owner/controller hostile row: the additive Food subtype
@@ -103,7 +103,7 @@ fn setup() -> (GameRunner, ObjectId, ObjectId, ObjectId, ObjectId) {
 /// receives the grant (CR 109.5) regardless of whose turn it is.
 #[test]
 fn food_subtype_only_during_controllers_turn() {
-    let (mut runner, gourmand, p0_artifact, p1_artifact, _) = setup();
+    let (mut runner, gourmand, p0_artifact, p1_artifact) = setup();
 
     // ----- Reach-guard: the level-1 line parsed to a real static, not a
     // dropped `Effect::Unimplemented`. Fails on revert (today: zero statics,
@@ -199,7 +199,7 @@ fn food_subtype_only_during_controllers_turn() {
 /// [something]` self-reference binds to the object it's on).
 #[test]
 fn granted_food_ability_activates_and_sacrifices_the_host() {
-    let (mut runner, gourmand, p0_artifact, _p1_artifact, _) = setup();
+    let (mut runner, gourmand, p0_artifact, _p1_artifact) = setup();
 
     runner.state_mut().active_player = P0;
     runner.state_mut().layers_dirty.mark_full();
@@ -412,6 +412,109 @@ fn granted_food_follows_controller_not_owner() {
     assert!(
         obj.abilities.is_empty(),
         "the granted ability must be gone on the opponent's turn: {:?}",
+        obj.abilities
+    );
+}
+
+/// CR 109.5 + CR 613.1b — the SOURCE side of the same binding: the window
+/// follows the controller of the Class, not its owner.
+///
+/// `granted_food_follows_controller_not_owner` above diverges owner from
+/// controller on the AFFECTED artifact, but leaves Gourmand's Talent itself
+/// owned and controlled by P0 — so an implementation that read the SOURCE's
+/// `owner` when evaluating `DuringYourTurn` would still pass it. This test
+/// closes that axis: P1 OWNS the Class, P0 CONTROLS it (moved through the real
+/// `Effect::GainControl` path), and the window must follow P0.
+///
+/// An owner-keyed window inverts every assertion below — it would switch the
+/// grant on during P1's turn and off during P0's.
+#[test]
+fn window_follows_source_controller_not_source_owner() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    // P0's own artifact — the grant recipient. Its control never moves, so the
+    // only owner/controller divergence in this test is on the SOURCE.
+    let p0_artifact = scenario
+        .add_artifact_from_oracle(P0, "Vanilla Artifact", "")
+        .id();
+    let thief = scenario
+        .add_creature_from_oracle(
+            P0,
+            "Enchantment Thief",
+            1,
+            1,
+            "{T}: Gain control of target enchantment.",
+        )
+        .id();
+    // OWNED BY P1. B1: subtype BEFORE oracle text (see this file's module doc).
+    let gourmand = scenario
+        .add_creature(P1, "Gourmand's Talent", 0, 0)
+        .as_enchantment()
+        .with_subtypes(vec!["Class"])
+        .from_oracle_text(GOURMANDS_TALENT)
+        .id();
+
+    let mut runner = scenario.build();
+
+    // Pre-state guard: P1 really does control its own Class right now.
+    assert_eq!(
+        runner.state().objects[&gourmand].controller,
+        P1,
+        "pre-state: the Class must start under its owner's control"
+    );
+
+    runner
+        .activate(thief, 0)
+        .target_objects(&[gourmand])
+        .resolve();
+
+    assert_eq!(
+        runner.state().objects[&gourmand].controller,
+        P0,
+        "CR 613.1b: the activated GainControl must move the Class to P0"
+    );
+    assert_eq!(
+        runner.state().objects[&gourmand].owner,
+        P1,
+        "the Class must still be OWNED by P1 — that divergence is the whole point"
+    );
+
+    // P0's turn: P0 controls the Class, so the window is open and P0's artifact
+    // is a Food. An owner-keyed window would be CLOSED here (owner is P1).
+    runner.state_mut().active_player = P0;
+    runner.state_mut().layers_dirty.mark_full();
+    evaluate_layers(runner.state_mut());
+    let obj = &runner.state().objects[&p0_artifact];
+    assert!(
+        obj.card_types.subtypes.iter().any(|s| s == "Food"),
+        "CR 109.5: 'your turn' is the CONTROLLER's turn (P0), even though P1 owns \
+         the Class: {:?}",
+        obj.card_types
+    );
+    assert_eq!(
+        obj.abilities.len(),
+        1,
+        "the granted ability must be present on the controller's turn: {:?}",
+        obj.abilities
+    );
+
+    // P1's turn: P1 OWNS the Class but no longer controls it, so the window is
+    // shut. An owner-keyed window would be OPEN here — this is the assertion
+    // that discriminates the two implementations.
+    runner.state_mut().active_player = P1;
+    runner.state_mut().layers_dirty.mark_full();
+    evaluate_layers(runner.state_mut());
+    let obj = &runner.state().objects[&p0_artifact];
+    assert!(
+        !obj.card_types.subtypes.iter().any(|s| s == "Food"),
+        "CR 102.1 + CR 109.5: the window must be shut on the OWNER's turn once \
+         control has moved away: {:?}",
+        obj.card_types
+    );
+    assert!(
+        obj.abilities.is_empty(),
+        "the granted ability must be gone on the owner's turn: {:?}",
         obj.abilities
     );
 }


### PR DESCRIPTION
## Summary

Follow-up to #8620, opened at that PR's review's request: four changes raised after it had already gone green, held back rather than pushed over a completed CI run. Comments and tests only — **no production code moves**, so #8620's parse-diff receipt is unaffected and this PR claims no parse impact of its own.

The substantive one is the third bullet below: the turn window's **source-side** control binding had no test holding it.

## Files changed

- `crates/engine/src/parser/oracle_classifier.rs`
- `crates/engine/src/parser/oracle_static/tests.rs`
- `crates/engine/tests/integration/gourmands_talent_turn_scoped_food_grant.rs`

## Track

Developer

## LLM

Model: claude-opus-5
Tier: Frontier
Thinking: high

## Implementation method (required)

Method: not-applicable — comments and tests only; zero executable production change (`crates/engine/src/parser/oracle_classifier.rs` moves one comment block, and the other two files are tests). The engine change this hardens went through `/engine-implementer` in #8620.

## CR references

- `CR 109.5` — "you"/"your" on a static ability is the current controller of the object it is on; the binding the new source-side test pins.
- `CR 613.1b` — Layer 2 control-changing effects; cited by the `Effect::GainControl` step that splits owner from controller.
- `CR 102.1` — "your turn" is the active player's turn.

No new CR annotations on production code; both numbers appear in test assertion messages and both grep-verify in `docs/MagicCompRules.txt`.

## Verification

- [x] Required checks ran clean, or the exact CI-owned alternative is stated below.
- [x] Gate A output below is for the current committed head.
- [x] Final review-impl below is clean for the current committed head.
- [x] Both anchors cite existing analogous code at the same seam.

All run at `c998d4025` on top of the merged `6b8b67e16`:

- `cargo fmt --all` — clean.
- `cargo clippy --all-targets -- -D warnings` — exit 0.
- `cargo test -p phase-engine --lib --tests` — **27,356 passed, 0 failed** (lib 20,792; aux 22; aux 9; integration 6,533).
- All 5 tests in `gourmands_talent_turn_scoped_food_grant.rs` green, including the new `window_follows_source_controller_not_source_owner`.
- `./scripts/check-parser-combinators.sh 6b8b67e166db198d46ad09b563c2d71c0ca0c4b2` — `Gate A PASS`, `Gate G PASS`.

No card-data regeneration and no fixture change: this PR adds no parser behavior, so the export is byte-identical to `6b8b67e16`.

## Gate A

Gate A PASS head=c998d4025e19e2f53ad75015798f60ba310d47c1 base=6b8b67e166db198d46ad09b563c2d71c0ca0c4b2

## Anchored on

- `crates/engine/tests/integration/gain_control_multi_target_6205.rs` (`jace_ultimate_steals_three_creatures_through_target_selection`) — the established way to drive a real `Effect::GainControl` through the runner: verbatim Oracle text on the source, `runner.activate(..).target_objects(&[..]).resolve()`, and a pre-state guard asserting the victim starts under the other player's control so the post-assertion cannot pass vacuously. `window_follows_source_controller_not_source_owner` follows that shape exactly, adding an explicit `owner` assertion because owner-vs-controller divergence is the whole point of the test.
- `crates/engine/tests/integration/gourmands_talent_turn_scoped_food_grant.rs` (`granted_food_follows_controller_not_owner`, landed in #8620) — the sibling on the *affected-object* axis. The new test is that same construction moved to the *source* object, which is the axis the sibling cannot reach.

## Final review-impl

Final review-impl PASS head=c998d4025e19e2f53ad75015798f60ba310d47c1

## Claimed parse impact

None. No production parser code changes, so no card's parse can move.

## Scope Expansion

None.

Detail on the third bullet, since it is the one that changes what the suite proves. `granted_food_follows_controller_not_owner` (from #8620) splits owner from controller on the **affected artifact**, but constructs Gourmand's Talent with `add_creature(P0, …)`, so the Class itself keeps `owner == controller == P0`. That pins the affected **filter's** control-binding and leaves the **window's** binding unguarded: an implementation resolving `DuringYourTurn` through the source's `owner` passes it unchanged. There is no live defect — `game/layers.rs` resolves `DuringYourTurn` through `state.objects[&source_id].controller`, never `owner` — but nothing held it there. `window_follows_source_controller_not_source_owner` puts the Class under P1 ownership and P0 control through a real `Effect::GainControl` and asserts the window follows P0 in both directions, so an owner-keyed implementation inverts every assertion rather than passing quietly.

## Validation Failures

None.

## CI Failures

None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added regression coverage confirming turn-based effects follow the current controller when control changes.
  - Improved validation of subtype- and land-type-granting effects, including their exact targets and modifications.
  - Expanded integration scenarios to verify behavior during both players’ turns.

- **Documentation**
  - Clarified internal test documentation for static classification behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->