### PR TITLE
ship/fix lobby dedupe aggregate online count

### DIFF
--- a/client/src/components/lobby/LobbyView.tsx
+++ b/client/src/components/lobby/LobbyView.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import type { FormatGroup, GameFormat } from "../../adapter/types";
+import { OFFICIAL_MULTIPLAYER_SERVER_URL } from "../../config/multiplayerServer";
 import { FORMAT_REGISTRY } from "../../data/formatRegistry";
 import { flagForServer, parseJoinCode } from "../../services/serverDetection";
 import { healthHint, refreshServerDirectory } from "../../services/serverDirectory";
@@ -412,29 +413,14 @@ export function LobbyView({
     });
   }, [entries, formatFilter, roomTypeFilter]);
 
-  // Every enabled source reports the number of WebSocket connections it sees,
-  // not identities that can be unioned across servers. The same player usually
-  // holds one lobby-broker socket and one or more dedicated-server sockets, so
-  // adding those cardinalities double-counts the overlapping population. Use
-  // the largest live count as the aggregate estimate instead. Two rules, both
-  // structural:
-  //   membership — selected from the CURRENT sources (as in `entries`), so a
-  //     source the user has removed leaves the estimate immediately;
-  //   liveness   — the count is read from that source's status row, which
-  //     the store rewrites on every connection state change and refills
-  //     only from a frame on the socket that is live now. A source that is
-  //     reconnecting, offline, or freshly re-opened without having reported
-  //     since therefore contributes nothing; there is no cached number here
-  //     that could outlive the socket that sent it.
-  const playerCount = useMemo(
-    () =>
-      sources.reduce(
-        (largest, source) =>
-          Math.max(largest, sourceStatus.get(source.url)?.playerCount ?? 0),
-        0,
-      ),
-    [sources, sourceStatus],
-  );
+  // The badge describes the shared online lobby, so its broker is the single
+  // population authority. Dedicated servers report their own WebSocket counts,
+  // which overlap with the broker population and with one another; neither a
+  // sum nor a maximum can recover a distinct-player count from those aggregate
+  // values. The status row is socket-generation scoped, so a disconnected or
+  // reconnecting broker contributes no stale count.
+  const playerCount =
+    sourceStatus.get(OFFICIAL_MULTIPLAYER_SERVER_URL)?.playerCount ?? 0;
 
   // Count-free by design: the picker lists each source with its own status,
   // which is where a number would be actionable.

--- a/client/src/components/lobby/LobbyView.tsx
+++ b/client/src/components/lobby/LobbyView.tsx
@@ -412,11 +412,14 @@ export function LobbyView({
     });
   }, [entries, formatFilter, roomTypeFilter]);
 
-  // Every enabled source reports its own online count; the chip shows the
-  // total reach of the lobby the user is browsing. Two rules, both
+  // Every enabled source reports the number of WebSocket connections it sees,
+  // not identities that can be unioned across servers. The same player usually
+  // holds one lobby-broker socket and one or more dedicated-server sockets, so
+  // adding those cardinalities double-counts the overlapping population. Use
+  // the largest live count as the aggregate estimate instead. Two rules, both
   // structural:
-  //   membership — summed over the CURRENT sources (as in `entries`), so a
-  //     source the user has removed leaves the total immediately;
+  //   membership — selected from the CURRENT sources (as in `entries`), so a
+  //     source the user has removed leaves the estimate immediately;
   //   liveness   — the count is read from that source's status row, which
   //     the store rewrites on every connection state change and refills
   //     only from a frame on the socket that is live now. A source that is
@@ -426,7 +429,8 @@ export function LobbyView({
   const playerCount = useMemo(
     () =>
       sources.reduce(
-        (sum, source) => sum + (sourceStatus.get(source.url)?.playerCount ?? 0),
+        (largest, source) =>
+          Math.max(largest, sourceStatus.get(source.url)?.playerCount ?? 0),
         0,
       ),
     [sources, sourceStatus],

--- a/client/src/components/lobby/__tests__/LobbyView.test.tsx
+++ b/client/src/components/lobby/__tests__/LobbyView.test.tsx
@@ -446,12 +446,22 @@ describe("LobbyView", () => {
     return ambient;
   }
 
+  it("does not add overlapping per-source connection counts", async () => {
+    renderTwoSources();
+
+    // Every lobby client subscribes to each enabled source, so these are
+    // overlapping cardinalities rather than disjoint populations. The largest
+    // live report is the de-duplicated aggregate estimate.
+    expect(await screen.findByText("5 online")).toBeInTheDocument();
+    expect(screen.queryByText("8 online")).not.toBeInTheDocument();
+  });
+
   it("counts only the sources still being browsed", async () => {
     renderTwoSources();
 
-    // Reach-guard: both counts really are in the total before the removal, so
+    // Reach-guard: B's larger count owns the estimate before the removal, so
     // the assertion after it measures the drop and not an empty chip.
-    expect(await screen.findByText("8 online")).toBeInTheDocument();
+    expect(await screen.findByText("5 online")).toBeInTheDocument();
 
     act(() => {
       useMultiplayerStore.setState({ userLobbySources: [SOURCE_A] });
@@ -460,15 +470,15 @@ describe("LobbyView", () => {
     // B's status row (and its count) survives until its channel closes; the
     // chip must not keep counting a server nobody browses.
     expect(await screen.findByText("3 online")).toBeInTheDocument();
-    expect(screen.queryByText("8 online")).not.toBeInTheDocument();
+    expect(screen.queryByText("5 online")).not.toBeInTheDocument();
   });
 
   it("drops a source's count from the total once that source goes offline", async () => {
     renderTwoSources();
 
-    // Reach-guard: both counts really are in the total while both sources are
+    // Reach-guard: B's larger count owns the estimate while both sources are
     // open, so the assertion after the flap measures the drop.
-    expect(await screen.findByText("8 online")).toBeInTheDocument();
+    expect(await screen.findByText("5 online")).toBeInTheDocument();
 
     act(() => {
       useMultiplayerStore.setState({
@@ -482,7 +492,7 @@ describe("LobbyView", () => {
     // is delivering nothing — counting it would advertise players on a
     // server shown as offline.
     expect(await screen.findByText("3 online")).toBeInTheDocument();
-    expect(screen.queryByText("8 online")).not.toBeInTheDocument();
+    expect(screen.queryByText("5 online")).not.toBeInTheDocument();
   });
 
   it("does not re-admit a source's old count when it reconnects without reporting", async () => {
@@ -491,9 +501,9 @@ describe("LobbyView", () => {
     // number must not come back — nothing live is backing it.
     renderTwoSources();
 
-    // Reach-guard: the pre-flap total is really 8, so the assertions below
+    // Reach-guard: the pre-flap estimate is really 5, so the assertions below
     // measure the count staying out and not an empty chip.
-    expect(await screen.findByText("8 online")).toBeInTheDocument();
+    expect(await screen.findByText("5 online")).toBeInTheDocument();
 
     act(() => {
       useMultiplayerStore.setState({
@@ -509,7 +519,7 @@ describe("LobbyView", () => {
     });
 
     expect(await screen.findByText("3 online")).toBeInTheDocument();
-    expect(screen.queryByText("8 online")).not.toBeInTheDocument();
+    expect(screen.queryByText("5 online")).not.toBeInTheDocument();
   });
 
   it("keeps its ambient subscription across a source's connection flap", async () => {

--- a/client/src/components/lobby/__tests__/LobbyView.test.tsx
+++ b/client/src/components/lobby/__tests__/LobbyView.test.tsx
@@ -3,6 +3,7 @@ import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import type { LobbyGame } from "../../../adapter/types";
+import { OFFICIAL_MULTIPLAYER_SERVER_URL } from "../../../config/multiplayerServer";
 import { LobbyView } from "../LobbyView";
 import { SERVER_PRESETS } from "../../../services/serverDetection";
 import type { DirectorySource } from "../../../services/serverDirectory";
@@ -438,7 +439,11 @@ describe("LobbyView", () => {
     const ambient = ambientFanOut();
     useMultiplayerStore.setState({
       userLobbySources: [SOURCE_A, SOURCE_B],
-      sourceStatus: statusRows([SOURCE_A.url, "open", 3], [SOURCE_B.url, "open", 5]),
+      sourceStatus: statusRows(
+        [OFFICIAL_MULTIPLAYER_SERVER_URL, "open", 4],
+        [SOURCE_A.url, "open", 3],
+        [SOURCE_B.url, "open", 5],
+      ),
       subscribeLobby: vi.fn(async () => () => {}),
       subscribeAmbientLobby: ambient.subscribe,
     });
@@ -446,80 +451,73 @@ describe("LobbyView", () => {
     return ambient;
   }
 
-  it("does not add overlapping per-source connection counts", async () => {
+  it("uses the lobby broker as the online-population authority", async () => {
     renderTwoSources();
 
-    // Every lobby client subscribes to each enabled source, so these are
-    // overlapping cardinalities rather than disjoint populations. The largest
-    // live report is the de-duplicated aggregate estimate.
-    expect(await screen.findByText("5 online")).toBeInTheDocument();
-    expect(screen.queryByText("8 online")).not.toBeInTheDocument();
+    // The broker reports 4 while dedicated sources report 3 and 5. Neither
+    // summing (12) nor taking the largest local count (5) is the lobby total.
+    expect(await screen.findByText("4 online")).toBeInTheDocument();
+    expect(screen.queryByText("5 online")).not.toBeInTheDocument();
+    expect(screen.queryByText("12 online")).not.toBeInTheDocument();
   });
 
-  it("counts only the sources still being browsed", async () => {
+  it("does not change the lobby count when a dedicated source is removed", async () => {
     renderTwoSources();
 
-    // Reach-guard: B's larger count owns the estimate before the removal, so
-    // the assertion after it measures the drop and not an empty chip.
-    expect(await screen.findByText("5 online")).toBeInTheDocument();
+    expect(await screen.findByText("4 online")).toBeInTheDocument();
 
     act(() => {
       useMultiplayerStore.setState({ userLobbySources: [SOURCE_A] });
     });
 
-    // B's status row (and its count) survives until its channel closes; the
-    // chip must not keep counting a server nobody browses.
-    expect(await screen.findByText("3 online")).toBeInTheDocument();
-    expect(screen.queryByText("5 online")).not.toBeInTheDocument();
+    expect(await screen.findByText("4 online")).toBeInTheDocument();
   });
 
-  it("drops a source's count from the total once that source goes offline", async () => {
+  it("hides the count when the lobby broker goes offline", async () => {
     renderTwoSources();
 
-    // Reach-guard: B's larger count owns the estimate while both sources are
-    // open, so the assertion after the flap measures the drop.
-    expect(await screen.findByText("5 online")).toBeInTheDocument();
+    expect(await screen.findByText("4 online")).toBeInTheDocument();
 
     act(() => {
       useMultiplayerStore.setState({
-        // Leaving `"open"` rewrites the row without a count — exactly what
-        // the store does on the `"offline"` transition.
-        sourceStatus: statusRows([SOURCE_A.url, "open", 3], [SOURCE_B.url, "offline", null]),
+        sourceStatus: statusRows(
+          [OFFICIAL_MULTIPLAYER_SERVER_URL, "offline", null],
+          [SOURCE_A.url, "open", 3],
+          [SOURCE_B.url, "open", 5],
+        ),
       });
     });
 
-    // B is still a browsed source (the picker shows it, marked down), but it
-    // is delivering nothing — counting it would advertise players on a
-    // server shown as offline.
-    expect(await screen.findByText("3 online")).toBeInTheDocument();
-    expect(screen.queryByText("5 online")).not.toBeInTheDocument();
+    expect(screen.queryByText(/\d+ online/)).not.toBeInTheDocument();
   });
 
-  it("does not re-admit a source's old count when it reconnects without reporting", async () => {
-    // The state a flapped source spends the rest of the session in: back to
-    // `"open"`, on a NEW socket that has sent no `PlayerCount` yet. The old
-    // number must not come back — nothing live is backing it.
+  it("does not re-admit the broker's old count when it reconnects without reporting", async () => {
     renderTwoSources();
 
-    // Reach-guard: the pre-flap estimate is really 5, so the assertions below
-    // measure the count staying out and not an empty chip.
-    expect(await screen.findByText("5 online")).toBeInTheDocument();
+    expect(await screen.findByText("4 online")).toBeInTheDocument();
 
     act(() => {
       useMultiplayerStore.setState({
-        sourceStatus: statusRows([SOURCE_A.url, "open", 3], [SOURCE_B.url, "offline", null]),
+        sourceStatus: statusRows(
+          [OFFICIAL_MULTIPLAYER_SERVER_URL, "offline", null],
+          [SOURCE_A.url, "open", 3],
+          [SOURCE_B.url, "open", 5],
+        ),
       });
     });
-    expect(await screen.findByText("3 online")).toBeInTheDocument();
+    expect(screen.queryByText(/\d+ online/)).not.toBeInTheDocument();
 
     act(() => {
       useMultiplayerStore.setState({
-        sourceStatus: statusRows([SOURCE_A.url, "open", 3], [SOURCE_B.url, "open", null]),
+        sourceStatus: statusRows(
+          [OFFICIAL_MULTIPLAYER_SERVER_URL, "open", null],
+          [SOURCE_A.url, "open", 3],
+          [SOURCE_B.url, "open", 5],
+        ),
       });
     });
 
-    expect(await screen.findByText("3 online")).toBeInTheDocument();
-    expect(screen.queryByText("5 online")).not.toBeInTheDocument();
+    expect(screen.queryByText(/\d+ online/)).not.toBeInTheDocument();
   });
 
   it("keeps its ambient subscription across a source's connection flap", async () => {
@@ -535,12 +533,20 @@ describe("LobbyView", () => {
 
     act(() => {
       useMultiplayerStore.setState({
-        sourceStatus: statusRows([SOURCE_A.url, "open", 3], [SOURCE_B.url, "reconnecting", null]),
+        sourceStatus: statusRows(
+          [OFFICIAL_MULTIPLAYER_SERVER_URL, "open", 4],
+          [SOURCE_A.url, "open", 3],
+          [SOURCE_B.url, "reconnecting", null],
+        ),
       });
     });
     act(() => {
       useMultiplayerStore.setState({
-        sourceStatus: statusRows([SOURCE_A.url, "open", 3], [SOURCE_B.url, "open", null]),
+        sourceStatus: statusRows(
+          [OFFICIAL_MULTIPLAYER_SERVER_URL, "open", 4],
+          [SOURCE_A.url, "open", 3],
+          [SOURCE_B.url, "open", null],
+        ),
       });
     });
 


### PR DESCRIPTION
- **fix(lobby): dedupe aggregate online count**
- **fix(lobby): use broker as online count authority**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the online player-count badge to show the official multiplayer lobby’s population.
  * The count no longer combines players from individually browsed servers.
  * The badge is hidden when the official lobby is offline or has not reported a current count.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->