### PR TITLE
Answer a nothing-naming loop-shortcut pin with the offer's canonical split

### DIFF
--- a/client/src/components/modal/LoopShortcutModal.tsx
+++ b/client/src/components/modal/LoopShortcutModal.tsx
@@ -397,13 +397,35 @@ function DeclareShortcutOffer({
   // answer for every iteration. No client-side default — an unanswered point disables Confirm.
   const [mayPicks, setMayPicks] = useState<Record<number, InteractionChoiceId>>({});
 
+  const [answer, setAnswer] = useState<InteractionPreview | null>(null);
+  const latest = useRef<PreviewRequestId | null>(null);
+  const minted = useRef(0);
+
+  // CR 732.2a: magnitudes are read off a CONFIRMABLE answer only. `?? null` collapses the
+  // binding's optional-and-nullable spellings into the one absent state.
+  const authoredPreview =
+    answer?.status.type === "confirmable" ? (answer.shortcutPreview ?? null) : null;
+
   const published: AmountAssignment[] = previewed?.allocation ?? [];
-  const publishedRaw = (id: InteractionChoiceId) =>
-    String(published.find((a) => a.choiceId === id)?.amount ?? 0);
+  // CR 732.2a + CR 601.2c: what the rows read. The offer publishes elements for a bounded SAMPLE
+  // of its own count window, so at an unsampled count there is no published split to seed them
+  // from and the engine's answer to the request below carries one. The answer is read only for
+  // the count it itself states, so an answer still in flight when the picker moves cannot seed
+  // rows for a different count. `published` stays the OFFER's own list: the authored-split
+  // comparison below is stated against what the offer published, which is what routes the
+  // returned magnitudes to the rendered lines at a count it published nothing for.
+  const rowSource: AmountAssignment[] =
+    previewed !== undefined
+      ? published
+      : authoredPreview?.count === chosen
+        ? (authoredPreview.allocation ?? [])
+        : [];
+  const sourcedRaw = (id: InteractionChoiceId) =>
+    String(rowSource.find((a) => a.choiceId === id)?.amount ?? 0);
   // The count tag travels with the edit: moving the picker moves `previewed`, this test goes
   // false, and an edit made at another count is DISCARDED rather than re-scaled.
   const rowRaw = (id: InteractionChoiceId) =>
-    authored?.count === chosen ? (authored.raw[id] ?? publishedRaw(id)) : publishedRaw(id);
+    authored?.count === chosen ? (authored.raw[id] ?? sourcedRaw(id)) : sourcedRaw(id);
 
   // The declaration, re-parsed from what the rows actually READ, in published order. `parseAmount`
   // is the single sanitization authority here exactly as it is for the count, so an out-of-window
@@ -527,21 +549,40 @@ function DeclareShortcutOffer({
     void dispatchInteraction(submission).catch(() => undefined);
   };
 
+  // CR 732.2a: the count the picker offers may be one the offer's bounded sample published no
+  // element for, and then the engine is the only source of the canonical split. `declaredResponse`
+  // already builds the pin that asks for it — naming nothing, because nothing is authored here.
+  // Shares `custom`'s leading conjuncts, so an UntilLethal offer never asks: its control takes the
+  // `subject` arm. A second announced-target point drops `pinRoute` (`renderable` requires the
+  // point's own group), which is the shape the engine refuses to complete.
+  const unsampled =
+    pinRoute &&
+    targetsControl?.kind === "allocation" &&
+    chosen !== null &&
+    previewed === undefined &&
+    authored?.count !== chosen;
+
+  // The player's OWN entries at the chosen count. NOT the effective split: the rows now derive
+  // that from the answer, so a key reading it would move the moment an answer landed and issue a
+  // second request for the same settled state.
+  const authoredEntries =
+    authored?.count === chosen
+      ? (targetsControl?.point.candidateIds ?? [])
+          .map((id) => `${id}:${authored.raw[id] ?? ""}`)
+          .join(",")
+      : "";
+
   // CR 732.2a: the settled declaration stated as primitives, so one request is issued per SETTLED
   // edit rather than one per keystroke. `null` while there is nothing to preview.
   const declarationKey =
-    custom && declarationComplete && offerId !== null
+    offerId !== null && ((custom && declarationComplete) || unsampled)
       ? [
           offerId,
           String(chosen),
-          effective.map((a) => `${a.choiceId}:${a.amount}`).join(","),
+          authoredEntries,
           mayPoints.map((p) => `${p.group}:${mayPicks[p.group]}`).join(","),
         ].join("|")
       : null;
-
-  const [answer, setAnswer] = useState<InteractionPreview | null>(null);
-  const latest = useRef<PreviewRequestId | null>(null);
-  const minted = useRef(0);
 
   useEffect(() => {
     // Load-bearing rather than cosmetic: the resolve guard below compares against the ANSWER's
@@ -566,11 +607,6 @@ function DeclareShortcutOffer({
     // from, and any wider identity would re-issue per keystroke.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [declarationKey]);
-
-  // CR 732.2a: magnitudes are read off a CONFIRMABLE answer only. `?? null` collapses the
-  // binding's optional-and-nullable spellings into the one absent state.
-  const authoredPreview =
-    answer?.status.type === "confirmable" ? (answer.shortcutPreview ?? null) : null;
 
   const handleDecline = useCallback(() => {
     // CR 732.2a: decline the auto-offer; the engine restores ordinary priority.

--- a/client/src/components/modal/__tests__/LoopShortcutModal.test.tsx
+++ b/client/src/components/modal/__tests__/LoopShortcutModal.test.tsx
@@ -1742,10 +1742,12 @@ describe("LoopShortcutModal", () => {
     expect(dispatchMock).not.toHaveBeenCalled();
   });
 
-  // P5-17: a count the offer published no element for renders zeros and refuses Confirm — no
-  // seeded split and no nearest match. Authoring a partition there is what makes it a rendered
-  // state, not a dead end.
-  it("seeds nothing at a count the engine published no element for (P5-17)", () => {
+  // P5-17: the FAIL-CLOSED end of the unsampled count. This transport cannot preview, so there is
+  // no engine answer to seed the rows from and the modal renders zeros and refuses Confirm —
+  // never a nearest match and never a client-computed split. Authoring a partition there is what
+  // makes it a rendered state rather than a dead end. The preview-capable end is the row below
+  // that installs a `previewInteraction` adapter.
+  it("seeds nothing at an unsampled count with no preview capability (P5-17)", () => {
     seed(
       buildLoopShortcutWaitingFor({ schema: { iteration_count: { Fixed: 8 } } }),
       {},
@@ -1760,6 +1762,9 @@ describe("LoopShortcutModal", () => {
         [seatCandidate("k4", 1), seatCandidate("k5", 2)],
       ),
     );
+    // The precondition this row's zeros are about, stated rather than inherited: an adapter with
+    // no `previewInteraction` is what makes the seam resolve `null`.
+    useGameStore.setState({ adapter: bareAdapter() });
     render(<DeclareShortcutModal />);
 
     // leg A — at the published count the rows read the published split and Confirm is enabled, so
@@ -1768,7 +1773,7 @@ describe("LoopShortcutModal", () => {
     expect(allocationRow("P3")).toHaveAttribute("aria-valuenow", "4");
     expect(confirmButton()).toBeEnabled();
 
-    // leg B — the gap. Nothing is seeded from anywhere.
+    // leg B — the gap, with nothing to seed from: the transport cannot answer.
     fireEvent.change(countBox(), { target: { value: "5" } });
     expect(allocationRow("P2")).toHaveAttribute("aria-valuenow", "0");
     expect(allocationRow("P3")).toHaveAttribute("aria-valuenow", "0");
@@ -2180,6 +2185,20 @@ function answerWith(request: InteractionPreviewRequest, amount: number): Interac
   } as unknown as InteractionPreview;
 }
 
+/** An engine answer carrying the split the COMPLETION mints at `count` — the shape the seam
+ *  returns for a count the offer published no element for. */
+function answerAllocating(
+  request: InteractionPreviewRequest,
+  count: number,
+  allocation: AmountAssignment[],
+  amount: number,
+): InteractionPreview {
+  return {
+    ...answerWith(request, amount),
+    shortcutPreview: element(count, allocation, [{ family: "life", player: 2, amount }]),
+  } as InteractionPreview;
+}
+
 /** The pin-route offer rows 9 and 10 author a split on: two announced seats, an even published
  *  split of the count, and one published life line. */
 function seedPreviewOffer(store: StoreOverrides = {}) {
@@ -2529,5 +2548,56 @@ describe("DeclareShortcutModal — authored-split preview", () => {
     expect(useAppNotificationStore.getState().notification?.description).toBe(
       "This game connection does not support interaction responses",
     );
+  });
+
+  // Row 12: at a count the offer's bounded sample published no element for, the modal asks the
+  // engine for the canonical split with a pin naming NOTHING, then reads the answer into its rows
+  // and its dispatch. The two iterations issue the IDENTICAL request and differ only in what the
+  // engine answered, so a client-side recomputation renders and dispatches the same split twice.
+  it("completes an unsampled count from the engine's own answer", async () => {
+    for (const [amount, allocation] of [
+      [-8, [amt("k4", 2), amt("k5", 2)]],
+      [-6, [amt("k4", 3), amt("k5", 1)]],
+    ] as const) {
+      cleanup();
+      vi.mocked(dispatchInteraction).mockClear();
+      const previewInteraction = vi.fn((request: InteractionPreviewRequest) =>
+        Promise.resolve(answerAllocating(request, 4, [...allocation], amount)),
+      );
+      seedPreviewOffer({ adapter: { ...bareAdapter(), previewInteraction } as EngineAdapter });
+      render(<DeclareShortcutModal />);
+
+      // NEGATIVE SIBLING: at the offer's OWN published count, with nothing authored, the widened
+      // gate asks nothing and the rows read the published split.
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(previewInteraction).not.toHaveBeenCalled();
+      expect(allocationRow("P2")).toHaveAttribute("aria-valuenow", "3");
+      expect(allocationRow("P3")).toHaveAttribute("aria-valuenow", "2");
+
+      fireEvent.change(countBox(), { target: { value: "4" } });
+      expect(await screen.findByText(`${amount} life — P3`)).toBeInTheDocument();
+
+      // ONE request per settled state, naming nothing over the announced point.
+      expect(previewInteraction).toHaveBeenCalledOnce();
+      expect(previewInteraction.mock.calls[0][0].response).toEqual({
+        type: "shortcut",
+        data: {
+          decision: { type: "fixed", data: { iterations: 4 } },
+          pins: [{ group: 2, choiceIds: [], amounts: [] }],
+        },
+      });
+
+      expect(allocationRow("P2")).toHaveAttribute("aria-valuenow", String(allocation[0].amount));
+      expect(allocationRow("P3")).toHaveAttribute("aria-valuenow", String(allocation[1].amount));
+      expect(confirmButton()).toBeEnabled();
+      fireEvent.click(confirmButton());
+      expect(vi.mocked(dispatchInteraction).mock.calls[0][0].response).toEqual({
+        type: "shortcut",
+        data: {
+          decision: { type: "fixed", data: { iterations: 4 } },
+          pins: [{ group: 2, choiceIds: ["k4", "k5"], amounts: [...allocation] }],
+        },
+      });
+    }
   });
 });

--- a/crates/engine/src/game/interaction.rs
+++ b/crates/engine/src/game/interaction.rs
@@ -3048,25 +3048,136 @@ fn loop_shortcut_preview(
         .collect()
 }
 
+/// CR 732.2a: the declaration a pin naming NOTHING states — the offer's own canonical split of
+/// the declared count, minted on demand at any count in the published window.
+///
+/// The offer's `preview` list is a bounded SAMPLE of that window (`shortcut_preview_counts`),
+/// while the ingress admits every count in it. At an unsampled count there is no published
+/// element to restate, so the pin the client can honestly send names nothing — and CR 732.2a
+/// leaves the count the proposer's to specify regardless of how many the payload published.
+/// This completes that declaration with the same `canonical_allocation` the sampled counts
+/// already publish, so the answer at an unsampled count is the offer's own answer.
+///
+/// It is a COMPLETION of the player's declaration, not the engine making a CR 601.2c
+/// announcement for them, and every conjunct below is what keeps that true:
+///
+/// * An AUTHORED pin wins — the substitution fires only on a pin naming no ids and no amounts.
+///   An ABSENT pin is not a nothing-naming one: the `?` on the lookup returns `None`, leaving
+///   the ingress's own missing-pin refusal exactly where it is.
+/// * `(min, max) == (1, 1)` on the announced point, each half buying its own outcome. `max == 1`
+///   is the ingress's own gate on a sequenced partition (`sequenced_partition`), so the minted
+///   pin is the shape it accepts a split on. `min == 1` is what makes the empty pin a
+///   non-declaration: at `min == 0` the point is OPTIONAL and an empty pin already MEANS
+///   "announce no target here", which is confirmable today, so completing it would replace one
+///   stated declaration with a different one.
+/// * The domain's point is the offer's ONLY announced-target point, asked by re-calling
+///   `allocation_point` over the points after it rather than by a second `Targets` predicate.
+///   With a second such point published, the offer's one published split is not a complete
+///   answer to the declaration, and an empty pin there is a decision the player has not made.
+///
+/// The count resolution is the exhaustive `(decision, count_spec)` match
+/// `declared_shortcut_preview` performs, `AcceptSuggested` included — that decision reaches this
+/// completion exactly as a `Fixed` one does. `UntilLethal` names no number to partition and
+/// returns on every arm, so this is structurally unreachable there; a new
+/// `InteractionShortcutCountSpec` variant build-breaks the match rather than falling through.
+///
+/// Consulted BEFORE legality, at the one chokepoint both the preview and the submit paths share,
+/// so a request that previews `Confirmable` submits the same sequenced announcement.
+fn completed_shortcut_declaration(
+    interaction_id: &InteractionId,
+    projection: &LoopShortcutProjection,
+    response: &InteractionResponse,
+) -> Option<InteractionResponse> {
+    let InteractionResponse::Shortcut { decision, pins } = response else {
+        return None;
+    };
+    let count = match (*decision, projection.count) {
+        (
+            InteractionShortcutDecision::AcceptSuggested,
+            InteractionShortcutCountSpec::Fixed { suggested, .. },
+        ) => suggested,
+        (
+            InteractionShortcutDecision::Fixed { iterations },
+            InteractionShortcutCountSpec::Fixed { .. },
+        ) => iterations,
+        (InteractionShortcutDecision::Decline, _)
+        | (
+            InteractionShortcutDecision::AcceptSuggested,
+            InteractionShortcutCountSpec::UntilLethal,
+        )
+        | (InteractionShortcutDecision::Fixed { .. }, InteractionShortcutCountSpec::UntilLethal) => {
+            return None;
+        }
+    };
+    // The offer publishes a sampled element list at all: without a basis it publishes none, and
+    // there is no published split for a nothing-naming pin to defer to.
+    shortcut_preview_basis(interaction_id, projection)?;
+    let domain = shortcut_allocation_domain(interaction_id, projection)?;
+    let sole_point = allocation_point(
+        projection
+            .points
+            .iter()
+            .skip(usize::try_from(domain.group).ok()? + 1),
+    )
+    .is_none();
+    if domain.ids.is_empty() || (domain.point.min, domain.point.max) != (1, 1) || !sole_point {
+        return None;
+    }
+    let pin = pins.iter().find(|pin| pin.group == domain.group)?;
+    if !pin.choice_ids.is_empty() || !pin.amounts.is_empty() {
+        return None;
+    }
+    let allocation = canonical_allocation(&domain.ids, count);
+    if allocation.is_empty() {
+        return None;
+    }
+    Some(InteractionResponse::Shortcut {
+        decision: *decision,
+        pins: pins
+            .iter()
+            .map(|pin| {
+                if pin.group != domain.group {
+                    return pin.clone();
+                }
+                InteractionShortcutPin {
+                    group: pin.group,
+                    choice_ids: allocation
+                        .iter()
+                        .map(|assignment| assignment.choice_id.clone())
+                        .collect(),
+                    amounts: allocation.clone(),
+                }
+            })
+            .collect(),
+    })
+}
+
 /// CR 732.2a: the previewed element for the declaration this response states — the same
 /// arithmetic the published list carries, over the allocation the player authored.
 ///
 /// CR 732.1b: the sequence is deliberately never performed, so this is `n x delta` and reaches
 /// no `GameState`.
 ///
-/// Fail-closed: a pin carrying no `amounts` states no split, so no element is minted for it
-/// rather than one being invented from the canonical order. The count is not re-validated
-/// here — an out-of-window count is refused by the ingress in the same call, and the payload
-/// is attached only on the confirmable arm.
+/// Fail-closed: a pin NAMING a subject but carrying no `amounts` states no split, so no element
+/// is minted for it rather than one being invented from the canonical order. A pin naming
+/// NOTHING is `completed_shortcut_declaration`'s own case and reaches the destructure below
+/// already carrying the offer's canonical split. The count is not re-validated here — an
+/// out-of-window count is refused by the ingress in the same call, and the payload is attached
+/// only on the confirmable arm.
 fn declared_shortcut_preview(
     waiting_for: &WaitingFor,
     interaction_id: &InteractionId,
     response: &InteractionResponse,
 ) -> Option<InteractionShortcutPreview> {
-    let InteractionResponse::Shortcut { decision, pins } = response else {
+    let projection = loop_shortcut_projection(waiting_for).ok()?;
+    // The same completion the ingress consults, over an EQUAL projection minted from the state
+    // both preview entry points hand to this function and to `materialize_response`. Sharing the
+    // authority rather than the value is what keeps the element and the action one declaration.
+    let completed = completed_shortcut_declaration(interaction_id, &projection, response);
+    let InteractionResponse::Shortcut { decision, pins } = completed.as_ref().unwrap_or(response)
+    else {
         return None;
     };
-    let projection = loop_shortcut_projection(waiting_for).ok()?;
     let count = match (*decision, projection.count) {
         (
             InteractionShortcutDecision::AcceptSuggested,
@@ -10831,13 +10942,17 @@ fn materialize_response(
             if *proposer != semantic_owner {
                 return Err(InteractionReasonCode::InvalidAuthorityState);
             }
+            // CR 732.2a: a pin naming nothing over the offer's one announced-target point is
+            // completed with the offer's own canonical split BEFORE legality, so the preview and
+            // the submit paths — which share this chokepoint — answer one question.
+            let completed = completed_shortcut_declaration(interaction_id, &projection, response);
             return materialize_loop_shortcut_response(
                 interaction_id,
                 &projection,
                 *proposer,
                 schema,
                 authoritative_state,
-                response,
+                completed.as_ref().unwrap_or(response),
             );
         }
         HumanResponseModel::AmountAssignments => {

--- a/crates/engine/tests/integration/interaction_contract.rs
+++ b/crates/engine/tests/integration/interaction_contract.rs
@@ -3548,6 +3548,14 @@ fn loop_shortcut_preview_never_routes_through_the_clone_apply_previewer() {
          waiting-for state and the response that states them — not from a board. The pin is what \
          keeps that a fact about the signature rather than a search result"
     );
+    assert_eq!(
+        params_of("completed_shortcut_declaration"),
+        "interaction_id: &InteractionId, projection: &LoopShortcutProjection, response: \
+         &InteractionResponse",
+        "type-level pin: the nothing-naming pin's completion sits on the preview path beside \
+         every producer above it, and it runs on the SUBMIT path too. Widening it to anything \
+         reaching a `GameState` reopens the clone-apply route through a span no textual ban reads"
+    );
 
     for (span_name, body) in [
         ("preview_interaction's attach arm", &response_attach),
@@ -8747,6 +8755,505 @@ fn an_unpartitioned_pin_states_no_magnitude_and_accept_suggested_states_the_offe
         "paired positive: the accepted element states magnitudes over more than one segment, so \
          the count equality above is not read off an empty element"
     );
+}
+
+/// Re-bind the interaction authority over an EDITED offer board and hand back its proposer. The
+/// edit moves the published schema, so the offer's ids are re-minted under a fresh session rather
+/// than carried over.
+fn f4_rebound(mut state: GameState, session: &str) -> (GameState, PlayerId) {
+    let WaitingFor::LoopShortcut { proposer, .. } = state.waiting_for else {
+        panic!(
+            "the edited board must still sit at the CR 732.2a offer, got {:?}",
+            state.waiting_for
+        );
+    };
+    bind_interaction_authority(&mut state, InteractionSessionId(session.to_string()))
+        .expect("the interaction authority binds over the edited offer");
+    assert_eq!(
+        viewer_interaction(&state, proposer).opportunities.len(),
+        1,
+        "liveness control: the edited board still publishes the proposer's own opportunity, so a \
+         refusal below is the ingress's answer and not a dead projection"
+    );
+    (state, proposer)
+}
+
+/// The F4 offer board with its announced `Targets` point made OPTIONAL (`min_targets == 0`),
+/// carried through `PersistedGameState::into_game_state` so the bound under test is one the
+/// production restore contract admits.
+fn f4_optional_announcement_board() -> (GameState, PlayerId) {
+    let (mut state, _) = f4_offer_board();
+    {
+        let WaitingFor::LoopShortcut { schema, .. } = &mut state.waiting_for else {
+            panic!("the F4 board sits at the CR 732.2a offer");
+        };
+        let point = schema
+            .points
+            .iter_mut()
+            .find(|point| matches!(point.kind, DecisionPointKind::Targets { .. }))
+            .expect("the F4 offer announces a Targets point");
+        let DecisionPointKind::Targets { min_targets, .. } = &mut point.kind else {
+            unreachable!("found under that same predicate")
+        };
+        *min_targets = 0;
+    }
+    let restored = engine::types::game_state::PersistedGameState::capture(state)
+        .into_game_state()
+        .expect("the edited snapshot satisfies the checked restore contract");
+    f4_rebound(restored, "interaction-contract-f4-optional")
+}
+
+/// The F4 offer board publishing a SECOND announced-target point — the schema's own `Targets`
+/// point duplicated under a distinct `DecisionSlot` index, which is what makes both publish.
+fn f4_second_announcement_board() -> (GameState, PlayerId) {
+    let (mut state, _) = f4_offer_board();
+    {
+        let WaitingFor::LoopShortcut { schema, .. } = &mut state.waiting_for else {
+            panic!("the F4 board sits at the CR 732.2a offer");
+        };
+        let mut duplicate = schema
+            .points
+            .iter()
+            .find(|point| matches!(point.kind, DecisionPointKind::Targets { .. }))
+            .expect("the F4 offer announces a Targets point")
+            .clone();
+        duplicate.slot.index = duplicate
+            .slot
+            .index
+            .checked_add(1)
+            .expect("the announced slot's sub-index leaves room for a sibling");
+        schema.points.push(duplicate);
+    }
+    f4_rebound(state, "interaction-contract-f4-two-announcements")
+}
+
+/// The announced `Targets` schema point's slot and the seats its candidates name, in published
+/// order — the two halves the submitted announcement is compared against.
+fn f4_announced_slot(state: &GameState) -> (DecisionSlot, Vec<PlayerId>) {
+    let WaitingFor::LoopShortcut { schema, .. } = &state.waiting_for else {
+        panic!("the board sits at the CR 732.2a offer");
+    };
+    let point = schema
+        .points
+        .iter()
+        .find(|point| matches!(point.kind, DecisionPointKind::Targets { .. }))
+        .expect("the F4 offer announces a Targets point");
+    let DecisionPointKind::Targets { legal_targets, .. } = &point.kind else {
+        unreachable!("found under that same predicate")
+    };
+    (
+        point.slot.clone(),
+        legal_targets
+            .iter()
+            .map(|target| match target {
+                TargetRef::Player(seat) => *seat,
+                TargetRef::Object(id) => panic!("the F4 offer announces seats, got object {id:?}"),
+            })
+            .collect(),
+    )
+}
+
+/// **Row 3b** — a pin naming NOTHING is answered, and accepted, with the offer's own canonical
+/// split at a count the published sample omits. The complement of the unpartitioned-pin row
+/// above: that one pins the shape naming WHO without a magnitude, this one the shape naming
+/// neither.
+///
+/// # Discrimination
+///
+/// Each leg names its own failing change:
+/// * leg 1 — without the completion the request is `Rejected { ConstraintUnsatisfied }` with no
+///   element on the answering entry point and `Err` on the other;
+/// * leg 2 — consult the completion at the preview entry points instead of at the ingress and
+///   this leg is `Err` while leg 1 passes, which is the divergence itself;
+/// * leg 3 — mint anything but `canonical_allocation` over the domain's ids and the equality
+///   against the offer's own published element fails;
+/// * leg 4 — drop the `min == 1` conjunct and an element appears where an empty announcement is
+///   already the declaration;
+/// * leg 5 — drop the sole-point conjunct and the answered-second member turns `Confirmable` and
+///   submits, while the both-empty member stays refused either way.
+#[test]
+fn a_nothing_naming_pin_is_completed_with_the_offers_canonical_split() {
+    use engine::analysis::decision_template::PinnedDecision;
+
+    let (state, proposer) = f4_offer_board();
+    let view = viewer_interaction(&state, proposer);
+    let interaction_id = view.opportunities[0].interaction_id.clone();
+    let points = shortcut_points(&view);
+    let point = f4_allocation_point(&points);
+    let (count_spec, published) = f4_published(&view);
+    let InteractionShortcutCountSpec::Fixed { min, max, .. } = count_spec else {
+        panic!("the F4 offer publishes a Fixed count window, got {count_spec:?}");
+    };
+    assert!(
+        (point.min, point.max) == (1, 1) && point.candidate_ids.len() > 1,
+        "reach-guard: the completion fires only on a MANDATORY single-subject announced point, \
+         and a second candidate is what makes its split observable; min={} max={} candidates={}",
+        point.min,
+        point.max,
+        point.candidate_ids.len()
+    );
+    // `f4_pins(.., &[])` builds the nothing-naming pin over the announced point — no ids and no
+    // amounts — while every other answerable point is answered from its own candidate list.
+    let nothing_named = f4_pins(&points, &[]);
+    assert!(
+        nothing_named.iter().any(|pin| pin.group == point.group
+            && pin.choice_ids.is_empty()
+            && pin.amounts.is_empty()),
+        "reach-guard: the request under test must NAME NOTHING over the announced point, else \
+         every leg below is about some other pin shape"
+    );
+
+    // ── LEG 1: the first in-window count the offer's bounded sample published no element for.
+    let unsampled = (min..=max)
+        .find(|count| !published.iter().any(|element| element.count == *count))
+        .expect(
+            "reach-guard: the payload cap must omit a count inside the offer's own window, else \
+             this row is about a fully sampled window and asserts nothing",
+        );
+    let answered = f4_preview(
+        &state,
+        proposer,
+        &interaction_id,
+        unsampled,
+        nothing_named.clone(),
+    );
+    assert_eq!(
+        answered.status,
+        InteractionPreviewStatus::Confirmable,
+        "CR 732.2a: the count is the proposer's to specify, and a pin naming nothing defers to \
+         the offer's own split — a payload cap on which counts PUBLISH an element cannot narrow \
+         which may be declared"
+    );
+    let element = answered
+        .shortcut_preview
+        .clone()
+        .expect("a confirmable completed declaration carries its previewed element");
+    assert_eq!(
+        element.count, unsampled,
+        "the element states the count the request declared"
+    );
+    assert!(
+        !element.entries.is_empty(),
+        "paired positive: the completed element states magnitudes, so the equalities below are \
+         not read off an empty element"
+    );
+    assert!(
+        !element.allocation.is_empty() && element.allocation.iter().all(|part| part.amount > 0),
+        "CR 601.2c: every announced segment takes at least one repetition; {:?}",
+        element.allocation
+    );
+    assert_eq!(
+        element
+            .allocation
+            .iter()
+            .map(|part| part.amount)
+            .sum::<u32>(),
+        unsampled,
+        "the split is a partition OF the declared count"
+    );
+    let rejecting = preview_interaction_with_rejection(
+        &state,
+        proposer,
+        &f4_request(&interaction_id, unsampled, nothing_named.clone()),
+    )
+    .expect("the completed declaration answers on the rejection-typed entry point too");
+    assert_eq!(
+        rejecting.shortcut_preview.as_ref(),
+        Some(&element),
+        "both preview entry points answer one request with one element"
+    );
+
+    // ── LEG 2: the same request SUBMITS, carrying that allocation as a sequenced announcement.
+    let mut submitted = state.clone();
+    let applied = submit_interaction(
+        &mut submitted,
+        proposer,
+        InteractionSubmission {
+            interaction_id: interaction_id.clone(),
+            response: InteractionResponse::Shortcut {
+                decision: InteractionShortcutDecision::Fixed {
+                    iterations: unsampled,
+                },
+                pins: nothing_named.clone(),
+            },
+        },
+    )
+    .expect("what previews confirmable submits: the completion sits at the chokepoint both share");
+    let GameAction::DeclareShortcut {
+        count,
+        template: Some(template),
+    } = &applied.action
+    else {
+        panic!(
+            "a declared shortcut submits a template, got {:?}",
+            applied.action
+        );
+    };
+    assert_eq!(
+        *count,
+        IterationCount::Fixed(unsampled),
+        "the accepted action drives the count the request declared"
+    );
+    let (announced_slot, announced_seats) = f4_announced_slot(&state);
+    let segments = indexed(&point, &element.allocation);
+    let starts: Vec<u32> = segments
+        .iter()
+        .scan(0u32, |start, (_, amount)| {
+            let at = *start;
+            *start += amount;
+            Some(at)
+        })
+        .collect();
+    let seats: Vec<PlayerId> = segments
+        .iter()
+        .map(|(candidate, _)| announced_seats[*candidate])
+        .collect();
+    assert!(
+        template.decisions.contains(&piecewise_pin(
+            announced_slot,
+            &starts,
+            &seat_subjects(&seats)
+        )),
+        "CR 601.2c: the accepted declaration announces the completed split per repetition; \
+         got {:?}",
+        template.decisions
+    );
+
+    // ── LEG 3: the SAMPLED control — the completion's answer is the offer's own published one.
+    let sampled = published
+        .iter()
+        .find(|candidate| {
+            candidate.allocation.len() > 1
+                && candidate
+                    .allocation
+                    .iter()
+                    .any(|part| part.amount != candidate.allocation[0].amount)
+        })
+        .expect(
+            "reach-guard: a published NON-UNIFORM multi-segment element is what keeps an even \
+             split from satisfying the equality below",
+        );
+    let control = f4_preview(
+        &state,
+        proposer,
+        &interaction_id,
+        sampled.count,
+        nothing_named.clone(),
+    );
+    assert_eq!(control.status, InteractionPreviewStatus::Confirmable);
+    assert_eq!(
+        control.shortcut_preview.as_ref(),
+        Some(sampled),
+        "CR 732.2a: at a count the offer DID publish, the completion states that published \
+         element — allocation and entries alike"
+    );
+
+    // ── LEG 4: the OPTIONAL end of the class, where the empty pin is ALREADY a declaration.
+    let (optional_state, optional_proposer) = f4_optional_announcement_board();
+    let optional_view = viewer_interaction(&optional_state, optional_proposer);
+    let optional_id = optional_view.opportunities[0].interaction_id.clone();
+    let optional_points = shortcut_points(&optional_view);
+    let optional_point = f4_allocation_point(&optional_points);
+    assert_eq!(
+        (optional_point.min, optional_point.max),
+        (0, 1),
+        "reach-guard: the restored board must publish the OPTIONAL bound, else this leg is the \
+         mandatory one over again"
+    );
+    let optional_pins = f4_pins(&optional_points, &[]);
+    let optional_preview = f4_preview(
+        &optional_state,
+        optional_proposer,
+        &optional_id,
+        unsampled,
+        optional_pins.clone(),
+    );
+    assert_eq!(
+        optional_preview.status,
+        InteractionPreviewStatus::Confirmable,
+        "an OPTIONAL announced point's empty pin is a legal answer, exactly as it is today"
+    );
+    assert!(
+        optional_preview.shortcut_preview.is_none(),
+        "CR 601.2c: at `min == 0` the empty pin already MEANS 'announce no target here', so \
+         completing it would replace one stated declaration with a different one"
+    );
+    let mut optional_submitted = optional_state.clone();
+    let optional_applied = submit_interaction(
+        &mut optional_submitted,
+        optional_proposer,
+        InteractionSubmission {
+            interaction_id: optional_id,
+            response: InteractionResponse::Shortcut {
+                decision: InteractionShortcutDecision::Fixed {
+                    iterations: unsampled,
+                },
+                pins: optional_pins,
+            },
+        },
+    )
+    .expect("the optional announcement submits, as it does today");
+    let GameAction::DeclareShortcut {
+        template: Some(optional_template),
+        ..
+    } = &optional_applied.action
+    else {
+        panic!(
+            "a declared shortcut submits a template, got {:?}",
+            optional_applied.action
+        );
+    };
+    assert!(
+        optional_template
+            .decisions
+            .contains(&PinnedDecision::Targets {
+                slot: f4_announced_slot(&optional_state).0,
+                targets: Vec::new(),
+            }),
+        "the EMPTY announcement is what submits; got {:?}",
+        optional_template.decisions
+    );
+
+    // ── LEG 5: a SECOND announced-target point leaves the offer's one published split an
+    //    incomplete answer, so nothing is completed on either member.
+    let (spliced_state, spliced_proposer) = f4_second_announcement_board();
+    let spliced_view = viewer_interaction(&spliced_state, spliced_proposer);
+    let spliced_id = spliced_view.opportunities[0].interaction_id.clone();
+    let spliced_points = shortcut_points(&spliced_view);
+    let announced: Vec<&InteractionShortcutPoint> = spliced_points
+        .iter()
+        .filter(|candidate| candidate.kind == InteractionShortcutPointKind::Targets)
+        .collect();
+    assert_eq!(
+        announced.len(),
+        2,
+        "reach-guard: the spliced board must publish TWO announced-target points, else this leg \
+         is the single-point board over again"
+    );
+    let second_group = announced[1].group;
+    let answered_second: Vec<InteractionShortcutPin> = spliced_points
+        .iter()
+        .filter(|candidate| !candidate.read_only)
+        .map(|candidate| match candidate.kind {
+            InteractionShortcutPointKind::Targets if candidate.group == second_group => {
+                sequenced_pin(candidate, &[(0, unsampled)])
+            }
+            InteractionShortcutPointKind::Targets => sequenced_pin(candidate, &[]),
+            _ => InteractionShortcutPin {
+                group: candidate.group,
+                choice_ids: vec![candidate.candidate_ids[0].clone()],
+                amounts: Vec::new(),
+            },
+        })
+        .collect();
+    for (name, pins) in [
+        ("answered-second", answered_second),
+        ("both-empty", f4_pins(&spliced_points, &[])),
+    ] {
+        let refused = f4_preview(
+            &spliced_state,
+            spliced_proposer,
+            &spliced_id,
+            unsampled,
+            pins.clone(),
+        );
+        assert_eq!(
+            refused.status,
+            InteractionPreviewStatus::Rejected {
+                reason: InteractionReasonCode::ConstraintUnsatisfied
+            },
+            "CR 601.2c: with a second announced-target point published the offer's one split is \
+             not a complete answer, so the {name} member keeps today's refusal"
+        );
+        assert!(
+            refused.shortcut_preview.is_none(),
+            "a refused declaration states no magnitude; {name} rendered one"
+        );
+        assert!(
+            preview_interaction_with_rejection(
+                &spliced_state,
+                spliced_proposer,
+                &f4_request(&spliced_id, unsampled, pins.clone()),
+            )
+            .is_err(),
+            "the rejection-typed entry point refuses the {name} member too"
+        );
+        let mut spliced_submitted = spliced_state.clone();
+        assert!(
+            submit_interaction(
+                &mut spliced_submitted,
+                spliced_proposer,
+                InteractionSubmission {
+                    interaction_id: spliced_id.clone(),
+                    response: InteractionResponse::Shortcut {
+                        decision: InteractionShortcutDecision::Fixed {
+                            iterations: unsampled,
+                        },
+                        pins,
+                    },
+                },
+            )
+            .is_err(),
+            "the submit path refuses the {name} member too"
+        );
+    }
+
+    // ── HOSTILE SIBLINGS, all three at the SAME unsampled count leg 1 completes.
+    // A pin naming ONE choice id with empty amounts states WHO without partitioning anything —
+    // still confirmable, and still carrying no element, because the completion fires only on a
+    // pin naming nothing.
+    let one_named: Vec<InteractionShortcutPin> = nothing_named
+        .iter()
+        .cloned()
+        .map(|mut pin| {
+            if pin.group == point.group {
+                pin.choice_ids = vec![point.candidate_ids[0].clone()];
+            }
+            pin
+        })
+        .collect();
+    let unpartitioned = f4_preview(&state, proposer, &interaction_id, unsampled, one_named);
+    assert_eq!(
+        unpartitioned.status,
+        InteractionPreviewStatus::Confirmable,
+        "an unpartitioned declaration stays a legal answer at an unsampled count"
+    );
+    assert!(
+        unpartitioned.shortcut_preview.is_none(),
+        "CR 732.2a: a pin NAMING a subject states no split, so the completion leaves it alone"
+    );
+    // Dropping another point's pin entirely: the completion substitutes the announced group and
+    // nothing else, so a declaration another point leaves unanswered stays refused.
+    let missing_other = nothing_named
+        .iter()
+        .filter(|pin| pin.group == point.group)
+        .cloned()
+        .collect::<Vec<_>>();
+    assert!(
+        missing_other.len() < nothing_named.len(),
+        "reach-guard: the offer must publish a second answerable point for this sibling to drop"
+    );
+    let incomplete = f4_preview(&state, proposer, &interaction_id, unsampled, missing_other);
+    assert_eq!(
+        incomplete.status,
+        InteractionPreviewStatus::Rejected {
+            reason: InteractionReasonCode::ConstraintUnsatisfied
+        },
+        "the completion is group-local: it cannot carry a declaration another point leaves \
+         unanswered"
+    );
+    assert!(incomplete.shortcut_preview.is_none());
+    // The window is `materialize_loop_shortcut_response`'s single authority, and the completion
+    // does not restate it: an out-of-window count is refused after the substitution as before it.
+    let out_of_window = f4_preview(&state, proposer, &interaction_id, max + 1, nothing_named);
+    assert_eq!(
+        out_of_window.status,
+        InteractionPreviewStatus::Rejected {
+            reason: InteractionReasonCode::ConstraintUnsatisfied
+        },
+        "CR 732.2a: a count outside the offer's own window is refused, completion or not"
+    );
+    assert!(out_of_window.shortcut_preview.is_none());
 }
 
 /// **Row 4** — a declaration the ingress REFUSES carries no magnitude, each refusal asserted by


### PR DESCRIPTION
## Summary

The loop-shortcut picker offers every count in the offer's window, but the engine published magnitudes
for only a bounded sample of it (`MAX_SHORTCUT_PREVIEW_ELEMENTS`). At an in-window count outside that
sample no allocation was published, so every allocation row read `0`, the declaration never completed,
and Confirm stayed disabled — the player could not declare a count the picker itself offered. The
engine now answers such a request with the offer's own canonical split, through the materialization
path preview and both submit routes already share.

## Files changed

- `crates/engine/src/game/interaction.rs` — `completed_shortcut_declaration`, consulted from
  `materialize_response`'s `LoopShortcut` arm and from `declared_shortcut_preview`
- `crates/engine/tests/integration/interaction_contract.rs` — the new contract row and its siblings
- `client/src/components/modal/LoopShortcutModal.tsx` — ask-gate trigger and row source
- `client/src/components/modal/__tests__/LoopShortcutModal.test.tsx` — new row + P5-17 restated

## Track

Developer

## LLM

Model: claude-opus-5
Tier: Frontier
Thinking: high

## Implementation method (required)

Method: /engine-implementer

## CR references

- CR 732.2a — the proposer specifies the repetition count; the publication cap must not narrow it.
- CR 601.2c — the player announces their choice, which is what the narrowing conjuncts protect.

## Verification

- [ ] Required checks ran clean, or the exact CI-owned alternative is stated below.
- [ ] Gate A output below is for the current committed head.
- [ ] Final review-impl below is clean for the current committed head.
- [ ] Both anchors cite existing analogous code at the same seam.

- `cargo fmt --all -- --check` — PASS
- `cargo clippy --all-targets -- -D warnings` — PASS
- `cargo nextest run -p phase-engine` — PASS
- `pnpm exec tsc -b --noEmit --force` — PASS
- `pnpm lint` — PASS (0 errors; 50 pre-existing warnings, none in `LoopShortcutModal*`)
- `pnpm vitest run src/components/modal/__tests__/LoopShortcutModal.test.tsx` — PASS, 60/60
- `pnpm vitest run` (whole client suite, run twice unfiltered at this tree) — **not green on this
  machine, and not attributable to this change.** Run 1: 2 failed / 6312 passed
  (`GameLogPanel` "capped history rolls", `devServerPort`). Run 2: 1 failed / 6312+ passed
  (`AudioManagerDisabled` "warmUp is a device-free no-op"), with run 1's two failures passing.
  **The failing set moves between runs at a fixed tree**, which a regression from a fixed diff cannot
  do. Each failure is a 5000 ms timeout accompanied by `ECONNREFUSED ::1:3000` noise; each file passes
  on an isolated re-run; and none is reachable from this diff — neither `GameLogPanel` nor the audio
  or config tests reference `LoopShortcutModal` or anything under `modal/` (positive control: the same
  grep finds the 4 files that do). `AudioManagerDisabled` and `devServerPort` are already-known
  members of this class. CI is the authority for this suite.

## Gate A

Gate A PASS head=566ced2fa01327774021c6ba98a9af0520beb931 base=d6d28370c09242182488cac72e16e5a84941885f

Disclosure: this diff changes **zero** files under `crates/engine/src/parser/`, so Gate A's PASS is
real over its fork-relative range (69 files scanned) but is not evidence about this change.

## Anchored on

- crates/engine/src/game/interaction.rs:3167 — `declared_shortcut_preview`, the sibling that already
  derives the published element from the same response and projection; the completion sits beside it
  and both now consult one answer.
- crates/engine/src/game/interaction.rs:2749 — `canonical_allocation`, already the engine's answer at
  sampled counts and already total for any count >= 1 over non-empty ids.

## Final review-impl

Final review-impl PASS head=566ced2fa01327774021c6ba98a9af0520beb931

Five advisory findings (1 MED, 4 LOW), none blocking; all dropped with a verdict rather than carried:

- MED, optional-announcement sub-class (`min_targets: 0`) stays undeclarable and now costs a
  round-trip — **not worth its cost**: measured unreachable in production (the only shortcut-schema
  producer hard-codes `min_targets: 1, max_targets: 1`; every `min_targets: 0` in the tree is under
  `#[cfg(test)]`), the engine side is correct here per CR 601.2c, and the remedy is a separate modal
  design rather than a change to this seam.
- LOW, the `shortcut_preview_basis` conjunct has no discriminating test (a `no-basis` mutant survives)
  — **not worth its cost**: relaxing it produces no wrong result and the only exercising board is
  synthetic, so such a test would assert the conjunct exists rather than that it protects anything.
- LOW, `domain.ids.is_empty()` is subsumed by the `allocation.is_empty()` guard — **not worth its
  cost**: zero behavioural difference either way.
- LOW, one doc sentence over-claims what the `max == 1` half buys — **not worth its cost**:
  comment-only.
- LOW, a frontend fixture's window is not engine-realizable — **not worth its cost**: the modal reads
  only (published elements, chosen count), so no path divergence follows.

## Pipeline

Pipeline-reviewed head: 566ced2fa01327774021c6ba98a9af0520beb931
Current branch head: 566ced2fa01327774021c6ba98a9af0520beb931
Pipeline status: current
Current-head review: clean at 566ced2fa01327774021c6ba98a9af0520beb931

Plan-review rounds: 3 (5 -> 2 -> 0 design findings), no surgical-fix mode.
Implementation-review rounds: 1, clean.
Phase-fit: single-phase (T1 = 1 unit, T2 = 4 scope paths; both triggers failed independently at all
three adjudications).

## Claimed parse impact

None.

## Scope Expansion

None.

## Validation Failures

None.

## CI Failures

None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Loop shortcut declarations can now use the engine’s canonical allocation for eligible fixed counts when a required single target is left unpartitioned.
  - The shortcut modal displays and submits the canonical allocation for unsampled counts when preview support is available.

- **Bug Fixes**
  - Preview and submission now consistently handle completed shortcut allocations.
  - Unsupported, optional, ambiguous, or invalid declarations remain unavailable for confirmation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->