### PR TITLE
fix(engine): a stated cast lifetime is a lingering permission, paid or free

### DIFF
--- a/crates/engine/src/parser/oracle_effect/lower.rs
+++ b/crates/engine/src/parser/oracle_effect/lower.rs
@@ -6279,6 +6279,7 @@ pub(crate) fn strip_trailing_duration(text: &str) -> (&str, Option<Duration>) {
     let lower = duration_text.to_lowercase();
     if target_relative_clause_owns_suffix(lower.as_str())
         || player_lookback_relative_clause_owns_suffix(lower.as_str())
+        || spell_history_relative_clause_owns_suffix(lower.as_str())
         || cant_be_activated_clause_owns_tapped_suffix(lower.as_str())
     {
         return (text, None);
@@ -6524,6 +6525,70 @@ fn cant_be_activated_clause_owns_tapped_suffix(input: &str) -> bool {
             Ok((i, ()))
         })
         .is_some()
+}
+
+/// CR 608.2i + CR 611.2a: True when the trailing " this turn" belongs to a
+/// spell-history *look-back* relative clause on an OBJECT — "the same name as a
+/// spell that WAS CAST this turn" (Twinning Glass), "permanents that WERE CAST
+/// this turn" (Emrakul, the World Anew) — rather than being the effect's own
+/// duration. CR 608.2i is the look-back rule — such an effect asks about a
+/// previous game action rather than the current state — so the clause's "this
+/// turn" belongs to that question. CR 611.2a then supplies what follows: the
+/// effect states no duration of its own, and an effect with no stated duration
+/// is not one that ends at end of turn.
+///
+/// Without this guard `strip_trailing_duration` amputates the "this turn" and
+/// stamps `Duration::UntilEndOfTurn` on a clause that states no duration at
+/// all. On Twinning Glass that invented duration is not inert: it reaches the
+/// CR 611.2a cast-mechanism reconciliation below `lower_imperative_clause`,
+/// which reads a stated lifetime as proof that the permission is exercised at a
+/// later priority window (CR 117.1a) — turning a during-resolution free cast
+/// into a turn-long standing permission.
+///
+/// The object sibling of `player_lookback_relative_clause_owns_suffix`. Like
+/// that one it is self-standing rather than delegating to
+/// `parse_that_clause_suffix`: the target grammar has no filter property for
+/// "was cast this turn", so there is nothing there to consume the clause, and
+/// inventing one would claim a target restriction this guard does not
+/// implement. It recognizes the clause STRUCTURE (which owns the suffix), not
+/// its semantics — the spell-history restriction itself stays a coverage gap on
+/// both cards; only the duration becomes right.
+///
+/// MEASURED over `client/public/card-data.json`: the "that was/were cast this
+/// turn" wording appears on exactly those two cards, and only Twinning Glass's
+/// clause reaches this stripper — Emrakul parses byte-identically with and
+/// without the guard, so its `were cast` arm is unreached today and is here
+/// because the wording is, not because a card exercises it.
+///
+/// Positional discipline as in `player_lookback_relative_clause_owns_suffix`,
+/// the one sibling that shares it: anchored on the LAST " that " and required
+/// to consume through end-of-input, so a genuine OUTER duration after the
+/// relative clause leaves a non-empty remainder and still strips.
+/// (`target_relative_clause_owns_suffix` anchors on the FIRST " that " instead,
+/// via `take_until`.)
+fn spell_history_relative_clause_owns_suffix(input: &str) -> bool {
+    // allow-noncombinator: rfind anchors the word-boundary slice for the nom scan below (Pattern 5), not parsing dispatch.
+    let Some(that_idx) = input.rfind(" that ") else {
+        return false;
+    };
+    let after_that = &input[that_idx + " that ".len()..];
+    let Ok((rest, _)) = preceded(
+        alt((tag::<_, _, OracleError<'_>>("was cast"), tag("were cast"))),
+        tag::<_, _, OracleError<'_>>(" this turn"),
+    )
+    .parse(after_that) else {
+        return false;
+    };
+    // The relative clause must own the suffix: nothing but optional punctuation
+    // may follow, so an outer duration is not suppressed.
+    (
+        multispace0,
+        opt(alt((tag::<_, _, OracleError<'_>>("."), tag(",")))),
+        multispace0,
+        eof,
+    )
+        .parse(rest)
+        .is_ok()
 }
 
 fn target_relative_clause_owns_suffix(input: &str) -> bool {

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -17334,37 +17334,48 @@ fn lower_imperative_clause(text: &str, ctx: &mut ParseContext) -> ParsedEffectCl
             clause = with_clause_duration(clause, duration);
         }
     }
-    // CR 611.2a: A during-resolution cast happens AS the ability resolves and
-    // cannot carry a lingering play-window duration. When the anaphor branch set
-    // the paid graveyard "cast that card" driver to `DuringResolution` from the
-    // chosen target's zone alone, but a trailing duration was stripped above
-    // ("cast that card THIS TURN" — Emry, Lurker in the Loch), this is really a
-    // standing `LingeringPermission` grant — restore it. The optionality
-    // reconciliation for the no-duration paid case (clearing the redundant
-    // `OptionalEffectChoice`) happens at the chunk-level `is_optional` derivation,
-    // where the offer's "may" is recognized (mirroring `FreeCastFromZones`).
+    // CR 611.2a + CR 608.2g: the trailing-duration seam of the shared cast-mechanism
+    // reconciliation. A stripped trailing duration means the grant is exercised at a
+    // LATER priority window (CR 117.1a), which is the defining property of a lingering
+    // permission — so both resolution-scoped mechanisms degrade back to one:
+    // `DuringResolution` for the single card an anaphor names ("cast that card THIS
+    // TURN" — Emry, Lurker of the Loch) and `ResolutionWindow` for the batch form
+    // ("You may cast spells with exactly three colors from among them THIS TURN" —
+    // Meeting of the Five).
+    //
+    // `CastFromZoneDriver::with_lingering_duration` is the single authority for that
+    // judgement; this seam only calls it. It used to be asked ONLY about the batch
+    // form, with the single-card degrade hand-written HERE behind a
+    // `without_paying_mana_cost: false` guard — a guard that decided by who pays, when
+    // CR 118.9 governs what a permission COSTS and not when it is exercised (CR 608.2g
+    // + CR 117.1a).
+    //
+    // WHAT THIS BLOCK STILL DOES — measured twice, because the answer is not the obvious
+    // one. A reach marker here fires over the corpus, so the block is NOT unreachable;
+    // every hit arrives already carrying `LingeringPermission`, because the trailing peel
+    // above routes through `with_clause_duration` → `apply_duration_to_effect`, which
+    // asked the same authority a few lines earlier. Neutralizing this block entirely and
+    // re-parsing leaves the affected grants byte-identical.
+    //
+    // So the block is redundant for a cast clause rather than dead, and the hand-written
+    // guard's defect was its CONDITION, not its address — a wider guard written here
+    // would have reached the trailing-duration members. It would still have missed the
+    // LEADING-duration ones: their duration is stamped in `parse_effect_clause` after
+    // this function has already returned, so they never see this gate. Only the shared
+    // authority covers both, which is why the judgement lives there and not in an
+    // `if let` at one seam.
+    //
+    // And the degrade is refusable, which is why `with_lingering_duration` returns an
+    // `Option`: a batch window that printed a cast cap ("up to two") or a running-total
+    // budget would otherwise land on a per-object permission with nowhere to keep the
+    // shared bound. No rules coordinate is cited for that because none states it — it is
+    // a property of the representation, and `cast_bound_lost_to_duration_gap` is the
+    // honest gap it produces.
+    //
+    // The optionality reconciliation for the no-duration paid case (clearing the
+    // redundant `OptionalEffectChoice`) happens at the chunk-level `is_optional`
+    // derivation, where the offer's "may" is recognized (mirroring `FreeCastFromZones`).
     if clause.duration.is_some() {
-        if let Effect::CastFromZone {
-            driver: driver @ crate::types::ability::CastFromZoneDriver::DuringResolution,
-            without_paying_mana_cost: false,
-            ..
-        } = &mut clause.effect
-        {
-            *driver = crate::types::ability::CastFromZoneDriver::LingeringPermission;
-        }
-        // CR 611.2a + CR 608.2g: same reconciliation for the FREE batch window
-        // ("… from among them"). A stripped trailing duration means the grant is
-        // exercised at a later priority window (Meeting of the Five: "You may
-        // cast spells with exactly three colors from among them THIS TURN"), so
-        // the resolution-scoped window degrades to a lingering permission. The
-        // `without_paying_mana_cost: false` guard above is deliberately NOT
-        // shared: it belongs to the paid chosen-target case, and this class is
-        // free by construction.
-        //
-        // CR 608.2c: and the degrade is refusable here for the same reason it is
-        // at the other two seams — a stripped trailing "… this turn" on a window
-        // that printed "up to two" (or a CR 202.3 running total) would otherwise
-        // land on a per-object permission with no shared budget.
         let mut refused_bound = None;
         if let Effect::CastFromZone { driver, .. } = &mut clause.effect {
             match driver.with_lingering_duration() {
@@ -26464,16 +26475,22 @@ fn cast_target_is_hand_origin(target: &TargetFilter) -> bool {
 /// NOT routed through here — its identical field tuple maps to the opposite
 /// driver (anaphor of a just-exiled single card vs. a standing filter pool).
 ///
-/// DURATION IS DELIBERATELY NOT A PARAMETER. The driver is decided while any
+/// DURATION IS DELIBERATELY NOT A PARAMETER, and this function is therefore NOT
+/// the last word on a durational clause. The driver is decided while any
 /// leading duration is stripped (`parse_effect_clause`), and the duration is
 /// stamped by a *separate* orthogonal pass (`with_clause_duration`) that never
-/// touches `driver`. The engine ships hand-origin `DuringResolution` casts that
-/// ALSO carry `duration=UntilEndOfTurn` (twinning glass, chandra flame's
-/// catalyst ultimate); a durational hand-origin free-cast is NOT lingering. The
-/// real discriminator is the *alternative casting method* (`without_paying` OR
-/// an alternative cost), proven by Sen Triplets (hand-origin, durational,
-/// FULL-cost → lingering) sitting opposite twinning glass (hand-origin,
-/// durational, FREE → during-resolution).
+/// touches `driver`. What this function answers is the NO-DURATION question:
+/// which casting mechanism a clause that states no lifetime uses. A stated
+/// lifetime is reconciled afterwards by
+/// `CastFromZoneDriver::with_lingering_duration`, which every duration seam
+/// calls (Chandra's own runs through `with_clause_duration` →
+/// `apply_duration_to_effect`) and which degrades any `DuringResolution` back to
+/// `LingeringPermission` (CR 611.2a + CR 608.2g + CR 117.1a: a stated lifetime
+/// means a later priority window, which a during-resolution cast has not got).
+/// So a hand-origin free cast that really is durational — Chandra, Flame's
+/// Catalyst's ultimate, "Until end of turn, you may cast spells from your hand
+/// without paying their mana costs" — ends as a lingering permission despite
+/// the `DuringResolution` this function returns for it.
 ///
 /// Casts during resolution iff it is a `Cast` (CR 601.2, not a CR 305.1 land
 /// play) from a `hand` origin via an alternative casting method — free

--- a/crates/engine/src/parser/oracle_effect/tests.rs
+++ b/crates/engine/src/parser/oracle_effect/tests.rs
@@ -47560,10 +47560,13 @@ fn duration_reconciliation_refuses_a_bound_the_lingering_grant_cannot_carry() {
         Some(LingeringPermission),
         "reach guard: an unbounded window must still degrade to the lingering grant"
     );
-    // The two single-card mechanisms carry no batch bound and are untouched.
+    // The two single-card mechanisms carry no batch bound, so neither can refuse
+    // — but the during-resolution one still DEGRADES: CR 608.2g + CR 117.1a, a
+    // cast that happens as the ability resolves has no later priority window,
+    // which is exactly what a stated lifetime claims.
     assert_eq!(
         CastFromZoneDriver::DuringResolution.with_lingering_duration(),
-        Some(CastFromZoneDriver::DuringResolution)
+        Some(LingeringPermission)
     );
     assert_eq!(
         LingeringPermission.with_lingering_duration(),
@@ -53892,9 +53895,13 @@ fn face_of_boe_clause_folds_suspend_cost_and_during_resolution() {
 /// CR 608.2g vs CR 611.2: the shared filter-form DRIVER authority is
 /// duration-blind — the discriminator is mode + hand-origin + an alternative
 /// casting method (`without_paying` OR an alternative cost). Duration is
-/// intentionally not a parameter: twinning glass (durational, free →
-/// DuringResolution) and Sen Triplets (durational, full-cost → Lingering)
-/// prove the wp/alt axis decides, not duration.
+/// intentionally not a parameter because this authority answers the
+/// NO-DURATION question; a stated lifetime is reconciled afterwards by
+/// `CastFromZoneDriver::with_lingering_duration`, which degrades every
+/// `DuringResolution` it sees. So the rows below are the mechanism a clause
+/// gets BEFORE any duration is stamped, and Sen Triplets (hand-origin,
+/// full-cost → lingering) opposite Brain in a Jar (hand-origin, free →
+/// during-resolution) is what shows the wp/alt axis deciding.
 #[test]
 fn filter_cast_driver_authority_is_duration_blind() {
     let d = super::during_resolution_for_filter_cast_clause;
@@ -53905,7 +53912,7 @@ fn filter_cast_driver_authority_is_duration_blind() {
     assert_eq!(d(Cast, false, false, true), LingeringPermission);
     // Memory Plunder / Tasha: non-hand free pool.
     assert_eq!(d(Cast, true, false, false), LingeringPermission);
-    // Expertise cycle / Brain in a Jar / twinning glass / chandra: hand free.
+    // Expertise cycle / Brain in a Jar / Twinning Glass: hand free.
     assert_eq!(d(Cast, true, false, true), DuringResolution);
     // Xander's Pact: exile-origin alt cost — hand gate, not duration.
     assert_eq!(d(Cast, false, true, false), LingeringPermission);
@@ -61493,5 +61500,249 @@ fn subject_anchored_delayed_may_binds_the_named_player_not_the_caster() {
             "the caster's half draws for the caster"
         ),
         other => panic!("expected the caster half to Draw, got {other:?}"),
+    }
+}
+
+/// CR 611.2a + CR 608.2g + CR 117.1a: a stated lifetime and a during-resolution
+/// cast are mutually exclusive, and CR 118.9 (who pays) does not enter the
+/// question. All three free members of the "for as long as it remains exiled"
+/// shape must lower to `LingeringPermission` carrying the printed lifetime.
+///
+/// DISCRIMINATING: before the fix `with_lingering_duration` answered
+/// `Some(DuringResolution)` and the single seam that degraded anyway did so
+/// behind a `without_paying_mana_cost: false` guard, so every row here was
+/// `DuringResolution`. Measured over every card with Oracle text, the free
+/// `mode: Cast` members of this wording are these three plus Gale's Redirection.
+///
+/// PARSER-LEVEL FOR THESE THREE ONLY, and not by choice. The shape's end-to-end
+/// proof is `lasting_play_from_exile_permission::a_free_for_as_long_as_exiled_lifetime_is_not_a_declinable_resolution_offer`,
+/// which drives Gale's Redirection through `GameRunner`. The three here have no
+/// runtime fixture, MEASURED with a probe at `cast_from_zone::resolve`:
+/// Thranduil's Decree and Kheru Spellsnatcher never reach that resolver at all
+/// (the countered card lands in exile and the tracked set holds it, but the
+/// grant clause under the `ZoneChangedThisWay` link never resolves), and
+/// Planeswalker's Mischief reaches it with an empty tracked set (the "reveals a
+/// card at random … exile it" anaphor never binds the revealed card, so nothing
+/// is exiled). Both are separate defects upstream of this seam — issue #7132 is
+/// open on the first — and neither is repaired here.
+#[test]
+fn a_free_cast_grant_with_a_stated_lifetime_is_a_lingering_permission() {
+    // Verbatim Oracle text and printed card types (`client/public/card-data.json`).
+    let cards: [(&str, &str, &[&str], &[&str]); 3] = [
+        (
+            "Thranduil's Decree",
+            "Counter target spell. If a permanent spell is countered this way, exile it instead \
+             of putting it into its owner's graveyard. You may cast that card without paying its \
+             mana cost for as long as it remains exiled.",
+            &["Instant"],
+            &[],
+        ),
+        (
+            "Planeswalker's Mischief",
+            "{3}{U}: Target opponent reveals a card at random from their hand. If it's an \
+             instant or sorcery card, exile it. You may cast it without paying its mana cost for \
+             as long as it remains exiled. At the beginning of the next end step, if you haven't \
+             cast it, return it to its owner's hand. Activate only as a sorcery.",
+            &["Enchantment"],
+            &[],
+        ),
+        (
+            // The turned-face-up trigger alone; the printed Morph reminder line
+            // above it carries no cast grant.
+            "Kheru Spellsnatcher",
+            "When this creature is turned face up, counter target spell. If that spell is \
+             countered this way, exile it instead of putting it into its owner's graveyard. You \
+             may cast that card without paying its mana cost for as long as it remains exiled.",
+            &["Creature"],
+            &["Snake", "Wizard"],
+        ),
+    ];
+    for (name, text, types, subs) in cards {
+        let types: Vec<String> = types.iter().map(|s| s.to_string()).collect();
+        let subs: Vec<String> = subs.iter().map(|s| s.to_string()).collect();
+        let parsed = parse_oracle_text(text, name, &[], &types, &subs);
+        let mut casts = Vec::new();
+        for def in parsed.abilities.iter() {
+            collect_cast_from_zone_defs(def, &mut casts);
+        }
+        for trigger in parsed.triggers.iter() {
+            if let Some(execute) = trigger.execute.as_ref() {
+                collect_cast_from_zone_defs(execute, &mut casts);
+            }
+        }
+        assert_eq!(
+            casts.len(),
+            1,
+            "{name}: reach guard — exactly one cast grant must be produced, got {casts:?}"
+        );
+        let def = &casts[0];
+        let Effect::CastFromZone {
+            without_paying_mana_cost,
+            duration,
+            driver,
+            ..
+        } = &*def.effect
+        else {
+            unreachable!("filtered above");
+        };
+        assert!(
+            *without_paying_mana_cost,
+            "{name}: reach guard — this is the FREE half of the class, the half the removed \
+             `without_paying_mana_cost: false` guard excluded"
+        );
+        assert_eq!(
+            *duration,
+            Some(Duration::ForAsLongAs {
+                condition: crate::types::StaticCondition::Unrecognized {
+                    text: "it remains exiled".to_string(),
+                },
+            }),
+            "{name}: the printed lifetime must reach the effect's own duration slot"
+        );
+        assert_eq!(
+            *driver, LingeringPermission,
+            "{name}: CR 611.2a — a stated lifetime means the permission is exercised at a later \
+             priority window, so the mechanism is the lingering grant"
+        );
+        assert!(
+            !def.optional,
+            "{name}: CR 608.2d — a lingering grant states no resolution-time choice, so the \
+             clause's \"may\" must not become an optional-effect prompt"
+        );
+    }
+}
+
+/// CR 611.2a: the HAND-ORIGIN row of the same reconciliation, which no
+/// integration fixture can reach — its runtime is the named gap below. "Until
+/// end of turn, you may cast spells from your hand without paying their mana
+/// costs" (Chandra, Flame's Catalyst's ultimate) is a hand-origin free cast, so
+/// `during_resolution_for_filter_cast_clause` selects `DuringResolution`, and
+/// the stated lifetime then degrades it.
+///
+/// DISCRIMINATING: this row is why the degrade belongs in
+/// `with_lingering_duration` rather than in an `if let` at one seam. A wider
+/// guard at the trailing-duration block in `lower_imperative_clause` would have
+/// reached the trailing-duration members of the class — MEASURED, a reach
+/// marker there fires over the corpus — but never this one: a sentence-leading
+/// duration is stamped around the body lowering, after `lower_imperative_clause`
+/// has returned, so it never sees that gate. Only the shared authority covers
+/// both.
+///
+/// A PARSE CLAIM, NOT A BEHAVIOUR CLAIM. Chandra is the hand-origin card this
+/// change gives the lingering mechanism to — Twinning Glass is hand-origin too,
+/// but it loses an invented duration and keeps its during-resolution cast — and
+/// at runtime it moves nothing: MEASURED end-to-end
+/// through `GameRunner` with and without the degrade, the ultimate stops at the
+/// same `WaitingFor::EffectZoneChoice { effect_kind: CastFromZone, zone: Hand,
+/// up_to: true, duration: None }` either way — a pick-one-now offer raised
+/// while the ability resolves, with no permission recorded on any hand card and
+/// none castable afterwards. `resolve` consults the driver before that branch —
+/// for the library one-shot and for `window_bounds()` — but neither route's
+/// remaining conditions hold for a hand pool with no resolved targets, and the
+/// branch it does take reads neither the driver nor the duration
+/// (`open_private_zone_cast_selection` writes `duration: None` as a literal).
+/// So the hand-origin half of this class stays as wrong as it is on main;
+/// repairing it is runtime work this change does not do. What the
+/// assertion below buys today is an honest AST and export for that card, and
+/// the one seam through which a later runtime fix can see the lifetime at all.
+#[test]
+fn a_leading_duration_also_degrades_the_cast_mechanism() {
+    // Verbatim Oracle text (`client/public/card-data.json`, key
+    // `chandra, flame's catalyst`), the ultimate alone.
+    let def = parse_effect_chain(
+        "Discard your hand, then draw seven cards. Until end of turn, you may cast spells from \
+         your hand without paying their mana costs.",
+        AbilityKind::Activated,
+    );
+    let mut casts = Vec::new();
+    collect_cast_from_zone_defs(&def, &mut casts);
+    assert_eq!(
+        casts.len(),
+        1,
+        "reach guard — the ultimate must produce exactly one cast grant, got {casts:?}"
+    );
+    let Effect::CastFromZone {
+        without_paying_mana_cost,
+        duration,
+        driver,
+        ..
+    } = &*casts[0].effect
+    else {
+        unreachable!("filtered above");
+    };
+    assert!(
+        *without_paying_mana_cost,
+        "reach guard — the free, hand-origin shape the filter-form authority sends to \
+         `DuringResolution`"
+    );
+    assert_eq!(
+        *duration,
+        Some(Duration::UntilEndOfTurn),
+        "the sentence-leading lifetime must reach the effect's own duration slot"
+    );
+    assert_eq!(
+        *driver, LingeringPermission,
+        "CR 611.2a + CR 117.1a: \"Until end of turn\" means the spells are cast at later \
+         priority windows, not as the ultimate resolves"
+    );
+}
+
+/// CR 608.2i: "a spell that WAS CAST this turn" looks back at a previous game
+/// action; its "this turn" scopes that look-back, not the effect. Twinning
+/// Glass states no duration at all, and `strip_trailing_duration` must not
+/// invent one.
+///
+/// DISCRIMINATING, and the reason this guard ships with the reconciliation
+/// above rather than separately: with the invented `UntilEndOfTurn` in place,
+/// the widened degrade would read it as proof of a later priority window and
+/// turn a during-resolution free cast into a turn-long standing permission —
+/// strictly worse than the bug being fixed. Removing
+/// `spell_history_relative_clause_owns_suffix` flips both assertions.
+///
+/// NOT REPAIRED HERE, and visible in the same parse: the "if it has the same
+/// name as …" condition is still swallowed (`OracleDiagnostic::SwallowedClause`,
+/// detector `Condition_If`), so the clause offers every card in hand rather
+/// than the matching one. That is a separate coverage gap; this test asserts
+/// only the duration and the mechanism.
+#[test]
+fn a_spell_history_lookback_does_not_invent_a_duration() {
+    // Verbatim Oracle text (`client/public/card-data.json`, key
+    // `twinning glass`), the activated ability's effect alone.
+    let def = parse_effect_chain(
+        "You may cast a spell from your hand without paying its mana cost if it has the same \
+         name as a spell that was cast this turn.",
+        AbilityKind::Activated,
+    );
+    let mut casts = Vec::new();
+    collect_cast_from_zone_defs(&def, &mut casts);
+    assert_eq!(
+        casts.len(),
+        1,
+        "reach guard — the clause must still produce its cast grant, got {casts:?}"
+    );
+    let Effect::CastFromZone {
+        duration, driver, ..
+    } = &*casts[0].effect
+    else {
+        unreachable!("filtered above");
+    };
+    assert_eq!(
+        *duration, None,
+        "CR 608.2i: the relative clause owns its \"this turn\"; no duration may be stamped"
+    );
+    assert_eq!(
+        *driver, DuringResolution,
+        "CR 608.2g: with no stated lifetime the hand-origin free cast keeps the \
+         during-resolution mechanism"
+    );
+}
+
+/// Collect every `CastFromZone`-carrying definition in a `sub_ability` chain.
+fn collect_cast_from_zone_defs(def: &AbilityDefinition, out: &mut Vec<AbilityDefinition>) {
+    if matches!(*def.effect, Effect::CastFromZone { .. }) {
+        out.push(def.clone());
+    }
+    if let Some(sub) = def.sub_ability.as_ref() {
+        collect_cast_from_zone_defs(sub, out);
     }
 }

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -2039,13 +2039,16 @@ impl CastFromZoneDriver {
     }
 
     /// CR 611.2a: Reconcile this driver with a durational scope the parser
-    /// stamped on the grant AFTER the clause body was lowered (a leading
-    /// "Until end of turn, …" via `with_clause_duration`, or a stripped trailing
-    /// "… this turn"). A stated duration means the controller casts at a LATER
-    /// priority window, which is the defining property of a lingering
-    /// permission — so a resolution-scoped window degrades to one. The two
-    /// single-card mechanisms are unchanged here; the paid-cast downgrade has
-    /// its own narrower guard at the clause seam.
+    /// stamped on the grant AFTER the clause body was lowered — a leading
+    /// "Until end of turn, …", a stripped trailing "… this turn", or a duration
+    /// carried onto a coordinated cast conjunct. Every seam that stamps one
+    /// calls this. A stated duration means the controller casts at a LATER
+    /// priority window (CR 117.1a), which is the defining property of a
+    /// lingering permission — so both resolution-scoped mechanisms are asked to
+    /// degrade, the batch window and the single card alike. CR 118.9 governs
+    /// what the permission costs, never when it is exercised, so payment is not
+    /// part of this question. Only the batch window can REFUSE, and only when it
+    /// carries a bound; see the next paragraph.
     ///
     /// `None` is a REFUSAL, and the fallible return type is the point: the
     /// degrade is expressed as `for_batch_bounds(LingeringPermission, …)`, so a
@@ -2061,12 +2064,24 @@ impl CastFromZoneDriver {
             CastFromZoneDriver::ResolutionWindow { bounds } => {
                 Self::for_batch_bounds(CastMechanism::LingeringPermission, bounds)
             }
-            // CR 608.2g: the two single-card mechanisms carry no batch bound to
-            // lose, so a stated duration leaves them untouched (the paid
-            // `DuringResolution` → lingering move for a chosen single target
-            // — Emry, Lurker in the Loch — has its own narrower guard at the
-            // trailing-duration seam, which runs before this call).
-            other => Some(other),
+            // CR 608.2g + CR 117.1a: a during-resolution cast happens AS the
+            // ability resolves, with no priority window in between. A stated
+            // lifetime says the opposite, so the two are mutually exclusive and
+            // the single-card mechanism degrades as well — carrying no batch
+            // bound, it can never refuse. This arm used to answer
+            // `Some(DuringResolution)`, with the degrade hand-written at ONE
+            // seam behind a `without_paying_mana_cost: false` guard, so every
+            // FREE single-card grant with a printed lifetime kept a one-shot
+            // mechanism its own text contradicts. CR 118.9 governs what the
+            // permission COSTS, not when it is exercised. The affected cards are
+            // measured in the double parse cited by the change that moved this
+            // arm, not listed here, where the list would go stale unnoticed.
+            CastFromZoneDriver::DuringResolution => Some(CastFromZoneDriver::LingeringPermission),
+            // Already the lingering mechanism; a stated duration only stamps its
+            // lifetime.
+            CastFromZoneDriver::LingeringPermission => {
+                Some(CastFromZoneDriver::LingeringPermission)
+            }
         }
     }
 }

--- a/crates/engine/tests/integration/lasting_play_from_exile_permission.rs
+++ b/crates/engine/tests/integration/lasting_play_from_exile_permission.rs
@@ -18,17 +18,20 @@
 //!     duration at all.
 //!
 //! F3 — the field gained a value it never carried, so its five reader sites were
-//! walked: `assembly.rs:2384`, `cast_from_zone.rs:733`, `:764`, `:1380`,
-//! `ability_rw.rs:3419`. The first and fourth are the two above. The other three
-//! cannot move for any input:
+//! walked: `is_lingering_cast_from_zone` (assembly), the two `duration.is_none()`
+//! gates in `cast_from_zone::resolve` (`immediate_graveyard_free_cast` and
+//! `paid_during_resolution_cast`), `record_lingering_permissions`, and
+//! `legacy_duration` (ability_rw). Named rather than numbered on purpose: the
+//! line numbers this paragraph once carried had all rotted by the time the
+//! fourth defect below was written. The first and fourth are the two above. The
+//! other three cannot move for any input:
 //!
-//!   * `cast_from_zone.rs:733` and `:764` both require `duration.is_none()`, so
-//!     populating the field can only ever CLOSE them, never open one.
-//!   * `ability_rw.rs:3419` feeds the duration to `legacy_duration`
-//!     (`ability_rw.rs:2115`), a two-armed match: `ForAsLongAs` delegates to
+//!   * both `duration.is_none()` gates require exactly that, so populating the
+//!     field can only ever CLOSE them, never open one.
+//!   * `legacy_duration` is a two-armed match: `ForAsLongAs` delegates to
 //!     `legacy_static_condition`, where the `Unrecognized` conditions this fix
-//!     installs are a `false` arm (`:2099`); every other variant is `false`
-//!     outright (`:2118-2128`). No duration this fix can install moves it.
+//!     installs are a `false` arm; every other variant is `false` outright. No
+//!     duration this fix can install moves it.
 //!
 //! Fix (first half): route that assignment through `with_clause_duration`.
 //!
@@ -102,15 +105,89 @@
 //! Both print "for as long as you CONTROL ~" and so carry
 //! `Duration::WhileControllingHost` (see the third defect set above).
 //!
-//! NOT covered: `Duration::ForAsLongAs` permissions. Both #8029 members carry
-//! that shape and neither reaches a usable fixture — Spelljack's countered card
-//! lands in exile behind a synthetic stack entry, and Resourceful Collector's
-//! grant hangs off a random end-step pick. Measured rather than assumed:
-//! Spelljack's node really is `ForAsLongAs { "it remains exiled" }`, NOT the
-//! `Duration::Permanent` that `parser::oracle_ir::ast::normalize_play_from_exile_duration`
-//! produces — that normalization only touches
-//! `GrantCastingPermission { PlayFromExile }`, and Spelljack lowers to
-//! `Effect::CastFromZone`.
+//! THE READER WALK ABOVE COVERS ONE DIRECTION ONLY, and this change is the
+//! first to need the other: "populating the field can only ever CLOSE them" is
+//! true of a write, and Twinning Glass is a CLEAR — it loses the invented
+//! `UntilEndOfTurn`. Both `duration.is_none()` gates were re-read for that
+//! direction and both stay shut: `immediate_graveyard_free_cast` additionally
+//! requires a target in `Zone::Graveyard`, `paid_during_resolution_cast`
+//! additionally requires `!without_paying`, and Twinning Glass is a free cast
+//! from the hand.
+//!
+//! FOURTH DEFECT, the free half of the same class (issue #8029, reported from
+//! play on Thranduil's Decree as #7132): recording, enforcing and typing the
+//! lifetime is still not enough while the CASTING MECHANISM ignores it. A
+//! stated lifetime and a CR 608.2g during-resolution cast are mutually
+//! exclusive — a cast that happens as the ability resolves has no later
+//! priority window (CR 117.1a), which is exactly what a printed lifetime
+//! claims. `CastFromZoneDriver::with_lingering_duration` nevertheless answered
+//! `Some(DuringResolution)` for the single-card mechanism, and the one seam
+//! that degraded it anyway did so behind a `without_paying_mana_cost: false`
+//! guard. So the free members of the shape kept the one-shot CR 608.2g
+//! mechanism their own text contradicts — surfacing, wherever the clause's
+//! "may" was promoted, as the CR 608.2d prompt this file is named after. CR
+//! 118.9 governs what a permission COSTS, never when it is exercised, and it
+//! was doing the deciding.
+//!
+//! Fix (fourth): the degrade moves INTO `with_lingering_duration`, the shared
+//! authority every duration seam already calls, and the hand-written guard goes.
+//! MEASURED, because "write the guard wider where it stood" is the obvious
+//! alternative and it does not work: a reach marker at that block does fire over
+//! the corpus, so a wider guard there would have reached the TRAILING-duration
+//! members — but a sentence-leading duration is stamped around the body
+//! lowering, after `lower_imperative_clause` has returned, and never sees that
+//! gate at all. Only the shared authority covers both. (With the judgement in
+//! the authority the block is now redundant for a cast clause: neutralizing it
+//! entirely leaves every cast grant in the corpus byte-identical.)
+//!
+//! NOT REPAIRED, and named because it is reachable and wrong rather than
+//! merely untested: the HAND-RESIDENT members. Chandra, Flame's Catalyst's
+//! ultimate offers the hand through a filter; Karlach, Tiefling Spellrager's
+//! sought card lands there by a different road. (Twinning Glass is hand-origin
+//! too, but it loses an invented duration and keeps its during-resolution
+//! cast.) For both this change moves the AST and nothing else. MEASURED end-to-end
+//! through `GameRunner`, with the degrade and without it, the ultimate stops at
+//! the same `WaitingFor::EffectZoneChoice { effect_kind: CastFromZone, zone:
+//! Hand, up_to: true, duration: None }`: a pick-one-now offer raised while the
+//! ability is still resolving, no permission recorded on any hand card, none
+//! castable afterwards. `resolve` does consult the driver earlier — for the
+//! library one-shot and for `window_bounds()` — but neither route's remaining
+//! conditions hold for a hand pool with no resolved targets, and the branch it
+//! does take reads neither field (`open_private_zone_cast_selection` writes
+//! `duration: None` as a literal). So the card behaves exactly as it does on
+//! main. This is not a
+//! wrong lifetime left standing: no permission is granted for the hand pool at
+//! all, before or after, so nothing outlives anything. The card already carried
+//! `duration: UntilEndOfTurn` on main; what the change buys it is an AST whose
+//! MECHANISM finally matches that printed lifetime, which is the field a runtime
+//! repair would have to read. Its parse side is pinned in
+//! `parser::oracle_effect::tests::a_leading_duration_also_degrades_the_cast_mechanism`.
+//!
+//! The `Duration::ForAsLongAs` half of that set IS covered, through Gale's
+//! Redirection — CR 202.3 makes its d20 table deterministic for a countered
+//! spell of mana value 14, so the 15+ row is reached without touching the die.
+//! Its three siblings are NOT reachable end-to-end, measured with a probe at
+//! `cast_from_zone::resolve`: Thranduil's Decree and Kheru Spellsnatcher never
+//! reach that resolver at all (the countered card lands in exile and the tracked
+//! set holds it, but the grant clause under the `ZoneChangedThisWay` link never
+//! resolves), and Planeswalker's Mischief reaches it with an empty tracked set
+//! (the "reveals a card at random … exile it" anaphor never binds the revealed
+//! card). Separate defects upstream of this seam; #7132 is open on the first and
+//! stays open.
+//!
+//! The PLURAL members are a third such case, and the reason a plural grant is a
+//! different FORM rather than a different anaphor ("cards exiled this way …
+//! their mana costs" on Dream Harvest, "those cards … their mana costs" on
+//! Ugin, Eye of the Storms):
+//! `driver_free_cast` binds a single object. Driven through `GameRunner` with
+//! the degrade and without it, Dream Harvest exiles its cards and records a
+//! permission on NONE of them either way — unchanged, like the hand pool below.
+//! Ugin, Eye of the Storms prints the same plural.
+//!
+//! Their parse side is pinned in
+//! `parser::oracle_effect::tests::a_free_cast_grant_with_a_stated_lifetime_is_a_lingering_permission`.
+//! Spelljack and Resourceful Collector print a similar lifetime but were already
+//! lingering (and Spelljack is `mode: Play`, CR 305.1), so neither discriminates.
 //!
 //! CR 611.2a: a continuous effect generated by the resolution of a spell or
 //! ability "lasts as long as stated by the spell or ability creating it".
@@ -1163,5 +1240,201 @@ fn control_bound_duration_ends_a_stolen_artifact_grant() {
         "CR 611.2b: \"for as long as you control this creature\" ends when control of that \
          creature changes, so the stolen artifact goes back — the Master Thief example from \
          the rule itself"
+    );
+}
+
+/// Verbatim Oracle text (`client/public/card-data.json`, key `stolen goods`).
+const STOLEN_GOODS: &str =
+    "Target opponent exiles cards from the top of their library until they exile a nonland \
+     card. Until end of turn, you may cast that card without paying its mana cost.";
+
+/// The second free branch of the same class, reached through the OTHER printed
+/// lifetime: "Until end of turn, you may cast that card without paying its mana
+/// cost" (Stolen Goods). Several further cards print the same free grant; which
+/// ones is measured in the double parse, not counted here.
+///
+/// DISCRIMINATING, and this is what the counter-probe MEASURED rather than what
+/// the shape suggests: restoring `Some(DuringResolution)` fails this test at the
+/// reach guard below — the exiled card is not in exile at all any more, because
+/// the one-shot mechanism casts it as Stolen Goods resolves. There is no later
+/// window to be offered one in.
+///
+/// The turn-boundary assertion is the POSITIVE COUNTER-DIRECTION: a permission
+/// that is now lingering must still END where the card says it does (CR 514.2),
+/// so over-suppression — a grant that outlives its printed turn — fails here too.
+#[test]
+fn a_free_until_end_of_turn_permission_is_exercised_at_a_later_priority_window() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    // CR 104.3c: the cleanup assertion below is made after a turn boundary, so
+    // both players must survive their draw steps. Without this the run reaches
+    // it in a `GameOver` state — the assertion stayed true (CR 514.2 prunes at
+    // cleanup, before the boundary) but it was no longer measuring a live game.
+    // Seeded BEFORE the exile target, because both library helpers prepend: the
+    // card Stolen Goods must find has to end up on top of the filler.
+    scenario.with_library_top(P0, &["P0 Filler A", "P0 Filler B", "P0 Filler C"]);
+    scenario.with_library_top(P1, &["P1 Filler A", "P1 Filler B", "P1 Filler C"]);
+    let loot = scenario
+        .add_spell_to_library_top(P1, "Opponent Top Card", false)
+        .with_mana_cost(ManaCost::zero())
+        .id();
+    let goods = scenario
+        .add_spell_to_hand_from_oracle(P0, "Stolen Goods", false, STOLEN_GOODS)
+        .with_mana_cost(ManaCost::zero())
+        .id();
+    let mut runner = scenario.build();
+
+    runner.cast(goods).target_player(P1).commit();
+    let saw_optional = settle_declining_optionals(&mut runner);
+
+    assert_eq!(
+        zone_of(&runner, loot),
+        Zone::Exile,
+        "reach guard: Stolen Goods must exile the opponent's top nonland card"
+    );
+    assert!(
+        !saw_optional,
+        "CR 611.2a: \"Until end of turn\" states the permission's lifetime, so resolution \
+         offers no CR 608.2d choice"
+    );
+    assert!(
+        can_cast(&runner, loot),
+        "CR 117.1a: the exiled card must be castable at a later priority window"
+    );
+    assert_eq!(
+        recorded_permission_durations(&runner, loot),
+        vec![Some(Duration::UntilEndOfTurn)],
+        "CR 611.2a: the grant must carry the printed turn-long lifetime"
+    );
+
+    // CR 514.2: the counter-direction — the permission must still expire.
+    runner.advance_to_phase(Phase::Cleanup);
+    runner.advance_to_phase(Phase::PreCombatMain);
+    assert!(
+        !matches!(runner.state().waiting_for, WaitingFor::GameOver { .. }),
+        "reach guard: the prune must be measured in a live game, not after a player decked out"
+    );
+    assert!(
+        recorded_permission_durations(&runner, loot).is_empty(),
+        "CR 514.2: the turn-long permission must be pruned at the cleanup step, not outlive it"
+    );
+}
+
+/// Verbatim Oracle text (`client/public/card-data.json`, key
+/// `gale's redirection`).
+const GALES_REDIRECTION: &str =
+    "Exile target spell, then roll a d20 and add that spell's mana value.\n\
+     1\u{2014}14 | You may cast the exiled card for as long as it remains exiled, and you may \
+     spend mana as though it were mana of any color to cast that spell.\n\
+     15+ | You may cast the exiled card without paying its mana cost for as long as it remains \
+     exiled.";
+
+/// The `Duration::ForAsLongAs` branch of the same class, end-to-end — the shape
+/// the module doc above named as NOT covered: "you may cast the exiled card
+/// WITHOUT PAYING ITS MANA COST for as long as it remains exiled" (Gale's
+/// Redirection's 15+ row; the module doc above names the three further members
+/// of that exact wording, none of which reaches the resolver).
+///
+/// DETERMINISTIC WITHOUT TOUCHING THE DIE. CR 202.3: the row is chosen by
+/// `d20 + that spell's mana value`, so a countered spell of mana value 14 puts
+/// every possible roll on the 15+ row. The die is rolled for real; the fixture
+/// only removes the branch it could otherwise land on.
+///
+/// DISCRIMINATING, and MEASURED: restoring `Some(DuringResolution)` in
+/// `with_lingering_duration` fails this test on `!saw_optional` — the clause's
+/// "may" becomes an `AbilityDefinition.optional` prompt raised while Gale's
+/// Redirection is still resolving. This is the row that pins the CR 608.2d
+/// offer itself; its Stolen Goods sibling pins the other face of the same
+/// defect, the card never staying in exile.
+///
+/// The zero-cost assertion is also the branch guard: the 1—14 row grants a
+/// FULL-cost permission with a colour concession, so a fixture that drifted
+/// onto it would fail here rather than pass vacuously.
+///
+/// Positive reach-guards: the countered spell really left the stack for EXILE,
+/// and the assertion is made on the grant holder's own turn, where they hold
+/// priority (CR 117.1a).
+#[test]
+fn a_free_for_as_long_as_exiled_lifetime_is_not_a_declinable_resolution_offer() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let fatty = scenario
+        .add_creature_to_hand(P0, "Big Spell", 5, 5)
+        .with_mana_cost(ManaCost::Cost {
+            generic: 14,
+            shards: vec![],
+        })
+        .id();
+    let gale = scenario
+        .add_spell_to_hand_from_oracle(P1, "Gale's Redirection", true, GALES_REDIRECTION)
+        .with_mana_cost(ManaCost::zero())
+        .id();
+    for _ in 0..14 {
+        scenario.add_basic_land(P0, engine::types::mana::ManaColor::Blue);
+    }
+    // CR 104.3c: the assertion below is made on the grant holder's own turn, so
+    // BOTH players must survive their draw steps rather than losing to an empty
+    // library — the turn passes through the opponent's draw step to get there.
+    scenario.with_library_top(P0, &["P0 Filler A", "P0 Filler B", "P0 Filler C"]);
+    scenario.with_library_top(P1, &["P1 Filler A", "P1 Filler B", "P1 Filler C"]);
+    let mut runner = scenario.build();
+
+    runner.cast(fatty).commit();
+    // CR 117.3c: the caster keeps priority after putting the spell on the stack;
+    // the opponent's window to answer it opens only once it is passed.
+    runner
+        .act(GameAction::PassPriority)
+        .expect("the active player must be able to pass priority with the spell on the stack");
+    runner.cast(gale).target_object(fatty).commit();
+    let saw_optional = settle_declining_optionals(&mut runner);
+
+    assert_eq!(
+        zone_of(&runner, fatty),
+        Zone::Exile,
+        "reach guard: Gale's Redirection must resolve and exile the targeted spell"
+    );
+    assert!(
+        !saw_optional,
+        "CR 611.2a: \"for as long as it remains exiled\" states the permission's own lifetime, \
+         so resolution offers no CR 608.2d choice"
+    );
+    assert_eq!(
+        recorded_permission_durations(&runner, fatty),
+        vec![Some(Duration::ForAsLongAs {
+            condition: engine::types::StaticCondition::Unrecognized {
+                text: "it remains exiled".to_string(),
+            },
+        })],
+        "CR 611.2b: the grant must carry the printed \"for as long as\" lifetime"
+    );
+    let free = runner.state().objects[&fatty]
+        .casting_permissions
+        .iter()
+        .any(|p| matches!(p, CastingPermission::ExileWithAltCost { cost, .. } if *cost == ManaCost::zero()));
+    assert!(
+        free,
+        "branch guard: mana value 14 forces the 15+ row, whose permission is the FREE one — \
+         the 1—14 row grants a full-cost permission instead: {:?}",
+        runner.state().objects[&fatty].casting_permissions
+    );
+
+    // CR 117.1a: hand priority to the grant holder, on their own turn.
+    for _ in 0..4 {
+        if runner.state().active_player == P1 {
+            break;
+        }
+        runner.advance_to_phase(Phase::Cleanup);
+        runner.advance_to_phase(Phase::PreCombatMain);
+    }
+    assert_eq!(
+        runner.state().active_player,
+        P1,
+        "reach guard: the assertion below must be made while the grant holder holds priority"
+    );
+    assert!(
+        can_cast(&runner, fatty),
+        "CR 117.1a: the exiled card must be castable at a later priority window through the \
+         standing permission — and \"for as long as it remains exiled\" states no turn-based end, \
+         so the turn boundary must not have revoked it"
     );
 }


### PR DESCRIPTION
## A stated cast lifetime is a lingering permission — paid or free

CR 611.2a + CR 608.2g + CR 117.1a: a cast that happens AS an ability resolves has no
later priority window. A printed lifetime says there is one. The two are mutually
exclusive.

`CastFromZoneDriver::with_lingering_duration` is the shared authority every duration seam
calls. It answered `Some(DuringResolution)` for the single-card mechanism, and the one
seam that degraded it anyway did so behind a `without_paying_mana_cost: false` guard — so
CR 118.9, which governs what a permission COSTS, was deciding when it is exercised.

The degrade moves into the authority and that guard goes. **Why there and not wider where
it stood** — the obvious alternative, and it does not work: a reach marker at that seam
does fire over the corpus, so a wider guard there would have reached the trailing-duration
members, but a sentence-leading duration is stamped around the body lowering, *after*
`lower_imperative_clause` has returned, and never sees that gate at all. Only the shared
authority covers both. With the judgement there, the old block is redundant for a cast
clause: neutralizing it entirely leaves every cast grant in the corpus byte-identical.

**Second change, shipped together because the first needs it.** CR 608.2i is the look-back
rule — such an effect asks about a previous game action rather than the current state — so
the "this turn" in "a spell that WAS CAST this turn" belongs to that question; CR 611.2a
supplies the rest, since the effect then states no duration at all.
`strip_trailing_duration` invented `UntilEndOfTurn` from it on Twinning Glass, and the
widened degrade would read that invented lifetime as proof of a later window — worse than
the bug being fixed. `spell_history_relative_clause_owns_suffix` is the object sibling of
the existing `player_lookback_relative_clause_owns_suffix`.

Reported from play on Thranduil's Decree (#7132). **This does not close #7132** — that
card is held up by a separate upstream defect, measured below.

### Measured — double parse of every card with Oracle text (35434 of 35800 keys)

The invariant rather than the count: **after this change no cast grant in the corpus
carries `DuringResolution` together with a duration.** Fourteen did before.

| | |
|---|---|
| cards whose cast grant changes | 14 |
| … gain the lingering mechanism | 13 |
| … lose an invented duration (Twinning Glass) | 1 |
| any other cast grant | unchanged |
| of the thirteen: `optional: false` | 13 / 13 |

The last row is measured because `is_lingering_cast_from_zone` gates on three fields
besides the driver: no card gains a standing permission and keeps a resolution-time prompt
as well.

The look-back guard is measured separately, because `strip_trailing_duration` has readers
far outside cast clauses. The wording sits on exactly two cards; **Emrakul, the World
Anew** parses byte-identically with and without the guard (its protection line never
reaches the stripper), so Twinning Glass is the whole blast radius.

The thirteen: Chandra, Flame's Catalyst · Codie, Vociferous Codex · Djeru and Hazoret ·
Dream Harvest · Gale's Redirection · Karlach, Tiefling Spellrager · Kheru Spellsnatcher ·
Limitless Rekindling · Nicol Bolas, God-Pharaoh · Planeswalker's Mischief · Stolen Goods ·
Thranduil's Decree · Ugin, Eye of the Storms.

### Counter-probe

| probe | tests red |
|---|---|
| `with_lingering_duration` back to `Some(DuringResolution)` | 6 (4 lib, 2 integration) |
| `spell_history_relative_clause_owns_suffix` removed | 1 |

The two integration rows pin the defect from both sides: Gale's Redirection fails on the
CR 608.2d prompt appearing, Stolen Goods on its card never staying in exile — the one-shot
mechanism casts it as the spell resolves.

### Tests

Both printed lifetimes are driven end-to-end through `GameRunner`, one each:

* **`Until end of turn`** — Stolen Goods: no resolution-time offer, castable at a later
  priority window, and pruned at the cleanup step. That last assertion is the
  counter-direction, so an over-broad degrade that outlives its printed turn fails too.
* **`for as long as it remains exiled`** — Gale's Redirection. CR 202.3 makes its d20
  table deterministic for a countered spell of mana value 14, so the 15+ row is reached
  without touching the die; the zero-cost assertion is the branch guard, since the 1—14
  row grants a full-cost permission instead.

Three parser-level tests cover the hand-origin row, the look-back guard, and the three
cards named below. Stolen Goods was also played by hand on a local build, including the
counter-direction (not free again the next turn).

### What this does NOT repair

Two grant shapes the runtime records **no permission for at all**. Each was driven
end-to-end with the degrade and without it and behaves identically both ways, so this
change moves their AST and nothing else. Neither is a wrong lifetime left standing — no
permission is granted, before or after.

* **Hand-resident grants.** Chandra, Flame's Catalyst's ultimate offers its hand through
  `WaitingFor::EffectZoneChoice { effect_kind: CastFromZone, zone: Hand, up_to: true,
  duration: None }` either way. `resolve` does consult the driver earlier — the library
  one-shot and `window_bounds()` — but neither route's remaining conditions hold for a
  hand pool with no resolved targets, and the branch it does take reads neither field.
  Karlach, Tiefling Spellrager reaches the same shape by a different road: its sought card
  lands in the hand, with no permission either way (measured by driving its grant clause,
  not the `specialize` trigger). Chandra already carried `duration: UntilEndOfTurn` on
  main; what this change buys both is an AST whose **mechanism** matches the printed
  lifetime, which is the field a runtime repair reads.
* **Plural grants.** "cast cards exiled this way … their mana costs" (Dream Harvest) and
  "cast those cards … their mana costs" (Ugin, Eye of the Storms) are a different form,
  not a different anaphor: `driver_free_cast` binds a single object. Dream Harvest exiles
  its cards and records a permission on none.

Three of the four free `mode: Cast` "for as long as it remains exiled" cards are also not
repaired, for a different reason — they never reach the grant. Probed at
`cast_from_zone::resolve`: Thranduil's Decree and Kheru Spellsnatcher never reach it (the
countered card lands in exile and the tracked set holds it, but the grant clause under the
`ZoneChangedThisWay` link never resolves); Planeswalker's Mischief reaches it with an empty
tracked set. #7132 stays open. The fourth, Gale's Redirection, is repaired and is the
end-to-end regression above.

Twinning Glass's "same name as …" condition is still swallowed (`SwallowedClause`,
detector `Condition_If`), so the clause still offers every card in hand.

Fixes #8029

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V2sfFLrGQyVSkdA5FDwMKP


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed parsing for phrases such as “a spell that was cast this turn” so the duration is not incorrectly applied to the overall effect.
  - Corrected cast permissions with stated lifetimes, ensuring they remain usable beyond the spell’s resolution when appropriate.
  - Fixed free cast and play permissions from exile or hand, including effects lasting until end of turn or as long as a card remains exiled.
  - Improved handling across nested ability chains and later priority windows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->