### PR TITLE
Fix Ripple aborting the engine at its reveal prompt

### DIFF
--- a/crates/engine/src/game/interaction.rs
+++ b/crates/engine/src/game/interaction.rs
@@ -228,7 +228,6 @@ fn human_response_model(waiting_for: &WaitingFor, semantic_owner: PlayerId) -> H
         | WaitingFor::KeepWithinTotalPowerChoice { .. }
         | WaitingFor::KeepExactPermanentsChoice { .. }
         | WaitingFor::ScryChoice { .. }
-        | WaitingFor::RippleRevealChoice { .. }
         | WaitingFor::RippleBottomOrder { .. }
         | WaitingFor::ArrangePlanarDeckTopChoice { .. }
         | WaitingFor::DigChoice { .. }
@@ -315,6 +314,12 @@ fn human_response_model(waiting_for: &WaitingFor, semantic_owner: PlayerId) -> H
         | WaitingFor::SpliceOffer { .. }
         | WaitingFor::DefilerPayment { .. }
         | WaitingFor::CastOffer { .. }
+        // CR 702.60a: Ripple's "you **may** reveal the top N" is a binary
+        // reveal/decline offer answered with `GameAction::RippleChoice` — the
+        // same finite two-action shape as the `CastOffer` free-cast decision
+        // above it, and it selects no cards. Only `RippleBottomOrder` (the
+        // "in any order" permutation) is a `Select`.
+        | WaitingFor::RippleRevealChoice { .. }
         | WaitingFor::ModalFaceChoice { .. }
         | WaitingFor::AlternativeCastChoice { .. }
         | WaitingFor::MutateMergeChoice { .. }

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -1559,3 +1559,4 @@ mod zhulodok_double_cascade;
 
 mod context_ref_slot_hygiene;
 mod exchange_control_of_a_spell;
+mod ripple_reveal_choice_interaction;

--- a/crates/engine/tests/integration/ripple_reveal_choice_interaction.rs
+++ b/crates/engine/tests/integration/ripple_reveal_choice_interaction.rs
@@ -1,0 +1,194 @@
+//! Regression: the Ripple "you may reveal the top N" prompt panicked the
+//! interaction-opportunity builder.
+//!
+//! CR 702.60a splits Ripple into two decisions with different response shapes:
+//!
+//!   * `WaitingFor::RippleRevealChoice` — the binary "you **may** reveal"
+//!     offer, answered with `GameAction::RippleChoice { Cast | Decline }`. It
+//!     is the same response shape as the `WaitingFor::CastOffer` free-cast
+//!     decision that follows it, and it selects no cards at all.
+//!   * `WaitingFor::RippleBottomOrder` — the "in any order" permutation of the
+//!     uncast revealed pile, answered with `GameAction::SelectCards`. That one
+//!     really is a selection.
+//!
+//! `human_response_model` classified BOTH as `HumanResponseModel::Select`, but
+//! only `RippleBottomOrder` has a `selection_projection` arm. Building any
+//! viewer's interaction while the reveal offer was open therefore reached
+//! `unreachable!("selection model requires selection projection")` — a panic
+//! that aborts the WASM engine, so the user saw a bare "unreachable" and every
+//! subsequent action failed the same way.
+//!
+//! The gate is `derive_viewer_interaction` completing for both seats at each
+//! Ripple prompt, and the reveal offer presenting as a two-way offer rather
+//! than a card selection.
+
+use engine::game::interaction::{bind_interaction_authority, derive_viewer_interaction};
+use engine::game::scenario::{GameRunner, GameScenario, P0, P1};
+use engine::game::scenario_db::GameScenarioDbExt;
+use engine::types::actions::{CastChoice, GameAction};
+use engine::types::game_state::{GameState, WaitingFor};
+use engine::types::identifiers::{CardId, ObjectId};
+use engine::types::interaction::{
+    InteractionOpportunityResponse, InteractionResponseSpec, InteractionSessionId,
+};
+use engine::types::mana::{ManaType, ManaUnit};
+use engine::types::zones::Zone;
+
+use crate::support::shared_card_db as load_db;
+
+/// Give the controller a library deep enough for a Ripple 4 reveal.
+fn seed_library(runner: &mut GameRunner, count: usize) {
+    let state = runner.state_mut();
+    for i in 0..count {
+        let card_id = CardId(state.next_object_id);
+        engine::game::zones::create_object(
+            state,
+            card_id,
+            P0,
+            format!("Library Card {i}"),
+            Zone::Library,
+        );
+    }
+}
+
+fn add_mana(runner: &mut GameRunner, mana: &[ManaType]) {
+    let dummy = ObjectId(0);
+    let pool = &mut runner
+        .state_mut()
+        .players
+        .iter_mut()
+        .find(|p| p.id == P0)
+        .unwrap()
+        .mana_pool;
+    for m in mana {
+        pool.add(ManaUnit::new(*m, dummy, false, vec![]));
+    }
+}
+
+/// Return the response the prompt's controller (P0) is offered, and pin that
+/// the non-owner seat is gated out before any opportunity is built.
+///
+/// Only the owner reaches `opportunity_for_slot`: `derive_viewer_interaction`
+/// returns early with no opportunities once `can_submit` is false. That is why
+/// the crash still reached users through the AI seat's `getAiActionProposal` —
+/// `ai_semantic_owner` resolves an AI seat that is not an acting player to the
+/// live prompt's owner, so the AI built the OWNER's view, not its own.
+fn response_for_controller(state: &mut GameState) -> InteractionOpportunityResponse {
+    bind_interaction_authority(state, InteractionSessionId("test-session".to_string()))
+        .expect("interaction authority binds");
+    let state = &*state;
+    assert!(
+        derive_viewer_interaction(state, state, P1)
+            .opportunities
+            .is_empty(),
+        "the non-owner seat is gated out before an opportunity is built"
+    );
+    derive_viewer_interaction(state, state, P0)
+        .opportunities
+        .into_iter()
+        .next()
+        .expect("the prompt's controller is offered an interaction")
+        .response
+}
+
+/// CR 702.60a: drive a Ripple 4 spell to its reveal offer and assert the
+/// interaction builder survives both Ripple prompts for both seats.
+#[test]
+fn ripple_prompts_derive_interaction_for_every_seat() {
+    let Some(db) = load_db() else {
+        return;
+    };
+
+    let mut scenario = GameScenario::new();
+    let spell = scenario.add_real_card(P0, "Surging Flame", Zone::Hand, db);
+    let hit = scenario.add_real_card(P0, "Surging Flame", Zone::Library, db);
+    let mut runner = scenario.build();
+    engine::game::rehydrate_game_from_card_db(runner.state_mut(), db);
+    seed_library(&mut runner, 4);
+    // CR 702.60a: put the same-named card inside the revealed top four so the
+    // reveal offer is followed by a free-cast offer and a bottom-order prompt —
+    // all three Ripple prompts on one run.
+    {
+        let state = runner.state_mut();
+        let player = state.players.iter_mut().find(|p| p.id == P0).unwrap();
+        player.library.retain(|id| *id != hit);
+        player.library.push_front(hit);
+    }
+    add_mana(&mut runner, &[ManaType::Red, ManaType::Red, ManaType::Red]);
+
+    let mut commit = runner.cast(spell).target_player(P1).commit();
+
+    // CR 603.3 + CR 608.1: the Ripple trigger became the topmost object on the
+    // stack, so the first pair of passes resolves it and opens the reveal.
+    commit.act(GameAction::PassPriority).expect("P0 passes");
+    commit.act(GameAction::PassPriority).expect("P1 passes");
+
+    assert!(
+        matches!(
+            commit.state_mut().waiting_for,
+            WaitingFor::RippleRevealChoice { .. }
+        ),
+        "the resolved Ripple trigger must open the optional-reveal prompt, got {:?}",
+        commit.state_mut().waiting_for
+    );
+    // CR 702.60a: the reveal offer is a finite two-way decision, so it must
+    // present as exact choices (reveal / decline) rather than a card selection.
+    let reveal = response_for_controller(commit.state_mut());
+    match &reveal {
+        InteractionOpportunityResponse::ExactChoices { choices } => assert_eq!(
+            choices.len(),
+            2,
+            "the reveal offer is exactly reveal-or-decline, got {choices:?}"
+        ),
+        other => panic!("reveal offer must present as exact choices, got {other:?}"),
+    }
+
+    // CR 702.60a: accepting the reveal opens the free-cast offer for the
+    // same-named card, which shares the reveal prompt's response shape.
+    commit
+        .act(GameAction::RippleChoice {
+            choice: CastChoice::Cast,
+        })
+        .expect("reveal accepted");
+    assert!(
+        matches!(commit.state_mut().waiting_for, WaitingFor::CastOffer { .. }),
+        "revealing a same-named card must open the free-cast offer, got {:?}",
+        commit.state_mut().waiting_for
+    );
+    // CR 702.60a: the free-cast offer shares the reveal offer's shape — this is
+    // the sibling the reveal decision was mistakenly separated from.
+    let offer = response_for_controller(commit.state_mut());
+    assert!(
+        matches!(offer, InteractionOpportunityResponse::ExactChoices { .. }),
+        "the Ripple free-cast offer must present as exact choices, got {offer:?}"
+    );
+
+    // CR 702.60a + CR 608.2d: declining the free cast bottoms the whole pile,
+    // which is the genuine selection prompt of the three.
+    commit
+        .act(GameAction::RippleChoice {
+            choice: CastChoice::Decline,
+        })
+        .expect("free cast declined");
+    assert!(
+        matches!(
+            commit.state_mut().waiting_for,
+            WaitingFor::RippleBottomOrder { .. }
+        ),
+        "declining the free cast must open the bottom-order prompt, got {:?}",
+        commit.state_mut().waiting_for
+    );
+    // CR 608.2d: the bottom-placement order genuinely IS a selection — the one
+    // Ripple prompt that belongs to the `Select` response model.
+    let order = response_for_controller(commit.state_mut());
+    assert!(
+        matches!(
+            order,
+            InteractionOpportunityResponse::Schema {
+                spec: InteractionResponseSpec::Select { .. },
+                ..
+            }
+        ),
+        "the bottom-order prompt must present as a selection schema, got {order:?}"
+    );
+}


### PR DESCRIPTION
## Summary

Every Ripple card aborted the WASM engine the moment its trigger resolved: `human_response_model` classified `WaitingFor::RippleRevealChoice` as `HumanResponseModel::Select`, but only `RippleBottomOrder` has a `selection_projection` arm, so building the prompt owner's interaction hit `unreachable!("selection model requires selection projection")`. This moves that one variant to `ExactCandidates(AuditedExactCandidates)` beside its sibling `WaitingFor::CastOffer` and adds a regression test.

## Files changed

- `crates/engine/src/game/interaction.rs` — move `WaitingFor::RippleRevealChoice` from the `Select` arm to `ExactCandidates(AuditedExactCandidates)`, with a CR 702.60a note on why.
- `crates/engine/tests/integration/ripple_reveal_choice_interaction.rs` — new regression test.
- `crates/engine/tests/integration/main.rs` — `mod` line for the above.

### Why this seam

CR 702.60a splits Ripple into two decisions with different response shapes. The reveal offer is a binary "you **may** reveal", answered with `GameAction::RippleChoice { Cast | Decline }`, and selects no cards. The bottom placement is the CR 608.2d "in any order" permutation, answered with `GameAction::SelectCards`. Only the second is a selection.

Every other classifier in the file already grouped them that way — `classify_waiting_for` and `selection_projection` both place `RippleRevealChoice` beside `CastOffer` and `RippleBottomOrder` with the selection prompts. `human_response_model` was the lone outlier, so the fix is to bring it into line rather than to invent a projection for a prompt that selects nothing.

`ExactCandidates`' `AuditedExactCandidates` token is an explicit completeness claim, and it holds: `ai_support::candidates` enumerates this prompt as exactly Cast and Decline, with no pruning.

### Blast radius, and how it reached users

`crates/engine/src/game/interaction.rs` has three `human_response_model` call sites. Only `opportunity_for_slot` panics on a missing projection; `materialize_response` falls through an `if let Some(..)` and `attachment_fans_for_slot` uses `.ok().flatten()`. `opportunity_for_slot` has exactly one caller, `derive_viewer_interaction`.

The release profile sets `panic = 'abort'`, so the panic aborts the module and reaches the client as the bare string `"unreachable"` with no diagnostic value. `derive_viewer_interaction` returns early with no opportunities once `can_submit` is false, so only the prompt's owner reaches the panic — but the AI seat still hit it, because `ai_semantic_owner` (`crates/engine-wasm/src/lib.rs:603`) resolves an AI seat that is not an acting player to the live prompt's owner. That is why the user-visible symptom was a repeating `ai-getAction-panic` on an opponent's Ripple.

I checked the rest of the class rather than only this variant: after the fix, no `Select`-classified variant lacks a `selection_projection` arm. `PayCost` appears in both lists only at variant granularity — its `RemoveCounter { selection: AmongObjects }` sub-pattern is routed to `AssignAmounts` by an earlier arm, so the two matches agree at sub-pattern granularity.

Nothing prevents this mismatch recurring on another variant, and the penalty is a production WASM abort. A `syn` source census asserting the two sets stay disjoint (following `waiting_for_actor_authority_census.rs`) would close the class; I left it out of this PR as separate work.

## Track

Developer

## LLM

Model: claude-opus-5
Tier: Frontier
Thinking: high

## Implementation method (required)

Method: not-applicable — this changes the interaction/protocol response-model classifier, not engine game logic. No parser, effect, resolver, targeting, or rules behavior is touched; the diff is one variant moved between arms of a presentation classifier plus a test.

## CR references

- `CR 702.60a` — Ripple's two decisions; cited in the new classifier comment. Verified at `docs/MagicCompRules.txt:4466`.
- `CR 608.2d` — choices announced while applying an effect; cited on the bottom-order step. Verified at `docs/MagicCompRules.txt:2799`.
- `CR 603.3` + `CR 608.1` — the trigger becomes the topmost stack object and resolves when all players pass. Verified at `docs/MagicCompRules.txt:2585` and `:2787`.

## Verification

- [x] Required checks ran clean, or the exact CI-owned alternative is stated below.
- [x] Gate A output below is for the current committed head.
- [x] Final review-impl below is clean for the current committed head.
- [x] Both anchors cite existing analogous code at the same seam.

All Tilt resources (`clippy`, `test-engine`, `wasm`, `check-frontend`) were **disabled** on this machine, so every check was run directly rather than through `tilt-wait.sh`.

- `cargo fmt --all` — clean.
- `cargo clippy -p phase-engine --all-targets` — clean.
- `cargo nextest run -p phase-engine` — 27301/27302 passed. The single failure, `game_state_stack_budget::four_player_commander_action_fits_a_bounded_stack` (SIGABRT), is **pre-existing and unrelated**: it fails identically on the base commit, captured in this machine's Tilt `test-engine` log before this branch existed (`26708 passed, 1 failed`, same test). It is a 3 MiB-thread stack-depth budget test and touches nothing in this diff.
- `cargo nextest run -p phase-ai` — 2525 passed.
- `cargo nextest run -p phase-engine --test integration ripple_prompts_derive` — passes; reverting the production line reproduces `panicked at crates/engine/src/game/interaction.rs:8367:29: internal error: entered unreachable code: selection model requires selection projection`, byte-identical to the user's report.

Three environment notes, all stated rather than worked around:

- **The `pre-push` hook could not run.** It aborted partway through `cargo clippy --workspace --all-targets --features engine/proptest` with `error: failed to build archive at target/debug/deps/libengine-*.rlib: No space left on device (os error 28)`. The machine is at 100% disk (1.2 GiB free of 926 GiB; `target/` alone is 493 GB). This is an environment failure, not a finding — the hook never reached a check that could pass or fail on the diff. Pushed with `--no-verify`, which is the same path this repo's `ship-commits` skill takes. The hook's Rust checks are covered directly above; its workspace-wide clippy, card-data pipeline, coverage-regression, and frontend checks are left to CI and have NOT been run locally.

- Committed with `--no-verify`: `scripts/check-prelowered-ratchet.sh` uses `declare -A` and cannot run under this machine's bash 3.2.57 (the only `bash` present). That gate counts `OracleNodeIr::PreLowered*` producers under `crates/engine/src/parser`; this diff touches no parser file and adds no `PreLowered` occurrence. The parser combinator gate in the same hook ran and passed before the ratchet aborted.
- `client/src/wasm/engine_wasm.d.ts` is modified in my working tree by a local `wasm-dev` build and is **deliberately not in this commit** — it drops exports (`init_panic_hook`, `get_game_state`, `get_legal_actions_js`, `getFormatRegistry`, `create_initial_state`, `clear_replay_playback`, `get_stack_pressure`) and is unrelated generated churn, not an intended API change.

## Gate A

```
Gate G PASS (router/grant architecture: strict router vs permissive grant boundary intact)
Gate A SKIPPED (no files under crates/engine/src/parser changed in 96e2bc518318227e9c1caeabad6491fcaa177d2d..84bc9cd44608ad5f2a83ee28400677d12b4445cc)
Gate A PASS head=84bc9cd44608ad5f2a83ee28400677d12b4445cc base=96e2bc518318227e9c1caeabad6491fcaa177d2d
```

## Anchored on

- `crates/engine/src/game/interaction.rs:562` — `classify_waiting_for` already groups `RippleRevealChoice` with `CastOffer` in one `Choose` arm; this change makes `human_response_model` agree with it.
- `crates/engine/src/game/interaction.rs:4546` — `selection_projection` already groups `RippleRevealChoice` with `CastOffer` in its `None` arm, which is what made the old `Select` classification unanswerable.
- `crates/engine/src/ai_support/candidates.rs:686` — the sibling `CastOffer { kind: Ripple }` producer, a complete two-action Cast/Decline enumeration; `candidates.rs:714` is this prompt's own producer with the same shape, which is what `AuditedExactCandidates` asserts.

## Final review-impl

Final review-impl PASS head=84bc9cd44608ad5f2a83ee28400677d12b4445cc

Run in-session via the repo's `review-impl` skill against the committed head (not by an independent agent — flagging that so a maintainer can weigh it). It raised two findings, both on the new test, both fixed in the amended head:

- **MED** — the test's "both seats" rationale was false and its non-owner call was inert, because `derive_viewer_interaction` early-returns on `!can_submit`. The call is now an assertion that the non-owner receives zero opportunities, and the comment states the real route through `ai_semantic_owner`.
- **LOW** — `CR 603.3b` was miscited (that rule covers ordering *multiple simultaneous* triggers). Corrected to `CR 603.3 + CR 608.1`.

Re-reviewed the amended delta: the new negative assertion is paired with a positive reach-guard in the same test (the owner's opportunity and its exact response shape), so it is not vacuous.

## Claimed parse impact

None.

## Scope Expansion

None.

## Validation Failures

None.

## CI Failures

None observed — but note that the local `pre-push` gate could not run to completion (disk exhaustion, detailed under Verification), so CI is the first place the workspace-wide clippy, card-data, coverage-regression, and frontend checks will execute for this branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed an issue where opening Ripple’s reveal prompt could cause the game engine to stop responding.
  - The reveal decision now displays the correct two choices: reveal or decline.
  - Ripple’s subsequent card-ordering prompt continues to use the appropriate card-selection interface.
  - Interaction prompts now appear correctly for all players during Ripple resolution.

- **Tests**
  - Added coverage for the complete Ripple interaction flow, including reveal, free-cast, and card-ordering decisions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->