### PR TITLE
test(client): inline react-i18next so the vitest suite loads under pnpm

### DIFF
--- a/client/vitest.config.ts
+++ b/client/vitest.config.ts
@@ -84,6 +84,27 @@ export default defineConfig({
   },
   test: {
     environment: "happy-dom",
+    server: {
+      deps: {
+        /**
+         * `react-i18next` must be processed by Vite rather than externalized to
+         * the Node ESM loader.
+         *
+         * Its `TransWithoutContext` entry does a bare `import
+         * "html-parse-stringify"`. Under pnpm that dependency is reached
+         * through a symlink, and Vitest 4's externalized path resolves the
+         * IMPORTER to its realpath under `.pnpm/react-i18next@.../`, then looks
+         * for `html-parse-stringify` beneath that directory instead of
+         * following the link — so every test file fails to load at import time
+         * with "Cannot find package ...". Node's own resolver handles it fine
+         * (`require.resolve` finds it); only the externalized loader does not.
+         *
+         * `test-setup.ts` imports `react-i18next` globally, so this took down
+         * the WHOLE suite, not just the tests that render translated UI.
+         */
+        inline: ["react-i18next"],
+      },
+    },
     include: ["src/**/*.test.{ts,tsx}"],
     exclude: ["src/**/*.integration.test.{ts,tsx}"],
     setupFiles: ["src/test-setup.ts"],


### PR DESCRIPTION
## Summary

Every frontend test file currently fails at import under pnpm:

```
Error: Cannot find package '.../.pnpm/react-i18next@.../node_modules/
html-parse-stringify/package.json' imported from
.../react-i18next/dist/es/TransWithoutContext.js
```

`react-i18next`'s `TransWithoutContext` entry does a bare `import "html-parse-stringify"`. Under pnpm that dependency is reached through a symlink, and Vitest 4's externalized ESM path resolves the **importer** to its realpath under `.pnpm/react-i18next@…/`, then looks for `html-parse-stringify` beneath that directory instead of following the link. Node's own resolver handles it — `require.resolve` finds it at the realpath — so only the externalized loader is affected.

`src/test-setup.ts` imports `react-i18next` globally, so this took down the **whole suite**, not just tests that render translated UI. No test file could be collected at all.

Inlining the one package routes it through Vite's resolver instead.

## Files changed

- `client/vitest.config.ts` — adds `test.server.deps.inline: ["react-i18next"]` with a comment recording the failure mode.

`client/vitest.integration.config.ts` spreads `...base.test`, so it inherits this without a second edit.

## Track

Test infrastructure. No product code, no engine code, no wire-format change.

## Verification

Verified in both directions on a clean `pnpm install --frozen-lockfile`:

- **Without** the change: the suite fails to collect any test file (`Test Files 1 failed | Tests no tests`), reproduced on a file that has nothing to do with i18n.
- **With** it: `vitest run src/components/hud` → **117/117 passing** across 11 files.

## Scope note

This is **not a CI blocker** — CI runs `ubuntu-latest`, where the suite is green today, so the symlink resolution differs there. This repairs local runs on Windows/pnpm checkouts.

Split out of #8670 at reviewer request: a harness change with suite-wide blast radius deserves its own PR and its own revert handle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
