### PR TITLE
fix(wasm): discard stale AI stack-pass proposals

### DIFF
--- a/crates/engine-wasm/src/lib.rs
+++ b/crates/engine-wasm/src/lib.rs
@@ -8,8 +8,9 @@ use serde::Serialize;
 use wasm_bindgen::prelude::*;
 
 use engine::ai_support::{
-    auto_pass_recommended, auto_pass_recommended_for_viewer, end_continuous_effect_offers,
-    legal_actions_for_viewer, legal_actions_full, AiDecisionContract,
+    apply_ai_action_proposal, auto_pass_recommended, auto_pass_recommended_for_viewer,
+    end_continuous_effect_offers, legal_actions_for_viewer, legal_actions_full,
+    AiDecisionContract, AiProposalApplication,
 };
 use engine::database::legality::{any_ai_difficulty_is_cedh, validate_cedh_bracket};
 use engine::database::{CardDatabase, CardSearchQuery};
@@ -512,137 +513,6 @@ enum AiProposalSubmission {
     Rejected {
         rejection: ActionRejection,
     },
-}
-
-/// Natively-testable core of the AI proposal submission boundary. The
-/// `wasm_bindgen` shell owns proposal-token lookup and serialization; this core
-/// owns the state/contract decision that must be identical for browser and
-/// native regression coverage.
-enum AiProposalApplication {
-    AppliedStackPass {
-        result: Box<engine::types::game_state::ActionResult>,
-    },
-    AppliedAction {
-        result: Box<engine::types::game_state::ActionResult>,
-    },
-    Stale,
-    Rejected {
-        rejection: ActionRejection,
-    },
-}
-
-fn apply_ai_action_proposal_inner(
-    state: &mut GameState,
-    contract: &AiDecisionContract,
-    actor: PlayerId,
-    action: GameAction,
-) -> AiProposalApplication {
-    // Classification lives in the engine (`verified_ai_stack_pass_player`),
-    // not in this adapter: it is the same call the callee gates on, so the
-    // two cannot disagree. CLAUDE.md — transport layers hold zero game logic.
-    let verified_stack_pass =
-        engine::game::engine::verified_ai_stack_pass_player(state, &action).is_some();
-    // Every proposal, including a stack recheck pass, is bound to the revision
-    // that issued it. Resolve All legitimately advances that revision while an
-    // AI proposal is in flight; report the old capability as stale so the
-    // controller re-queries instead of counting an ordinary race as an AI
-    // failure.
-    if !contract.permits(state, actor, &action) {
-        return AiProposalApplication::Stale;
-    }
-    let applied = if verified_stack_pass {
-        engine::game::engine::apply_verified_ai_priority_pass_with_rejection(
-            state, actor, contract, action,
-        )
-    } else {
-        apply_interaction_with_rejection(state, actor, contract.semantic_owner, action)
-    };
-    match applied {
-        Ok(result) if verified_stack_pass => AiProposalApplication::AppliedStackPass {
-            result: Box::new(result),
-        },
-        Ok(result) => AiProposalApplication::AppliedAction {
-            result: Box::new(result),
-        },
-        Err(rejection) => AiProposalApplication::Rejected { rejection },
-    }
-}
-
-#[cfg(test)]
-mod ai_proposal_submission_tests {
-    use super::*;
-    use engine::types::ability::{Effect, ResolvedAbility};
-    use engine::types::game_state::{
-        StackEntry, StackEntryKind, StackResolutionPolicy, WaitingFor,
-    };
-    use engine::types::identifiers::ObjectId;
-    use engine::types::phase::Phase;
-
-    fn priority_state(player: PlayerId) -> GameState {
-        let mut state = GameState::new_two_player(42);
-        state.phase = Phase::PreCombatMain;
-        state.active_player = player;
-        state.priority_player = player;
-        state.waiting_for = WaitingFor::Priority { player };
-        state
-    }
-
-    fn no_op_stack_entry(id: u64, controller: PlayerId) -> StackEntry {
-        let object_id = ObjectId(id);
-        StackEntry {
-            id: object_id,
-            source_id: object_id,
-            controller,
-            kind: StackEntryKind::ActivatedAbility {
-                source_id: object_id,
-                ability: Box::new(ResolvedAbility::new(
-                    Effect::NoOp,
-                    vec![],
-                    object_id,
-                    controller,
-                )),
-            },
-        }
-    }
-
-    #[test]
-    fn stack_pass_proposal_uses_the_verified_recheck_seam() {
-        let player = PlayerId(0);
-        let mut state = priority_state(player);
-        state
-            .stack
-            .push_back(no_op_stack_entry(70_101, PlayerId(1)));
-        let contract = AiDecisionContract::issue(&state, player);
-
-        assert!(matches!(
-            apply_ai_action_proposal_inner(&mut state, &contract, player, GameAction::PassPriority),
-            AiProposalApplication::AppliedStackPass { .. }
-        ));
-        assert_eq!(
-            state
-                .stack_resolution_session
-                .as_ref()
-                .map(|session| session.policy),
-            Some(StackResolutionPolicy::RecheckNoMeaningfulPriorityAction),
-        );
-    }
-
-    #[test]
-    fn stale_stack_pass_proposal_is_not_a_rejected_ai_decision() {
-        let player = PlayerId(0);
-        let mut state = priority_state(player);
-        state
-            .stack
-            .push_back(no_op_stack_entry(70_102, PlayerId(1)));
-        let contract = AiDecisionContract::issue(&state, player);
-        state.state_revision = state.state_revision.wrapping_add(1);
-
-        assert!(matches!(
-            apply_ai_action_proposal_inner(&mut state, &contract, player, GameAction::PassPriority),
-            AiProposalApplication::Stale
-        ));
-        assert!(state.stack_resolution_session.is_none());
-    }
 }
 
 /// Private WASM boundary outcome for expected engine rejections. Serialization
@@ -3436,17 +3306,21 @@ pub fn submit_ai_action_proposal(token: &str, actor: u8, action: JsValue) -> JsV
     };
 
     match with_state_mut(|state| {
-        apply_ai_action_proposal_inner(state, &proposal.contract, actor, action.clone())
+        apply_ai_action_proposal(state, &proposal.contract, actor, action.clone())
     }) {
         Ok(AiProposalApplication::AppliedStackPass { result }) => {
             record_verified_ai_priority_pass(actor, proposal.contract.semantic_owner);
             invalidate_ai_proposals();
-            to_js(&AiProposalSubmission::Applied { result })
+            to_js(&AiProposalSubmission::Applied {
+                result: Box::new(result),
+            })
         }
         Ok(AiProposalApplication::AppliedAction { result }) => {
             record_replay_action(false, actor, action);
             invalidate_ai_proposals();
-            to_js(&AiProposalSubmission::Applied { result })
+            to_js(&AiProposalSubmission::Applied {
+                result: Box::new(result),
+            })
         }
         Ok(AiProposalApplication::Stale) => to_js(&AiProposalSubmission::Stale {
             reason: "decision_changed_or_action_outside_issued_bounds",

--- a/crates/engine-wasm/src/lib.rs
+++ b/crates/engine-wasm/src/lib.rs
@@ -519,9 +519,11 @@ enum AiProposalSubmission {
 /// owns the state/contract decision that must be identical for browser and
 /// native regression coverage.
 enum AiProposalApplication {
-    Applied {
+    AppliedStackPass {
         result: Box<engine::types::game_state::ActionResult>,
-        verified_stack_pass: bool,
+    },
+    AppliedAction {
+        result: Box<engine::types::game_state::ActionResult>,
     },
     Stale,
     Rejected {
@@ -556,9 +558,11 @@ fn apply_ai_action_proposal_inner(
         apply_interaction_with_rejection(state, actor, contract.semantic_owner, action)
     };
     match applied {
-        Ok(result) => AiProposalApplication::Applied {
+        Ok(result) if verified_stack_pass => AiProposalApplication::AppliedStackPass {
             result: Box::new(result),
-            verified_stack_pass,
+        },
+        Ok(result) => AiProposalApplication::AppliedAction {
+            result: Box::new(result),
         },
         Err(rejection) => AiProposalApplication::Rejected { rejection },
     }
@@ -612,10 +616,7 @@ mod ai_proposal_submission_tests {
 
         assert!(matches!(
             apply_ai_action_proposal_inner(&mut state, &contract, player, GameAction::PassPriority),
-            AiProposalApplication::Applied {
-                verified_stack_pass: true,
-                ..
-            }
+            AiProposalApplication::AppliedStackPass { .. }
         ));
         assert_eq!(
             state
@@ -3437,15 +3438,13 @@ pub fn submit_ai_action_proposal(token: &str, actor: u8, action: JsValue) -> JsV
     match with_state_mut(|state| {
         apply_ai_action_proposal_inner(state, &proposal.contract, actor, action.clone())
     }) {
-        Ok(AiProposalApplication::Applied {
-            result,
-            verified_stack_pass,
-        }) => {
-            if verified_stack_pass {
-                record_verified_ai_priority_pass(actor, proposal.contract.semantic_owner);
-            } else {
-                record_replay_action(false, actor, action);
-            }
+        Ok(AiProposalApplication::AppliedStackPass { result }) => {
+            record_verified_ai_priority_pass(actor, proposal.contract.semantic_owner);
+            invalidate_ai_proposals();
+            to_js(&AiProposalSubmission::Applied { result })
+        }
+        Ok(AiProposalApplication::AppliedAction { result }) => {
+            record_replay_action(false, actor, action);
             invalidate_ai_proposals();
             to_js(&AiProposalSubmission::Applied { result })
         }

--- a/crates/engine-wasm/src/lib.rs
+++ b/crates/engine-wasm/src/lib.rs
@@ -591,7 +591,12 @@ mod ai_proposal_submission_tests {
             controller,
             kind: StackEntryKind::ActivatedAbility {
                 source_id: object_id,
-                ability: ResolvedAbility::new(Effect::NoOp, vec![], object_id, controller),
+                ability: Box::new(ResolvedAbility::new(
+                    Effect::NoOp,
+                    vec![],
+                    object_id,
+                    controller,
+                )),
             },
         }
     }

--- a/crates/engine-wasm/src/lib.rs
+++ b/crates/engine-wasm/src/lib.rs
@@ -9,17 +9,16 @@ use wasm_bindgen::prelude::*;
 
 use engine::ai_support::{
     apply_ai_action_proposal, auto_pass_recommended, auto_pass_recommended_for_viewer,
-    end_continuous_effect_offers, legal_actions_for_viewer, legal_actions_full,
-    AiDecisionContract, AiProposalApplication,
+    end_continuous_effect_offers, legal_actions_for_viewer, legal_actions_full, AiDecisionContract,
+    AiProposalApplication,
 };
 use engine::database::legality::{any_ai_difficulty_is_cedh, validate_cedh_bracket};
 use engine::database::{CardDatabase, CardSearchQuery};
 #[cfg(test)]
 use engine::game::engine::apply;
 use engine::game::engine::{
-    apply_interaction_with_rejection, apply_with_rejection, preflight_debug_action_with_rejection,
-    resume_restored_stack_automation, RestoredStackAutomationOutcome,
-    RestoredStackAutomationPresentation,
+    apply_with_rejection, preflight_debug_action_with_rejection, resume_restored_stack_automation,
+    RestoredStackAutomationOutcome, RestoredStackAutomationPresentation,
 };
 use engine::game::interaction::{
     bind_interaction_authority, preview_interaction, submit_interaction_with_rejection,

--- a/crates/engine-wasm/src/lib.rs
+++ b/crates/engine-wasm/src/lib.rs
@@ -514,6 +514,131 @@ enum AiProposalSubmission {
     },
 }
 
+/// Natively-testable core of the AI proposal submission boundary. The
+/// `wasm_bindgen` shell owns proposal-token lookup and serialization; this core
+/// owns the state/contract decision that must be identical for browser and
+/// native regression coverage.
+enum AiProposalApplication {
+    Applied {
+        result: Box<engine::types::game_state::ActionResult>,
+        verified_stack_pass: bool,
+    },
+    Stale,
+    Rejected {
+        rejection: ActionRejection,
+    },
+}
+
+fn apply_ai_action_proposal_inner(
+    state: &mut GameState,
+    contract: &AiDecisionContract,
+    actor: PlayerId,
+    action: GameAction,
+) -> AiProposalApplication {
+    // Classification lives in the engine (`verified_ai_stack_pass_player`),
+    // not in this adapter: it is the same call the callee gates on, so the
+    // two cannot disagree. CLAUDE.md — transport layers hold zero game logic.
+    let verified_stack_pass =
+        engine::game::engine::verified_ai_stack_pass_player(state, &action).is_some();
+    // Every proposal, including a stack recheck pass, is bound to the revision
+    // that issued it. Resolve All legitimately advances that revision while an
+    // AI proposal is in flight; report the old capability as stale so the
+    // controller re-queries instead of counting an ordinary race as an AI
+    // failure.
+    if !contract.permits(state, actor, &action) {
+        return AiProposalApplication::Stale;
+    }
+    let applied = if verified_stack_pass {
+        engine::game::engine::apply_verified_ai_priority_pass_with_rejection(
+            state, actor, contract, action,
+        )
+    } else {
+        apply_interaction_with_rejection(state, actor, contract.semantic_owner, action)
+    };
+    match applied {
+        Ok(result) => AiProposalApplication::Applied {
+            result: Box::new(result),
+            verified_stack_pass,
+        },
+        Err(rejection) => AiProposalApplication::Rejected { rejection },
+    }
+}
+
+#[cfg(test)]
+mod ai_proposal_submission_tests {
+    use super::*;
+    use engine::types::ability::{Effect, ResolvedAbility};
+    use engine::types::game_state::{
+        StackEntry, StackEntryKind, StackResolutionPolicy, WaitingFor,
+    };
+    use engine::types::identifiers::ObjectId;
+    use engine::types::phase::Phase;
+
+    fn priority_state(player: PlayerId) -> GameState {
+        let mut state = GameState::new_two_player(42);
+        state.phase = Phase::PreCombatMain;
+        state.active_player = player;
+        state.priority_player = player;
+        state.waiting_for = WaitingFor::Priority { player };
+        state
+    }
+
+    fn no_op_stack_entry(id: u64, controller: PlayerId) -> StackEntry {
+        let object_id = ObjectId(id);
+        StackEntry {
+            id: object_id,
+            source_id: object_id,
+            controller,
+            kind: StackEntryKind::ActivatedAbility {
+                source_id: object_id,
+                ability: ResolvedAbility::new(Effect::NoOp, vec![], object_id, controller),
+            },
+        }
+    }
+
+    #[test]
+    fn stack_pass_proposal_uses_the_verified_recheck_seam() {
+        let player = PlayerId(0);
+        let mut state = priority_state(player);
+        state
+            .stack
+            .push_back(no_op_stack_entry(70_101, PlayerId(1)));
+        let contract = AiDecisionContract::issue(&state, player);
+
+        assert!(matches!(
+            apply_ai_action_proposal_inner(&mut state, &contract, player, GameAction::PassPriority),
+            AiProposalApplication::Applied {
+                verified_stack_pass: true,
+                ..
+            }
+        ));
+        assert_eq!(
+            state
+                .stack_resolution_session
+                .as_ref()
+                .map(|session| session.policy),
+            Some(StackResolutionPolicy::RecheckNoMeaningfulPriorityAction),
+        );
+    }
+
+    #[test]
+    fn stale_stack_pass_proposal_is_not_a_rejected_ai_decision() {
+        let player = PlayerId(0);
+        let mut state = priority_state(player);
+        state
+            .stack
+            .push_back(no_op_stack_entry(70_102, PlayerId(1)));
+        let contract = AiDecisionContract::issue(&state, player);
+        state.state_revision = state.state_revision.wrapping_add(1);
+
+        assert!(matches!(
+            apply_ai_action_proposal_inner(&mut state, &contract, player, GameAction::PassPriority),
+            AiProposalApplication::Stale
+        ));
+        assert!(state.stack_resolution_session.is_none());
+    }
+}
+
 /// Private WASM boundary outcome for expected engine rejections. Serialization
 /// keeps recoverable action failures distinct from raw WASM/runtime errors,
 /// which continue to cross this boundary as strings or thrown `JsValue`s.
@@ -3305,53 +3430,26 @@ pub fn submit_ai_action_proposal(token: &str, actor: u8, action: JsValue) -> JsV
     };
 
     match with_state_mut(|state| {
-        // Classification lives in the engine (`verified_ai_stack_pass_player`),
-        // not in this adapter: it is the same call the callee gates on, so the
-        // two cannot disagree. CLAUDE.md — transport layers hold zero game
-        // logic.
-        let is_stack_recheck_pass =
-            engine::game::engine::verified_ai_stack_pass_player(state, &action).is_some();
-        // A payment finalize is no longer misclassified, so it now passes
-        // through `permits` — whose `state_revision` equality check can report
-        // `Stale` for a proposal minted against a superseded state. The client
-        // treats `Stale` as a benign race and re-queries without counting a
-        // failure, which is the intended handling for every other action.
-        if !is_stack_recheck_pass && !proposal.contract.permits(state, actor, &action) {
-            return AiProposalSubmission::Stale {
-                reason: "decision_changed_or_action_outside_issued_bounds",
-            };
-        }
-        let applied = if is_stack_recheck_pass {
-            engine::game::engine::apply_verified_ai_priority_pass_with_rejection(
-                state,
-                actor,
-                &proposal.contract,
-                action.clone(),
-            )
-        } else {
-            apply_interaction_with_rejection(
-                state,
-                actor,
-                proposal.contract.semantic_owner,
-                action.clone(),
-            )
-        };
-        match applied {
-            Ok(result) => {
-                if is_stack_recheck_pass {
-                    record_verified_ai_priority_pass(actor, proposal.contract.semantic_owner);
-                } else {
-                    record_replay_action(false, actor, action);
-                }
-                invalidate_ai_proposals();
-                AiProposalSubmission::Applied {
-                    result: Box::new(result),
-                }
-            }
-            Err(rejection) => AiProposalSubmission::Rejected { rejection },
-        }
+        apply_ai_action_proposal_inner(state, &proposal.contract, actor, action.clone())
     }) {
-        Ok(outcome) => to_js(&outcome),
+        Ok(AiProposalApplication::Applied {
+            result,
+            verified_stack_pass,
+        }) => {
+            if verified_stack_pass {
+                record_verified_ai_priority_pass(actor, proposal.contract.semantic_owner);
+            } else {
+                record_replay_action(false, actor, action);
+            }
+            invalidate_ai_proposals();
+            to_js(&AiProposalSubmission::Applied { result })
+        }
+        Ok(AiProposalApplication::Stale) => to_js(&AiProposalSubmission::Stale {
+            reason: "decision_changed_or_action_outside_issued_bounds",
+        }),
+        Ok(AiProposalApplication::Rejected { rejection }) => {
+            to_js(&AiProposalSubmission::Rejected { rejection })
+        }
         Err(_) => to_js(&AiProposalSubmission::Stale {
             reason: "state_unavailable",
         }),
@@ -4258,35 +4356,6 @@ mod tests {
     }
 
     #[test]
-    fn stack_pass_proposal_uses_the_verified_recheck_seam() {
-        let player = PlayerId(0);
-        let mut state = priority_state(player);
-        state
-            .stack
-            .push_back(no_op_stack_entry(70_101, PlayerId(1)));
-        add_non_mana_recheck_action(&mut state, PlayerId(1));
-        let action = GameAction::PassPriority;
-        let token = install_issued_candidate(state, player, &action);
-
-        assert_eq!(
-            proposal_outcome(&token, player, &action)["status"],
-            "applied"
-        );
-        with_state(|state| {
-            assert_eq!(
-                state
-                    .stack_resolution_session
-                    .as_ref()
-                    .map(|session| session.policy),
-                Some(engine::types::game_state::StackResolutionPolicy::RecheckNoMeaningfulPriorityAction),
-                "the WASM proposal boundary must not downgrade a verified stack pass"
-            );
-        })
-        .expect("test state must remain installed");
-        clear_game_state();
-    }
-
-    #[test]
     fn public_proposal_issuer_mints_a_submitable_priority_capability() {
         let player = PlayerId(0);
         clear_game_state();
@@ -4840,28 +4909,6 @@ mod tests {
             })));
         });
         assert!(has_replay_recording());
-    }
-
-    fn add_non_mana_recheck_action(state: &mut GameState, controller: PlayerId) {
-        let object_id = create_object(
-            state,
-            CardId(70_100),
-            controller,
-            "Wasm Recheck Action".to_string(),
-            Zone::Battlefield,
-        );
-        let object = state
-            .objects
-            .get_mut(&object_id)
-            .expect("created battlefield object");
-        object.card_types.core_types.push(CoreType::Artifact);
-        Arc::make_mut(&mut object.abilities).push(AbilityDefinition::new(
-            AbilityKind::Activated,
-            Effect::Draw {
-                count: QuantityExpr::Fixed { value: 1 },
-                target: TargetFilter::Controller,
-            },
-        ));
     }
 
     #[test]

--- a/crates/engine/src/ai_support/context.rs
+++ b/crates/engine/src/ai_support/context.rs
@@ -1,4 +1,5 @@
-use crate::types::game_state::{GameState, WaitingFor};
+use crate::types::action_rejection::ActionRejection;
+use crate::types::game_state::{ActionResult, GameState, WaitingFor};
 
 use crate::game::turn_control;
 use crate::types::actions::GameAction;
@@ -29,6 +30,52 @@ pub struct AiDecisionContract {
     pub authorized_actor: PlayerId,
     pub state_revision: u64,
     pub candidates: Vec<CandidateAction>,
+}
+
+/// The engine's outcome when it applies an action bound to an issued AI
+/// decision contract. Transport adapters use `Stale` to request a fresh
+/// decision and surface only `Rejected` as an action failure.
+#[derive(Debug)]
+pub enum AiProposalApplication {
+    AppliedStackPass { result: ActionResult },
+    AppliedAction { result: ActionResult },
+    Stale,
+    Rejected { rejection: ActionRejection },
+}
+
+/// Applies an AI proposal after re-validating its engine-issued contract.
+///
+/// A verified stack-priority pass takes the retained stack-resolution path;
+/// all other actions use the normal interaction boundary. An invalidated
+/// contract is an expected race with state progression, not a rejected action.
+pub fn apply_ai_action_proposal(
+    state: &mut GameState,
+    contract: &AiDecisionContract,
+    actor: PlayerId,
+    action: GameAction,
+) -> AiProposalApplication {
+    let verified_stack_pass =
+        crate::game::engine::verified_ai_stack_pass_player(state, &action).is_some();
+    if !contract.permits(state, actor, &action) {
+        return AiProposalApplication::Stale;
+    }
+    let applied = if verified_stack_pass {
+        crate::game::engine::apply_verified_ai_priority_pass_with_rejection(
+            state, actor, contract, action,
+        )
+    } else {
+        crate::game::engine::apply_interaction_with_rejection(
+            state,
+            actor,
+            contract.semantic_owner,
+            action,
+        )
+    };
+    match applied {
+        Ok(result) if verified_stack_pass => AiProposalApplication::AppliedStackPass { result },
+        Ok(result) => AiProposalApplication::AppliedAction { result },
+        Err(rejection) => AiProposalApplication::Rejected { rejection },
+    }
 }
 
 impl AiDecisionContract {
@@ -252,8 +299,10 @@ mod tests {
     use super::*;
     use crate::game::zones::create_object;
     use crate::types::{
+        ability::{Effect, ResolvedAbility},
         actions::GameAction,
         card_type::CoreType,
+        game_state::{StackEntry, StackEntryKind, StackResolutionPolicy},
         identifiers::{CardId, ObjectId},
         player::PlayerId,
         zones::Zone,
@@ -383,5 +432,71 @@ mod tests {
                 cards: vec![second, first],
             },
         ));
+    }
+
+    fn priority_state(player: PlayerId) -> GameState {
+        let mut state = GameState::new_two_player(42);
+        state.phase = Phase::PreCombatMain;
+        state.active_player = player;
+        state.priority_player = player;
+        state.waiting_for = WaitingFor::Priority { player };
+        state
+    }
+
+    fn no_op_stack_entry(id: u64, controller: PlayerId) -> StackEntry {
+        let object_id = ObjectId(id);
+        StackEntry {
+            id: object_id,
+            source_id: object_id,
+            controller,
+            kind: StackEntryKind::ActivatedAbility {
+                source_id: object_id,
+                ability: Box::new(ResolvedAbility::new(
+                    Effect::NoOp,
+                    vec![],
+                    object_id,
+                    controller,
+                )),
+            },
+        }
+    }
+
+    #[test]
+    fn stack_pass_proposal_uses_the_verified_recheck_seam() {
+        let player = PlayerId(0);
+        let mut state = priority_state(player);
+        state
+            .stack
+            .push_back(no_op_stack_entry(70_101, PlayerId(1)));
+        let contract = AiDecisionContract::issue(&state, player);
+
+        assert!(matches!(
+            apply_ai_action_proposal(&mut state, &contract, player, GameAction::PassPriority),
+            AiProposalApplication::AppliedStackPass { .. }
+        ));
+        assert_eq!(
+            state
+                .stack_resolution_session
+                .as_ref()
+                .map(|session| session.policy),
+            Some(StackResolutionPolicy::RecheckNoMeaningfulPriorityAction),
+        );
+    }
+
+    #[test]
+    fn stale_stack_pass_proposal_is_not_a_rejected_ai_decision() {
+        let player = PlayerId(0);
+        let mut state = priority_state(player);
+        state
+            .stack
+            .push_back(no_op_stack_entry(70_102, PlayerId(1)));
+        let contract = AiDecisionContract::issue(&state, player);
+        state.state_revision = state.state_revision.wrapping_add(1);
+
+        assert!(matches!(
+            apply_ai_action_proposal(&mut state, &contract, player, GameAction::PassPriority),
+            AiProposalApplication::Stale
+        ));
+        assert!(state.stack_resolution_session.is_none());
     }
 }

--- a/crates/engine/src/ai_support/mod.rs
+++ b/crates/engine/src/ai_support/mod.rs
@@ -55,8 +55,8 @@ pub use combat_withdrawal::{
     combat_withdrawal_fact_for_current_target, CombatWithdrawalFact, CombatWithdrawalTargetRole,
 };
 pub use context::{
-    build_decision_context, build_decision_context_for_semantic_owner, AiDecisionContext,
-    AiDecisionContract,
+    apply_ai_action_proposal, build_decision_context, build_decision_context_for_semantic_owner,
+    AiDecisionContext, AiDecisionContract, AiProposalApplication,
 };
 pub use copy::{
     copy_effect_adds_flying, copy_target_filter, copy_target_mana_value_ceiling,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - AI action proposals are now revalidated before application, preventing outdated proposals from being applied.
  - Verified stack-priority passes and regular actions are handled through their appropriate application paths, with stale and rejected proposals reported correctly.

- **Tests**
  - Added coverage for proposal revalidation, including verified stack passes and stale proposals.
  - Removed obsolete WebAssembly-specific test coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->