### PR TITLE
fix(skill-doc): stop the self-test hook silently skipping

### DIFF
--- a/scripts/check-skill-doc.sh
+++ b/scripts/check-skill-doc.sh
@@ -15,7 +15,10 @@
 #       interleaved handlers are documented as `| — |` rows, which the count
 #       ignores.
 set -euo pipefail
-cd "$(dirname "$0")/.."
+# Resolved BEFORE the cd: a relative $0 re-resolves against the new working
+# directory, and the self-test block below would then silently find no suite.
+SELF_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$SELF_DIR/.."
 
 SKILL=".claude/skills/oracle-parser/SKILL.md"
 ORACLE="crates/engine/src/parser/oracle.rs"
@@ -240,15 +243,18 @@ done < <(grep -oE '// Priority [^:]+:' "$ORACLE" | sed -E 's#// Priority ##; s#:
 # `extract_keyword_line_v2()` trips the dead-cite guard. Both fail closed (a
 # spurious red, never a silent green), which is why this trailed invariant (2).
 #
-# The anchor is trailing-only, so a live `try_extract_keyword_line` would still
-# trip both guards. That also fails closed, and no such name exists today.
+# Anchored on BOTH edges. Trailing alone still absorbs on the leading side, so a
+# legitimate citation of `new_extract_keyword_line()` matched retired
+# `extract_keyword_line` and redded a tree that was not stale. The non-vacuity
+# guard needs no leading `\b`: `fn ` already pins that edge, and a leading
+# boundary there would reject the `pub fn ` and `fn ` forms it must match.
 #
 # As with invariant (2), these are EREs now: an entry below must be a bare
 # identifier with no unescaped ERE metacharacter, or grep exits 2 and the `||`
 # reports a regex bug as doc drift.
 while IFS= read -r dead; do
   [ -n "$dead" ] || continue
-  if grep -qE "$dead\b" "$SKILL"; then
+  if grep -qE "\b$dead\b" "$SKILL"; then
     err "SKILL.md cites '$dead', which no longer exists in the parser tree (renamed/removed)"
   fi
   # Non-vacuity: if the symbol came BACK, this list is the stale thing.
@@ -273,10 +279,19 @@ EOF
 # The guard is also the recursion stop: the throwaway repos the suite builds
 # copy only this script, so the file is absent there and the fixture's own
 # invocation skips this block.
+#
+# Skipped when the tree is already failing. The fixtures copy the LIVE tree, so
+# genuine drift breaks them too, and reporting it a second time as "self-tests
+# failed" points at the suite rather than at the drift that actually caused it.
 # ---------------------------------------------------------------------------
-if [ -f "$(dirname "$0")/check_skill_doc_tests.py" ]; then
-  python3 "$(dirname "$0")/check_skill_doc_tests.py" >/dev/null 2>&1 ||
-    err "gate self-tests failed — run: python3 scripts/check_skill_doc_tests.py"
+if [ "$fail" -eq 0 ] && [ -f "$SELF_DIR/check_skill_doc_tests.py" ]; then
+  # Invoked through the repo-relative path (we are at the repo root by now), so
+  # the interpreter never sees $SELF_DIR's shell-native spelling -- which is not
+  # the same string as a native path on every host.
+  if ! self_test_output="$(python3 scripts/check_skill_doc_tests.py 2>&1)"; then
+    printf '%s\n' "$self_test_output" >&2
+    err "gate self-tests failed — rerun: python3 scripts/check_skill_doc_tests.py"
+  fi
 fi
 
 if [ "$fail" -ne 0 ]; then

--- a/scripts/check_skill_doc_tests.py
+++ b/scripts/check_skill_doc_tests.py
@@ -178,6 +178,12 @@ class SkillDocGate(unittest.TestCase):
                 "row " + repr(pat) + " carries an unescaped ERE metacharacter",
             )
             keywords, _, symbol = body.rpartition(" ")
+            # The row is an ERE, so a metacharacter it carries is backslash
+            # escaped. Drop those escapes before `re.escape`, which would
+            # otherwise escape the backslash itself and send `decl` looking for
+            # a literal one -- failing the row with "names no declaration"
+            # rather than matching the declaration it does name.
+            symbol = re.sub(r"\\(.)", r"\1", symbol)
             decl = re.compile(
                 re.escape(keywords) + r"\s+" + re.escape(symbol) + r"\b"
             )
@@ -250,6 +256,52 @@ class SkillDocGate(unittest.TestCase):
             0,
             "a longer-named citation must not fire the dead-cite guard",
         )
+
+    @gate
+    def test_skill_citing_prefix_sibling_does_not_false_fire(self, g: Gate) -> None:
+        """The leading edge of the dead-cite anchor.
+
+        Companion to the suffix case above. Anchored only on the trailing side,
+        retired `extract_keyword_line` matched a legitimate citation of
+        `new_extract_keyword_line()` and redded a tree that was not stale.
+        """
+        g.write(SKILL, g.read(SKILL) + "\nSee `new_extract_keyword_line()`.\n")
+        self.assertEqual(
+            g.run().returncode,
+            0,
+            "a prefix-sibling citation must not fire the dead-cite guard",
+        )
+
+    @gate
+    def test_self_test_hook_survives_a_relative_invocation(self, g: Gate) -> None:
+        """The gate must not skip its own suite when invoked by a relative path.
+
+        The script `cd`s, so a relative `$0` re-resolves against the new working
+        directory. Before `SELF_DIR`, `cd crates && bash ../scripts/...` printed
+        the success line and exited 0 without running the suite at all -- a
+        self-test hook silently bypassed, which is the failure class this gate
+        exists to refuse.
+
+        Asserted behaviourally: a deliberately broken stand-in suite is planted
+        beside the gate, so reaching it MUST red. A green here means the hook
+        did not run.
+        """
+        (g.root / "scripts" / "check_skill_doc_tests.py").write_text(
+            "import sys\nsys.exit(1)\n", encoding="utf-8", newline="\n"
+        )
+        result = subprocess.run(
+            [SHELL_BIN, "../scripts/" + SCRIPT.name],
+            cwd=g.root / "crates",
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(
+            result.returncode,
+            1,
+            "the self-test hook was skipped under a relative invocation: "
+            + (result.stdout or "") + (result.stderr or ""),
+        )
+        self.assertIn("gate self-tests failed", result.stderr)
 
     @gate
     def test_missing_documented_path_is_caught(self, g: Gate) -> None:


### PR DESCRIPTION
## Summary

Follow-up to #8639, taking all four findings from its approval. The first is the one that matters: **the self-test hook I landed there could be bypassed with no signal at all.**

## 🔴 The hook could silently skip

`check-skill-doc.sh` `cd`s at the top, so a *relative* `$0` re-resolves against the new working directory and the `[ -f ]` guard finds nothing. Reproduced against `main`:

| invocation | time | output | suite ran? |
|---|---|---|---|
| `bash ./scripts/check-skill-doc.sh` (CI's form) | 75s | `✓ oracle-parser skill references valid` | yes |
| `cd crates && bash ../scripts/check-skill-doc.sh` | **6.3s** | `✓ oracle-parser skill references valid` | **no** |

Same success line, same exit 0. A self-test hook that can be skipped silently is the identical false-green class this gate exists to refuse — a gate reporting green about work it never did. Fixed by capturing `SELF_DIR` before the `cd`.

Credit where due: @matthewevans caught this in the snippet he'd handed me, and flagged it as his own.

## The other three

- **Double-reporting.** The fixtures copy the live tree, so genuine `SKILL.md` drift breaks them too and previously redded three times — once truthfully, then as "self-tests failed", then as STALE. The block now runs only when `$fail` is 0, and captures the suite's output instead of `>/dev/null 2>&1`, so a real failure prints which property broke rather than a bare pointer.
- **The dead-cite guard was anchored on one edge only.** A legitimate citation of `new_extract_keyword_line()` matched retired `extract_keyword_line` and redded a clean tree. Now `\b$dead\b`. Checked both directions: the false fire goes quiet, a true dead cite is still caught. The non-vacuity guard deliberately keeps its trailing-only anchor — `fn ` already pins that edge, and a leading `\b` there would reject the `pub fn ` form it must match.
- **The metacharacter fix hadn't reached the mutation.** `re.escape` was escaping the backslash of an ERE-escaped symbol, so `decl` searched for a literal backslash and the row failed with `names no declaration` — the same wrong-message class the screen fix was meant to end. Escapes are now stripped before building the regex.

## Two regression cases

Both **fail against `main`'s gate and pass against this one**, so neither is vacuous:

- `test_skill_citing_prefix_sibling_does_not_false_fire` — the leading edge, companion to the existing suffix case.
- `test_self_test_hook_survives_a_relative_invocation` — plants a deliberately failing stand-in suite beside the gate and invokes through `../scripts/`, so **reaching it must red**. A green there means the hook did not run. Against `main` it fails with the tell-tale `0 != 1 : the self-test hook was skipped under a relative invocation: ✓ oracle-parser skill references valid`.

## Verification

- Suite: **10/10**.
- Both invocation paths now run it: 3m29s from the repo root, 2m9s from a subdirectory. That is Windows tempdir/`copytree` cost across 10 fixtures over the 24MB parser tree; @matthewevans measured this suite at 7–10s on Linux, which is what CI runs.
- The `>/dev/null` removal is what surfaced a second latent problem while I was testing: passing `$SELF_DIR` to `python3` handed a shell-native path to the interpreter, which does not round-trip on every host. The suite is invoked through the repo-relative path instead, since the script is already at the repo root by that point.

Not addressed here: nothing. The description of #8639 has also been corrected — its "needs one maintainer line to actually run" section is stale now that the hook is wired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation when the documentation check is run from a relative path.
  * Prevented valid references to similarly named, newer symbols from being incorrectly flagged.
  * Improved failure reporting for the check’s self-tests.
  * Corrected handling of escaped special characters in declaration checks.
* **Tests**
  * Added coverage for relative invocation, similarly named symbols, and escaped pattern characters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->