### PR TITLE
feat(client): show the dungeon card with the venture marker on hover

### DIFF
--- a/client/src/adapter/__tests__/p2p-adapter-multiplayer.test.ts
+++ b/client/src/adapter/__tests__/p2p-adapter-multiplayer.test.ts
@@ -4407,14 +4407,14 @@ describe("P2P wire-protocol version gate", () => {
   // Both halves stamp LITERALS. A frame built from WIRE_PROTOCOL_VERSION
   // cannot tell a bumped client from an unbumped one, which is why every
   // other handshake fixture in the suite is useless as an instrument for a
-  // bump. Revert 49 → 48 and BOTH halves red: the v48 frame stops being
-  // refused, and the v49 frame stops being admitted. The admitting half is
-  // the reach-guard — without it "refuses v48" is also satisfied by a client
+  // bump. Revert 50 → 49 and BOTH halves red: the v49 frame stops being
+  // refused, and the v50 frame stops being admitted. The admitting half is
+  // the reach-guard — without it "refuses v49" is also satisfied by a client
   // that refuses everything.
-  it("refuses the previous wire protocol (v48) and admits its own (v49)", async () => {
+  it("refuses the previous wire protocol (v49) and admits its own (v50)", async () => {
     const refusing = makeGuest();
     await refusing.adapter.initialize();
-    await refusing.conn.simulateData(setupFrameAt(48));
+    await refusing.conn.simulateData(setupFrameAt(49));
 
     await expect(refusing.adapter.initializeGame()).rejects.toMatchObject({
       code: "P2P_REJECTED",
@@ -4426,7 +4426,7 @@ describe("P2P wire-protocol version gate", () => {
 
     const admitting = makeGuest();
     await admitting.adapter.initialize();
-    await admitting.conn.simulateData(setupFrameAt(49));
+    await admitting.conn.simulateData(setupFrameAt(50));
 
     await expect(admitting.adapter.initializeGame()).resolves.toBeDefined();
     expect(admitting.emitted).not.toHaveBeenCalledWith(

--- a/client/src/adapter/types.ts
+++ b/client/src/adapter/types.ts
@@ -63,6 +63,45 @@ export interface DungeonRoomView {
   room: RoomPreview;
   /** Total rooms on the dungeon card, for "room 3 of 7". */
   room_count: number;
+  /** The printed dungeon card's Scryfall identity (CR 309.1). */
+  card: DungeonCardView;
+  /** Every room on the card in printed order, with edges and card geometry. */
+  rooms: DungeonRoomNodeView[];
+}
+
+// Mirrors `engine::game::derived_views::DungeonCardView`.
+//
+// Two ids, because the five dungeons are NOT indexed uniformly by the client's
+// Scryfall sidecars. Four are `layout: "normal"` and resolve from
+// `scryfall-data.json` by `oracle_id`; Undercity is printed as the
+// double-faced `Undercity // The Initiative`, a layout that
+// `gen-scryfall-images.sh` excludes as non-playable, so it exists ONLY in
+// `scryfall-token-images.json`, keyed by printing id. Callers try the card
+// table and fall back to the token table.
+export interface DungeonCardView {
+  oracle_id: string;
+  scryfall_id: string;
+  /** Selects the dungeon face of the double-faced Undercity printing. */
+  face_name: string;
+}
+
+// Mirrors `engine::game::derived_views::DungeonRoomNodeView`. `RoomPreview` is
+// flattened into this by serde, so `index`/`name`/`text` sit alongside the
+// edges and geometry rather than under a nested key.
+export interface DungeonRoomNodeView extends RoomPreview {
+  /** Rooms the venture marker may move to from here (CR 309.5a); empty for
+   *  the bottommost room. */
+  next_rooms: number[];
+  /** Where this room is drawn on the card face. */
+  marker: RoomMarkerPoint;
+}
+
+// Mirrors `engine::game::dungeon::RoomMarkerPoint`. Permille (0-1000) of the
+// card image rather than a fraction, so the engine's derived views can keep
+// deriving `Eq` (f32 is not `Eq`).
+export interface RoomMarkerPoint {
+  x_permille: number;
+  y_permille: number;
 }
 
 // ── Game Format ─────────────────────────────────────────────────────────

--- a/client/src/adapter/types.ts
+++ b/client/src/adapter/types.ts
@@ -63,7 +63,7 @@ export interface DungeonRoomView {
   room: RoomPreview;
   /** Total rooms on the dungeon card, for "room 3 of 7". */
   room_count: number;
-  /** The printed dungeon card's Scryfall identity (CR 309.1). */
+  /** The printed dungeon card's Scryfall identity. */
   card: DungeonCardView;
   /** Every room on the card in printed order, with edges and card geometry. */
   rooms: DungeonRoomNodeView[];

--- a/client/src/adapter/ws-adapter.ts
+++ b/client/src/adapter/ws-adapter.ts
@@ -208,6 +208,15 @@ export class NativeEngineVersionMismatchError extends Error {
  * `crates/server-core/src/protocol.rs`. Bump in lockstep when either side
  * adds, removes, renames, or changes the type of a protocol variant field.
  *
+ * 67 — DerivedViews.dungeon_rooms entries gained required `card` and `rooms`
+ *      fields, carrying the dungeon card's Scryfall identity and the whole
+ *      room graph (each room's edges plus its position on the printed card).
+ *      A PARSE bump like 66, not a capability bump like 24: neither field is
+ *      serde-optional, so a v66 peer fails deserialization on any snapshot
+ *      where a player is venturing rather than degrading silently. The
+ *      reverse skew is equally hard — this client destructures `card`
+ *      unconditionally to resolve the card art, so a v66 host would throw in
+ *      render, not merely omit the map panel.
  * 65 — DraftMatchStart now announces the exact Full-session identity for the
  *      spawned match. Draft reconnect attaches the authenticated draft seat
  *      to that Full-session lifetime, and Full follow-up frames carry the key
@@ -441,7 +450,7 @@ export class NativeEngineVersionMismatchError extends Error {
  *      into a MulliganDecisionPhase::BottomCards sub-phase on
  *      WaitingFor::MulliganDecision.
  */
-export const PROTOCOL_VERSION = 66;
+export const PROTOCOL_VERSION = 67;
 
 /**
  * Lowest server protocol version this client will accept in the handshake.

--- a/client/src/components/hud/DungeonMapPopover.tsx
+++ b/client/src/components/hud/DungeonMapPopover.tsx
@@ -1,0 +1,163 @@
+import { useEffect, useMemo, useState } from "react";
+import { createPortal } from "react-dom";
+import { useTranslation } from "react-i18next";
+
+import { useDungeonCardImage } from "../../hooks/useDungeonCardImage.ts";
+import type { DungeonRoomView } from "../../adapter/types.ts";
+
+interface Props {
+  anchorEl: HTMLElement;
+  /** Engine projection of the dungeon and where this player's marker sits.
+   *  Every value rendered here is engine-authored (CR 309.4); this component
+   *  positions and styles them and computes nothing about the game. */
+  view: DungeonRoomView;
+}
+
+const ANCHOR_GAP_PX = 10;
+
+/** Rendered width of the dungeon card inside the popover. The card scans are
+ *  488x680 (`normal`) and 672x936 (`large`); 340 CSS px sits between the two,
+ *  so the `large` rung the hook requests is downscaled slightly rather than
+ *  upscaled — the room labels printed on these cards stay legible, which is the
+ *  whole point of showing the card rather than a redrawn map. */
+const CARD_WIDTH_PX = 340;
+const CARD_ASPECT = 680 / 488;
+
+/**
+ * Hover/click panel for the dungeon HUD badge: the printed dungeon card with
+ * the player's venture marker drawn on the room they currently occupy.
+ *
+ * Why the card image rather than a redrawn map — the five dungeon cards are the
+ * unusual case where the art IS the game state. Each card is a labeled floor
+ * plan whose rooms are drawn as rectangles with their names and effects printed
+ * inside, so overlaying a marker on the real card shows a player exactly what
+ * they would see across the table. `marker` positions come from the engine
+ * (`DungeonRoomNodeView.marker`, permille of the card face).
+ *
+ * Mirrors `RingBenefitsPopover`: portaled to `document.body` (HudPlate's
+ * `transform` would otherwise clip it) and auto-flipped above/below based on
+ * the anchor's viewport half. Unlike that one this panel is NOT
+ * `pointer-events-none` — it is hoverable so the pointer can travel from the
+ * badge into the card without dismissing it.
+ */
+export function DungeonMapPopover({ anchorEl, view }: Props) {
+  const { t } = useTranslation("game");
+  const [pos, setPos] = useState<{
+    left: number;
+    top: number;
+    placement: "above" | "below";
+  } | null>(null);
+
+  const { src, isLoading } = useDungeonCardImage(view.card);
+
+  useEffect(() => {
+    function recompute() {
+      const rect = anchorEl.getBoundingClientRect();
+      const placement: "above" | "below" =
+        rect.top < window.innerHeight / 2 ? "below" : "above";
+      const left = rect.left + rect.width / 2;
+      const top = placement === "above" ? rect.top - ANCHOR_GAP_PX : rect.bottom + ANCHOR_GAP_PX;
+      setPos({ left, top, placement });
+    }
+    recompute();
+    window.addEventListener("resize", recompute);
+    window.addEventListener("scroll", recompute, true);
+    return () => {
+      window.removeEventListener("resize", recompute);
+      window.removeEventListener("scroll", recompute, true);
+    };
+  }, [anchorEl]);
+
+  // CR 309.5a: the rooms reachable from where the marker stands. Engine-
+  // provided edges; this only reads them into a set for styling.
+  const reachable = useMemo(() => {
+    const current = view.rooms.find((room) => room.index === view.room.index);
+    return new Set(current?.next_rooms ?? []);
+  }, [view.rooms, view.room.index]);
+
+  if (!pos) return null;
+
+  const transform =
+    pos.placement === "above" ? "translate(-50%, -100%)" : "translate(-50%, 0)";
+  // CR 309.4a: the marker starts on room index 0; players count from 1.
+  const position = view.room.index + 1;
+
+  return createPortal(
+    <div
+      className="fixed z-[130]"
+      style={{ left: pos.left, top: pos.top, transform }}
+      role="dialog"
+      aria-label={t("badges.dungeonAriaLabel", {
+        name: view.dungeon_name,
+        roomName: view.room.name,
+        room: position,
+        total: view.room_count,
+      })}
+    >
+      <div className="rounded-xl border border-violet-300/25 bg-slate-950/95 p-3 shadow-[0_18px_50px_rgba(0,0,0,0.6)] backdrop-blur-sm">
+        <div className="mb-2 flex items-baseline justify-between gap-3">
+          <span className="text-[11px] font-semibold uppercase tracking-[0.14em] text-violet-200">
+            {view.dungeon_name}
+          </span>
+          <span className="text-[11px] tabular-nums text-slate-400">
+            {t("badges.dungeonRoomTooltip", {
+              roomName: view.room.name,
+              room: position,
+              total: view.room_count,
+            })}
+          </span>
+        </div>
+
+        <div
+          className="relative overflow-hidden rounded-lg bg-slate-900"
+          style={{ width: CARD_WIDTH_PX, height: Math.round(CARD_WIDTH_PX * CARD_ASPECT) }}
+        >
+          {src ? (
+            <img
+              src={src}
+              alt={view.dungeon_name}
+              className="absolute inset-0 h-full w-full object-contain"
+              draggable={false}
+            />
+          ) : (
+            <div className="absolute inset-0 grid place-items-center px-4 text-center text-[11px] text-slate-500">
+              {isLoading ? t("badges.dungeonMapLoading") : t("badges.dungeonMapUnavailable")}
+            </div>
+          )}
+
+          {/* The marker layer. Drawn even when the card image is missing so the
+              room list below still reads as a map; without the art it simply
+              floats on the placeholder. */}
+          {view.rooms.map((room) => {
+            const isCurrent = room.index === view.room.index;
+            const isReachable = reachable.has(room.index);
+            if (!isCurrent && !isReachable) return null;
+            return (
+              <span
+                key={room.index}
+                aria-hidden
+                title={room.name}
+                className={
+                  isCurrent
+                    ? "absolute h-4 w-4 -translate-x-1/2 -translate-y-1/2 rounded-full border-2 border-white bg-violet-500 shadow-[0_0_0_3px_rgba(139,92,246,0.45),0_0_14px_rgba(139,92,246,0.9)]"
+                    : "absolute h-2.5 w-2.5 -translate-x-1/2 -translate-y-1/2 rounded-full border border-white/70 bg-white/25"
+                }
+                style={{
+                  left: `${room.marker.x_permille / 10}%`,
+                  top: `${room.marker.y_permille / 10}%`,
+                }}
+              />
+            );
+          })}
+        </div>
+
+        {view.room.text ? (
+          <p className="mt-2 max-w-[340px] text-[11px] leading-snug text-slate-300">
+            {view.room.text}
+          </p>
+        ) : null}
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/client/src/components/hud/DungeonMapPopover.tsx
+++ b/client/src/components/hud/DungeonMapPopover.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useState, type RefObject } from "react";
 import { createPortal } from "react-dom";
 import { useTranslation } from "react-i18next";
 
@@ -7,6 +7,11 @@ import type { DungeonRoomView } from "../../adapter/types.ts";
 
 interface Props {
   anchorEl: HTMLElement;
+  /** Ref to the panel's root. The panel portals to `document.body`, so an
+   *  outside-click handler anchored on the chip alone would treat a tap
+   *  INSIDE the panel as outside and dismiss it. Touch has no hover to fall
+   *  back on, so without this the pinning gesture defeats itself. */
+  panelRef?: RefObject<HTMLDivElement | null>;
   /** Engine projection of the dungeon and where this player's marker sits.
    *  Every value rendered here is engine-authored (CR 309.4); this component
    *  positions and styles them and computes nothing about the game. */
@@ -40,7 +45,7 @@ const CARD_ASPECT = 680 / 488;
  * `pointer-events-none` — it is hoverable so the pointer can travel from the
  * badge into the card without dismissing it.
  */
-export function DungeonMapPopover({ anchorEl, view }: Props) {
+export function DungeonMapPopover({ anchorEl, view, panelRef }: Props) {
   const { t } = useTranslation("game");
   const [pos, setPos] = useState<{
     left: number;
@@ -84,6 +89,7 @@ export function DungeonMapPopover({ anchorEl, view }: Props) {
 
   return createPortal(
     <div
+      ref={panelRef}
       className="fixed z-[130]"
       style={{ left: pos.left, top: pos.top, transform }}
       role="dialog"

--- a/client/src/components/hud/HudBadges.tsx
+++ b/client/src/components/hud/HudBadges.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState, type ReactNode } from "react";
 import { useTranslation } from "react-i18next";
 
+import { DungeonMapPopover } from "./DungeonMapPopover.tsx";
 import { RingBenefitsPopover } from "./RingBenefitsPopover.tsx";
 import { ManaFontIcon } from "../icons/ManaFontIcon.tsx";
 import { GameplayTooltip } from "../ui/GameplayTooltip.tsx";
@@ -136,6 +137,55 @@ interface DungeonBadgeProps {
 
 export function DungeonBadge({ room }: DungeonBadgeProps) {
   const { t } = useTranslation("game");
+  const chipRef = useRef<HTMLButtonElement>(null);
+  const [hoverOpen, setHoverOpen] = useState(false);
+  // Click latches the panel open so it survives the pointer leaving, and so
+  // touch devices — which never fire hover — can open it at all.
+  const [pinned, setPinned] = useState(false);
+  const closeTimerRef = useRef<number | null>(null);
+
+  const cancelClose = useCallback(() => {
+    if (closeTimerRef.current != null) {
+      window.clearTimeout(closeTimerRef.current);
+      closeTimerRef.current = null;
+    }
+  }, []);
+  const onEnter = useCallback(() => {
+    cancelClose();
+    setHoverOpen(true);
+  }, [cancelClose]);
+  const onLeave = useCallback(() => {
+    cancelClose();
+    closeTimerRef.current = window.setTimeout(() => {
+      setHoverOpen(false);
+      closeTimerRef.current = null;
+    }, DUNGEON_HOVER_CLOSE_DELAY_MS);
+  }, [cancelClose]);
+  useEffect(() => () => cancelClose(), [cancelClose]);
+
+  // Dismiss a pinned panel on the next outside click or on Escape — the two
+  // gestures a latched overlay has to answer to.
+  useEffect(() => {
+    if (!pinned) return undefined;
+    const onPointerDown = (event: PointerEvent) => {
+      if (
+        event.target instanceof Node
+        && chipRef.current?.contains(event.target) !== true
+      ) {
+        setPinned(false);
+      }
+    };
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") setPinned(false);
+    };
+    window.addEventListener("pointerdown", onPointerDown);
+    window.addEventListener("keydown", onKeyDown);
+    return () => {
+      window.removeEventListener("pointerdown", onPointerDown);
+      window.removeEventListener("keydown", onKeyDown);
+    };
+  }, [pinned]);
+
   // CR 309.4a: the marker starts on room index 0; players count from 1.
   const position = room.room.index + 1;
   const labelArgs = {
@@ -144,28 +194,32 @@ export function DungeonBadge({ room }: DungeonBadgeProps) {
     room: position,
     total: room.room_count,
   };
-  // CR 309.4b-c: name the room and say what its room ability did. The chip has
-  // no space for either, and most rooms are entered without a prompt, so the
-  // tooltip is where a player reads them back.
-  const tooltip = [
-    t("badges.dungeonTooltip", labelArgs),
-    t("badges.dungeonRoomTooltip", labelArgs),
-    room.room.text,
-  ]
-    .filter(Boolean)
-    .join("\n");
+  const open = hoverOpen || pinned;
   return (
-    <BadgeTip text={tooltip}>
-      <span
-        role="img"
+    <>
+      <button
+        type="button"
+        ref={chipRef}
         aria-label={t("badges.dungeonAriaLabel", labelArgs)}
-        className="relative inline-flex h-6 shrink-0 items-center gap-1 overflow-hidden rounded-full bg-violet-500/85 px-2 text-[10px] font-semibold uppercase tracking-[0.12em] text-violet-50 ring-1 ring-violet-300/70 shadow-[0_0_12px_rgba(139,92,246,0.45)]"
+        aria-expanded={open}
+        title={t("badges.dungeonTooltip", labelArgs)}
+        onMouseEnter={onEnter}
+        onMouseLeave={onLeave}
+        onFocus={onEnter}
+        onBlur={onLeave}
+        onClick={() => setPinned((wasPinned) => !wasPinned)}
+        className="relative inline-flex h-6 shrink-0 cursor-pointer items-center gap-1 overflow-hidden rounded-full bg-violet-500/85 px-2 text-[10px] font-semibold uppercase tracking-[0.12em] text-violet-50 ring-1 ring-violet-300/70 shadow-[0_0_12px_rgba(139,92,246,0.45)] transition hover:bg-violet-400/90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-violet-200"
       >
         <span aria-hidden className="text-[12px] leading-none drop-shadow-[0_1px_1px_rgba(0,0,0,0.5)]">🏰</span>
         <span className="relative truncate">{room.dungeon_name}</span>
         <span className="relative tabular-nums text-white">{position}/{room.room_count}</span>
-      </span>
-    </BadgeTip>
+      </button>
+      {open && chipRef.current ? (
+        <span onMouseEnter={onEnter} onMouseLeave={onLeave}>
+          <DungeonMapPopover anchorEl={chipRef.current} view={room} />
+        </span>
+      ) : null}
+    </>
   );
 }
 
@@ -674,6 +728,10 @@ function RingChip({
 // Brief dismiss delay smoothing cursor jitter on the chip edge (mirrors
 // EnchantmentsBadge's HOVER_CLOSE_DELAY_MS).
 const RING_HOVER_CLOSE_DELAY_MS = 80;
+
+/** Matches the Ring popover's grace period, so the pointer can cross the gap
+ *  between the dungeon chip and its panel without the panel closing. */
+const DUNGEON_HOVER_CLOSE_DELAY_MS = 80;
 
 /**
  * The player's OWN Ring badge: the gold level chip plus a hover popover

--- a/client/src/components/hud/HudBadges.tsx
+++ b/client/src/components/hud/HudBadges.tsx
@@ -138,6 +138,9 @@ interface DungeonBadgeProps {
 export function DungeonBadge({ room }: DungeonBadgeProps) {
   const { t } = useTranslation("game");
   const chipRef = useRef<HTMLButtonElement>(null);
+  // The panel portals to `document.body`, so containment has to be tested
+  // against its own root as well as the chip — see the pointerdown handler.
+  const panelRef = useRef<HTMLDivElement>(null);
   const [hoverOpen, setHoverOpen] = useState(false);
   // Click latches the panel open so it survives the pointer leaving, and so
   // touch devices — which never fire hover — can open it at all.
@@ -168,9 +171,15 @@ export function DungeonBadge({ room }: DungeonBadgeProps) {
   useEffect(() => {
     if (!pinned) return undefined;
     const onPointerDown = (event: PointerEvent) => {
+      // Both roots, not just the chip: the panel is portaled out of this
+      // subtree, so testing the chip alone dismisses on a tap INSIDE the
+      // panel. Desktop hides that (the wrapper span still receives the
+      // bubbled synthetic event, keeping `hoverOpen` true), but touch has no
+      // hover — the panel would close the moment it was touched.
       if (
         event.target instanceof Node
         && chipRef.current?.contains(event.target) !== true
+        && panelRef.current?.contains(event.target) !== true
       ) {
         setPinned(false);
       }
@@ -216,7 +225,7 @@ export function DungeonBadge({ room }: DungeonBadgeProps) {
       </button>
       {open && chipRef.current ? (
         <span onMouseEnter={onEnter} onMouseLeave={onLeave}>
-          <DungeonMapPopover anchorEl={chipRef.current} view={room} />
+          <DungeonMapPopover anchorEl={chipRef.current} view={room} panelRef={panelRef} />
         </span>
       ) : null}
     </>

--- a/client/src/components/hud/__tests__/DungeonBadge.map.test.tsx
+++ b/client/src/components/hud/__tests__/DungeonBadge.map.test.tsx
@@ -1,0 +1,194 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { DungeonRoomView } from "../../../adapter/types.ts";
+import { DungeonBadge } from "../HudBadges.tsx";
+
+// The panel resolves its art through the Scryfall sidecars, which are static
+// assets the test environment does not serve. Stubbing the service keeps these
+// tests about the badge's behaviour — what opens the panel, and where the
+// venture marker lands — rather than about image loading.
+//
+// The default (see `beforeEach`) is the card-table hit that four of the five
+// dungeons take. Two tests below override it to REJECT, which is what the real
+// service does for Undercity: its `double_faced_token` layout is excluded from
+// `scryfall-data.json`, so only the token table can carry it. Both branches are
+// real production paths, not error handling.
+const fetchCardImageAssetByOracleId = vi.fn();
+const fetchTokenImageByRef = vi.fn();
+
+vi.mock("../../../services/scryfall.ts", () => ({
+  fetchCardImageAssetByOracleId: (...args: unknown[]) =>
+    fetchCardImageAssetByOracleId(...args),
+  fetchTokenImageByRef: (...args: unknown[]) => fetchTokenImageByRef(...args),
+  deriveImageUrl: (url: string, size: string) =>
+    url.replace("/normal/", `/${size}/`),
+}));
+
+/** Lost Mine of Phandelver with the marker in Goblin Lair (room index 1).
+ *  Shaped exactly like `DerivedViews.dungeon_rooms` — the engine is the only
+ *  source of room names, edges and card geometry. */
+function lostMine(overrides: Partial<DungeonRoomView> = {}): DungeonRoomView {
+  return {
+    dungeon: "LostMineOfPhandelver",
+    dungeon_name: "Lost Mine of Phandelver",
+    room: {
+      index: 1,
+      name: "Goblin Lair",
+      text: "Create a 1/1 red Goblin creature token.",
+    },
+    room_count: 7,
+    card: {
+      oracle_id: "5c446a7f-0301-4343-b0df-146cf2db605b",
+      scryfall_id: "59b11ff8-f118-4978-87dd-509dc0c8c932",
+      face_name: "Lost Mine of Phandelver",
+    },
+    rooms: [
+      {
+        index: 0,
+        name: "Cave Entrance",
+        text: "Scry 1.",
+        next_rooms: [1, 2],
+        marker: { x_permille: 500, y_permille: 215 },
+      },
+      {
+        index: 1,
+        name: "Goblin Lair",
+        text: "Create a 1/1 red Goblin creature token.",
+        next_rooms: [3, 4],
+        marker: { x_permille: 310, y_permille: 390 },
+      },
+      {
+        index: 2,
+        name: "Mine Tunnels",
+        text: "Create a Treasure token.",
+        next_rooms: [4, 5],
+        marker: { x_permille: 690, y_permille: 390 },
+      },
+      {
+        index: 3,
+        name: "Storeroom",
+        text: "Put a +1/+1 counter on target creature.",
+        next_rooms: [6],
+        marker: { x_permille: 180, y_permille: 610 },
+      },
+      {
+        index: 4,
+        name: "Dark Pool",
+        text: "Each opponent loses 1 life and you gain 1 life.",
+        next_rooms: [6],
+        marker: { x_permille: 500, y_permille: 610 },
+      },
+    ],
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  // Default: the card table resolves. Individual tests override this to
+  // exercise the Undercity fallback and the no-art path. Set explicitly rather
+  // than left as a bare `vi.fn()` so a test that never reaches the image code
+  // is not silently relying on `undefined` throwing inside the hook.
+  fetchCardImageAssetByOracleId.mockResolvedValue({
+    src: "https://cards.scryfall.io/normal/front/5/9/59b11ff8.jpg",
+  });
+  fetchTokenImageByRef.mockResolvedValue(null);
+});
+
+afterEach(() => {
+  cleanup();
+  vi.resetAllMocks();
+});
+
+describe("DungeonBadge map panel", () => {
+  it("stays closed until the player hovers the dungeon name", () => {
+    render(<DungeonBadge room={lostMine()} />);
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+
+  it("opens on hover and closes when the pointer leaves", async () => {
+    render(<DungeonBadge room={lostMine()} />);
+    const chip = screen.getByRole("button", { name: /venturing in/i });
+
+    fireEvent.mouseEnter(chip);
+    expect(await screen.findByRole("dialog")).toBeInTheDocument();
+
+    fireEvent.mouseLeave(chip);
+    await waitFor(() => expect(screen.queryByRole("dialog")).toBeNull());
+  });
+
+  it("stays open after a click, so touch devices and pinning work", async () => {
+    render(<DungeonBadge room={lostMine()} />);
+    const chip = screen.getByRole("button", { name: /venturing in/i });
+
+    fireEvent.click(chip);
+    expect(await screen.findByRole("dialog")).toBeInTheDocument();
+
+    // A pinned panel must survive the hover ending.
+    fireEvent.mouseLeave(chip);
+    await new Promise((resolve) => setTimeout(resolve, 120));
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+
+    // Escape releases the pin.
+    fireEvent.keyDown(window, { key: "Escape" });
+    await waitFor(() => expect(screen.queryByRole("dialog")).toBeNull());
+  });
+
+  // CR 309.4a: the marker sits on the room the engine reports, positioned from
+  // that room's own card geometry — never the first room, and never a position
+  // the client computed.
+  it("draws the venture marker at the current room's printed position", async () => {
+    render(<DungeonBadge room={lostMine()} />);
+    fireEvent.mouseEnter(screen.getByRole("button", { name: /venturing in/i }));
+
+    const marker = await screen.findByTitle("Goblin Lair");
+    // Room 1's marker is (310, 390) permille → 31% / 39% of the card face.
+    expect(marker).toHaveStyle({ left: "31%", top: "39%" });
+  });
+
+  // CR 309.5a: only the rooms reachable from here are marked; the rest of the
+  // card is left alone so the marker reads unambiguously.
+  it("marks the rooms the marker can move to next, and no others", async () => {
+    render(<DungeonBadge room={lostMine()} />);
+    fireEvent.mouseEnter(screen.getByRole("button", { name: /venturing in/i }));
+    await screen.findByRole("dialog");
+
+    // Goblin Lair leads to Storeroom (3) and Dark Pool (4).
+    expect(screen.getByTitle("Storeroom")).toBeInTheDocument();
+    expect(screen.getByTitle("Dark Pool")).toBeInTheDocument();
+    // Cave Entrance is behind the marker; Mine Tunnels is a sibling branch.
+    expect(screen.queryByTitle("Cave Entrance")).toBeNull();
+    expect(screen.queryByTitle("Mine Tunnels")).toBeNull();
+  });
+
+  // The Undercity path: absent from the card table, present in the token table.
+  it("falls back to the token table when the card table has no entry", async () => {
+    fetchCardImageAssetByOracleId.mockRejectedValue(new Error("not in local data"));
+    fetchTokenImageByRef.mockResolvedValue(
+      "https://cards.scryfall.io/normal/front/2/c/2c65185b.jpg",
+    );
+
+    render(<DungeonBadge room={lostMine()} />);
+    fireEvent.mouseEnter(screen.getByRole("button", { name: /venturing in/i }));
+
+    const image = await screen.findByRole("img", { name: "Lost Mine of Phandelver" });
+    // And the panel upgrades to the `large` rung — these cards are floor plans
+    // whose room text has to stay readable.
+    expect(image).toHaveAttribute(
+      "src",
+      "https://cards.scryfall.io/large/front/2/c/2c65185b.jpg",
+    );
+  });
+
+  it("still shows the map when no art resolves at all", async () => {
+    fetchCardImageAssetByOracleId.mockRejectedValue(new Error("not in local data"));
+    fetchTokenImageByRef.mockResolvedValue(null);
+
+    render(<DungeonBadge room={lostMine()} />);
+    fireEvent.mouseEnter(screen.getByRole("button", { name: /venturing in/i }));
+
+    await screen.findByRole("dialog");
+    // The marker layer does not depend on the art having loaded.
+    expect(await screen.findByTitle("Goblin Lair")).toBeInTheDocument();
+  });
+});

--- a/client/src/components/hud/__tests__/DungeonBadge.map.test.tsx
+++ b/client/src/components/hud/__tests__/DungeonBadge.map.test.tsx
@@ -180,6 +180,27 @@ describe("DungeonBadge map panel", () => {
     );
   });
 
+  // Regression: `fetchTokenImageAssetByRef` reaches `resolveImageUrl`, which
+  // THROWS when the table holds an entry with no URL for the requested rung.
+  // That call used to sit outside the hook's `try`, and the promise chain had
+  // no `.catch`, so the rejection escaped: `setIsLoading(false)` never ran and
+  // the panel sat on "Loading dungeon card…" forever. Resolving-to-null (the
+  // test below) does NOT cover this — it is a different branch, which is how
+  // the suite read green over the bug.
+  it("shows the unavailable state when the token table REJECTS", async () => {
+    fetchCardImageAssetByOracleId.mockRejectedValue(new Error("not in local data"));
+    fetchTokenImageByRef.mockRejectedValue(new Error("No normal image for \"Undercity\""));
+
+    render(<DungeonBadge room={lostMine()} />);
+    fireEvent.mouseEnter(screen.getByRole("button", { name: /venturing in/i }));
+
+    // Settles into the unavailable message rather than hanging on "Loading".
+    expect(await screen.findByText("Dungeon card image unavailable")).toBeInTheDocument();
+    expect(screen.queryByText("Loading dungeon card…")).toBeNull();
+    // And the marker layer still renders, so the panel stays useful.
+    expect(screen.getByTitle("Goblin Lair")).toBeInTheDocument();
+  });
+
   it("still shows the map when no art resolves at all", async () => {
     fetchCardImageAssetByOracleId.mockRejectedValue(new Error("not in local data"));
     fetchTokenImageByRef.mockResolvedValue(null);

--- a/client/src/components/hud/__tests__/OpponentHud.designations.test.tsx
+++ b/client/src/components/hud/__tests__/OpponentHud.designations.test.tsx
@@ -156,6 +156,20 @@ describe("OpponentHud designations (single-opponent path)", () => {
                 dungeon_name: "Tomb of Annihilation",
                 room: { index: 0, name: "Trapped Entry", text: "Each player loses 1 life." },
                 room_count: 5,
+                card: {
+                  oracle_id: "d2ea2605-0ca0-4782-851d-e706bd0114e4",
+                  scryfall_id: "70b284bd-7a8f-4b60-8238-f746bdc5b236",
+                  face_name: "Tomb of Annihilation",
+                },
+                rooms: [
+                  {
+                    index: 0,
+                    name: "Trapped Entry",
+                    text: "Each player loses 1 life.",
+                    next_rooms: [1, 2],
+                    marker: { x_permille: 500, y_permille: 220 },
+                  },
+                ],
               },
             },
           },

--- a/client/src/components/hud/__tests__/PlayerHud.designations.test.tsx
+++ b/client/src/components/hud/__tests__/PlayerHud.designations.test.tsx
@@ -172,6 +172,27 @@ describe("PlayerHud designations", () => {
                     text: "Create a 1/1 red Goblin creature token.",
                   },
                   room_count: 7,
+                  card: {
+                    oracle_id: "5c446a7f-0301-4343-b0df-146cf2db605b",
+                    scryfall_id: "59b11ff8-f118-4978-87dd-509dc0c8c932",
+                    face_name: "Lost Mine of Phandelver",
+                  },
+                  rooms: [
+                    {
+                      index: 0,
+                      name: "Cave Entrance",
+                      text: "Scry 1.",
+                      next_rooms: [1, 2],
+                      marker: { x_permille: 500, y_permille: 215 },
+                    },
+                    {
+                      index: 1,
+                      name: "Goblin Lair",
+                      text: "Create a 1/1 red Goblin creature token.",
+                      next_rooms: [3, 4],
+                      marker: { x_permille: 310, y_permille: 390 },
+                    },
+                  ],
                 },
               },
             },
@@ -183,9 +204,9 @@ describe("PlayerHud designations", () => {
         screen.getByLabelText("Venturing in Lost Mine of Phandelver, Goblin Lair, room 2 of 7"),
       ).toBeInTheDocument();
       expect(screen.getByText("Lost Mine of Phandelver")).toBeInTheDocument();
-      // CR 309.4b-c: the tooltip names the room and repeats what it did.
-      expect(screen.getByText("Goblin Lair — room 2 of 7")).toBeInTheDocument();
-      expect(screen.getByText("Create a 1/1 red Goblin creature token.")).toBeInTheDocument();
+      // The chip itself shows the marker's place in the dungeon; the room's
+      // name and printed effect now live in the map panel the chip opens.
+      expect(screen.getByText("2/7")).toBeInTheDocument();
     });
 
     it("does not render when the player has progress but no active dungeon", () => {
@@ -216,6 +237,20 @@ describe("PlayerHud designations", () => {
                   dungeon_name: "Undercity",
                   room: { index: 0, name: "Secret Entrance", text: "Scry 1." },
                   room_count: 9,
+                  card: {
+                    oracle_id: "36b61021-72f0-4c22-a41d-9b2f093d7ca8",
+                    scryfall_id: "2c65185b-6cf0-451d-985e-56aa45d9a57d",
+                    face_name: "Undercity",
+                  },
+                  rooms: [
+                    {
+                      index: 0,
+                      name: "Secret Entrance",
+                      text: "Scry 1.",
+                      next_rooms: [1, 2],
+                      marker: { x_permille: 500, y_permille: 268 },
+                    },
+                  ],
                 },
               },
             },

--- a/client/src/hooks/useDungeonCardImage.ts
+++ b/client/src/hooks/useDungeonCardImage.ts
@@ -1,0 +1,92 @@
+import { useEffect, useState } from "react";
+
+import {
+  deriveImageUrl,
+  fetchCardImageAssetByOracleId,
+  fetchTokenImageByRef,
+} from "../services/scryfall.ts";
+import type { DungeonCardView } from "../adapter/types.ts";
+
+interface UseDungeonCardImageResult {
+  src: string | null;
+  isLoading: boolean;
+}
+
+/**
+ * Resolve the printed dungeon card's image.
+ *
+ * This exists as its own hook rather than reusing `useCardImage` because a
+ * dungeon is not a game object: it never enters the battlefield (CR 309.3 puts
+ * it in the command zone), so there is no `GameObject` with a `printed_ref` to
+ * feed that hook, and none of its machinery — visual packs, art-selection
+ * chains, printing pickers, face-down backs, the failed-source ladder — has
+ * anything to act on for a card that has exactly one relevant printing.
+ *
+ * Two lookup paths, because the five dungeons are not indexed uniformly by the
+ * Scryfall sidecars (verified against the Scryfall API):
+ *
+ *   1. `scryfall-data.json` by `oracle_id`. Covers Lost Mine of Phandelver,
+ *      Dungeon of the Mad Mage, Tomb of Annihilation and Baldur's Gate
+ *      Wilderness, all `layout: "normal"`.
+ *   2. `scryfall-token-images.json` by printing id. This is the ONLY path that
+ *      resolves Undercity, which is printed as the double-faced
+ *      `Undercity // The Initiative`; `gen-scryfall-images.sh` lists
+ *      `double_faced_token` in its NON_PLAYABLE exclusions, so Undercity is
+ *      absent from the card table entirely.
+ *
+ * The engine hands over both ids (`DungeonCardView`), so this tries the card
+ * table first and falls back to the token table without knowing which dungeon
+ * is which — no per-dungeon special case reaches the display layer.
+ *
+ * The result is upgraded to the `large` rung (672x936, vs `normal`'s 488x680).
+ * These cards are floor plans with room names and rules text printed inside
+ * each room, so the extra resolution is legibility, not polish.
+ */
+export function useDungeonCardImage(card: DungeonCardView): UseDungeonCardImageResult {
+  const [src, setSrc] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  const { oracle_id: oracleId, scryfall_id: scryfallId, face_name: faceName } = card;
+
+  useEffect(() => {
+    let cancelled = false;
+    setIsLoading(true);
+    setSrc(null);
+
+    async function resolve(): Promise<string | null> {
+      try {
+        const asset = await fetchCardImageAssetByOracleId(oracleId, faceName, "normal");
+        if (asset.src) return asset.src;
+      } catch {
+        // Not in the card table — expected for Undercity, and for any dungeon
+        // if the sidecar has not loaded. Fall through to the token table.
+      }
+      return await fetchTokenImageByRef(
+        {
+          scryfall_id: scryfallId,
+          scryfall_oracle_id: oracleId,
+          face_name: faceName,
+          // `TokenImageRef.preset_id` is a token-preset concept with no meaning
+          // for a dungeon card. `fetchTokenImageAssetByRef` reads only the ids
+          // and the face name; this is here to satisfy the shared type.
+          preset_id: "",
+        },
+        "normal",
+      );
+    }
+
+    void resolve().then((resolved) => {
+      if (cancelled) return;
+      // `deriveImageUrl` returns its input unchanged for anything that is not a
+      // sized Scryfall URL, so this is safe on every value that reaches it.
+      setSrc(resolved ? deriveImageUrl(resolved, "large") : null);
+      setIsLoading(false);
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [oracleId, scryfallId, faceName]);
+
+  return { src, isLoading };
+}

--- a/client/src/hooks/useDungeonCardImage.ts
+++ b/client/src/hooks/useDungeonCardImage.ts
@@ -16,7 +16,7 @@ interface UseDungeonCardImageResult {
  * Resolve the printed dungeon card's image.
  *
  * This exists as its own hook rather than reusing `useCardImage` because a
- * dungeon is not a game object: it never enters the battlefield (CR 309.3 puts
+ * dungeon is not a game object: it never enters the battlefield (CR 309.2b puts
  * it in the command zone), so there is no `GameObject` with a `printed_ref` to
  * feed that hook, and none of its machinery — visual packs, art-selection
  * chains, printing pickers, face-down backs, the failed-source ladder — has
@@ -61,27 +61,41 @@ export function useDungeonCardImage(card: DungeonCardView): UseDungeonCardImageR
         // Not in the card table — expected for Undercity, and for any dungeon
         // if the sidecar has not loaded. Fall through to the token table.
       }
-      return await fetchTokenImageByRef(
-        {
-          scryfall_id: scryfallId,
-          scryfall_oracle_id: oracleId,
-          face_name: faceName,
-          // `TokenImageRef.preset_id` is a token-preset concept with no meaning
-          // for a dungeon card. `fetchTokenImageAssetByRef` reads only the ids
-          // and the face name; this is here to satisfy the shared type.
-          preset_id: "",
-        },
-        "normal",
-      );
+      // Inside the `try` as well: `fetchTokenImageAssetByRef` reaches
+      // `resolveImageUrl`, which THROWS ("No <size> image for ...") when the
+      // table has an entry that carries no URL for the requested rung. That is
+      // a reachable path, not defensive padding — `loadTokenImagesData`
+      // swallows its own network failures with `.catch(() => null)`, so this
+      // throw is the live failure vector, and it is the Undercity path, the
+      // one dungeon that MUST resolve through this table.
+      try {
+        return await fetchTokenImageByRef(
+          {
+            scryfall_id: scryfallId,
+            scryfall_oracle_id: oracleId,
+            face_name: faceName,
+            // `TokenImageRef.preset_id` is a token-preset concept with no
+            // meaning for a dungeon card. `fetchTokenImageAssetByRef` reads
+            // only the ids and the face name; this is here to satisfy the
+            // shared type.
+            preset_id: "",
+          },
+          "normal",
+        );
+      } catch {
+        return null;
+      }
     }
 
-    void resolve().then((resolved) => {
-      if (cancelled) return;
-      // `deriveImageUrl` returns its input unchanged for anything that is not a
-      // sized Scryfall URL, so this is safe on every value that reaches it.
-      setSrc(resolved ? deriveImageUrl(resolved, "large") : null);
-      setIsLoading(false);
-    });
+    void resolve()
+      .catch(() => null)
+      .then((resolved) => {
+        if (cancelled) return;
+        // `deriveImageUrl` returns its input unchanged for anything that is not
+        // a sized Scryfall URL, so this is safe on every value that reaches it.
+        setSrc(resolved ? deriveImageUrl(resolved, "large") : null);
+        setIsLoading(false);
+      });
 
     return () => {
       cancelled = true;

--- a/client/src/i18n/locales/de/game.json
+++ b/client/src/i18n/locales/de/game.json
@@ -511,6 +511,8 @@
     "enduringStoryTooltip": "Bleibende Geschichte — erhalten, wenn du eine Storied bleibende Karte und drei oder mehr Artefakte, legendäre bleibende Karten und/oder Sagen kontrollierst; bleibt für den Rest der Partie bestehen",
     "dungeonAriaLabel": "Wagt sich in {{name}} vor, {{roomName}}, Raum {{room}} von {{total}}",
     "dungeonRoomTooltip": "{{roomName}} — Raum {{room}} von {{total}}",
+    "dungeonMapLoading": "Verlieskarte wird geladen…",
+    "dungeonMapUnavailable": "Bild der Verlieskarte nicht verfügbar",
     "dungeonTooltip": "Wagt sich in {{name}} vor",
     "poisonAriaLabel_one": "{{count}} Giftmarke",
     "poisonAriaLabel_other": "{{count}} Giftmarken",

--- a/client/src/i18n/locales/en/game.json
+++ b/client/src/i18n/locales/en/game.json
@@ -544,6 +544,8 @@
     "enduringStoryTooltip": "Enduring Story — gained by controlling a Storied permanent and three or more artifacts, legendary permanents, and/or Sagas; lasts for the rest of the game",
     "dungeonAriaLabel": "Venturing in {{name}}, {{roomName}}, room {{room}} of {{total}}",
     "dungeonRoomTooltip": "{{roomName}} — room {{room}} of {{total}}",
+    "dungeonMapLoading": "Loading dungeon card…",
+    "dungeonMapUnavailable": "Dungeon card image unavailable",
     "dungeonTooltip": "Venturing in {{name}}",
     "poisonAriaLabel_one": "{{count}} poison counter",
     "poisonAriaLabel_other": "{{count}} poison counters",

--- a/client/src/i18n/locales/es/game.json
+++ b/client/src/i18n/locales/es/game.json
@@ -511,6 +511,8 @@
     "enduringStoryTooltip": "Historia perdurable — se obtiene al controlar un permanente con Storied y tres o más artefactos, permanentes legendarios y/o sagas; dura el resto del juego",
     "dungeonAriaLabel": "Aventurándose en {{name}}, {{roomName}}, sala {{room}} de {{total}}",
     "dungeonRoomTooltip": "{{roomName}} — sala {{room}} de {{total}}",
+    "dungeonMapLoading": "Cargando carta de mazmorra…",
+    "dungeonMapUnavailable": "Imagen de la carta de mazmorra no disponible",
     "dungeonTooltip": "Aventurándose en {{name}}",
     "poisonAriaLabel_one": "{{count}} contador de veneno",
     "poisonAriaLabel_other": "{{count}} contadores de veneno",

--- a/client/src/i18n/locales/fr/game.json
+++ b/client/src/i18n/locales/fr/game.json
@@ -511,6 +511,8 @@
     "enduringStoryTooltip": "Histoire durable — obtenue en contrôlant un permanent avec Storied et au moins trois artefacts, permanents légendaires et/ou sagas ; dure pour le reste de la partie",
     "dungeonAriaLabel": "Aventure dans {{name}}, {{roomName}}, salle {{room}} sur {{total}}",
     "dungeonRoomTooltip": "{{roomName}} — salle {{room}} sur {{total}}",
+    "dungeonMapLoading": "Chargement de la carte de donjon…",
+    "dungeonMapUnavailable": "Image de la carte de donjon indisponible",
     "dungeonTooltip": "Aventure dans {{name}}",
     "poisonAriaLabel_one": "{{count}} marqueur poison",
     "poisonAriaLabel_other": "{{count}} marqueurs poison",

--- a/client/src/i18n/locales/it/game.json
+++ b/client/src/i18n/locales/it/game.json
@@ -511,6 +511,8 @@
     "enduringStoryTooltip": "Storia duratura — ottenuta controllando un permanente con Storied e tre o più artefatti, permanenti leggendari e/o saghe; dura per il resto della partita",
     "dungeonAriaLabel": "Avventura in {{name}}, {{roomName}}, stanza {{room}} di {{total}}",
     "dungeonRoomTooltip": "{{roomName}} — stanza {{room}} di {{total}}",
+    "dungeonMapLoading": "Caricamento della carta sotterraneo…",
+    "dungeonMapUnavailable": "Immagine della carta sotterraneo non disponibile",
     "dungeonTooltip": "Avventura in {{name}}",
     "poisonAriaLabel_one": "{{count}} segnalino veleno",
     "poisonAriaLabel_other": "{{count}} segnalini veleno",

--- a/client/src/i18n/locales/pl/game.json
+++ b/client/src/i18n/locales/pl/game.json
@@ -511,6 +511,8 @@
     "enduringStoryTooltip": "Trwała historia — zdobyta za kontrolowanie permanenta ze Storied i co najmniej trzech artefaktów, legendarnych permanentów i/lub Sag; trwa do końca gry",
     "dungeonAriaLabel": "Wyprawa w {{name}}, {{roomName}}, pokój {{room}} z {{total}}",
     "dungeonRoomTooltip": "{{roomName}} — pokój {{room}} z {{total}}",
+    "dungeonMapLoading": "Wczytywanie karty lochu…",
+    "dungeonMapUnavailable": "Obraz karty lochu niedostępny",
     "dungeonTooltip": "Wyprawa w {{name}}",
     "poisonAriaLabel_one": "{{count}} znacznik trucizny",
     "poisonAriaLabel_other": "{{count}} znaczników trucizny",

--- a/client/src/i18n/locales/pt/game.json
+++ b/client/src/i18n/locales/pt/game.json
@@ -511,6 +511,8 @@
     "enduringStoryTooltip": "História duradoura — obtida ao controlar um permanente com Storied e três ou mais artefatos, permanentes lendários e/ou sagas; dura pelo resto do jogo",
     "dungeonAriaLabel": "Aventurando-se em {{name}}, {{roomName}}, sala {{room}} de {{total}}",
     "dungeonRoomTooltip": "{{roomName}} — sala {{room}} de {{total}}",
+    "dungeonMapLoading": "Carregando carta de masmorra…",
+    "dungeonMapUnavailable": "Imagem da carta de masmorra indisponível",
     "dungeonTooltip": "Aventurando-se em {{name}}",
     "poisonAriaLabel_one": "{{count}} marcador de veneno",
     "poisonAriaLabel_other": "{{count}} marcadores de veneno",

--- a/client/src/network/__tests__/protocol.test.ts
+++ b/client/src/network/__tests__/protocol.test.ts
@@ -71,8 +71,8 @@ const PREVIEW_ANSWER = {
 } as never;
 
 describe("encodeWireMessage / decodeWireMessage", () => {
-  it("pins the P2P wire protocol to v49", () => {
-    expect(WIRE_PROTOCOL_VERSION).toBe(49);
+  it("pins the P2P wire protocol to v50", () => {
+    expect(WIRE_PROTOCOL_VERSION).toBe(50);
   });
 
   it("defaults shortcut actions for a legacy payload created before the additive field", () => {

--- a/client/src/network/protocol.ts
+++ b/client/src/network/protocol.ts
@@ -106,6 +106,16 @@ export function legalActionsFromWire(wire: LegalActionsWire): LegalActionsResult
  * seat or adopts reconnect state.
  *
  * Bumps to date:
+ *  50 — DerivedViews.dungeon_rooms entries gained required `card` and `rooms`
+ *       fields: the dungeon card's Scryfall identity, and every room with its
+ *       outgoing edges (CR 309.5a) and its position on the printed card face.
+ *       A PARSE bump like 49, not a silent capability loss like 39: neither
+ *       field carries a serde default, so a v49 peer cannot parse a snapshot
+ *       in which anyone is venturing. Nor is the reverse benign — this client
+ *       reads `card` unconditionally when resolving the dungeon art, so a v49
+ *       host would throw in render rather than drop the panel. Since
+ *       game_setup and reconnect_ack carry GameState, first contact rejects
+ *       the skew instead of allowing either failure.
  *  49 — ReplacementCondition.FirstTokenCreationEachTurn moved its required
  *       player field to an optional active_player_req, and CopyTargetPurpose
  *       gained a CopyTokenSource variant. Both are one-way parse breaks: the
@@ -349,7 +359,7 @@ export type P2PInteractionPreviewAnswer =
   | { type: "preview"; preview: InteractionPreview }
   | { type: "failed"; message: string };
 
-export const WIRE_PROTOCOL_VERSION = 49 as const;
+export const WIRE_PROTOCOL_VERSION = 50 as const;
 
 export type P2PMessage = P2PAuthorityWire & (
   | {

--- a/crates/engine/src/game/derived_views.rs
+++ b/crates/engine/src/game/derived_views.rs
@@ -588,6 +588,42 @@ pub struct DungeonRoomView {
     /// CR 309.4: total rooms on the dungeon card, so the badge can place the
     /// marker ("room 3 of 7") rather than showing a naked index.
     pub room_count: u8,
+    /// CR 309.1: the printed dungeon card's Scryfall identity, so the client
+    /// can show the card the venture marker moves across. A dungeon is never
+    /// on the battlefield (CR 309.3 puts it in the command zone), so there is
+    /// no `printed_ref`-carrying object for the client to resolve art from.
+    pub card: DungeonCardView,
+    /// CR 309.4a-c: every room on the card, in printed order, each with the
+    /// rooms it leads to and where it sits on the card face. This is what lets
+    /// the client draw the venture marker in the right place and show the path
+    /// taken; without it the frontend would need its own copy of the dungeon
+    /// tables, which the display-layer rule forbids.
+    pub rooms: Vec<DungeonRoomNodeView>,
+}
+
+/// CR 309.1: The printed dungeon card, as the client looks it up on Scryfall.
+///
+/// Both ids ride along because the five dungeons are not indexed uniformly by
+/// the client's Scryfall sidecars — Undercity is a `double_faced_token` that
+/// only `scryfall-token-images.json` carries. See `dungeon::DungeonCardRef`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DungeonCardView {
+    pub oracle_id: String,
+    pub scryfall_id: String,
+    pub face_name: String,
+}
+
+/// CR 309.4: One room as the client draws it — its preview, its outgoing
+/// edges, and its position on the printed card face.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DungeonRoomNodeView {
+    #[serde(flatten)]
+    pub room: crate::game::dungeon::RoomPreview,
+    /// CR 309.5a: the rooms the venture marker may move to from here. Empty
+    /// for the bottommost room (CR 309.5).
+    pub next_rooms: Vec<u8>,
+    /// Where this room is drawn on the card, as a fraction of the image.
+    pub marker: crate::game::dungeon::RoomMarkerPoint,
 }
 
 /// Engine-authored projections used by the display layer. Keep this struct
@@ -1185,6 +1221,40 @@ fn pending_payment_remaining(state: &GameState, viewer: PlayerId) -> Option<Mana
     ))
 }
 
+/// CR 309.1: Project the printed dungeon card's Scryfall identity.
+fn dungeon_card_view(dungeon: crate::game::dungeon::DungeonId) -> DungeonCardView {
+    let card = crate::game::dungeon::card_ref(dungeon);
+    DungeonCardView {
+        oracle_id: card.oracle_id.to_string(),
+        scryfall_id: card.scryfall_id.to_string(),
+        face_name: card.face_name.to_string(),
+    }
+}
+
+/// CR 309.4 + CR 309.5a: Project the whole dungeon graph — every room, its
+/// outgoing edges, and where it is drawn on the card.
+///
+/// The client needs all of it at once: it draws the marker on the current room
+/// and dims the rooms that can no longer be reached, and neither is derivable
+/// from the current room alone.
+fn dungeon_room_nodes(dungeon: crate::game::dungeon::DungeonId) -> Vec<DungeonRoomNodeView> {
+    let markers = crate::game::dungeon::marker_points(dungeon);
+    (0..crate::game::dungeon::room_count(dungeon))
+        .filter_map(|index| {
+            // `dungeon_marker_points_cover_every_room` pins these lists to the
+            // same length, so a miss is unreachable. Skipping rather than
+            // indexing keeps a future table edit from panicking the whole state
+            // projection on a purely cosmetic field.
+            let marker = *markers.get(index as usize)?;
+            Some(DungeonRoomNodeView {
+                room: crate::game::dungeon::room_preview(dungeon, index),
+                next_rooms: crate::game::dungeon::next_rooms(dungeon, index).to_vec(),
+                marker,
+            })
+        })
+        .collect()
+}
+
 /// CR 309.4a-c: name the room each venturing player's marker currently sits on.
 ///
 /// `dungeon_progress` may keep an entry with `current_dungeon: None` after a
@@ -1206,6 +1276,8 @@ fn dungeon_rooms(state: &GameState) -> BTreeMap<PlayerId, DungeonRoomView> {
                         .to_string(),
                     room: crate::game::dungeon::room_preview(dungeon, progress.current_room),
                     room_count: crate::game::dungeon::room_count(dungeon),
+                    card: dungeon_card_view(dungeon),
+                    rooms: dungeon_room_nodes(dungeon),
                 },
             ))
         })

--- a/crates/engine/src/game/derived_views.rs
+++ b/crates/engine/src/game/derived_views.rs
@@ -588,10 +588,13 @@ pub struct DungeonRoomView {
     /// CR 309.4: total rooms on the dungeon card, so the badge can place the
     /// marker ("room 3 of 7") rather than showing a naked index.
     pub room_count: u8,
-    /// CR 309.1: the printed dungeon card's Scryfall identity, so the client
-    /// can show the card the venture marker moves across. A dungeon is never
-    /// on the battlefield (CR 309.3 puts it in the command zone), so there is
-    /// no `printed_ref`-carrying object for the client to resolve art from.
+    /// The printed dungeon card's Scryfall identity, so the client can show the
+    /// card the venture marker moves across.
+    ///
+    /// CR 309.2b: a dungeon card brought into the game is put into the command
+    /// zone, so it is never a battlefield object and no `printed_ref`-carrying
+    /// object exists for the client to resolve art from. (Matches the citation
+    /// on `dungeon_rooms` below.) The ids themselves implement no rule.
     pub card: DungeonCardView,
     /// CR 309.4a-c: every room on the card, in printed order, each with the
     /// rooms it leads to and where it sits on the card face. This is what lets
@@ -622,7 +625,8 @@ pub struct DungeonRoomNodeView {
     /// CR 309.5a: the rooms the venture marker may move to from here. Empty
     /// for the bottommost room (CR 309.5).
     pub next_rooms: Vec<u8>,
-    /// Where this room is drawn on the card, as a fraction of the image.
+    /// Where this room is drawn on the card. Permille of the image — see
+    /// `RoomMarkerPoint`, which documents why it is not a fraction.
     pub marker: crate::game::dungeon::RoomMarkerPoint,
 }
 
@@ -1234,8 +1238,8 @@ fn dungeon_card_view(dungeon: crate::game::dungeon::DungeonId) -> DungeonCardVie
 /// CR 309.4 + CR 309.5a: Project the whole dungeon graph — every room, its
 /// outgoing edges, and where it is drawn on the card.
 ///
-/// The client needs all of it at once: it draws the marker on the current room
-/// and dims the rooms that can no longer be reached, and neither is derivable
+/// The client needs all of it at once: it places the marker on the current room
+/// and marks the rooms reachable from it (CR 309.5a), and neither is derivable
 /// from the current room alone.
 fn dungeon_room_nodes(dungeon: crate::game::dungeon::DungeonId) -> Vec<DungeonRoomNodeView> {
     let markers = crate::game::dungeon::marker_points(dungeon);

--- a/crates/engine/src/game/derived_views.rs
+++ b/crates/engine/src/game/derived_views.rs
@@ -604,7 +604,9 @@ pub struct DungeonRoomView {
     pub rooms: Vec<DungeonRoomNodeView>,
 }
 
-/// CR 309.1: The printed dungeon card, as the client looks it up on Scryfall.
+/// The printed dungeon card, as the client looks it up on Scryfall.
+///
+/// Identity plumbing, not a rule — deliberately unannotated.
 ///
 /// Both ids ride along because the five dungeons are not indexed uniformly by
 /// the client's Scryfall sidecars — Undercity is a `double_faced_token` that
@@ -1225,7 +1227,7 @@ fn pending_payment_remaining(state: &GameState, viewer: PlayerId) -> Option<Mana
     ))
 }
 
-/// CR 309.1: Project the printed dungeon card's Scryfall identity.
+/// Project the printed dungeon card's Scryfall identity.
 fn dungeon_card_view(dungeon: crate::game::dungeon::DungeonId) -> DungeonCardView {
     let card = crate::game::dungeon::card_ref(dungeon);
     DungeonCardView {
@@ -3282,6 +3284,69 @@ mod tests {
         assert_eq!(room.room.name, "Mine Tunnels");
         assert_eq!(room.room.text, "Create a Treasure token.");
         assert_eq!(room.room_count, 7);
+
+        // The card identity and the room graph are the two fields the client
+        // cannot function without: the popover destructures `card` to resolve
+        // the art and indexes `rooms` to place the venture marker. They are
+        // also the fields that forced the protocol bump, so a silent
+        // regression here is a wire break, not a cosmetic one.
+        assert_eq!(room.card.oracle_id, "5c446a7f-0301-4343-b0df-146cf2db605b");
+        assert_eq!(
+            room.card.scryfall_id,
+            "59b11ff8-f118-4978-87dd-509dc0c8c932"
+        );
+        assert_eq!(room.card.face_name, "Lost Mine of Phandelver");
+
+        assert_eq!(
+            room.rooms.len(),
+            7,
+            "the whole graph ships, not just the current room"
+        );
+        // CR 309.5a: Mine Tunnels (index 2) leads to Dark Pool and Fungi Cavern.
+        let current = &room.rooms[2];
+        assert_eq!(current.room.name, "Mine Tunnels");
+        assert_eq!(current.next_rooms, vec![4, 5]);
+        // The bottommost room has no outgoing arrows (CR 309.5).
+        assert!(room.rooms[6].next_rooms.is_empty());
+        // Every room carries a marker inside the card face.
+        for node in &room.rooms {
+            assert!(node.marker.x_permille <= 1000 && node.marker.y_permille <= 1000);
+        }
+    }
+
+    /// The double-faced dungeon is the reason `DungeonCardView` carries two ids
+    /// rather than one: `Undercity // The Initiative` is a `double_faced_token`,
+    /// which `gen-scryfall-images.sh` excludes from `scryfall-data.json`, so the
+    /// client resolves it through the token table by printing id. If this
+    /// projection ever emitted only an oracle id, Undercity would render artless
+    /// and nothing else would fail.
+    #[test]
+    fn dungeon_rooms_projects_the_double_faced_undercity_card_identity() {
+        use crate::game::dungeon::{DungeonId, DungeonProgress};
+
+        let mut state = GameState::new_two_player(42);
+        state.dungeon_progress.insert(
+            PlayerId(0),
+            DungeonProgress {
+                current_dungeon: Some(DungeonId::Undercity),
+                current_room: 0,
+                ..Default::default()
+            },
+        );
+
+        let views = derive_views(&state, None);
+        let room = views
+            .dungeon_rooms
+            .get(&PlayerId(0))
+            .expect("venturing player is projected");
+
+        assert_eq!(
+            room.card.scryfall_id,
+            "2c65185b-6cf0-451d-985e-56aa45d9a57d"
+        );
+        // Selects the dungeon half of `Undercity // The Initiative`.
+        assert_eq!(room.card.face_name, "Undercity");
+        assert_eq!(room.rooms.len(), 9);
     }
 
     /// CR 309.7: a completed dungeon leaves a `current_dungeon: None` entry

--- a/crates/engine/src/game/dungeon.rs
+++ b/crates/engine/src/game/dungeon.rs
@@ -98,6 +98,228 @@ pub struct DungeonDefinition {
     pub rooms: &'static [RoomDefinition],
 }
 
+/// CR 309.4: Where a room sits on the printed dungeon card, as a fraction of
+/// the card image (0.0-1.0, origin top-left).
+///
+/// The dungeon cards are the rare case where the "art" IS the game state: each
+/// card is a labeled floor plan whose rooms are drawn as rectangles, not a
+/// framed illustration. That is what makes overlaying a venture marker on the
+/// image meaningful rather than decorative — the marker lands in the drawn room
+/// it represents.
+///
+/// Fractions, not pixels, because the client renders the card at whatever width
+/// the panel gives it and picks an image rung by viewport. Fractions also
+/// transfer across printings: the token-set and oversized printings of a
+/// dungeon are the same layout at the same proportions (verified by comparing
+/// the `tafr` and `oafr` Lost Mine scans, identical at every rung).
+///
+/// `x`/`y` are the room rectangle's CENTER, which is where the marker is drawn.
+///
+/// Stored as PERMILLE (0-1000) rather than a float. `DerivedViews` derives `Eq`
+/// so that state snapshots can be compared for equality, and `f32` is not `Eq`
+/// — a float here would force the whole projection down to `PartialEq`. Permille
+/// is far finer than the overlay needs: one part in a thousand of a 672px card
+/// is under a pixel.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RoomMarkerPoint {
+    /// Distance from the card's left edge, in thousandths of its width.
+    pub x_permille: u16,
+    /// Distance from the card's top edge, in thousandths of its height.
+    pub y_permille: u16,
+}
+
+/// Authoring helper: the coordinates are read off the card as fractions, so
+/// they are written as fractions and converted once, here.
+const fn pt(x_permille: u16, y_permille: u16) -> RoomMarkerPoint {
+    RoomMarkerPoint {
+        x_permille,
+        y_permille,
+    }
+}
+
+/// CR 309.4: Centers of each room's drawn rectangle on the dungeon card,
+/// indexed in the same order as the dungeon's `rooms` table.
+///
+/// Authored from the printed card faces; there is no coordinate data on
+/// Scryfall (its `oracle_text` gives only ordered "Name — Effect. (Leads to:)"
+/// lines), so these are the single place the geometry exists. The
+/// `dungeon_marker_points_cover_every_room` test pins each list's length to its
+/// room table so a dungeon can never carry a partial or stale list.
+pub fn marker_points(id: DungeonId) -> &'static [RoomMarkerPoint] {
+    match id {
+        DungeonId::LostMineOfPhandelver => &LOST_MINE_MARKERS,
+        DungeonId::DungeonOfTheMadMage => &MAD_MAGE_MARKERS,
+        DungeonId::TombOfAnnihilation => &TOMB_MARKERS,
+        DungeonId::Undercity => &UNDERCITY_MARKERS,
+        DungeonId::BaldursGateWilderness => &BALDURS_GATE_MARKERS,
+    }
+}
+
+/// Lost Mine of Phandelver — 4 rows: full / halves / thirds / full.
+/// Read off the printed card face (AFR token #021).
+static LOST_MINE_MARKERS: [RoomMarkerPoint; 7] = [
+    pt(500, 215), // 0 Cave Entrance   (full width)
+    pt(310, 390), // 1 Goblin Lair     (left half)
+    pt(690, 390), // 2 Mine Tunnels    (right half)
+    pt(180, 610), // 3 Storeroom       (left third)
+    pt(500, 610), // 4 Dark Pool       (centre third)
+    pt(810, 610), // 5 Fungi Cavern    (right third)
+    pt(500, 800), // 6 Temple of Dumathoin (full width)
+];
+
+/// Dungeon of the Mad Mage — alternating full-width corridors and half-width
+/// branch pairs. The branch rows are drawn roughly twice as tall as the
+/// single-room corridors, so the y values are not evenly spaced.
+/// Read off the printed card face (AFR token #020).
+static MAD_MAGE_MARKERS: [RoomMarkerPoint; 9] = [
+    pt(500, 184), // 0 Yawning Portal      (full width)
+    pt(500, 259), // 1 Dungeon Level       (full width)
+    pt(290, 376), // 2 Goblin Bazaar       (left half, tall)
+    pt(715, 376), // 3 Twisted Caverns     (right half, tall)
+    pt(500, 494), // 4 Lost Level          (full width)
+    pt(290, 606), // 5 Runestone Caverns   (left half, tall)
+    pt(715, 606), // 6 Muiral's Graveyard  (right half, tall)
+    pt(500, 723), // 7 Deep Mines          (full width)
+    pt(500, 814), // 8 Mad Wizard's Lair   (full width, bottommost)
+];
+
+/// Tomb of Annihilation — irregular: Oubliette is a single TALL room on the
+/// right spanning the vertical extent of both Veils of Fear and Sandfall Cell,
+/// which are stacked on the left. Not a 2x2 grid.
+/// Read off the printed card face (AFR token #022).
+static TOMB_MARKERS: [RoomMarkerPoint; 5] = [
+    pt(500, 220), // 0 Trapped Entry           (full width)
+    pt(290, 400), // 1 Veils of Fear           (left, upper)
+    pt(720, 480), // 2 Oubliette               (right, spans both left rows)
+    pt(290, 580), // 3 Sandfall Cell           (left, lower)
+    pt(500, 775), // 4 Cradle of the Death God (full width, bottommost)
+];
+
+/// Undercity — the "You can't enter this dungeon unless you 'venture into
+/// Undercity.'" line above the grid pushes every row down relative to the AFR
+/// dungeons, and the Trap!/Arena/Stash row is asymmetric (Arena is a narrow
+/// centre room). Archives/Catacombs below it are unequal halves.
+/// Read off the printed card face (CLB token #020).
+static UNDERCITY_MARKERS: [RoomMarkerPoint; 9] = [
+    pt(500, 248), // 0 Secret Entrance
+    pt(310, 370), // 1 Forge            (left half)
+    pt(710, 370), // 2 Lost Well        (right half)
+    pt(200, 508), // 3 Trap!            (left)
+    pt(490, 508), // 4 Arena            (narrow centre)
+    pt(780, 508), // 5 Stash            (right)
+    pt(280, 654), // 6 Archives         (left)
+    pt(700, 660), // 7 Catacombs        (right, taller)
+    pt(500, 818), // 8 Throne of the Dead Three (bottommost)
+];
+
+/// Baldur's Gate Wilderness — 19 rooms in an alternating lattice, NOT a
+/// diamond: one full-width entry, then rows of 3 and 2 alternating down the
+/// card (3/2/3/2/3/2/3). Rooms in the 3-rows sit at the thirds; rooms in the
+/// 2-rows sit offset between them, which is what makes the diagonal corridors
+/// line up on the printed card.
+/// Read off the printed card face (CLB token, 2024 printing).
+static BALDURS_GATE_MARKERS: [RoomMarkerPoint; 19] = [
+    // Row 1 — full width
+    pt(500, 170), // 0  Crash Landing
+    // Row 2 — three
+    pt(210, 253), // 1  Goblin Camp
+    pt(500, 253), // 2  Emerald Grove
+    pt(800, 253), // 3  Auntie's Teahouse
+    // Row 3 — two
+    pt(295, 336), // 4  Defiled Temple
+    pt(730, 336), // 5  Mountain Pass
+    // Row 4 — three
+    pt(210, 440), // 6  Ebonlake Grotto
+    pt(500, 440), // 7  Grymforge
+    pt(800, 440), // 8  Githyanki Crèche
+    // Row 5 — two
+    pt(285, 545), // 9  Last Light Inn
+    pt(700, 545), // 10 Reithwin Tollhouse
+    // Row 6 — three
+    pt(210, 622), // 11 Moonrise Towers
+    pt(500, 622), // 12 Gauntlet of Shar
+    pt(800, 622), // 13 Balthazar's Lab
+    // Row 7 — two
+    pt(300, 710), // 14 Circus of the Last Days
+    pt(715, 710), // 15 Undercity Ruins
+    // Row 8 — three (bottommost row)
+    pt(190, 822), // 16 Steel Watch Foundry
+    pt(500, 822), // 17 Ansur's Sanctum
+    pt(810, 822), // 18 Temple of Bhaal
+];
+
+/// CR 309.1: The dungeon card's identity on Scryfall, so the client can show
+/// the printed card the venture marker moves across.
+///
+/// A dungeon is a real printed card, not a synthesized object, so it has no
+/// `printed_ref` on any battlefield object to borrow — a dungeon never enters
+/// the battlefield (CR 309.3: it goes to the command zone). This is the only
+/// place its printing identity exists, which is why it lives beside the room
+/// tables rather than in the client.
+///
+/// Two lookup paths, because the five dungeons are not indexed uniformly by the
+/// client's Scryfall sidecars (verified against the Scryfall API):
+///
+///   * Four dungeons are `layout: "normal"`, so `scryfall-data.json` keys them
+///     by `oracle_id` like any other card.
+///   * Undercity is `layout: "double_faced_token"` — it is printed as
+///     `Undercity // The Initiative`, whose front face is the dungeon. That
+///     layout is in `gen-scryfall-images.sh`'s NON_PLAYABLE exclusion list, so
+///     it is absent from `scryfall-data.json` entirely and resolves ONLY
+///     through `scryfall-token-images.json`, which is keyed by printing id.
+///
+/// Emitting both ids lets the client try the card table and fall back to the
+/// token table without knowing which dungeon is which — the asymmetry stays
+/// here, in the engine, instead of becoming a special case in the display layer.
+pub struct DungeonCardRef {
+    /// Scryfall `oracle_id` — the `scryfall-data.json` key.
+    pub oracle_id: &'static str,
+    /// Scryfall printing id of the token-set printing — the
+    /// `scryfall-token-images.json` key. This is the `tafr`/`tclb` printing,
+    /// whose art is identical at every image rung to its oversized `oafr`/`oclb`
+    /// twin (both scan to 488x680 `normal` / 672x936 `large`), so nothing is
+    /// lost by pinning one.
+    pub scryfall_id: &'static str,
+    /// The dungeon's own face name. Meaningful only for the double-faced
+    /// Undercity, where it selects the dungeon face over `The Initiative`;
+    /// for the single-faced dungeons it equals the card name.
+    pub face_name: &'static str,
+}
+
+/// CR 309.1: The printed card behind each dungeon. Ids verified against the
+/// Scryfall API rather than transcribed from memory.
+pub fn card_ref(id: DungeonId) -> DungeonCardRef {
+    match id {
+        DungeonId::LostMineOfPhandelver => DungeonCardRef {
+            oracle_id: "5c446a7f-0301-4343-b0df-146cf2db605b",
+            scryfall_id: "59b11ff8-f118-4978-87dd-509dc0c8c932",
+            face_name: "Lost Mine of Phandelver",
+        },
+        DungeonId::DungeonOfTheMadMage => DungeonCardRef {
+            oracle_id: "30d0398c-bf5a-4b30-936f-afdb5a109b4b",
+            scryfall_id: "6f509dbe-6ec7-4438-ab36-e20be46c9922",
+            face_name: "Dungeon of the Mad Mage",
+        },
+        DungeonId::TombOfAnnihilation => DungeonCardRef {
+            oracle_id: "d2ea2605-0ca0-4782-851d-e706bd0114e4",
+            scryfall_id: "70b284bd-7a8f-4b60-8238-f746bdc5b236",
+            face_name: "Tomb of Annihilation",
+        },
+        // CR 309.1: the only double-faced dungeon. `face_name` is what picks the
+        // dungeon face out of `Undercity // The Initiative`.
+        DungeonId::Undercity => DungeonCardRef {
+            oracle_id: "36b61021-72f0-4c22-a41d-9b2f093d7ca8",
+            scryfall_id: "2c65185b-6cf0-451d-985e-56aa45d9a57d",
+            face_name: "Undercity",
+        },
+        DungeonId::BaldursGateWilderness => DungeonCardRef {
+            oracle_id: "06b9590d-01bf-4fae-9837-352c9e04267a",
+            scryfall_id: "a9d56324-8293-4500-a9ad-fed351ccf966",
+            face_name: "Baldur's Gate Wilderness",
+        },
+    }
+}
+
 /// CR 309: Look up a dungeon's static definition.
 pub fn get_definition(id: DungeonId) -> &'static DungeonDefinition {
     match id {
@@ -2149,5 +2371,85 @@ mod tests {
             get_definition(DungeonId::BaldursGateWilderness).rooms.len(),
             19
         );
+    }
+
+    /// Every dungeon must carry exactly one marker point per room.
+    ///
+    /// This is the guard that keeps the hand-authored geometry honest. The
+    /// coordinates are read off the printed card faces and cannot be derived
+    /// from anything the engine or Scryfall stores, so the failure mode they
+    /// invite is a silent one: add a room, forget the point, and the client
+    /// draws the venture marker on the wrong room — asserting something false
+    /// about game state rather than merely looking wrong.
+    #[test]
+    fn dungeon_marker_points_cover_every_room() {
+        for id in ALL_DUNGEONS {
+            let rooms = get_definition(id).rooms.len();
+            let points = marker_points(id).len();
+            assert_eq!(
+                points, rooms,
+                "{id} has {rooms} rooms but {points} marker points",
+            );
+        }
+    }
+
+    /// Marker points are permille of the card image, so every coordinate has to
+    /// land inside it. A point past 1000 would place the marker off the card
+    /// entirely.
+    #[test]
+    fn dungeon_marker_points_are_normalized() {
+        for id in ALL_DUNGEONS {
+            for (index, point) in marker_points(id).iter().enumerate() {
+                assert!(
+                    point.x_permille <= 1000 && point.y_permille <= 1000,
+                    "{id} room {index} marker {point:?} is outside the card",
+                );
+            }
+        }
+    }
+
+    /// Rooms are drawn top-to-bottom on the card in the same order the room
+    /// table lists them, so a room can never sit ABOVE one that precedes it.
+    /// This catches a transposed or misordered coordinate list — the shape of
+    /// error that `dungeon_marker_points_cover_every_room` cannot see because
+    /// the count still matches.
+    #[test]
+    fn dungeon_marker_points_descend_the_card() {
+        for id in ALL_DUNGEONS {
+            let points = marker_points(id);
+            for (index, window) in points.windows(2).enumerate() {
+                assert!(
+                    window[1].y_permille >= window[0].y_permille,
+                    "{id}: room {} sits above room {index} ({:?} then {:?})",
+                    index + 1,
+                    window[0],
+                    window[1],
+                );
+            }
+        }
+    }
+
+    /// The Scryfall ids behind each dungeon must be distinct and well-formed.
+    /// Undercity is the one that matters most: it is the only double-faced
+    /// dungeon, and its `face_name` is what selects the dungeon half of
+    /// `Undercity // The Initiative`.
+    #[test]
+    fn dungeon_card_refs_are_distinct_and_well_formed() {
+        let mut oracle_ids = std::collections::BTreeSet::new();
+        let mut scryfall_ids = std::collections::BTreeSet::new();
+        for id in ALL_DUNGEONS {
+            let card = card_ref(id);
+            assert_eq!(card.oracle_id.len(), 36, "{id} oracle_id is not a uuid");
+            assert_eq!(card.scryfall_id.len(), 36, "{id} scryfall_id is not a uuid");
+            assert!(!card.face_name.is_empty(), "{id} has no face name");
+            assert!(
+                oracle_ids.insert(card.oracle_id),
+                "{id} duplicate oracle_id"
+            );
+            assert!(
+                scryfall_ids.insert(card.scryfall_id),
+                "{id} duplicate scryfall_id",
+            );
+        }
     }
 }

--- a/crates/engine/src/game/dungeon.rs
+++ b/crates/engine/src/game/dungeon.rs
@@ -107,8 +107,8 @@ pub struct DungeonDefinition {
 /// image meaningful rather than decorative — the marker lands in the drawn room
 /// it represents.
 ///
-/// Fractions, not pixels, because the client renders the card at whatever width
-/// the panel gives it and picks an image rung by viewport. Fractions also
+/// Relative units, not pixels, because the client renders the card at whatever
+/// width the panel gives it and picks an image rung by viewport. They also
 /// transfer across printings: the token-set and oversized printings of a
 /// dungeon are the same layout at the same proportions (verified by comparing
 /// the `tafr` and `oafr` Lost Mine scans, identical at every rung).
@@ -128,8 +128,9 @@ pub struct RoomMarkerPoint {
     pub y_permille: u16,
 }
 
-/// Authoring helper: the coordinates are read off the card as fractions, so
-/// they are written as fractions and converted once, here.
+/// Authoring shorthand so the tables below read as coordinate pairs rather
+/// than repeated struct literals. Takes permille directly — the values are
+/// measured off the card face and written in the stored unit.
 const fn pt(x_permille: u16, y_permille: u16) -> RoomMarkerPoint {
     RoomMarkerPoint {
         x_permille,
@@ -137,8 +138,12 @@ const fn pt(x_permille: u16, y_permille: u16) -> RoomMarkerPoint {
     }
 }
 
-/// CR 309.4: Centers of each room's drawn rectangle on the dungeon card,
-/// indexed in the same order as the dungeon's `rooms` table.
+/// Centers of each room's drawn rectangle on the dungeon card, indexed in the
+/// same order as the dungeon's `rooms` table.
+///
+/// Deliberately carries no CR annotation: this is display geometry, not a rule.
+/// CR 309.4 describes the rooms and the venture marker but specifies no
+/// coordinates, and annotating plumbing would surface it as rules coverage.
 ///
 /// Authored from the printed card faces; there is no coordinate data on
 /// Scryfall (its `oracle_text` gives only ordered "Name — Effect. (Leads to:)"
@@ -217,7 +222,7 @@ static UNDERCITY_MARKERS: [RoomMarkerPoint; 9] = [
 /// card (3/2/3/2/3/2/3). Rooms in the 3-rows sit at the thirds; rooms in the
 /// 2-rows sit offset between them, which is what makes the diagonal corridors
 /// line up on the printed card.
-/// Read off the printed card face (CLB token, 2024 printing).
+/// Read off the printed card face (`tclb` token, released 2022-06-10).
 static BALDURS_GATE_MARKERS: [RoomMarkerPoint; 19] = [
     // Row 1 — full width
     pt(500, 170), // 0  Crash Landing
@@ -248,14 +253,14 @@ static BALDURS_GATE_MARKERS: [RoomMarkerPoint; 19] = [
     pt(810, 822), // 18 Temple of Bhaal
 ];
 
-/// CR 309.1: The dungeon card's identity on Scryfall, so the client can show
-/// the printed card the venture marker moves across.
+/// The dungeon card's identity on Scryfall, so the client can show the printed
+/// card the venture marker moves across.
 ///
 /// A dungeon is a real printed card, not a synthesized object, so it has no
 /// `printed_ref` on any battlefield object to borrow — a dungeon never enters
-/// the battlefield (CR 309.3: it goes to the command zone). This is the only
-/// place its printing identity exists, which is why it lives beside the room
-/// tables rather than in the client.
+/// the battlefield (CR 309.2b: a dungeon card brought into the game is put into
+/// the command zone). This is the only place its printing identity exists,
+/// which is why it lives beside the room tables rather than in the client.
 ///
 /// Two lookup paths, because the five dungeons are not indexed uniformly by the
 /// client's Scryfall sidecars (verified against the Scryfall API):
@@ -286,8 +291,9 @@ pub struct DungeonCardRef {
     pub face_name: &'static str,
 }
 
-/// CR 309.1: The printed card behind each dungeon. Ids verified against the
-/// Scryfall API rather than transcribed from memory.
+/// The printed card behind each dungeon. Ids verified against the Scryfall API
+/// rather than transcribed from memory. Identity plumbing, not a rule — no CR
+/// annotation belongs here.
 pub fn card_ref(id: DungeonId) -> DungeonCardRef {
     match id {
         DungeonId::LostMineOfPhandelver => DungeonCardRef {
@@ -305,8 +311,8 @@ pub fn card_ref(id: DungeonId) -> DungeonCardRef {
             scryfall_id: "70b284bd-7a8f-4b60-8238-f746bdc5b236",
             face_name: "Tomb of Annihilation",
         },
-        // CR 309.1: the only double-faced dungeon. `face_name` is what picks the
-        // dungeon face out of `Undercity // The Initiative`.
+        // The only double-faced dungeon. `face_name` is what picks the dungeon
+        // face out of `Undercity // The Initiative`.
         DungeonId::Undercity => DungeonCardRef {
             oracle_id: "36b61021-72f0-4c22-a41d-9b2f093d7ca8",
             scryfall_id: "2c65185b-6cf0-451d-985e-56aa45d9a57d",

--- a/crates/engine/src/game/dungeon.rs
+++ b/crates/engine/src/game/dungeon.rs
@@ -98,8 +98,8 @@ pub struct DungeonDefinition {
     pub rooms: &'static [RoomDefinition],
 }
 
-/// CR 309.4: Where a room sits on the printed dungeon card, as a fraction of
-/// the card image (0.0-1.0, origin top-left).
+/// CR 309.4: Where a room sits on the printed dungeon card, in permille of
+/// the card image (0-1000, origin top-left).
 ///
 /// The dungeon cards are the rare case where the "art" IS the game state: each
 /// card is a labeled floor plan whose rooms are drawn as rectangles, not a

--- a/crates/lobby-broker/src/protocol.rs
+++ b/crates/lobby-broker/src/protocol.rs
@@ -56,6 +56,18 @@ pub struct TournamentRequestId(pub u64);
 /// rather than a parse error, and the handshake is the only place that pairing
 /// can be refused. See 24.
 ///
+/// 67 — `DerivedViews::DungeonRoomView` gained required `card`
+///      (`DungeonCardView`) and `rooms` (`Vec<DungeonRoomNodeView>`) fields,
+///      publishing the dungeon card's Scryfall identity and the full room
+///      graph with each room's outgoing edges and its position on the card
+///      face. A PARSE bump like 66, not a silent capability loss like 24:
+///      neither field carries a serde default, so a v66 peer cannot
+///      deserialize a snapshot in which anyone is venturing. The break is
+///      symmetric — a v67 client reading a v66 host's `dungeon_rooms` entry
+///      finds no `card` and throws in render rather than degrading. Follows
+///      the same reasoning as the earlier dungeon-projection bump, which
+///      chose a parse break over letting a mismatched peer play on with a
+///      dead panel.
 /// 66 — `ReplacementCondition::FirstTokenCreationEachTurn` moved its required
 ///      `player` field to an optional `active_player_req`, and
 ///      `CopyTargetPurpose` gained a `CopyTokenSource` variant. Both are
@@ -400,7 +412,7 @@ pub struct TournamentRequestId(pub u64);
 ///      payload; mulligan bottoming folded into a
 ///      `MulliganDecisionPhase::BottomCards` sub-phase on
 ///      `WaitingFor::MulliganDecision`.
-pub const PROTOCOL_VERSION: u32 = 66;
+pub const PROTOCOL_VERSION: u32 = 67;
 
 /// Minimum protocol version accepted by lobby-only brokers at the hello
 /// handshake **from clients that predate [`LOBBY_PROTOCOL_VERSION`]** — the

--- a/crates/lobby-broker/src/protocol.rs
+++ b/crates/lobby-broker/src/protocol.rs
@@ -1411,12 +1411,12 @@ mod tests {
 
     #[test]
     fn protocol_version_tracks_full_game_wire_additions() {
-        assert_eq!(PROTOCOL_VERSION, 66);
+        assert_eq!(PROTOCOL_VERSION, 67);
         // Lobby keeps its one-version rollout window; full-game servers stay
         // current-only (`server_core::MIN_SUPPORTED_PROTOCOL == PROTOCOL_VERSION`),
         // which refuses an older full-game peer that cannot preserve the exact
         // Full-session identity across draft match attachment and follow-ups.
-        assert_eq!(MIN_SUPPORTED_PROTOCOL, 65);
+        assert_eq!(MIN_SUPPORTED_PROTOCOL, 66);
     }
 
     #[test]

--- a/crates/server-core/src/protocol.rs
+++ b/crates/server-core/src/protocol.rs
@@ -3194,8 +3194,8 @@ mod tests {
     }
 
     #[test]
-    fn protocol_version_is_66_for_token_copy_source_shapes() {
-        assert_eq!(PROTOCOL_VERSION, 66);
+    fn protocol_version_is_67_for_dungeon_card_and_room_graph() {
+        assert_eq!(PROTOCOL_VERSION, 67);
     }
 
     /// The bump alone is inert — a version number nobody enforces prevents no
@@ -3206,7 +3206,7 @@ mod tests {
     ///
     /// REVERT-PROBE: relax to `PROTOCOL_VERSION - 1` — the exact regression
     /// this guards — and this test reds while
-    /// `protocol_version_is_66_for_token_copy_source_shapes` stays
+    /// `protocol_version_is_67_for_dungeon_card_and_room_graph` stays
     /// green, which is why the two are separate assertions.
     #[test]
     fn full_game_floor_is_current_only_not_a_rollout_window() {

--- a/scripts/check-protocol-version.mjs
+++ b/scripts/check-protocol-version.mjs
@@ -3,7 +3,7 @@ import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
-const EXPECTED_PROTOCOL_VERSION = 66;
+const EXPECTED_PROTOCOL_VERSION = 67;
 // The LOBBY message-set version, not derived from the full-game number above.
 // The classifier below refuses an expression only on the SOURCE constants; this
 // script never reads itself, so its own EXPECTED_* must stay literals.
@@ -30,7 +30,7 @@ const EXPECTED_MIN_LOBBY_PROTOCOL_FOR_DEFAULT_SCORING = 6;
 // here, so a full-game bump could ship with an unbumped P2P version and CI
 // stayed green — a v(n-1) host and a v(n) guest would then complete a
 // handshake and only fail when the incompatible payload arrived.
-const EXPECTED_WIRE_PROTOCOL_VERSION = 49;
+const EXPECTED_WIRE_PROTOCOL_VERSION = 50;
 
 function extractVersion(source, pattern, label) {
   const match = source.match(pattern);


### PR DESCRIPTION
## Summary

Adds a dungeon map panel to the player dock. Hovering or clicking the dungeon name opens the **printed dungeon card** with the player's **venture marker drawn on the room they currently occupy** (CR 309.4a), plus markers on the rooms reachable from there (CR 309.5a). Works on opponents' badges too — dungeon progress is public under CR 309.

Overlaying the marker on the real card art is meaningful rather than decorative because dungeon cards are the unusual case where the art *is* the game state: each card is a labeled floor plan whose rooms are drawn as rectangles. CR 309.4 describes exactly this — "a series of rooms connected to one another with arrows. A player uses a venture marker placed on the dungeon card."

## Files changed

- `crates/engine/src/game/dungeon.rs`
- `crates/engine/src/game/derived_views.rs`
- `crates/lobby-broker/src/protocol.rs`
- `crates/server-core/src/protocol.rs`
- `scripts/check-protocol-version.mjs`
- `client/src/adapter/types.ts`
- `client/src/adapter/ws-adapter.ts`
- `client/src/network/protocol.ts`
- `client/src/hooks/useDungeonCardImage.ts`
- `client/src/components/hud/DungeonMapPopover.tsx`
- `client/src/components/hud/HudBadges.tsx`
- `client/src/components/hud/__tests__/DungeonBadge.map.test.tsx`
- `client/src/components/hud/__tests__/PlayerHud.designations.test.tsx`
- `client/src/components/hud/__tests__/OpponentHud.designations.test.tsx`
- `client/src/network/__tests__/protocol.test.ts`
- `client/src/adapter/__tests__/p2p-adapter-multiplayer.test.ts`
- `client/src/i18n/locales/{en,de,es,fr,it,pl,pt}/game.json`

## CR references

- `CR 309.2b` — a dungeon card brought into the game is put into the command zone; this is why no `printed_ref`-carrying object exists to resolve art from. Corrected from an incorrect `CR 309.3` (the one-at-a-time rule) after review.
- `CR 309.4` / `CR 309.4a` — rooms and the venture marker; the marker starts on the topmost room.
- `CR 309.5` / `CR 309.5a` — the bottommost room has no outgoing arrows; the reachable set follows the arrows away from the current room.

Deliberately **not** annotated: `card_ref` (Scryfall ids) and `marker_points` (pixel geometry). Neither implements a rule, and per CLAUDE.md annotating plumbing would surface it as rules coverage under `grep -rn "CR \d"`.

## Implementation method (required)

Method: not-applicable — frontend display feature plus its engine projection; no parser or card-behavior work, so `/engine-implementer`'s plan→review→implement loop for engine mechanics does not apply. The mandatory `/review-impl` pass was still run (see below) and its findings were fixed.

## Track

Developer

## LLM

Model: claude-opus-5
Tier: Frontier
Thinking: high

## Verification

- [x] Required checks ran clean, or the exact CI-owned alternative is stated below.
- [x] Gate A output below is for the current committed head.
- [x] Final review-impl below is clean for the current committed head.
- [x] Both anchors cite existing analogous code at the same seam.

- `cargo fmt --all --check` — exit 0
- `cargo test -p phase-engine --lib dungeon` — **41 passed; 0 failed**
- `cargo test -p lobby-broker --lib protocol_version_tracks` — **1 passed; 0 failed** (the guard the maintainer fixed at `bbc7032`, re-verified on this head)
- `cargo test -p server-core --lib protocol_version_is_67` — **1 passed; 0 failed**
- `node scripts/check-protocol-version.mjs` — exit 0
- `pnpm exec tsc -b --noEmit` — exit 0
- `pnpm exec eslint <changed files>` — 0 errors
- `pnpm vitest run src/components/hud src/network/__tests__/protocol.test.ts src/adapter/__tests__/p2p-adapter-multiplayer.test.ts` — **286 passed; 0 failed** (13 files)
- CI on the previous head: Frontend, Rust lint (fmt/clippy/parser gate), Card data, WASM, Android, Lobby worker — all pass

**Browser verification was not performed.** The panel's layout, the marker's visual alignment against the real card art, and touch behaviour on a device are unverified by any check here; the marker coordinates were authored by reading the five printed card faces and are guarded only by the ordering/bounds tests described below.

## Gate A

```
Gate G PASS (router/grant architecture: strict router vs permissive grant boundary intact)
Gate A: scanned 13 file(s) under crates/engine/src/parser (working tree vs 376fd1cb194b0f31b38968b3a3b1c4b538f635c3).
Gate A PASS head=6bc70168a3bea378b2f38df261ca89de29a191d9 base=376fd1cb194b0f31b38968b3a3b1c4b538f635c3
```

## Anchored on

- `crates/engine/src/game/derived_views.rs:1271` — `dungeon_rooms`, the existing projection this extends: same `BTreeMap<PlayerId, _>` shape, same `filter_map` over `dungeon_progress` gated on `current_dungeon`, same delegation to `game::dungeon` as the single authority for room text.
- `client/src/components/hud/RingBenefitsPopover.tsx:58` — the existing portaled HUD popover: same `createPortal(..., document.body)` (HudPlate's `transform` would otherwise clip it), same anchor-rect recompute on `resize`/`scroll`, same above/below flip on viewport half. `DungeonMapPopover` mirrors it, differing only in being pointer-interactive so the pointer can travel from chip to panel.

## Final review-impl

Final review-impl PASS head=6bc70168a3bea378b2f38df261ca89de29a191d9

The pass was not clean on first run — it surfaced two findings against my own diff, both fixed in `test(engine): assert the dungeon card identity and room graph project` and re-reviewed clean on this head:

1. **HIGH** — `card` and `rooms`, the two fields that forced the protocol bump, were asserted by no test. `dungeon_rooms_names_the_room_the_marker_is_on` checked every *old* field and nothing else, so a wrong `scryfall_id` or a dropped `next_rooms` edge would have shipped green. Fixed by extending that test and adding an Undercity-specific one. Verified discriminating: truncating the room graph to one entry fails 2 of the 3 tests (`left: 1, right: 9`).
2. **MED** — three `CR 309.1` citations survived the earlier cleanup on `DungeonCardView`, `dungeon_card_view` and the TS mirror. `CR 309.1` reads "Dungeon is a card type seen only on nontraditional Magic cards" — it does not describe a Scryfall id lookup.

## Claimed parse impact

None. No parser code is touched; `crates/engine/src/parser/**` is unmodified.

## Scope Expansion

The protocol bump (66→67, wire 49→50) was not in the original change but is required by it — `DungeonRoomView` gains two fields with no serde default. Applied across eight sites at reviewer direction, choosing the documented parse-bump idiom over graceful degradation.

The `react-i18next` vitest fix that originally rode along here has been **split out to #8678** at reviewer request.

## Validation Failures

None.

## CI Failures

None on this head. The previous head (`dee4887a8`) failed `Rust tests (shard 1/4)` on two stale assertions in `crates/lobby-broker/src/protocol.rs` that my bump missed — the maintainer fixed both at `bbc7032` rather than sending it back. My local `check-protocol-version.mjs` had stayed green because it matches the derivation expression (`saturating_sub(1)`) rather than a resolved integer, leaving a hardcoded literal in a Rust `assert_eq!` invisible to it. Both mechanisms are working as designed; I have since swept every `PROTOCOL_VERSION`/`MIN_SUPPORTED_PROTOCOL` literal in the workspace (now 67/67/66) and the TypeScript equivalents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an interactive dungeon map panel showing the dungeon card, current location, reachable rooms, room names, and details.
  * Dungeon badges now support hover, focus, click-to-pin, outside-click, and Escape-to-dismiss interactions.
  * Added loading and unavailable states for dungeon card images, including fallback image lookup.
* **Localization**
  * Added dungeon map status translations across supported languages.
* **Compatibility**
  * Updated network protocol versions to support the enhanced dungeon map data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->