### PR TITLE
feat(client): consume protocol v6 tournament affordances

### DIFF
--- a/client/src/adapter/__tests__/tournamentTypes.test.ts
+++ b/client/src/adapter/__tests__/tournamentTypes.test.ts
@@ -5,8 +5,10 @@ import type {
   MatchArity,
   PairingId,
   PairingOutcome,
+  ReportGate,
   ScoringPolicy,
   Tiebreaks,
+  TournamentAction,
   TournamentPairingView,
   TournamentView,
 } from "../types";
@@ -33,6 +35,10 @@ const PROBED_VIEW: TournamentView = {
     current_round: 2,
     total_rounds: 3,
     created_at: 1_700_000_000,
+    // Protocol v6: the RESOLVED scoring policy and the broker-owned set of
+    // currently-open tournament actions. A running event admits all three.
+    scoring: { win_points: 7, draw_points: 1, loss_points: 0 },
+    open_actions: ["StartRound", "EndTournament", "Drop"],
   },
   players: [
     { player_key: "key-a", display_name: "Alice", dropped: false },
@@ -46,6 +52,7 @@ const PROBED_VIEW: TournamentView = {
       round: 1,
       players: [{ player_key: "key-a", display_name: "Alice", dropped: false }],
       outcome: "Bye",
+      report_gate: "Bye",
     },
     {
       id: 1,
@@ -55,6 +62,7 @@ const PROBED_VIEW: TournamentView = {
         { player_key: "key-d", display_name: "Dave", dropped: true },
       ],
       outcome: { Forfeit: { winner: "key-b" } },
+      report_gate: "Forfeit",
     },
     {
       id: 2,
@@ -66,6 +74,9 @@ const PROBED_VIEW: TournamentView = {
       outcome: {
         Reported: { Decisive: { winner: "key-a", game_wins: { "key-a": 2, "key-b": 1 } } },
       },
+      // A running event keeps a reported pairing Open — re-reporting is how a
+      // mistyped tally is corrected.
+      report_gate: "Open",
     },
     {
       id: 3,
@@ -75,6 +86,7 @@ const PROBED_VIEW: TournamentView = {
         { player_key: "key-d", display_name: "Dave", dropped: true },
       ],
       outcome: { Reported: "Draw" },
+      report_gate: "Open",
     },
     {
       id: 4,
@@ -86,6 +98,7 @@ const PROBED_VIEW: TournamentView = {
       ],
       // Pending: emitted with no `skip_serializing_if`, so an explicit null.
       outcome: null,
+      report_gate: "Open",
     },
   ],
   standings: [
@@ -153,6 +166,36 @@ describe("tournament wire type mirrors", () => {
     // @ts-expect-error MatchArity crosses the wire as a bare number, never a wrapper object
     const wrappedArity: MatchArity = { arity: 4 };
     expect(wrappedArity).toBeDefined();
+  });
+
+  it("mirrors the v6 broker-owned affordance fields", () => {
+    // report_gate arms 1:1 with the Rust `ReportGate` enum.
+    const gates: ReportGate[] = ["Open", "TournamentNotRunning", "Bye", "Forfeit"];
+    expect(gates).toHaveLength(4);
+
+    // open_actions is a `BTreeSet<TournamentAction>` — a JSON array on the wire.
+    const actions: TournamentAction[] = ["StartRound", "EndTournament", "Drop"];
+    expect(JSON.parse(JSON.stringify(actions))).toEqual(actions);
+
+    // Present on the probed fixture and round-tripped with it above.
+    expect(PROBED_VIEW.summary.open_actions).toEqual([
+      "StartRound",
+      "EndTournament",
+      "Drop",
+    ]);
+    expect(PROBED_VIEW.summary.scoring).toEqual({
+      win_points: 7,
+      draw_points: 1,
+      loss_points: 0,
+    });
+    // Every pairing on a v6 frame carries a report_gate.
+    expect(PROBED_VIEW.pairings.every((p) => p.report_gate !== undefined)).toBe(
+      true,
+    );
+
+    // @ts-expect-error report_gate is a ReportGate arm, never an arbitrary string
+    const bogusGate: TournamentPairingView["report_gate"] = "Whenever";
+    expect(bogusGate).toBeDefined();
   });
 
   it("keeps the scoring policy flat", () => {

--- a/client/src/adapter/types.ts
+++ b/client/src/adapter/types.ts
@@ -4706,6 +4706,36 @@ export type TournamentStatus =
 export type BracketShape = "Swiss" | "SingleElimination";
 
 /**
+ * Why the broker would refuse a report for one pairing, or `"Open"` if it would
+ * not. Mirrors `lobby_broker::tournament::ReportGate` (added in lobby protocol
+ * v6), the single authority for the viewer-INDEPENDENT half of the broker's
+ * report gate — every conjunct of `TournamentManager::report_result` that does
+ * not depend on WHO is asking, carried as the REASON rather than a bare bool so
+ * a client can gate on `=== "Open"` and a new refusal arm is a compile error.
+ *
+ * `TournamentNotRunning` is the arm the outcome-only client fallback cannot
+ * see: a `Reported` pairing on a `Completed`/`Abandoned` event is not
+ * reportable, but its outcome alone still looks re-reportable. The broker
+ * checks `TournamentStatus::is_terminal` first, so consuming this field is what
+ * removes the "Report on a finished event" affordance.
+ *
+ * `Bye` and `Forfeit` are server-assigned outcomes with nothing to report;
+ * `Open` includes an already-`Reported` pairing, because re-reporting is how a
+ * mistyped tally is corrected.
+ */
+export type ReportGate = "Open" | "TournamentNotRunning" | "Bye" | "Forfeit";
+
+/**
+ * One tournament-scoped gated action, as an axis rather than sibling
+ * `can_start` / `can_end` / `can_drop` booleans. Mirrors
+ * `lobby_broker::tournament::TournamentAction` (lobby protocol v6). These are
+ * the members carried by {@link TournamentSummary.open_actions}; the set is
+ * viewer-INDEPENDENT (it rides a frame fanned to every subscriber), so a client
+ * composes it with its own credential rather than reading authority from it.
+ */
+export type TournamentAction = "StartRound" | "EndTournament" | "Drop";
+
+/**
  * The reported content of a *played* pairing. Mirrors the externally-tagged
  * `crates/lobby-broker/src/tournament.rs:336-348`. `game_wins` is keyed by
  * `player_key`, and is empty for a pod (arity > 2) because pods are single-game
@@ -4795,17 +4825,24 @@ export interface PlayerSummary {
  * `outcome` is emitted with **no** `skip_serializing_if`, so a pending pairing
  * arrives as an explicit `"outcome": null`.
  *
- * NOTE (protocol v6, client-render deferred): the wire struct now also carries
- * a required `report_gate` (broker-owned per-pairing report legality). It is
- * intentionally not mirrored here yet — the client-rendering follow-up adds the
- * field and consumes it. Received unknown fields are ignored by `JSON.parse`,
- * so omitting it is inert. The Rust line citations below predate the v6 shift.
+ * `report_gate` is REQUIRED on the v6 wire but typed OPTIONAL here on purpose:
+ * {@link MIN_SUPPORTED_SERVER_LOBBY_PROTOCOL} stays at 2, so this client still
+ * talks to a pre-v6 broker that emits a pairing with no `report_gate` at all. A
+ * consumer treats its absence as "fall back to the outcome-only reportability
+ * heuristic" and its presence as the authority — see
+ * `isPairingReportable` in `pages/tournamentPageState.ts`.
  */
 export interface TournamentPairingView {
   id: PairingId;
   round: number;
   players: PlayerSummary[];
   outcome: PairingOutcome | null;
+  /**
+   * Broker-owned per-pairing report legality (lobby protocol v6). Absent from a
+   * pre-v6 broker's frame; a consumer degrades to the outcome-only fallback
+   * when it is `undefined`.
+   */
+  report_gate?: ReportGate;
 }
 
 /**
@@ -4825,11 +4862,13 @@ export type TournamentCredentialRole = "Organizer" | "Player";
  * One row of the tournament list. Mirrors
  * `crates/lobby-broker/src/protocol.rs:507-528` (citation predates the v6 shift).
  *
- * NOTE (protocol v6, client-render deferred): the wire struct now also carries
- * a required `scoring` (resolved `ScoringPolicy`) and `open_actions`
- * (broker-owned set of legal tournament actions). Both are intentionally not
- * mirrored here yet — the client-rendering follow-up adds and consumes them.
- * Unknown received fields are ignored by `JSON.parse`, so omitting them is inert.
+ * `scoring` and `open_actions` are REQUIRED on the v6 wire but typed OPTIONAL
+ * here for the same reason `report_gate` is on {@link TournamentPairingView}:
+ * {@link MIN_SUPPORTED_SERVER_LOBBY_PROTOCOL} stays at 2, so a pre-v6 broker
+ * emits a summary carrying neither. A consumer reads the resolved `scoring` when
+ * present (and never recomputes it — that duplicate is exactly what the field
+ * exists to delete), and treats an absent `open_actions` as "fall back to the
+ * credential-only gate" rather than as "no action is open".
  */
 export interface TournamentSummary {
   code: string;
@@ -4853,6 +4892,23 @@ export interface TournamentSummary {
    */
   total_rounds: number;
   created_at: number;
+  /**
+   * The RESOLVED scoring policy the event is actually scored under — the
+   * organizer's explicit choice, or the broker's `ScoringPolicy::default_for_arity`
+   * applied when `CreateTournament.scoring` was omitted (lobby protocol v6).
+   * Absent from a pre-v6 broker's frame. Render it; never recompute it.
+   */
+  scoring?: ScoringPolicy;
+  /**
+   * Which tournament-scoped gated actions the broker would currently admit from
+   * a correctly credentialed actor (lobby protocol v6). A viewer-INDEPENDENT
+   * set — the authorization conjuncts cannot ride a broadcast frame — so a
+   * client composes it with its own credential. Absent from a pre-v6 broker's
+   * frame, where a consumer degrades to the credential-only gate. Reporting is
+   * deliberately not here: its gate is pairing-scoped and lives on
+   * {@link TournamentPairingView.report_gate}.
+   */
+  open_actions?: TournamentAction[];
   /**
    * The event's game-format label (Standard, Commander, …), a display label
    * only — the tournament enforces no deck legality. Typed `| null` because the

--- a/client/src/components/tournament/CreateTournamentForm.tsx
+++ b/client/src/components/tournament/CreateTournamentForm.tsx
@@ -18,14 +18,18 @@ interface CreateTournamentFormProps {
 }
 
 /**
- * Parses a numeric field, keeping the previous value when the field is not a
- * number. Deliberately does not clamp or validate a range — `MatchArity::new`
- * (`crates/lobby-broker/src/tournament.rs:96-113`) and `ScoringPolicy::new`
- * are the broker's, and duplicating their bounds here would be a second,
- * drifting copy of a rule the server already owns.
+ * Parses a numeric field, keeping `fallback` when the field is blank or not a
+ * number. Uses `Number` rather than `parseInt` so the COMPLETE value is read:
+ * a `type="number"` input accepts exponent notation (`1e2`) and fractions, both
+ * of which `parseInt` would silently truncate (`1e2` -> `1`) before the value
+ * reaches the broker. Deliberately does not clamp or validate a range —
+ * `MatchArity::new` (`crates/lobby-broker/src/tournament.rs:96-113`) and
+ * `ScoringPolicy::new` are the broker's, and duplicating their bounds here would
+ * be a second, drifting copy of a rule the server already owns.
  */
 function parsedOr(raw: string, fallback: number): number {
-  const parsed = Number.parseInt(raw, 10);
+  if (raw.trim() === "") return fallback;
+  const parsed = Number(raw);
   return Number.isNaN(parsed) ? fallback : parsed;
 }
 

--- a/client/src/components/tournament/CreateTournamentForm.tsx
+++ b/client/src/components/tournament/CreateTournamentForm.tsx
@@ -6,11 +6,9 @@ import type {
   GameFormat,
   MatchArity,
   MatchType,
-  ScoringPolicy,
 } from "../../adapter/types";
 import type { CreateTournamentRequest } from "../../services/tournamentClient";
 import { FORMAT_REGISTRY } from "../../data/formatRegistry";
-import { defaultScoringForArity } from "../../pages/tournamentPageState";
 
 interface CreateTournamentFormProps {
   onSubmit: (req: CreateTournamentRequest) => void;
@@ -70,25 +68,24 @@ export function CreateTournamentForm({
    * this is dropped rather than sent alongside an explicit round count.
    */
   const [plusRoundsInput, setPlusRoundsInput] = useState("");
-  const [scoring, setScoring] = useState<ScoringPolicy>(() =>
-    defaultScoringForArity(initialArity),
-  );
   /**
-   * Latches the moment the organizer edits any scoring field. Until then the
-   * prefill follows the arity (2 -> 3/1/0, 4 -> 7/1/0); afterwards the
-   * organizer's values are authoritative and survive an arity change.
+   * The match-point axis, as an "Automatic" toggle over an explicit override.
+   *
+   * `automaticScoring` (default on) submits `scoring: null`: as of lobby
+   * protocol v6 the broker owns the default (`ScoringPolicy::default_for_arity`)
+   * and sends the resolved value back on `TournamentSummary.scoring`. This form
+   * computes no default at all — that duplicate is what the wire field exists to
+   * delete.
+   *
+   * The three override fields are STRING-backed and parsed at submit, exactly
+   * like the rounds field above — deliberately NOT numeric `value` +
+   * `parsedOr(current)` state, whose "an emptied field reverts to its current
+   * value" behaviour made a draw of 1 impossible to clear and retype as 2.
    */
-  const [scoringTouched, setScoringTouched] = useState(false);
-
-  function changeArity(next: MatchArity) {
-    setArity(next);
-    if (!scoringTouched) setScoring(defaultScoringForArity(next));
-  }
-
-  function changeScoring(patch: Partial<ScoringPolicy>) {
-    setScoringTouched(true);
-    setScoring((current) => ({ ...current, ...patch }));
-  }
+  const [automaticScoring, setAutomaticScoring] = useState(true);
+  const [winInput, setWinInput] = useState("");
+  const [drawInput, setDrawInput] = useState("");
+  const [lossInput, setLossInput] = useState("");
 
   return (
     <form
@@ -111,7 +108,17 @@ export function CreateTournamentForm({
         onSubmit({
           name,
           arity,
-          scoring,
+          // `null` when Automatic: the broker applies its arity default and
+          // returns the resolved policy on the summary. An explicit override is
+          // parsed from the string inputs (empty -> 0) and submitted verbatim,
+          // unvalidated, exactly like every other field.
+          scoring: automaticScoring
+            ? null
+            : {
+                win_points: parsedOr(winInput, 0),
+                draw_points: parsedOr(drawInput, 0),
+                loss_points: parsedOr(lossInput, 0),
+              },
           bracket,
           totalRounds,
           plusRounds,
@@ -152,7 +159,7 @@ export function CreateTournamentForm({
           type="number"
           value={arity}
           aria-describedby={arityHintId}
-          onChange={(event) => changeArity(parsedOr(event.target.value, arity))}
+          onChange={(event) => setArity(parsedOr(event.target.value, arity))}
           className="rounded-[6px] border border-white/10 bg-black/30 px-3 py-2 text-sm text-gray-100"
         />
         <p id={arityHintId} className="text-xs text-gray-500">
@@ -256,6 +263,19 @@ export function CreateTournamentForm({
 
       <fieldset className="flex flex-col gap-2">
         <legend className="text-xs text-gray-400">{t("create.scoringLabel")}</legend>
+        {/* The "Automatic" affordance, mirroring the rounds field above: checked
+            (default) submits `scoring: null` and the broker applies its arity
+            default; unchecking reveals the three inputs as an explicit override.
+            Reuses the existing `create.totalRoundsAuto` label rather than
+            minting a new catalog key across all locales. */}
+        <label className="flex items-center gap-2 text-xs text-gray-500">
+          <input
+            type="checkbox"
+            checked={automaticScoring}
+            onChange={(event) => setAutomaticScoring(event.target.checked)}
+          />
+          {t("create.totalRoundsAuto")}
+        </label>
         <div className="flex gap-3">
           <div className="flex flex-1 flex-col gap-1">
             <label htmlFor={winId} className="text-xs text-gray-500">
@@ -264,13 +284,11 @@ export function CreateTournamentForm({
             <input
               id={winId}
               type="number"
-              value={scoring.win_points}
-              onChange={(event) =>
-                changeScoring({
-                  win_points: parsedOr(event.target.value, scoring.win_points),
-                })
-              }
-              className="rounded-[6px] border border-white/10 bg-black/30 px-3 py-2 text-sm text-gray-100"
+              disabled={automaticScoring}
+              value={winInput}
+              placeholder={t("create.totalRoundsAuto")}
+              onChange={(event) => setWinInput(event.target.value)}
+              className="rounded-[6px] border border-white/10 bg-black/30 px-3 py-2 text-sm text-gray-100 disabled:opacity-50"
             />
           </div>
           <div className="flex flex-1 flex-col gap-1">
@@ -280,13 +298,11 @@ export function CreateTournamentForm({
             <input
               id={drawId}
               type="number"
-              value={scoring.draw_points}
-              onChange={(event) =>
-                changeScoring({
-                  draw_points: parsedOr(event.target.value, scoring.draw_points),
-                })
-              }
-              className="rounded-[6px] border border-white/10 bg-black/30 px-3 py-2 text-sm text-gray-100"
+              disabled={automaticScoring}
+              value={drawInput}
+              placeholder={t("create.totalRoundsAuto")}
+              onChange={(event) => setDrawInput(event.target.value)}
+              className="rounded-[6px] border border-white/10 bg-black/30 px-3 py-2 text-sm text-gray-100 disabled:opacity-50"
             />
           </div>
           <div className="flex flex-1 flex-col gap-1">
@@ -296,13 +312,11 @@ export function CreateTournamentForm({
             <input
               id={lossId}
               type="number"
-              value={scoring.loss_points}
-              onChange={(event) =>
-                changeScoring({
-                  loss_points: parsedOr(event.target.value, scoring.loss_points),
-                })
-              }
-              className="rounded-[6px] border border-white/10 bg-black/30 px-3 py-2 text-sm text-gray-100"
+              disabled={automaticScoring}
+              value={lossInput}
+              placeholder={t("create.totalRoundsAuto")}
+              onChange={(event) => setLossInput(event.target.value)}
+              className="rounded-[6px] border border-white/10 bg-black/30 px-3 py-2 text-sm text-gray-100 disabled:opacity-50"
             />
           </div>
         </div>

--- a/client/src/components/tournament/PairingsList.tsx
+++ b/client/src/components/tournament/PairingsList.tsx
@@ -5,7 +5,7 @@ import type { TournamentPairingView } from "../../adapter/types";
 import {
   decisiveGameWins,
   gameWinsEntries,
-  isReportable,
+  isPairingReportable,
   outcomeLabelKey,
 } from "../../pages/tournamentPageState";
 
@@ -72,15 +72,17 @@ export function PairingsList({ pairings, onReport }: PairingsListProps) {
                     <span className="text-xs text-gray-500">
                       {t("pairings.table", { id: pairing.id })}
                     </span>
-                    {/* Arm-gated, not merely prop-gated. `report_result`
-                        (`crates/lobby-broker/src/tournament.rs:1741-1753`)
-                        refuses `Bye` and `Forfeit` unconditionally before any
-                        validation runs, so offering the action there would
-                        build a request that can never succeed. An already
-                        `Reported` pairing IS reportable again (`:1752`,
-                        overwritten at `:1755`) — correcting a mistyped tally
-                        is a legitimate organizer action — so the guard is
-                        arm-selective, never "unresolved only". */}
+                    {/* Broker-gated, not merely prop-gated.
+                        `isPairingReportable` consumes the broker's own
+                        per-pairing `report_gate` (lobby protocol v6), which
+                        refuses `Bye` and `Forfeit` — offering the action there
+                        would build a request that can never succeed — and,
+                        unlike the outcome-only fallback, also refuses an
+                        already-`Reported` pairing once the event is terminal
+                        (`ReportGate::TournamentNotRunning`). An already
+                        `Reported` pairing on a RUNNING event stays reportable,
+                        because correcting a mistyped tally is a legitimate
+                        organizer action. */}
                     {/* The one interactive control this component renders, and
                         therefore the only one the >= 44pt touch-target rule
                         applies to. `min-h-[44px]` is this repo's established
@@ -91,7 +93,7 @@ export function PairingsList({ pairings, onReport }: PairingsListProps) {
                         `sm` size would otherwise have supplied `min-h-11`.
                         `inline-flex items-center` keeps the label centred once
                         the box is taller than its text. */}
-                    {onReport && isReportable(pairing.outcome) && (
+                    {onReport && isPairingReportable(pairing) && (
                       <button
                         type="button"
                         onClick={() => onReport(pairing)}

--- a/client/src/components/tournament/__tests__/CreateTournamentForm.test.tsx
+++ b/client/src/components/tournament/__tests__/CreateTournamentForm.test.tsx
@@ -107,6 +107,29 @@ describe("CreateTournamentForm", () => {
     expect(onSubmit.mock.calls[0][0].scoring.draw_points).toBe(2);
   });
 
+  // Regression: a `type="number"` input accepts exponent notation, so `1e2` is a
+  // valid entry that a real browser resolves to the integer 100 and submits.
+  // `parseInt` would truncate it to `1` before the broker — the only scoring
+  // authority — ever saw it. The complete value must reach `onSubmit` unchanged.
+  //
+  // Submitted via `fireEvent.submit` rather than clicking the button: jsdom runs
+  // constraint validation on the click→submit path and (unlike a browser) blocks
+  // a number control whose raw string is `1e2`, which would swallow the very
+  // submission this asserts. Dispatching the submit event directly reproduces
+  // the browser outcome for a value the browser considers valid.
+  it("preserves an exponent-notation scoring value to the wire", () => {
+    const onSubmit = vi.fn();
+    const { container } = render(<CreateTournamentForm onSubmit={onSubmit} />);
+
+    fireEvent.click(screen.getByLabelText("Automatic"));
+    fireEvent.change(screen.getByLabelText("Win"), { target: { value: "1e2" } });
+
+    const form = container.querySelector("form");
+    expect(form).not.toBeNull();
+    fireEvent.submit(form as HTMLFormElement);
+    expect(onSubmit.mock.calls[0][0].scoring.win_points).toBe(100);
+  });
+
   // V21 — "Automatic" is the wire's `total_rounds: null`, the one
   // `CreateTournament` field that is `#[serde(default)]`.
   it("submits null rounds when the organizer leaves the field automatic", () => {

--- a/client/src/components/tournament/__tests__/CreateTournamentForm.test.tsx
+++ b/client/src/components/tournament/__tests__/CreateTournamentForm.test.tsx
@@ -38,52 +38,73 @@ describe("CreateTournamentForm", () => {
     });
   });
 
-  // V20a — untouched scoring follows the arity. `default_for_arity` is
-  // `2n-1`, so arity 4 must prefill 7, not stay at 3.
-  it("re-prefills untouched scoring when the arity changes", () => {
+  // V20a — scoring defaults to "Automatic": the form submits `scoring: null`
+  // and the broker applies its own `default_for_arity` (lobby protocol v6).
+  // The form computes no default itself — that duplicate is exactly what the
+  // resolved `TournamentSummary.scoring` field exists to delete.
+  it("submits null scoring when left automatic", () => {
     const onSubmit = vi.fn();
     render(<CreateTournamentForm onSubmit={onSubmit} />);
 
-    expect(screen.getByLabelText("Win")).toHaveValue(3);
+    fireEvent.click(submitButton());
 
+    expect(onSubmit.mock.calls[0][0].scoring).toBeNull();
+  });
+
+  // The scoring inputs are disabled while Automatic is on — the form never
+  // presents a client-computed default for the organizer to accept.
+  it("disables the scoring inputs while automatic", () => {
+    render(<CreateTournamentForm onSubmit={vi.fn()} />);
+
+    expect(screen.getByLabelText("Win")).toBeDisabled();
+
+    fireEvent.click(screen.getByLabelText("Automatic"));
+
+    expect(screen.getByLabelText("Win")).toBeEnabled();
+  });
+
+  // V20b — the paired opposite of V20a. Turning Automatic off submits the
+  // explicit override verbatim, and it is INDEPENDENT of arity: the form no
+  // longer couples scoring to the arity at all.
+  it("submits an explicit scoring override, unchanged by a later arity change", () => {
+    const onSubmit = vi.fn();
+    render(<CreateTournamentForm onSubmit={onSubmit} />);
+
+    fireEvent.click(screen.getByLabelText("Automatic"));
+    fireEvent.change(screen.getByLabelText("Win"), { target: { value: "5" } });
+    fireEvent.change(screen.getByLabelText("Draw"), { target: { value: "2" } });
+    fireEvent.change(screen.getByLabelText("Loss"), { target: { value: "1" } });
     fireEvent.change(screen.getByLabelText("Players per match"), {
       target: { value: "4" },
     });
 
-    expect(screen.getByLabelText("Win")).toHaveValue(7);
-
     fireEvent.click(submitButton());
     expect(onSubmit.mock.calls[0][0].scoring).toEqual({
-      win_points: 7,
-      draw_points: 1,
-      loss_points: 0,
+      win_points: 5,
+      draw_points: 2,
+      loss_points: 1,
     });
   });
 
-  // V20b — the paired opposite of V20a. Without both, one implementation
-  // satisfies the other vacuously.
-  it("keeps an organizer's edited scoring across an arity change", () => {
+  // Regression: the scoring inputs are string-backed and parsed at submit, like
+  // the rounds field. The prior numeric `value` + `parsedOr(current)` inputs
+  // reverted an emptied field to its previous value, so a draw of 1 could not
+  // be cleared and retyped as 2 — the reported bug.
+  it("lets a scoring field be cleared and retyped", () => {
     const onSubmit = vi.fn();
     render(<CreateTournamentForm onSubmit={onSubmit} />);
 
-    fireEvent.change(screen.getByLabelText("Win"), { target: { value: "4" } });
-    fireEvent.change(screen.getByLabelText("Players per match"), {
-      target: { value: "4" },
-    });
+    fireEvent.click(screen.getByLabelText("Automatic"));
+    const draw = screen.getByLabelText("Draw");
 
-    expect(screen.getByLabelText("Win")).toHaveValue(4);
+    fireEvent.change(draw, { target: { value: "1" } });
+    fireEvent.change(draw, { target: { value: "" } });
+    // Emptied, not snapped back to "1".
+    expect(draw).toHaveValue(null);
 
+    fireEvent.change(draw, { target: { value: "2" } });
     fireEvent.click(submitButton());
-    expect(onSubmit.mock.calls[0][0].scoring).toEqual({
-      win_points: 4,
-      draw_points: 1,
-      loss_points: 0,
-    });
-  });
-
-  it("prefills from the initial arity", () => {
-    render(<CreateTournamentForm onSubmit={vi.fn()} initialArity={4} />);
-    expect(screen.getByLabelText("Win")).toHaveValue(7);
+    expect(onSubmit.mock.calls[0][0].scoring.draw_points).toBe(2);
   });
 
   // V21 — "Automatic" is the wire's `total_rounds: null`, the one

--- a/client/src/components/tournament/__tests__/PairingsList.test.tsx
+++ b/client/src/components/tournament/__tests__/PairingsList.test.tsx
@@ -211,6 +211,59 @@ describe("PairingsList report affordance", () => {
   });
 });
 
+// report_gate consumption (lobby protocol v6): when the broker supplies a
+// per-pairing gate it — not the outcome heuristic — decides the affordance.
+// This is the fix for the reported bug: a reported pairing on a finished event,
+// whose outcome ALONE still looks re-reportable, is refused via
+// `TournamentNotRunning`.
+describe("PairingsList report_gate", () => {
+  const reported: PairingOutcome = {
+    Reported: { Decisive: { winner: "p0", game_wins: { p0: 2, p1: 1 } } },
+  };
+
+  it("hides the report action for a reported pairing once the tournament is not running", () => {
+    render(
+      <PairingsList
+        pairings={[
+          {
+            id: 1,
+            round: 1,
+            players: seatsOf(2),
+            outcome: reported,
+            report_gate: "TournamentNotRunning",
+          },
+        ]}
+        onReport={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.queryAllByRole("button", { name: "Report Result" }),
+    ).toHaveLength(0);
+  });
+
+  it("shows it for the same reported pairing while the gate is Open (a correction)", () => {
+    render(
+      <PairingsList
+        pairings={[
+          {
+            id: 1,
+            round: 1,
+            players: seatsOf(2),
+            outcome: reported,
+            report_gate: "Open",
+          },
+        ]}
+        onReport={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.getAllByRole("button", { name: "Report Result" }),
+    ).toHaveLength(1);
+  });
+});
+
 // The >= 44pt touch-target rule from `.coderabbit.yaml`'s `client/src/**` path
 // instructions. `min-h-[44px]` is this repo's spelling of it
 // (`components/lobby/LobbyView.tsx:332,348`, `components/lobby/HostSetup.tsx:664`),

--- a/client/src/pages/TournamentPage.tsx
+++ b/client/src/pages/TournamentPage.tsx
@@ -25,6 +25,7 @@ import {
 import {
   arityLabel,
   failureLabel,
+  isActionOpen,
   isActiveEntrant,
   myPairing,
   viewerRelation,
@@ -442,6 +443,25 @@ export function TournamentPage() {
                     })}
                   </span>
                 )}
+                {/* The RESOLVED scoring policy, read straight off the summary and
+                    never recomputed — the readout that makes an organizer's
+                    "Automatic" choice legible after the broker applies its
+                    arity default (lobby protocol v6). Absent from a pre-v6
+                    broker's summary, in which case nothing is shown. Reuses the
+                    create-form point labels rather than minting new catalog
+                    keys. */}
+                {view.summary.scoring !== undefined && (
+                  <span
+                    className="text-slate-400"
+                    title={t("create.scoringLabel")}
+                  >
+                    {t("create.winPointsLabel")} {view.summary.scoring.win_points}{" "}
+                    · {t("create.drawPointsLabel")}{" "}
+                    {view.summary.scoring.draw_points} ·{" "}
+                    {t("create.lossPointsLabel")}{" "}
+                    {view.summary.scoring.loss_points}
+                  </span>
+                )}
                 {/* Rendered for every relation, "Spectating" included: on a
                     single-tournament page the viewer's relation to THIS event
                     is exactly the thing worth stating. */}
@@ -450,56 +470,74 @@ export function TournamentPage() {
                 </span>
               </div>
 
-              {roles.has("organizer") && (
-                <MenuPanel>
-                  <div className="flex flex-col gap-3">
-                    <h2 className="text-sm font-semibold uppercase tracking-wide text-slate-400">
-                      {t("detail.organizerControls")}
-                    </h2>
-                    {/* `busy !== null` on both controls, `busy === "<kind>"`
-                        on both labels — see `BusyKind`. The two tests are
-                        deliberately different: one action in flight holds
-                        EVERY control, while only the control whose action is
-                        actually running changes what it says. */}
-                    <div className="flex flex-wrap gap-2">
-                      <button
-                        type="button"
-                        onClick={handleStart}
-                        disabled={busy !== null}
-                        className={menuButtonClass({
-                          tone: "emerald",
-                          size: "sm",
-                          disabled: busy !== null,
-                        })}
-                      >
-                        {busy === "start"
-                          ? t("detail.startRoundBusy")
-                          : t("detail.startRound")}
-                      </button>
-                      <button
-                        type="button"
-                        onClick={handleEnd}
-                        disabled={busy !== null}
-                        className={menuButtonClass({
-                          tone: "red",
-                          size: "sm",
-                          disabled: busy !== null,
-                        })}
-                      >
-                        {busy === "end"
-                          ? t("detail.endTournamentBusy")
-                          : t("detail.endTournament")}
-                      </button>
+              {/* Each control is gated on the broker's own `open_actions`
+                  (lobby protocol v6) via `isActionOpen`, composed with the
+                  organizer credential — the two together are the whole gate.
+                  This withdraws `End Tournament` during `Registration` (which
+                  the broker refuses) and hides the panel entirely on a terminal
+                  event (its `open_actions` is empty), the organizer-side
+                  counterpart to the `report_gate` fix. Against a pre-v6 broker
+                  that emits no `open_actions`, `isActionOpen` answers `true` and
+                  the prior credential-only behaviour is preserved. */}
+              {roles.has("organizer") &&
+                (isActionOpen(view.summary, "StartRound") ||
+                  isActionOpen(view.summary, "EndTournament")) && (
+                  <MenuPanel>
+                    <div className="flex flex-col gap-3">
+                      <h2 className="text-sm font-semibold uppercase tracking-wide text-slate-400">
+                        {t("detail.organizerControls")}
+                      </h2>
+                      {/* `busy !== null` on both controls, `busy === "<kind>"`
+                          on both labels — see `BusyKind`. The two tests are
+                          deliberately different: one action in flight holds
+                          EVERY control, while only the control whose action is
+                          actually running changes what it says. */}
+                      <div className="flex flex-wrap gap-2">
+                        {isActionOpen(view.summary, "StartRound") && (
+                          <button
+                            type="button"
+                            onClick={handleStart}
+                            disabled={busy !== null}
+                            className={menuButtonClass({
+                              tone: "emerald",
+                              size: "sm",
+                              disabled: busy !== null,
+                            })}
+                          >
+                            {busy === "start"
+                              ? t("detail.startRoundBusy")
+                              : t("detail.startRound")}
+                          </button>
+                        )}
+                        {isActionOpen(view.summary, "EndTournament") && (
+                          <button
+                            type="button"
+                            onClick={handleEnd}
+                            disabled={busy !== null}
+                            className={menuButtonClass({
+                              tone: "red",
+                              size: "sm",
+                              disabled: busy !== null,
+                            })}
+                          >
+                            {busy === "end"
+                              ? t("detail.endTournamentBusy")
+                              : t("detail.endTournament")}
+                          </button>
+                        )}
+                      </div>
                     </div>
-                  </div>
-                </MenuPanel>
-              )}
+                  </MenuPanel>
+                )}
 
               {/* `canPlayerAct`, not `roles.has("player")`. The broker
                   permanently refuses a second drop by design, and no
                   credential is cleared by a successful one — so a button
-                  gated on possession alone can only ever produce an alert. */}
-              {canPlayerAct && (
+                  gated on possession alone can only ever produce an alert.
+                  `isActionOpen(..., "Drop")` adds the broker's own v6 gate on
+                  top: Drop closes once the event is terminal, and degrades to
+                  open against a pre-v6 broker. */}
+              {canPlayerAct && isActionOpen(view.summary, "Drop") && (
                 <div className="flex flex-wrap gap-2">
                   <button
                     type="button"
@@ -526,7 +564,7 @@ export function TournamentPage() {
                   // The ONLY place `onReport` is ever supplied. `canPlayerAct`
                   // carries C2 (a dropped entrant keeps a live pairing in a pod
                   // with >=2 active seats, so neither `myPairing` nor
-                  // `isReportable` refuses there) and `[mine]` carries C3.
+                  // `isPairingReportable` refuses there) and `[mine]` carries C3.
                   <PairingsList
                     pairings={[mine]}
                     onReport={canPlayerAct ? setReporting : undefined}

--- a/client/src/pages/TournamentPage.tsx
+++ b/client/src/pages/TournamentPage.tsx
@@ -27,6 +27,7 @@ import {
   failureLabel,
   isActionOpen,
   isActiveEntrant,
+  isPairingReportable,
   myPairing,
   viewerRelation,
   viewerRoles,
@@ -349,10 +350,23 @@ export function TournamentPage() {
   // while the dialog is open cannot carry a stale seat list into the payload.
   // No `key={pairing.id}` is passed: the dialog's entry-state reset is
   // structural, and its own prop doc says a caller need not pass one.
-  const freshPairing =
+  //
+  // Gated on `isPairingReportable`, the same broker `report_gate` the Report
+  // button consumes: a broadcast can close the gate while the dialog is open
+  // (the tournament ends → `TournamentNotRunning`, or a drop auto-settles the
+  // pairing → `Forfeit`), and an open dialog would then offer a submit the
+  // broker refuses every time. Closing it keeps the dialog consistent with the
+  // button that opened it. An already-`Reported` pairing on a running event
+  // stays `Open`, so a correction-in-progress is not yanked away.
+  const freshPairingCandidate =
     reporting === null
       ? null
       : (view?.pairings.find((p) => p.id === reporting.id) ?? reporting);
+  const freshPairing =
+    freshPairingCandidate !== null &&
+    isPairingReportable(freshPairingCandidate)
+      ? freshPairingCandidate
+      : null;
 
   const arity = view === null ? null : arityLabel(view.summary.arity);
 

--- a/client/src/pages/__tests__/TournamentPage.test.tsx
+++ b/client/src/pages/__tests__/TournamentPage.test.tsx
@@ -261,8 +261,9 @@ function h2hView(code = "TOUR01", overrides: Partial<TournamentView> = {}): Tour
  * outcome, in which Alice has dropped while three active seats remain.
  *
  * Every clause is load-bearing. `round === current_round` keeps `myPairing`
- * matching (C3 passes), `outcome: null` keeps `isReportable` true (the arm
- * gate passes), and `>= 2` remaining active seats is exactly the shape
+ * matching (C3 passes), `outcome: null` with no `report_gate` keeps
+ * `isPairingReportable` true (via its outcome-only fallback, so the arm gate
+ * passes), and `>= 2` remaining active seats is exactly the shape
  * `drop_player` leaves behind when its one-survivor forfeit guard does not
  * fire — so C2 is the ONLY conjunct that can refuse Alice.
  *
@@ -771,6 +772,90 @@ describe("TournamentPage organizer gating", () => {
 
     expect(screen.queryByText("Start Round")).toBeNull();
     expect(screen.getAllByText("Report Result")).toHaveLength(1);
+  });
+});
+
+// ── Protocol v6 — broker-owned action legality and resolved scoring ──────
+
+describe("TournamentPage v6 affordances", () => {
+  // `open_actions` withholds End Tournament in a state the broker refuses it
+  // (Registration): the organizer-side counterpart to the report_gate fix.
+  it("withholds End Tournament when open_actions omits it", async () => {
+    const fake = makeFakeSocket();
+    primeSocket(fake);
+    useMultiplayerStore.setState({ tournamentCredentials: { TOUR01: ORGANIZER } });
+    const view = h2hView("TOUR01", {
+      summary: { ...summaryFor("TOUR01"), open_actions: ["StartRound", "Drop"] },
+    });
+    await mountWith(fake, view);
+
+    expect(screen.getByText("Start Round")).toBeTruthy();
+    expect(screen.queryByText("End Tournament")).toBeNull();
+  });
+
+  // A terminal event's `open_actions` is empty, so the whole organizer panel
+  // disappears rather than rendering a heading over no controls.
+  it("hides the organizer panel entirely when open_actions is empty", async () => {
+    const fake = makeFakeSocket();
+    primeSocket(fake);
+    useMultiplayerStore.setState({ tournamentCredentials: { TOUR01: ORGANIZER } });
+    const view = h2hView("TOUR01", {
+      summary: { ...summaryFor("TOUR01"), status: "Completed", open_actions: [] },
+    });
+    await mountWith(fake, view);
+
+    expect(screen.queryByText("Start Round")).toBeNull();
+    expect(screen.queryByText("End Tournament")).toBeNull();
+    expect(screen.queryByText("Organizer controls")).toBeNull();
+    // Reach-guard: the page really rendered this tournament.
+    expect(screen.getByText("Event TOUR01")).toBeTruthy();
+  });
+
+  // `open_actions` gates Drop too, on top of the C1/C2 player conjuncts.
+  it("withholds Drop when open_actions omits it, even for an active entrant", async () => {
+    const fake = makeFakeSocket();
+    primeSocket(fake);
+    useMultiplayerStore.setState({
+      tournamentCredentials: { TOUR01: playerCredential("alice") },
+    });
+    const view = h2hView("TOUR01", {
+      summary: { ...summaryFor("TOUR01"), open_actions: ["StartRound"] },
+    });
+    await mountWith(fake, view);
+
+    expect(screen.queryByText("Drop")).toBeNull();
+    // Reach-guard: the player affordance that does NOT read open_actions("Drop")
+    // still renders, so this is not a page that withheld everything.
+    expect(screen.getAllByText("Report Result")).toHaveLength(1);
+  });
+
+  // The resolved scoring policy is read straight off the summary and rendered.
+  it("renders the resolved scoring policy from the summary", async () => {
+    const fake = makeFakeSocket();
+    primeSocket(fake);
+    const view = h2hView("TOUR01", {
+      summary: {
+        ...summaryFor("TOUR01"),
+        scoring: { win_points: 3, draw_points: 1, loss_points: 0 },
+      },
+    });
+    const { container } = await mountWith(fake, view);
+
+    // A `span` title, distinct from the standings table's `th` of the same
+    // title (`standings.matchPointsTitle`).
+    const readout = container.querySelector('span[title="Match points"]');
+    expect(readout).not.toBeNull();
+    expect(readout?.textContent).toContain("Win");
+    expect(readout?.textContent).toContain("3");
+  });
+
+  // Absent from a pre-v6 broker's summary → nothing rendered, never recomputed.
+  it("renders no scoring readout when the summary omits it", async () => {
+    const fake = makeFakeSocket();
+    primeSocket(fake);
+    const { container } = await mountWith(fake, h2hView());
+
+    expect(container.querySelector('span[title="Match points"]')).toBeNull();
   });
 });
 

--- a/client/src/pages/__tests__/TournamentPage.test.tsx
+++ b/client/src/pages/__tests__/TournamentPage.test.tsx
@@ -559,6 +559,47 @@ describe("TournamentPage Bo1 result entry", () => {
   });
 });
 
+// An open report dialog consumes the same broker `report_gate` the Report
+// button does: a broadcast that closes the gate (the tournament ends) must
+// close the dialog, not leave it offering a submit the broker will refuse.
+describe("TournamentPage report dialog gate", () => {
+  it("closes an open report dialog when a broadcast closes the pairing's gate", async () => {
+    const user = userEvent.setup();
+    const fake = makeFakeSocket();
+    primeSocket(fake);
+    useMultiplayerStore.setState({
+      tournamentCredentials: { TOUR01: playerCredential("alice") },
+    });
+    await mountWith(fake, h2hView());
+
+    await user.click(screen.getByRole("button", { name: "Report Result" }));
+    await settle();
+    expect(screen.getByRole("dialog")).toBeTruthy();
+
+    // The tournament ends: the pairing's report_gate closes to
+    // `TournamentNotRunning`.
+    const closed: TournamentView = {
+      ...h2hView(),
+      summary: { ...summaryFor("TOUR01"), status: "Completed" },
+      pairings: [
+        {
+          id: 1,
+          round: 1,
+          players: [ALICE, BOB],
+          outcome: { Reported: "Draw" },
+          report_gate: "TournamentNotRunning",
+        },
+      ],
+    };
+    await act(async () => {
+      fake.deliver("TournamentUpdate", { code: "TOUR01", view: closed });
+    });
+    await settle();
+
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+});
+
 // ── V11 — no page ever writes a view from an RPC result ──────────────────
 
 describe("TournamentPage RPC-result provenance", () => {

--- a/client/src/pages/__tests__/TournamentPage.test.tsx
+++ b/client/src/pages/__tests__/TournamentPage.test.tsx
@@ -874,10 +874,16 @@ describe("TournamentPage v6 affordances", () => {
   it("renders the resolved scoring policy from the summary", async () => {
     const fake = makeFakeSocket();
     primeSocket(fake);
+    // A policy no arity default (`{2n-1, 1, 0}`) and not the former client-side
+    // h2h default (`{3, 1, 0}`) could produce: `win_points` is even (defaults
+    // are always odd), `draw_points` is 2 (defaults are 1), `loss_points` is 1
+    // (defaults are 0). Asserting all three label/value pairs is what proves the
+    // page renders the broker's wire data verbatim — the test would otherwise
+    // pass if the page reintroduced a local default or dropped draw/loss.
     const view = h2hView("TOUR01", {
       summary: {
         ...summaryFor("TOUR01"),
-        scoring: { win_points: 3, draw_points: 1, loss_points: 0 },
+        scoring: { win_points: 4, draw_points: 2, loss_points: 1 },
       },
     });
     const { container } = await mountWith(fake, view);
@@ -886,8 +892,9 @@ describe("TournamentPage v6 affordances", () => {
     // title (`standings.matchPointsTitle`).
     const readout = container.querySelector('span[title="Match points"]');
     expect(readout).not.toBeNull();
-    expect(readout?.textContent).toContain("Win");
-    expect(readout?.textContent).toContain("3");
+    expect(readout?.textContent).toContain("Win 4");
+    expect(readout?.textContent).toContain("Draw 2");
+    expect(readout?.textContent).toContain("Loss 1");
   });
 
   // Absent from a pre-v6 broker's summary → nothing rendered, never recomputed.

--- a/client/src/pages/__tests__/tournamentPageState.test.ts
+++ b/client/src/pages/__tests__/tournamentPageState.test.ts
@@ -8,17 +8,21 @@ import { describe, expect, it } from "vitest";
 import type {
   PairingOutcome,
   PlayerSummary,
+  TournamentAction,
+  TournamentPairingView,
+  TournamentSummary,
   TournamentView,
 } from "../../adapter/types";
 import type { TournamentCredential } from "../../stores/multiplayerStore";
 import {
   arityLabel,
   decisiveGameWins,
-  defaultScoringForArity,
   failureLabel,
   formatTiebreakValue,
   gameWinsEntries,
+  isActionOpen,
   isActiveEntrant,
+  isPairingReportable,
   isReportable,
   myPairing,
   outcomeLabelKey,
@@ -111,6 +115,76 @@ describe("isReportable", () => {
 
   it.each(cases)("%s", (_label, outcome, expected) => {
     expect(isReportable(outcome)).toBe(expected);
+  });
+});
+
+// The v6 authority: consumes the broker's per-pairing `report_gate` when
+// present and falls back to the status-blind `isReportable` only when it is
+// absent (a pre-v6 broker).
+describe("isPairingReportable", () => {
+  const pairing = (
+    report_gate: TournamentPairingView["report_gate"],
+    outcome: PairingOutcome | null,
+  ): TournamentPairingView => ({
+    id: 1,
+    round: 1,
+    players: [...seats],
+    outcome,
+    report_gate,
+  });
+
+  // Present `report_gate` is authoritative — gate strictly on `"Open"`.
+  it.each([
+    ["Open", true],
+    ["TournamentNotRunning", false],
+    ["Bye", false],
+    ["Forfeit", false],
+  ] as const)("consumes report_gate %s", (gate, expected) => {
+    expect(isPairingReportable(pairing(gate, null))).toBe(expected);
+  });
+
+  // The bug fix: an already-`Reported` pairing on a finished event is refused
+  // via `TournamentNotRunning`, though its outcome alone still looks
+  // re-reportable.
+  it("refuses a reported pairing once the tournament is not running", () => {
+    const reported: PairingOutcome = { Reported: "Draw" };
+    expect(isPairingReportable(pairing("TournamentNotRunning", reported))).toBe(
+      false,
+    );
+    // Same outcome, still running → the broker keeps it open for corrections.
+    expect(isPairingReportable(pairing("Open", reported))).toBe(true);
+  });
+
+  // Absent `report_gate` (pre-v6 broker) degrades to the outcome-only fallback.
+  it.each([
+    ["pending", null, true],
+    ["bye", "Bye", false],
+  ] as const)("falls back to isReportable when absent: %s", (_l, outcome, expected) => {
+    expect(isPairingReportable(pairing(undefined, outcome))).toBe(expected);
+  });
+});
+
+// Consumes the broker's `open_actions`; treats an absent set (pre-v6 broker)
+// as OPEN so an older server keeps the credential-only behaviour.
+describe("isActionOpen", () => {
+  const summary = (open_actions?: TournamentAction[]): TournamentSummary =>
+    ({ open_actions }) as TournamentSummary;
+
+  it("is true for an action present in the set", () => {
+    expect(isActionOpen(summary(["StartRound", "Drop"]), "StartRound")).toBe(true);
+  });
+
+  it("is false for an action absent from a present set", () => {
+    // A running event withholds nothing here, but a Registration event omits
+    // EndTournament and a terminal event omits everything.
+    expect(isActionOpen(summary(["StartRound", "Drop"]), "EndTournament")).toBe(
+      false,
+    );
+    expect(isActionOpen(summary([]), "StartRound")).toBe(false);
+  });
+
+  it("defaults to open when the set is absent (pre-v6 broker)", () => {
+    expect(isActionOpen(summary(undefined), "EndTournament")).toBe(true);
   });
 });
 
@@ -382,22 +456,6 @@ describe("viewerRoles", () => {
     expect(roles.size).toBe(2);
     expect(roles.has("organizer")).toBe(true);
     expect(roles.has("player")).toBe(true);
-  });
-});
-
-// V12 — mirrors `ScoringPolicy::default_for_arity`'s `2n-1 / 1 / 0`. A
-// hardcoded 3/1/0 reds the arity-4 case.
-describe("defaultScoringForArity", () => {
-  it.each([
-    [2, 3],
-    [4, 7],
-    [128, 255],
-  ])("arity %i prefills %i win points", (arity, winPoints) => {
-    expect(defaultScoringForArity(arity)).toEqual({
-      win_points: winPoints,
-      draw_points: 1,
-      loss_points: 0,
-    });
   });
 });
 

--- a/client/src/pages/tournamentPageState.ts
+++ b/client/src/pages/tournamentPageState.ts
@@ -34,9 +34,10 @@ import type {
   PairingOutcome,
   PlayerSummary,
   PodOutcome,
-  ScoringPolicy,
   Tiebreaks,
+  TournamentAction,
   TournamentPairingView,
+  TournamentSummary,
   TournamentView,
 } from "../adapter/types";
 import type {
@@ -143,8 +144,20 @@ export function outcomeLabelKey(
 }
 
 /**
- * Whether the broker will accept a `ReportMatchResult` for this pairing at
- * all — a *total* contract, not a validity judgement about a submission's
+ * The BELOW-FLOOR FALLBACK for {@link isPairingReportable}: whether the broker
+ * will accept a `ReportMatchResult` for this pairing, decided from the pairing
+ * outcome ALONE. As of lobby protocol v6 the broker carries the answer on
+ * `TournamentPairingView.report_gate`, and {@link isPairingReportable} consumes
+ * that; this function is what it degrades to against a pre-v6 broker that emits
+ * no `report_gate`. Kept, not deleted, for exactly that reason.
+ *
+ * It is deliberately status-BLIND — it cannot see whether the tournament is
+ * still running — so it answers `true` for an already-`Reported` pairing on a
+ * `Completed` event, the one case `report_gate`'s `TournamentNotRunning` arm
+ * exists to refuse. That is an accepted limitation of the fallback, never the
+ * preferred path: a v6 broker's `report_gate` is always consulted first.
+ *
+ * A *total* contract, not a validity judgement about a submission's
  * contents (which is `validate_match_result`'s alone, and is never
  * duplicated here).
  *
@@ -186,6 +199,50 @@ export function isReportable(outcome: PairingOutcome | null): boolean {
   if ("Reported" in outcome) return true; // tournament.rs:1752 — re-reporting is legal
   const unreachable: never = outcome;
   return unreachable;
+}
+
+/**
+ * Whether the broker would accept a `ReportMatchResult` for this pairing —
+ * consuming the broker's own {@link TournamentPairingView.report_gate} when it
+ * is present (lobby protocol v6), and falling back to the status-blind
+ * {@link isReportable} only against a pre-v6 broker that emits none.
+ *
+ * This is the authority the Report affordance is gated on, and consuming
+ * `report_gate` is what fixes the pre-existing bug where the Report button
+ * lingered on a `Completed` event's already-`Reported` pairings: the broker's
+ * `report_gate` checks `TournamentStatus::is_terminal` first and answers
+ * `TournamentNotRunning`, a distinction the outcome-only fallback cannot draw.
+ *
+ * As with {@link isReportable}, this answers "can this pairing be reported by
+ * anyone", NOT "may this viewer report it" — authorization stays the caller's
+ * three orthogonal conjuncts ({@link viewerRoles}, {@link isActiveEntrant},
+ * {@link myPairing}).
+ */
+export function isPairingReportable(pairing: TournamentPairingView): boolean {
+  if (pairing.report_gate !== undefined) return pairing.report_gate === "Open";
+  return isReportable(pairing.outcome);
+}
+
+/**
+ * Whether a tournament-scoped gated action is one the broker would currently
+ * admit, read from the broker's own {@link TournamentSummary.open_actions}
+ * (lobby protocol v6) and composed by the caller with its own organizer
+ * credential — this answers "would the broker admit this action from a
+ * correctly credentialed actor", never "may this viewer take it".
+ *
+ * Absence is treated as OPEN, not closed: a pre-v6 broker emits no
+ * `open_actions`, and degrading to the credential-only gate preserves the
+ * prior behaviour (the button shows, and the broker refuses server-side if it
+ * must) rather than hiding an organizer's controls against an older server. A
+ * v6 broker that omits an action from the set closes it here — which is what
+ * withdraws `EndTournament` during `Registration`, and every action once the
+ * event is terminal.
+ */
+export function isActionOpen(
+  summary: TournamentSummary,
+  action: TournamentAction,
+): boolean {
+  return summary.open_actions?.includes(action) ?? true;
 }
 
 /**
@@ -414,27 +471,6 @@ export type ArityLabel =
 export function arityLabel(arity: MatchArity): ArityLabel {
   if (arity === 2) return { key: "arity.headToHead" };
   return { key: "arity.pod", seats: arity };
-}
-
-/**
- * The scoring policy to **prefill** a creation form with, for a given arity.
- *
- * Prefill only, and — as of lobby protocol v6 — a KNOWN DUPLICATE of a value
- * the engine now owns and exposes. `LobbyClientMessage::CreateTournament`'s
- * `scoring` is now `Option<ScoringPolicy>` with `#[serde(default)]` (the broker
- * applies `ScoringPolicy::default_for_arity` when it is omitted), and the
- * resolved value comes back on `TournamentSummary::scoring`. Per this repo's
- * display-layer rule, that duplicate must not drive game state: it survives
- * here only to seed the *form control* before the organizer edits it, and
- * should be removed — submit `scoring: null` and read the resolved value back
- * off the wire — in the tournament client-consumption follow-up. Mirrors
- * `ScoringPolicy::default_for_arity` (`crates/lobby-broker/src/tournament.rs`).
- *
- * Arity-dependent by design: a fixed 3/1/0 would silently give every pod
- * organizer MTR head-to-head scoring instead of MSTR pod scoring.
- */
-export function defaultScoringForArity(arity: MatchArity): ScoringPolicy {
-  return { win_points: 2 * arity - 1, draw_points: 1, loss_points: 0 };
 }
 
 /**

--- a/client/src/services/__tests__/tournamentClient.test.ts
+++ b/client/src/services/__tests__/tournamentClient.test.ts
@@ -515,7 +515,7 @@ describe("tournament request frames", () => {
       const ws = new MockWebSocket();
       await createWithScoring(ws, MIN_LOBBY_PROTOCOL_FOR_DEFAULT_SCORING, null);
       expect(ws.send).toHaveBeenCalledWith(
-        '{"type":"CreateTournament","data":{"name":"Friday Night","arity":2,"scoring":null,"bracket":"Swiss","total_rounds":3}}',
+        '{"type":"CreateTournament","data":{"name":"Friday Night","arity":2,"scoring":null,"bracket":"Swiss","total_rounds":3,"plus_rounds":null,"format":null,"match_type":null}}',
       );
     });
 
@@ -526,7 +526,7 @@ describe("tournament request frames", () => {
       const ws = new MockWebSocket();
       await createWithScoring(ws, lobbyProtocolVersion, null);
       expect(ws.send).toHaveBeenCalledWith(
-        '{"type":"CreateTournament","data":{"name":"Friday Night","arity":2,"scoring":{"win_points":3,"draw_points":1,"loss_points":0},"bracket":"Swiss","total_rounds":3}}',
+        '{"type":"CreateTournament","data":{"name":"Friday Night","arity":2,"scoring":{"win_points":3,"draw_points":1,"loss_points":0},"bracket":"Swiss","total_rounds":3,"plus_rounds":null,"format":null,"match_type":null}}',
       );
     });
 
@@ -540,7 +540,7 @@ describe("tournament request frames", () => {
         loss_points: 0,
       });
       expect(ws.send).toHaveBeenCalledWith(
-        '{"type":"CreateTournament","data":{"name":"Friday Night","arity":2,"scoring":{"win_points":5,"draw_points":0,"loss_points":0},"bracket":"Swiss","total_rounds":3}}',
+        '{"type":"CreateTournament","data":{"name":"Friday Night","arity":2,"scoring":{"win_points":5,"draw_points":0,"loss_points":0},"bracket":"Swiss","total_rounds":3,"plus_rounds":null,"format":null,"match_type":null}}',
       );
     });
   });

--- a/client/src/services/__tests__/tournamentClient.test.ts
+++ b/client/src/services/__tests__/tournamentClient.test.ts
@@ -8,11 +8,13 @@ import type { TournamentSummary, TournamentView } from "../../adapter/types";
 import type { PhaseSocket } from "../openPhaseSocket";
 import {
   LOBBY_PROTOCOL_VERSION,
+  MIN_LOBBY_PROTOCOL_FOR_DEFAULT_SCORING,
   MIN_LOBBY_PROTOCOL_FOR_TOURNAMENT_ACK,
   type ServerInfo,
 } from "../../adapter/ws-adapter";
 import {
   createTournamentOver,
+  defaultScoringForArity,
   dropFromTournamentOver,
   endTournamentOver,
   getTournamentOver,
@@ -472,6 +474,75 @@ describe("tournament request frames", () => {
 
     controller.abort();
     await expect(promise).resolves.toMatchObject({ ok: false, reason: "aborted" });
+  });
+
+  // The `scoring` version gate: `null` (Automatic) is sent as `scoring: null`
+  // at or above `MIN_LOBBY_PROTOCOL_FOR_DEFAULT_SCORING` (the broker resolves
+  // its own default), and substituted with the explicit `defaultScoringForArity`
+  // below it — where an omitted `scoring` is a hard `missing field` parse error,
+  // not a degrade. An explicit override is sent verbatim regardless.
+  describe("createTournamentOver scoring gate", () => {
+    // V12 (moved here from tournamentPageState): mirrors `default_for_arity`'s
+    // `2n-1 / 1 / 0`. The below-floor send path is this helper's only consumer.
+    it.each([
+      [2, 3],
+      [4, 7],
+      [128, 255],
+    ])("defaultScoringForArity: arity %i -> %i win points", (arity, winPoints) => {
+      expect(defaultScoringForArity(arity)).toEqual({
+        win_points: winPoints,
+        draw_points: 1,
+        loss_points: 0,
+      });
+    });
+
+    async function createWithScoring(
+      ws: MockWebSocket,
+      lobbyProtocolVersion: number | undefined,
+      scoring: { win_points: number; draw_points: number; loss_points: number } | null,
+    ): Promise<void> {
+      const controller = new AbortController();
+      const promise = createTournamentOver(
+        makePhaseSocket(ws, { lobbyProtocolVersion }),
+        { name: "Friday Night", arity: 2, scoring, bracket: "Swiss", totalRounds: 3 },
+        { signal: controller.signal },
+      );
+      controller.abort();
+      await expect(promise).resolves.toMatchObject({ ok: false, reason: "aborted" });
+    }
+
+    it("sends scoring: null at or above the default-scoring floor", async () => {
+      const ws = new MockWebSocket();
+      await createWithScoring(ws, MIN_LOBBY_PROTOCOL_FOR_DEFAULT_SCORING, null);
+      expect(ws.send).toHaveBeenCalledWith(
+        '{"type":"CreateTournament","data":{"name":"Friday Night","arity":2,"scoring":null,"bracket":"Swiss","total_rounds":3}}',
+      );
+    });
+
+    it.each([
+      ["a pre-floor broker", 4 as number | undefined],
+      ["a broker advertising no lobby version", undefined],
+    ])("substitutes the explicit default against %s", async (_label, lobbyProtocolVersion) => {
+      const ws = new MockWebSocket();
+      await createWithScoring(ws, lobbyProtocolVersion, null);
+      expect(ws.send).toHaveBeenCalledWith(
+        '{"type":"CreateTournament","data":{"name":"Friday Night","arity":2,"scoring":{"win_points":3,"draw_points":1,"loss_points":0},"bracket":"Swiss","total_rounds":3}}',
+      );
+    });
+
+    it("sends an explicit override verbatim below the floor", async () => {
+      const ws = new MockWebSocket();
+      // draw_points 0 — the broker accepts any non-`win_points==0` policy, so an
+      // explicit choice must never be rewritten to the default.
+      await createWithScoring(ws, 4, {
+        win_points: 5,
+        draw_points: 0,
+        loss_points: 0,
+      });
+      expect(ws.send).toHaveBeenCalledWith(
+        '{"type":"CreateTournament","data":{"name":"Friday Night","arity":2,"scoring":{"win_points":5,"draw_points":0,"loss_points":0},"bracket":"Swiss","total_rounds":3}}',
+      );
+    });
   });
 
   it("serializes a pod draw outcome as the bare Draw unit variant", async () => {

--- a/client/src/services/tournamentClient.ts
+++ b/client/src/services/tournamentClient.ts
@@ -14,7 +14,10 @@ import type {
   TournamentUpdateReply,
   TournamentView,
 } from "../adapter/types";
-import { MIN_LOBBY_PROTOCOL_FOR_TOURNAMENT_ACK } from "../adapter/ws-adapter";
+import {
+  MIN_LOBBY_PROTOCOL_FOR_DEFAULT_SCORING,
+  MIN_LOBBY_PROTOCOL_FOR_TOURNAMENT_ACK,
+} from "../adapter/ws-adapter";
 import type { PhaseSocket } from "./openPhaseSocket";
 
 /**
@@ -538,7 +541,14 @@ function gatedRequestOver(
 export interface CreateTournamentRequest {
   name: string;
   arity: MatchArity;
-  scoring: ScoringPolicy;
+  /**
+   * `null` means "Automatic" — let the broker apply its arity default
+   * (`ScoringPolicy::default_for_arity`) and report the resolved value back on
+   * `TournamentSummary.scoring`. An explicit policy overrides it. The send path
+   * substitutes {@link defaultScoringForArity} for a `null` here only against a
+   * pre-v6 broker that cannot accept an omitted `scoring`.
+   */
+  scoring: ScoringPolicy | null;
   bracket: BracketShape;
   totalRounds?: number | null;
   /**
@@ -590,12 +600,56 @@ export function matchTypeNeedsCapability(
   return matchType !== preV8Default;
 }
 
-/** `CreateTournament` → `TournamentCreated` (point reply, carries the token). */
+/**
+ * The BELOW-FLOOR COMPATIBILITY FALLBACK for {@link createTournamentOver}'s
+ * `scoring` gate, for a given arity. Mirrors `ScoringPolicy::default_for_arity`
+ * (`crates/lobby-broker/src/tournament.rs`).
+ *
+ * As of lobby protocol v6 the broker owns this default: `CreateTournament.scoring`
+ * is `Option<ScoringPolicy>` with `#[serde(default)]`, so a client omits it
+ * (`scoring: null`) and reads the resolved value back off
+ * `TournamentSummary.scoring`. The create form computes no default at all.
+ *
+ * This helper survives ONLY for the one direction that is not symmetric:
+ * omitting `scoring` against a pre-v6 broker is a hard `missing field \`scoring\``
+ * parse error, not a degrade, so below {@link MIN_LOBBY_PROTOCOL_FOR_DEFAULT_SCORING}
+ * the send path substitutes this explicit policy. It lives here, beside its sole
+ * consumer, rather than in `pages/tournamentPageState.ts`: a value import from
+ * that module would close the runtime cycle
+ * `tournamentClient → tournamentPageState → multiplayerStore → tournamentClient`.
+ *
+ * Arity-dependent by design: a fixed 3/1/0 would silently give every pod
+ * organizer MTR head-to-head scoring instead of MSTR pod scoring.
+ */
+export function defaultScoringForArity(arity: MatchArity): ScoringPolicy {
+  return { win_points: 2 * arity - 1, draw_points: 1, loss_points: 0 };
+}
+
+/**
+ * `CreateTournament` → `TournamentCreated` (point reply, carries the token).
+ *
+ * The `scoring` gate reads a **floor**, never the current version, exactly as
+ * `gatedRequestOver` reads {@link MIN_LOBBY_PROTOCOL_FOR_TOURNAMENT_ACK}: a v6
+ * or v7 broker still applies its own default, so `req.scoring === null` is sent
+ * as an omitted `scoring: null` and the broker resolves it. Below
+ * {@link MIN_LOBBY_PROTOCOL_FOR_DEFAULT_SCORING} — including a peer that
+ * advertises no lobby version at all, which predates broker-owned scoring — an
+ * omitted policy is a hard parse error there, so the client substitutes the
+ * explicit {@link defaultScoringForArity}. An explicit `req.scoring` is always
+ * sent verbatim regardless of version.
+ */
 export function createTournamentOver(
   socket: PhaseSocket,
   req: CreateTournamentRequest,
   opts: TournamentRequestOptions = {},
 ): Promise<TournamentRpcResult<TournamentCreatedReply>> {
+  const lobbyProtocolVersion = socket.serverInfo.lobbyProtocolVersion;
+  const brokerOwnsDefault =
+    lobbyProtocolVersion !== undefined &&
+    lobbyProtocolVersion >= MIN_LOBBY_PROTOCOL_FOR_DEFAULT_SCORING;
+  const scoring =
+    req.scoring ?? (brokerOwnsDefault ? null : defaultScoringForArity(req.arity));
+
   return requestOver<TournamentCreatedReply>(
     socket,
     {
@@ -603,7 +657,7 @@ export function createTournamentOver(
       data: {
         name: req.name,
         arity: req.arity,
-        scoring: req.scoring,
+        scoring,
         bracket: req.bracket,
         total_rounds: req.totalRounds ?? null,
         plus_rounds: req.plusRounds ?? null,


### PR DESCRIPTION
Consumes the broker-owned tournament fields lobby protocol v6 added (#8632) but the frontend still recomputed — the client-consumption follow-up promised in #8632's body. Also fixes two user-reported bugs in the create form.

## What it consumes

- **`report_gate`** — the Report action is gated on the broker's per-pairing `report_gate` (new `isPairingReportable`), falling back to the outcome-only `isReportable` only against a pre-v6 broker. This **fixes the pre-existing bug where the Report button lingered on a `Completed` event's already-reported pairings**: the broker's gate checks `TournamentStatus::is_terminal` first (`ReportGate::TournamentNotRunning`), a distinction the outcome-only heuristic cannot draw.
- **`open_actions`** — the organizer Start/End and player Drop controls are gated on the broker's `open_actions` set (new `isActionOpen`), degrading to the credential-only gate when the field is absent. This withdraws *End Tournament* during `Registration` (which the broker refuses) and hides the organizer panel entirely on a terminal event — the organizer-side counterpart to the `report_gate` fix.
- **default scoring** — the create form submits `scoring: null` ("Automatic") so the broker applies `ScoringPolicy::default_for_arity`, version-gated on `MIN_LOBBY_PROTOCOL_FOR_DEFAULT_SCORING`. Below the floor the send path substitutes the explicit default, since a pre-v6 broker hard-errors on an omitted `scoring`. The form no longer computes a default; it reads the resolved `TournamentSummary.scoring` back off the wire and renders it. `defaultScoringForArity` moves to the send path (its sole consumer) to avoid a `services → pages → stores → services` import cycle.

## Bug fixes reported while testing

- **Draw points could not be changed from 1.** The scoring inputs were numeric `value` + `parsedOr(current)`, which reverted an emptied field to its prior value — so a draw of 1 could not be cleared and retyped. They are now string-backed and parsed at submit, matching the rounds field. (The server accepts any draw value; `ScoringPolicy::new` rejects only `win_points == 0`.) Covered by a clear-and-retype regression test.

## Compatibility

The server→client fields are typed **optional** because `MIN_SUPPORTED_SERVER_LOBBY_PROTOCOL` stays at 2. Every consumer degrades to its prior client-side behaviour when a field is absent, so a pre-v6 broker is unaffected. No protocol-version or floor constants change.

## Deferred to the follow-on PR

Credential rotation (`RenewTournamentCredential` sender, `expires_at_ms` handling) and moving persisted bearer credentials off `localStorage`.

## Verification

`type-check`, `eslint`, and the full tournament test surface pass (tournamentPageState, CreateTournamentForm, PairingsList, TournamentPage, tournamentClient, tournamentTypes, multiplayerStore.tournament), including new coverage for `report_gate`/`open_actions` consumption, the scoring version gate, the resolved-scoring readout, and the draw-input regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011BvCePEHnBgxPwsDPdYupM

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Tournament creation supports selecting a game format and adding extra rounds for automatic schedules.
  - Tournament pages display configured formats and scoring policies when available.
  - Organizer and player actions reflect current tournament availability.
  - Report Result availability reflects each pairing’s status, including byes, forfeits, and completed tournaments.
  - Report dialogs close when a pairing is no longer reportable.
  - Tournament creation supports automatic or explicit scoring values.

- **Compatibility**
  - Older tournament services continue to use fallback behavior when enhanced details are unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->