### PR TITLE
fix(engine): count only specified targets when checking fizzle (CR 608.2b)

### DIFF
--- a/crates/engine/src/game/ability_utils.rs
+++ b/crates/engine/src/game/ability_utils.rs
@@ -2031,7 +2031,8 @@ pub fn flatten_targets_in_chain(ability: &ResolvedAbility) -> Vec<TargetRef> {
 /// illegal the stamped node keeps them, `legal_targets` stays non-empty, and the
 /// spell resolves instead of being countered — the same CR 608.2b masking this
 /// function fixes for anaphoric riders, in a different class. That is a KNOWN,
-/// PRE-EXISTING gap, deliberately out of scope here and tracked separately; it
+/// PRE-EXISTING gap, deliberately out of scope here and tracked separately in
+/// issue #8684 (Grim Contest is the one affected printed card today); it
 /// is recorded so the omission is discoverable rather than latent. If this
 /// function is ever widened to cover it, the discriminator must key off
 /// `stamp_other_batch_source_targets`' own condition, exactly as it keys off the
@@ -11916,7 +11917,10 @@ mod tests {
             "reach-guard: the head must NOT be in the deferring set, or conjunct 1 \
              refuses first and the conjunct under test is never exercised"
         );
-        // REACH GUARD — the predicate must hold, or conjunct 3 refuses first:
+        // REACH GUARD — the predicate must hold. It is conjunct 3, evaluated
+        // LAST, so it does not refuse "first" in any ordering sense; the point
+        // is that a false predicate would make this test pass vacuously under
+        // the conjunct-2 deletion mutation, since `&&` would never reach it:
         assert!(
             sub_ability_inherits_parent_creature_target_only(
                 &ability,

--- a/crates/engine/src/game/ability_utils.rs
+++ b/crates/engine/src/game/ability_utils.rs
@@ -1985,7 +1985,8 @@ pub fn flatten_targets_in_chain(ability: &ResolvedAbility) -> Vec<TargetRef> {
 /// known information (issues #5965, #8058).
 ///
 /// The discriminator mirrors the GENERIC TAIL of those two functions — the
-/// condition under which the tail performs the push — conjunct for conjunct:
+/// condition under which the tail performs the push — in its three STRUCTURAL
+/// conjuncts, and deliberately NOT in its fourth, value-testing one:
 ///
 ///   `sub_ability_inherits_parent_creature_target_only(parent, sub)`
 ///   `  && !defers_sub_ability_target_selection(&parent.effect)`
@@ -1993,14 +1994,48 @@ pub fn flatten_targets_in_chain(ability: &ResolvedAbility) -> Vec<TargetRef> {
 ///
 /// Those three lines are a STATEMENT OF THE CONDITION, not of anyone's
 /// evaluation order. The producer evaluates the defer-head guard first
-/// (:7863), then the PREDICATE (:7872 — computed before the `as_mut()` borrow,
+/// (:7898), then the PREDICATE (:7907 — computed before the `as_mut()` borrow,
 /// because the helper needs `&parent` and `&sub` at once), then the defer-sub
-/// guard (:7881). The mirror below regroups BOTH gates ahead of the predicate,
+/// guard (:7916). The mirror below regroups BOTH gates ahead of the predicate,
 /// deliberately, so a reader sees both refusals before the classification.
 /// Same verdict either way — and only because all three conjuncts are pure and
 /// total over already-loaded fields, and none of them reads `.targets`. If any
 /// one of them ever gains a side effect or an early `.targets` read, the
 /// regrouping stops being free: re-derive it then rather than assuming it.
+///
+/// THE PRODUCER HAS A FOURTH GATE, AND MIRRORING IT WOULD BE A BUG. The push is
+/// additionally guarded by `if let Some(creature) = parent_creature_target`
+/// (:7920 / :8345) — a `find_map` over the PARENT's own `TargetRef::Object`s.
+/// It is omitted here for a reason stronger than redundancy: it is the one gate
+/// that READS `.targets`, and `.targets` is exactly the field
+/// `validate_targets_in_chain` rewrites. On the ORIGINAL side the head still
+/// holds its chosen object, so a fourth conjunct would say "inherited"; on the
+/// VALIDATED side the head's `targets` has been emptied by the very
+/// re-validation under test, so it would say "NOT inherited" and count the
+/// rider's snapshot — resurrecting the exact defect this function exists to fix.
+/// Omitting it is what keeps the verdict provably identical on both sides of the
+/// `check_fizzle` comparison. It is also inert in the only direction that could
+/// matter: when `parent_creature_target` is `None` the producer pushes nothing,
+/// so the sub's `targets` is empty from this writer and skipping an empty vector
+/// is a no-op.
+///
+/// LOCKSTEP — A SECOND ANNOUNCE-TIME SNAPSHOT WRITER THIS FUNCTION DOES NOT YET
+/// COVER. `stamp_other_batch_source_targets` (see above) also writes targets a
+/// node did not specify: for
+/// `EachSourceDealsDamage { sources: ParentTarget, recipient: OtherBatchSource }`
+/// it stamps the two nearest `TargetOnly` producers' objects onto a node that
+/// carries no instance of the word "target" of its own (Grim Contest, "Choose
+/// target creature you control and target creature an opponent controls. Each
+/// of those creatures deals damage equal to its toughness to the other."). Those
+/// stamped entries are NOT excluded here, so if BOTH announced targets become
+/// illegal the stamped node keeps them, `legal_targets` stays non-empty, and the
+/// spell resolves instead of being countered — the same CR 608.2b masking this
+/// function fixes for anaphoric riders, in a different class. That is a KNOWN,
+/// PRE-EXISTING gap, deliberately out of scope here and tracked separately; it
+/// is recorded so the omission is discoverable rather than latent. If this
+/// function is ever widened to cover it, the discriminator must key off
+/// `stamp_other_batch_source_targets`' own condition, exactly as it keys off the
+/// assigners' condition today.
 ///
 /// IT IS NOT THE WHOLE OF EITHER FUNCTION, and the difference is deliberate.
 /// Both open with six effect-keyed arms — an `AdditionalCostPaidInstead` sub,
@@ -2070,9 +2105,9 @@ pub(crate) fn flatten_specified_targets_in_chain(ability: &ResolvedAbility) -> V
         // ever changes.)
         if let Some(sub) = ability.sub_ability.as_deref() {
             // Mirror BOTH producer gates — `assign_targets_recursive`
-            // :7863 / :7881 and `assign_selected_slots_recursive`
-            // :8288 / :8306 — REGROUPED ahead of the predicate. This is NOT
-            // the producer's order: it evaluates the predicate at :7872,
+            // :7898 / :7916 and `assign_selected_slots_recursive`
+            // :8323 / :8341 — REGROUPED ahead of the predicate. This is NOT
+            // the producer's order: it evaluates the predicate at :7907,
             // BETWEEN its two gates. The regrouping is verdict-preserving
             // because all three conjuncts are pure and none reads `.targets`.
             // On the deferred path the sub receives REAL selected targets
@@ -11855,6 +11890,56 @@ mod tests {
         );
     }
 
+    /// V10b — the sibling that pins the SECOND defer guard,
+    /// `!defers_conditional_target_selection(sub)`. V10's head is `Surveil`, so
+    /// V10 is refused by conjunct 1 and would still pass if conjunct 2 were
+    /// deleted in isolation — a pair-wise mutation check cannot tell the two
+    /// apart. This fixture inverts that: a NON-deferring head (conjunct 1 holds)
+    /// over a `WhenYouDo`-conditioned GainLife anaphor sub, so conjunct 2 is the
+    /// only conjunct that can refuse. Delete it and this returns one entry, not
+    /// two.
+    #[test]
+    fn flatten_specified_targets_in_chain_keeps_conditional_deferred_sub_targets() {
+        let victim = ObjectId(77);
+        let mut ability = change_zone_head(Zone::Exile, vec![TargetRef::Object(victim)]);
+        let mut rider = gain_life_anaphor_rider(vec![TargetRef::Object(victim)]);
+        // CR 603.12 + CR 608.2d: a `WhenYouDo` reflexive rider chooses its
+        // targets while resolving, so the producer returns at the defer-sub
+        // guard BEFORE the snapshot push ever happens.
+        rider.condition = Some(AbilityCondition::WhenYouDo);
+        ability.sub_ability = Some(Box::new(rider));
+
+        // The verdict is decided by the FIRST failing conjunct, not the last one named.
+        // REACH GUARD (paired positive, MANDATORY) — conjunct 1 must NOT refuse:
+        assert!(
+            !defers_sub_ability_target_selection(&ability.effect),
+            "reach-guard: the head must NOT be in the deferring set, or conjunct 1 \
+             refuses first and the conjunct under test is never exercised"
+        );
+        // REACH GUARD — the predicate must hold, or conjunct 3 refuses first:
+        assert!(
+            sub_ability_inherits_parent_creature_target_only(
+                &ability,
+                ability.sub_ability.as_deref().unwrap()
+            ),
+            "reach-guard: the fixture must satisfy the predicate, or this test is vacuous"
+        );
+        // The conjunct actually under test:
+        assert!(
+            defers_conditional_target_selection(ability.sub_ability.as_deref().unwrap()),
+            "reach-guard: the sub must defer its target selection — that is the \
+             conjunct this test exists to pin"
+        );
+
+        assert_eq!(
+            flatten_specified_targets_in_chain(&ability),
+            vec![TargetRef::Object(victim), TargetRef::Object(victim)],
+            "CR 603.12 + CR 608.2d: a WhenYouDo rider receives NO announce-time \
+             snapshot push (the producer returns at the defer-sub guard), so \
+             whatever targets it holds are its own and must still be counted"
+        );
+    }
+
     /// V11 — the not-in-class boundary. `effect_player_filter_is_parent_target_anaphor`
     /// matches `Effect::GainLife` only, so a `Draw` rider never receives the
     /// inherited push and its targets must be counted as specified. This is the
@@ -11890,7 +11975,7 @@ mod tests {
         assert!(
             chain_has_target_sink(&ability),
             "reach-guard: the parent must be a target sink, or the predicate \
-             short-circuits at conjunct 1 (:4966) and this test never reaches \
+             short-circuits at conjunct 1 (:5001) and this test never reaches \
              the anaphor arm"
         );
         // REACH GUARD (paired positive, MANDATORY) — the upstream quantity-slot
@@ -11900,7 +11985,7 @@ mod tests {
             "reach-guard: the quantity-slot conjunct must HOLD, so the anaphor \
              arm is the only conjunct that can refuse"
         );
-        // With both reach-guards holding, the `_ => false` arm at :5075 is the
+        // With both reach-guards holding, the `_ => false` arm at :5110 is the
         // ONLY conjunct that can be refusing here.
         assert!(
             !sub_ability_inherits_parent_creature_target_only(&ability, sub),

--- a/crates/engine/src/game/ability_utils.rs
+++ b/crates/engine/src/game/ability_utils.rs
@@ -1957,6 +1957,144 @@ pub fn flatten_targets_in_chain(ability: &ResolvedAbility) -> Vec<TargetRef> {
     }
     targets
 }
+/// CR 608.2b + CR 115.10a: the targets this chain SPECIFIED — one entry per
+/// instance of the word "target" — as opposed to every `TargetRef` the chain
+/// happens to hold.
+///
+/// CR 608.2b's fizzle quantifier is "if all its targets, **for every instance of
+/// the word 'target'**, are now illegal". CR 115.10a: "Unless that object or
+/// player is identified by the word 'target' … it's not a target." So an
+/// anaphoric rider — Swords to Plowshares' "**its** controller gains life equal
+/// to **its** power", Condemn's toughness variant, Solitude's ETB — must not
+/// contribute to that count.
+///
+/// CR 608.2b's own Example says this outright:
+///   "Sorin's Thirst is a black instant that reads, 'Sorin's Thirst deals 2
+///    damage to target creature and you gain 2 life.' If the creature isn't a
+///    legal target during the resolution of Sorin's Thirst … then Sorin's Thirst
+///    doesn't resolve. Its controller doesn't gain any life."
+/// The rider clause has no instance of "target" of its own, so it does not keep
+/// the spell alive, and it does not happen.
+///
+/// The rider's `targets` entry is a snapshot of the PARENT's chosen object,
+/// pushed at announcement by `assign_targets_recursive` /
+/// `assign_selected_slots_recursive` so `Power { Target }` has something to read
+/// (issue #3864: the rider deliberately surfaces no slot of its own). Counting
+/// that snapshot let a spell whose ONLY specified target had become illegal
+/// resolve anyway — the exile no-opped and the life gain still fired off last
+/// known information (issues #5965, #8058).
+///
+/// The discriminator mirrors the GENERIC TAIL of those two functions — the
+/// condition under which the tail performs the push — conjunct for conjunct:
+///
+///   `sub_ability_inherits_parent_creature_target_only(parent, sub)`
+///   `  && !defers_sub_ability_target_selection(&parent.effect)`
+///   `  && !defers_conditional_target_selection(sub)`
+///
+/// Those three lines are a STATEMENT OF THE CONDITION, not of anyone's
+/// evaluation order. The producer evaluates the defer-head guard first
+/// (:7863), then the PREDICATE (:7872 — computed before the `as_mut()` borrow,
+/// because the helper needs `&parent` and `&sub` at once), then the defer-sub
+/// guard (:7881). The mirror below regroups BOTH gates ahead of the predicate,
+/// deliberately, so a reader sees both refusals before the classification.
+/// Same verdict either way — and only because all three conjuncts are pure and
+/// total over already-loaded fields, and none of them reads `.targets`. If any
+/// one of them ever gains a side effect or an early `.targets` read, the
+/// regrouping stops being free: re-derive it then rather than assuming it.
+///
+/// IT IS NOT THE WHOLE OF EITHER FUNCTION, and the difference is deliberate.
+/// Both open with six effect-keyed arms — an `AdditionalCostPaidInstead` sub,
+/// `MoveCounters`, `Attach`, a paired-subject effect, `Fight`, and multi-role
+/// mana — that recurse into `sub_ability` and return with NO inherits test, and
+/// `chain_has_target_sink` returns early for four of those same parent shapes.
+/// So this mirror can answer "inherited" on a parent whose producer arm never
+/// reached the push. That over-exclusion is INERT today, for two reasons that
+/// must be re-checked if either side moves. The only sub it can misclassify is
+/// a GainLife anaphor rider (`effect_player_filter_is_parent_target_anaphor` is
+/// `_ => false` for everything else), and for such a rider:
+///   * on FIVE of the six arms the slot builder surfaces no slot for it, so its
+///     `targets` is empty and skipping it is a no-op —
+///     `collect_target_slots_inner`'s `Fight` arm descends into no sub at all,
+///     and the other four route through `collect_sub_chain_slots`, whose
+///     descent gate is this same predicate;
+///   * on the `AdditionalCostPaidInstead` arm the slot builder DOES descend
+///     unfiltered and the rider CAN hold a player-selected target — but both
+///     assigners then execute `parent.targets = sub.targets.clone()` in that
+///     same arm, so the parent already contributes every entry the sub
+///     holds. On the ORIGINAL side that makes emptiness unchanged by
+///     construction. On the VALIDATED side it does not follow:
+///     `validate_targets_in_chain` has NO `AdditionalCostPaidInstead`
+///     arm, so parent and sub take different arms — the sub's
+///     context-ref arm keeps its entry unconditionally while the
+///     parent's copy is re-validated against the parent's own filter
+///     and can be dropped. A divergence needs a parent whose validation
+///     drops what the sub's does not: unreachable today only because no
+///     card produces an `AdditionalCostPaidInstead` `GainLife` anaphor
+///     rider. If one ever does, re-derive this bullet — do not assume it.
+///
+/// LOCKSTEP: if any of those six arms is ever made to surface a slot for an
+/// inheriting sub, this mirror must gain the corresponding arm in the SAME
+/// commit — the same rule that binds it to the two `defers_*` guards.
+///
+/// The predicate alone is NECESSARY BUT NOT SUFFICIENT. On the deferred path
+/// (`Scry`/`Dig`/`Surveil`/`ChooseCard`/`SearchLibrary`/`RevealHand`/`Choose`
+/// heads) the producer does not push a snapshot at all — it routes through
+/// `assign_targets_after_deferred_effect`, which writes REAL, player-selected
+/// targets into the sub, while the predicate still returns true. Skipping those
+/// would stop a chain fizzling that correctly fizzles today: the same defect,
+/// inverted.
+///
+/// All three conjuncts are purely structural — none reads `.targets` — and
+/// `validate_targets_in_chain` clones the ability and mutates only `.targets`,
+/// so the verdict is provably identical on the original and validated sides and
+/// on both sides of the fizzle comparison. Any future widening of the
+/// inherited-rider class is covered here automatically.
+///
+/// Scoped to SUB nodes deliberately. A ROOT node holding a context-ref snapshot
+/// is a different shape (a delayed-return trigger: Flickerwisp's "return that
+/// card", whose referent is legitimately in Exile) and keeps its entry, exactly
+/// as `validate_targets_in_chain`'s context-ref arm keeps it.
+pub(crate) fn flatten_specified_targets_in_chain(ability: &ResolvedAbility) -> Vec<TargetRef> {
+    fn visit(ability: &ResolvedAbility, targets_are_inherited: bool, out: &mut Vec<TargetRef>) {
+        if !targets_are_inherited {
+            if is_per_opponent_target_fanout(ability) {
+                out.extend(object_targets_only(&ability.targets));
+            } else {
+                out.extend(ability.targets.iter().cloned());
+            }
+        }
+        // An inherited node's own entries are skipped, but its sub-chain is
+        // still walked: a rider may itself carry a genuinely targeting child.
+        // (Today neither assign path recurses after the push, so this traversal
+        // is inert and preserves BASE exactly — it is the correct shape if that
+        // ever changes.)
+        if let Some(sub) = ability.sub_ability.as_deref() {
+            // Mirror BOTH producer gates — `assign_targets_recursive`
+            // :7863 / :7881 and `assign_selected_slots_recursive`
+            // :8288 / :8306 — REGROUPED ahead of the predicate. This is NOT
+            // the producer's order: it evaluates the predicate at :7872,
+            // BETWEEN its two gates. The regrouping is verdict-preserving
+            // because all three conjuncts are pure and none reads `.targets`.
+            // On the deferred path the sub receives REAL selected targets
+            // instead of a snapshot.
+            let inherited = !defers_sub_ability_target_selection(&ability.effect)
+                && !defers_conditional_target_selection(sub)
+                && sub_ability_inherits_parent_creature_target_only(ability, sub);
+            visit(sub, inherited, out);
+        }
+        // CR 601.2c: neither assign path writes an inherited target into an
+        // `else_ability` — both push only to `sub_ability`, and neither
+        // function references `else_ability` at all — so an else branch always
+        // owns whatever targets it holds.
+        if let Some(else_ability) = ability.else_ability.as_deref() {
+            visit(else_ability, false, out);
+        }
+    }
+
+    let mut out = Vec::new();
+    visit(ability, false, &mut out);
+    out
+}
 
 /// CR 601.2d: The node whose effect divides damage/counters among its own
 /// targets. Mirrors `extract_distribution_total`, which inspects only the
@@ -11523,6 +11661,259 @@ mod tests {
             ),
             "a delayed-return ParentTarget ability must not fizzle when its \
              snapshotted object is off the battlefield"
+        );
+    }
+
+    /// Helper: the Swords head — `ChangeZone { origin: None, destination:
+    /// Exile, target: Typed[Creature] }`, matching the committed IR snapshot.
+    fn change_zone_head(destination: Zone, targets: Vec<TargetRef>) -> ResolvedAbility {
+        ResolvedAbility::new(
+            Effect::ChangeZone {
+                origin: None,
+                destination,
+                target: TargetFilter::Typed(TypedFilter::creature()),
+                owner_library: false,
+                enter_transformed: false,
+                enters_under: None,
+                enter_tapped: crate::types::zones::EtbTapState::Unspecified,
+                enters_attacking: false,
+                up_to: false,
+                enter_with_counters: vec![],
+                conditional_enter_with_counters: vec![],
+                face_down_profile: None,
+                enters_modified_if: None,
+            },
+            targets,
+            ObjectId(99),
+            PlayerId(0),
+        )
+    }
+
+    /// Helper: the anaphoric rider — "Its controller gains life equal to its
+    /// power." `GainLife { player: ParentTargetController, amount:
+    /// Ref(Power { scope: Target }) }`, matching the committed IR snapshot.
+    fn gain_life_anaphor_rider(targets: Vec<TargetRef>) -> ResolvedAbility {
+        ResolvedAbility::new(
+            Effect::GainLife {
+                amount: QuantityExpr::Ref {
+                    qty: QuantityRef::Power {
+                        scope: ObjectScope::Target,
+                    },
+                },
+                player: TargetFilter::ParentTargetController,
+            },
+            targets,
+            ObjectId(99),
+            PlayerId(0),
+        )
+    }
+
+    /// V8 — CR 608.2b + CR 115.10a: the inherited rider's `targets` entry is a
+    /// snapshot of the parent's chosen object, not an instance of the word
+    /// "target", so `flatten_specified_targets_in_chain` must not count it.
+    /// This is the unit-level statement of the #5965 / #8058 fix.
+    #[test]
+    fn flatten_specified_targets_in_chain_excludes_inherited_rider_entry() {
+        let victim = ObjectId(77);
+        let mut ability = change_zone_head(Zone::Exile, vec![TargetRef::Object(victim)]);
+        ability.sub_ability = Some(Box::new(gain_life_anaphor_rider(vec![TargetRef::Object(
+            victim,
+        )])));
+
+        // REACH GUARD (paired positive, MANDATORY): the verdict is decided by
+        // the FIRST failing conjunct, not the last one named — so assert the
+        // discriminator itself, not a proxy for it.
+        assert!(
+            sub_ability_inherits_parent_creature_target_only(
+                &ability,
+                ability.sub_ability.as_deref().unwrap()
+            ),
+            "reach-guard: the fixture must actually be an inherited rider, or \
+             this test pins nothing"
+        );
+
+        // SHAPE check, NOT an inheritance control: `flatten_targets_in_chain`
+        // only concatenates `.targets` and never consults the discriminator, so
+        // it returns 2 for any two-node chain with one entry each. It is kept
+        // because the claim is about the old-vs-new pair; the assertion above
+        // is what makes this test non-vacuous.
+        assert_eq!(flatten_targets_in_chain(&ability).len(), 2);
+
+        assert_eq!(
+            flatten_specified_targets_in_chain(&ability),
+            vec![TargetRef::Object(victim)],
+            "CR 608.2b + CR 115.10a: 'its controller gains life equal to its \
+             power' has no instance of the word 'target' of its own, so its \
+             propagated snapshot must not keep the spell alive"
+        );
+    }
+
+    /// V9 — CR 603.7c: a ROOT node holding a `ParentTarget` snapshot
+    /// (Flickerwisp's "return that card") keeps its entry. The fixture is the
+    /// one from
+    /// `validate_targets_in_chain_preserves_parent_target_snapshot_off_battlefield`
+    /// above: a SINGLE-NODE `ResolvedAbility` with NO `sub_ability`, so this
+    /// test's verdict is decided entirely by the root seed
+    /// `visit(ability, false, ..)`. It does NOT exercise sub-scoping — that is
+    /// pinned by V8 (inherited sub dropped) and V10 (non-inherited sub kept).
+    /// What it IS: a regression pin against anyone changing that root seed to
+    /// `true`, which would silently fizzle every delayed return.
+    #[test]
+    fn flatten_specified_targets_in_chain_keeps_root_context_ref_snapshot() {
+        let format = FormatConfig::duel_commander();
+        let mut state = GameState::new(format, 2, 2);
+        let victim = create_object(
+            &mut state,
+            CardId(0),
+            PlayerId(1),
+            "Grizzly Bears".to_string(),
+            Zone::Exile,
+        );
+
+        let ability = ResolvedAbility::new(
+            Effect::ChangeZone {
+                origin: None,
+                destination: Zone::Battlefield,
+                target: TargetFilter::ParentTarget,
+                owner_library: false,
+                enter_transformed: false,
+                enters_under: None,
+                enter_tapped: crate::types::zones::EtbTapState::Unspecified,
+                enters_attacking: false,
+                up_to: false,
+                enter_with_counters: vec![],
+                conditional_enter_with_counters: vec![],
+                face_down_profile: None,
+                enters_modified_if: None,
+            },
+            vec![TargetRef::Object(victim)],
+            ObjectId(99),
+            PlayerId(0),
+        );
+
+        assert!(
+            ability.sub_ability.is_none(),
+            "reach-guard: this fixture is single-node — its verdict comes from \
+             the root seed, not from the discriminator"
+        );
+        assert_eq!(
+            flatten_specified_targets_in_chain(&ability),
+            vec![TargetRef::Object(victim)],
+            "CR 603.7c: a root-node ParentTarget snapshot is the delayed \
+             return's own referent and must keep its entry — narrowing the \
+             root seed would silently fizzle every delayed return"
+        );
+    }
+
+    /// V10 — the MG1 sibling-negative. On the DEFERRED path
+    /// (`Scry`/`Dig`/`Surveil`/`ChooseCard`/`SearchLibrary`/`RevealHand`/
+    /// `Choose` heads) the producer does NOT push a snapshot: it routes through
+    /// `assign_targets_after_deferred_effect`, which writes REAL,
+    /// player-selected targets into the sub — while the predicate still returns
+    /// true. Mirroring the predicate ALONE would skip those and stop a chain
+    /// fizzling that correctly fizzles today: the same defect, inverted.
+    #[test]
+    fn flatten_specified_targets_in_chain_keeps_deferred_head_sub_targets() {
+        let victim = ObjectId(77);
+        let mut ability = ResolvedAbility::new(
+            Effect::Surveil {
+                count: QuantityExpr::Fixed { value: 1 },
+                target: TargetFilter::Controller,
+            },
+            vec![],
+            ObjectId(99),
+            PlayerId(0),
+        );
+        ability.sub_ability = Some(Box::new(gain_life_anaphor_rider(vec![TargetRef::Object(
+            victim,
+        )])));
+
+        // REACH GUARD (paired positive, MANDATORY): the verdict is decided by
+        // the FIRST failing conjunct, not the last one named. Both halves must
+        // hold, or the deferred-head conjunct is never exercised and this test
+        // is vacuous.
+        assert!(
+            sub_ability_inherits_parent_creature_target_only(
+                &ability,
+                ability.sub_ability.as_deref().unwrap()
+            ),
+            "reach-guard: the fixture must satisfy the predicate, otherwise the \
+             deferred-head conjunct is never exercised and this test is vacuous"
+        );
+        assert!(
+            defers_sub_ability_target_selection(&ability.effect),
+            "reach-guard: the head must be in the deferring set — that is the \
+             conjunct under test"
+        );
+
+        assert_eq!(
+            flatten_specified_targets_in_chain(&ability),
+            vec![TargetRef::Object(victim)],
+            "CR 608.2b: on the deferred path the sub's targets are \
+             player-SELECTED (assign_targets_after_deferred_effect), not a \
+             propagated snapshot — they must still be counted"
+        );
+    }
+
+    /// V11 — the not-in-class boundary. `effect_player_filter_is_parent_target_anaphor`
+    /// matches `Effect::GainLife` only, so a `Draw` rider never receives the
+    /// inherited push and its targets must be counted as specified. This is the
+    /// test the forward-compatibility argument rests on: widen that predicate
+    /// and this fix covers the new members with no further edit, because the
+    /// fix reads the same predicate.
+    #[test]
+    fn flatten_specified_targets_in_chain_keeps_draw_rider_targets() {
+        let victim = ObjectId(77);
+        let mut ability = change_zone_head(Zone::Graveyard, vec![TargetRef::Object(victim)]);
+        ability.sub_ability = Some(Box::new(ResolvedAbility::new(
+            Effect::Draw {
+                // NOT Fixed(1): with a fixed count `effect_target_slot_filter`
+                // returns None for Draw, `effect_needs_target_creature_quantity_slot`
+                // is already false, and the predicate short-circuits ONE
+                // CONJUNCT EARLIER — the test would pass without ever reaching
+                // the anaphor arm it claims to pin.
+                count: QuantityExpr::Ref {
+                    qty: QuantityRef::Power {
+                        scope: ObjectScope::Target,
+                    },
+                },
+                target: TargetFilter::ParentTargetController,
+            },
+            vec![TargetRef::Object(victim)],
+            ObjectId(99),
+            PlayerId(0),
+        )));
+        let sub = ability.sub_ability.as_deref().unwrap();
+
+        // The verdict is decided by the FIRST failing conjunct, not the last one named.
+        // REACH GUARD (paired positive, MANDATORY) — conjunct 1:
+        assert!(
+            chain_has_target_sink(&ability),
+            "reach-guard: the parent must be a target sink, or the predicate \
+             short-circuits at conjunct 1 (:4966) and this test never reaches \
+             the anaphor arm"
+        );
+        // REACH GUARD (paired positive, MANDATORY) — the upstream quantity-slot
+        // conjunct must HOLD, so the anaphor arm is the only conjunct that can refuse.
+        assert!(
+            effect_needs_target_creature_quantity_slot(&sub.effect),
+            "reach-guard: the quantity-slot conjunct must HOLD, so the anaphor \
+             arm is the only conjunct that can refuse"
+        );
+        // With both reach-guards holding, the `_ => false` arm at :5075 is the
+        // ONLY conjunct that can be refusing here.
+        assert!(
+            !sub_ability_inherits_parent_creature_target_only(&ability, sub),
+            "CR 115.10a: a Draw rider is not a GainLife anaphor, so it is never \
+             an inherited rider"
+        );
+
+        assert_eq!(
+            flatten_specified_targets_in_chain(&ability),
+            flatten_targets_in_chain(&ability),
+            "nothing in this chain is inherited, so the two flattens must agree \
+             exactly — this is the boundary the forward-compatibility argument \
+             rests on"
         );
     }
 

--- a/crates/engine/src/game/stack.rs
+++ b/crates/engine/src/game/stack.rs
@@ -1720,7 +1720,7 @@ pub fn resolve_top(state: &mut GameState, events: &mut Vec<GameEvent>) {
         // UNVALIDATED chain, not `execute_effect(state, &validated, ..)` at :1793.
         // That branch is UNREACHABLE by this change, not merely harmless: the only
         // writer of an inherited entry pushes `parent_creature_target`, a `find_map`
-        // over the HEAD's own `TargetRef::Object`s (ability_utils.rs:7876-7879), so
+        // over the HEAD's own `TargetRef::Object`s (ability_utils.rs:7911-7914), so
         // an empty head pushes nothing and its sub is empty too. This flatten can
         // only be empty where the old one already was, so the gate is taken on
         // exactly the same chains as at BASE. Symmetry is safe by construction —

--- a/crates/engine/src/game/stack.rs
+++ b/crates/engine/src/game/stack.rs
@@ -26,7 +26,8 @@ use crate::types::resolved_commands::{
 use crate::types::zones::Zone;
 
 use super::ability_utils::{
-    build_target_slots, flatten_targets_in_chain, validate_targets_in_chain,
+    build_target_slots, flatten_specified_targets_in_chain, flatten_targets_in_chain,
+    validate_targets_in_chain,
 };
 use super::effects;
 use super::targeting;
@@ -1573,12 +1574,14 @@ pub fn resolve_top(state: &mut GameState, events: &mut Vec<GameEvent>) {
     let mut bestow_reverted_at_resolution = false;
     if casting_variant == CastingVariant::Bestow {
         let target_is_illegal = ability.as_ref().is_some_and(|a| {
-            let original = flatten_targets_in_chain(a);
+            // CR 702.103e asks CR 608.2b's question — use the same
+            // specified-target count as the main fizzle site below.
+            let original = flatten_specified_targets_in_chain(a);
             if original.is_empty() {
                 return false;
             }
             let validated = validate_targets_in_chain(state, a);
-            let legal = flatten_targets_in_chain(&validated);
+            let legal = flatten_specified_targets_in_chain(&validated);
             targeting::check_fizzle(&original, &legal)
         });
         let still_bestow_form = state
@@ -1706,7 +1709,24 @@ pub fn resolve_top(state: &mut GameState, events: &mut Vec<GameEvent>) {
     // Permanent spells with no spell ability (ability is None) skip straight to
     // zone-change handling below.
     if let Some(ref ability) = ability {
-        let original_targets = flatten_targets_in_chain(ability);
+        // CR 608.2b + CR 115.10a: count only the targets the spell SPECIFIED, not
+        // anaphoric snapshots an inheriting rider carries — see
+        // `flatten_specified_targets_in_chain`. BOTH sides use it: an all-anaphoric
+        // chain must report "no targets" and take the enclosing
+        // `!original_targets.is_empty()` gate ABOVE `check_fizzle` (stack.rs:1733;
+        // the bestow closure's own `if original.is_empty()` at :1580). Taking that
+        // gate skips `validate_targets_in_chain` at :1737 AND routes resolution to
+        // the `else` arm below — `execute_effect(state, ability, ..)` at :1795, the
+        // UNVALIDATED chain, not `execute_effect(state, &validated, ..)` at :1793.
+        // That branch is UNREACHABLE by this change, not merely harmless: the only
+        // writer of an inherited entry pushes `parent_creature_target`, a `find_map`
+        // over the HEAD's own `TargetRef::Object`s (ability_utils.rs:7876-7879), so
+        // an empty head pushes nothing and its sub is empty too. This flatten can
+        // only be empty where the old one already was, so the gate is taken on
+        // exactly the same chains as at BASE. Symmetry is safe by construction —
+        // `validate_targets_in_chain` clones and mutates only `.targets`, and the
+        // discriminator reads no `.targets`.
+        let original_targets = flatten_specified_targets_in_chain(ability);
         // CR 702.103e: when a bestowed Aura reverted at the start of resolution,
         // suppress the fizzle check — the spell is no longer an Aura and proceeds
         // to resolve as a creature spell with no remaining target.
@@ -1715,7 +1735,7 @@ pub fn resolve_top(state: &mut GameState, events: &mut Vec<GameEvent>) {
             && !mutate_reverted_at_resolution
         {
             let validated = validate_targets_in_chain(state, ability);
-            let legal_targets = flatten_targets_in_chain(&validated);
+            let legal_targets = flatten_specified_targets_in_chain(&validated);
             if targeting::check_fizzle(&original_targets, &legal_targets) {
                 // CR 608.2b: Fizzle — all targets illegal, spell is countered on resolution.
                 if is_spell {

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -1500,6 +1500,7 @@ mod suspect_printed_menace_701_60c;
 mod swashbuckler_extraordinaire_declined_sacrifice_3179;
 mod swashbuckler_repro_3179_accept;
 mod swords_life_equals_power_counters_2895;
+mod swords_target_legality_recheck;
 mod taigam_master_opportunist_exiles_cast_spell_749;
 mod taii_wakeen;
 mod tamiyo_inquisitive_student_flip;

--- a/crates/engine/tests/integration/swords_target_legality_recheck.rs
+++ b/crates/engine/tests/integration/swords_target_legality_recheck.rs
@@ -1,0 +1,348 @@
+//! Reproduction probes for the two open Swords to Plowshares target-legality
+//! defects, which are opposite failure modes of the same CR 608.2b recheck.
+//!
+//! Card (verified against the Scryfall API and against the committed IR
+//! snapshot
+//! `parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__swords_to_plowshares_lowered.snap`):
+//! > Exile target creature. Its controller gains life equal to its power.
+//!
+//! Clause by clause: one target, a creature; and "its controller"/"its power"
+//! are anaphors to that same target. So BOTH clauses depend on the one target.
+//! CR 608.2b: if every target is illegal as the spell tries to resolve, the
+//! spell doesn't resolve and NONE of its effects happen — no exile, no life.
+//!
+//!   - #5965: the target gains hexproof while the spell is on the stack, so the
+//!     spell must fizzle. MEASURED at BASE with a fixture that genuinely grants
+//!     hexproof (both keyword stores — see the CR 613.1 note below): BOTH halves
+//!     are red — the creature IS exiled AND its controller gains life equal to
+//!     its power.
+//!
+//!     The exile does NOT mean the resolution-time recheck is broken. Measured
+//!     on the resolving chain at BASE, the head node's re-validation is
+//!     CORRECT: it drops the hexproofed target and its validated `targets` is
+//!     empty (CR 702.11b, via `can_target`). The exile happens further
+//!     downstream, because the chain failed to fizzle (the rider's propagated
+//!     snapshot kept `legal_targets` non-empty), so `execute_effect` ran the
+//!     head anyway — and `change_zone::resolve` treats empty `targets` as "this
+//!     is an UNTARGETED effect" and falls through to its resolution-time
+//!     zone-scan, which re-derives a subject the spell never legally targeted.
+//!
+//!     That zone-scan fallback is a SECOND, INDEPENDENT defect. It is not fixed
+//!     here and it must get its own issue: this fix only makes it unreachable
+//!     for this card, because the chain now fizzles before `execute_effect` is
+//!     called at all. A chain with two instances of "target" where only one
+//!     becomes illegal still reaches it (CR 608.2b fizzles only when ALL targets
+//!     are illegal) — e.g. Grave Exchange, "Return target creature card from
+//!     your graveyard to your hand. Target player sacrifices a creature of
+//!     their choice."
+//!   - #8058: the target dies before resolution. The spell correctly moves the
+//!     creature nowhere, but its controller still gains life (measured at BASE:
+//!     P1 25 vs 20).
+
+use super::rules::{GameScenario, Phase, P0, P1};
+use engine::game::layers::evaluate_layers;
+use engine::types::keywords::Keyword;
+use engine::types::mana::ManaCost;
+use engine::types::zones::Zone;
+
+const SWORDS: &str = "Exile target creature. Its controller gains life equal to its power.";
+
+/// CR 608.2b + CR 702.11b (issue #5965): hexproof granted while Swords is on
+/// the stack makes the target illegal for an opponent's spell, so the spell is
+/// countered on resolution — the creature is NOT exiled and no life is gained.
+///
+/// READ THIS BEFORE TRUSTING THE ZONE ASSERTION. `zone == Battlefield` here is
+/// an invariant the FIZZLE provides, and nothing more. It is NOT evidence that
+/// `change_zone::resolve` handles a dropped target correctly — it demonstrably
+/// does not. Measured at BASE: the head's re-validation already emptied its
+/// `targets` (the CR 702.11b recheck works), and the creature was exiled ANYWAY
+/// by `change_zone::resolve`'s untargeted zone-scan fallback. This assertion is
+/// green after the fix only because the spell is now countered at the
+/// `check_fizzle` site and `execute_effect` is never reached. If a future change
+/// makes this chain resolve again, this assertion will go red for a reason that
+/// has nothing to do with target re-validation — fix the zone-scan fallback,
+/// do not weaken this assertion. The revert-failing assertion for THIS fix is
+/// `life(P1)`.
+#[test]
+fn issue_5965_hexproof_granted_mid_stack_fizzles_swords() {
+    let mut scenario = GameScenario::new_n_player(2, 42);
+    scenario.at_phase(Phase::PreCombatMain);
+
+    // P1's creature is the target; P0 casts the removal, so hexproof applies
+    // (CR 702.11b scopes hexproof to spells an OPPONENT controls).
+    let creature = scenario.add_creature(P1, "Hexproof Target", 2, 2).id();
+    let spell = scenario
+        .add_spell_to_hand_from_oracle(P0, "Swords to Plowshares", true, SWORDS)
+        .with_mana_cost(ManaCost::zero())
+        .id();
+
+    let mut runner = scenario.build();
+    let p1_life_before = runner.life(P1);
+
+    // Put the spell on the stack WITHOUT resolving it.
+    runner.cast(spell).target_object(creature).commit();
+
+    // Reach-guard: the creature is a legal target at announcement.
+    assert_eq!(
+        runner.state().objects[&creature].zone,
+        Zone::Battlefield,
+        "reach-guard: the target must be on the battlefield when the spell is cast"
+    );
+
+    // Grant hexproof while the spell is on the stack.
+    let obj = runner.state_mut().objects.get_mut(&creature).unwrap();
+    obj.keywords.push(Keyword::Hexproof);
+    // CR 613.1: the grant must survive the layers reseed.
+    // `sync_missing_base_characteristics` (game_object.rs:2290) early-returns
+    // once `base_characteristics_initialized` is set — which it sets ITSELF at
+    // :2365 — so the :2322 whole-vector back-fill cannot be relied on.
+    // `seed_live_characteristics_from_base` (layers.rs:2409) then restores
+    // `keywords` from `base_keywords` on every pass, wiping a live-only push.
+    // Same idiom as scenario.rs:1010 `push_keyword`; casting_tests.rs:23527
+    // does exactly this for Hexproof. Do this push LAST: writing to
+    // `base_keywords` while it is empty falsifies the `is_empty()` guard on the
+    // back-fill at game_object.rs:2321-2322, so a keyword set on the fixture
+    // BEFORE this push would be dropped from base. Inert here —
+    // `add_creature` grants no other keyword.
+    obj.base_keywords.push(Keyword::Hexproof);
+    evaluate_layers(runner.state_mut());
+
+    // Reach-guard: without this the fizzle assertions below could pass for the
+    // wrong reason (a target that was never hexproof is not a fizzle test).
+    assert!(
+        runner.state().objects[&creature].has_keyword(&Keyword::Hexproof),
+        "reach-guard: the mid-stack grant must survive the CR 613.1 layers reseed \
+         (`seed_live_characteristics_from_base` restores `keywords` from \
+         `base_keywords` on every pass — layers.rs:2409 — which is why the grant \
+         must be written to BOTH stores) — without this, the fizzle assertion \
+         below could pass for the wrong reason"
+    );
+
+    runner.advance_until_stack_empty();
+
+    // Reach-guard (CR 608.2b): the assertion below is equally satisfied by "the
+    // spell never resolved". This pair pins that the spell LEFT THE STACK and
+    // reached its owner's graveyard, which distinguishes "fizzled" from "never
+    // resolved". That is ALL it proves: it does not prove countering, because an
+    // instant that resolves normally is also put into its owner's graveyard
+    // (CR 608.2n). What proves the effects did not happen is the assertion
+    // below — never delete that one on the strength of this pair.
+    assert!(
+        runner.state().stack.is_empty(),
+        "reach-guard: the spell must have left the stack"
+    );
+    assert_eq!(
+        runner.state().objects[&spell].zone,
+        Zone::Graveyard,
+        "CR 608.2b: a spell countered on resolution is removed from the stack and \
+         put into its owner's graveyard — this distinguishes 'fizzled' from \
+         'never resolved'"
+    );
+
+    assert_eq!(
+        runner.state().objects[&creature].zone,
+        Zone::Battlefield,
+        "CR 608.2b: the spell must fizzle — a hexproof creature is an illegal \
+         target for an opponent's spell, so it is NOT exiled"
+    );
+    assert_eq!(
+        runner.life(P1),
+        p1_life_before,
+        "CR 608.2b: a countered-on-resolution spell does none of its effects, \
+         so no life is gained either"
+    );
+}
+
+/// CR 608.2b (issue #8058): the target dies before Swords resolves. The spell
+/// is countered on resolution, so the life-gain clause must NOT fire.
+#[test]
+fn issue_8058_dead_target_gains_no_life() {
+    let mut scenario = GameScenario::new_n_player(2, 42);
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let creature = scenario.add_creature(P1, "Doomed Target", 5, 5).id();
+    let spell = scenario
+        .add_spell_to_hand_from_oracle(P0, "Swords to Plowshares", true, SWORDS)
+        .with_mana_cost(ManaCost::zero())
+        .id();
+
+    let mut runner = scenario.build();
+    let p1_life_before = runner.life(P1);
+
+    runner.cast(spell).target_object(creature).commit();
+
+    assert_eq!(
+        runner.state().objects[&creature].zone,
+        Zone::Battlefield,
+        "reach-guard: the target must be live when the spell is cast"
+    );
+
+    // The target dies while Swords is still on the stack.
+    let mut events = Vec::new();
+    engine::game::zones::move_to_zone(runner.state_mut(), creature, Zone::Graveyard, &mut events);
+
+    runner.advance_until_stack_empty();
+
+    // Reach-guard (CR 608.2b): the assertion below is equally satisfied by "the
+    // spell never resolved". This pair pins that the spell LEFT THE STACK and
+    // reached its owner's graveyard, which distinguishes "fizzled" from "never
+    // resolved". That is ALL it proves: it does not prove countering, because an
+    // instant that resolves normally is also put into its owner's graveyard
+    // (CR 608.2n). What proves the effects did not happen is the assertion
+    // below — never delete that one on the strength of this pair.
+    assert!(
+        runner.state().stack.is_empty(),
+        "reach-guard: the spell must have left the stack"
+    );
+    assert_eq!(
+        runner.state().objects[&spell].zone,
+        Zone::Graveyard,
+        "CR 608.2b: a spell countered on resolution is removed from the stack and \
+         put into its owner's graveyard — this distinguishes 'fizzled' from \
+         'never resolved'"
+    );
+
+    assert_eq!(
+        runner.life(P1),
+        p1_life_before,
+        "CR 608.2b: Swords is countered on resolution because its only target is \
+         gone, so 'its controller gains life equal to its power' must NOT fire"
+    );
+    assert_ne!(
+        runner.state().objects[&creature].zone,
+        Zone::Exile,
+        "a countered spell exiles nothing"
+    );
+}
+
+/// A bare exile with NO anaphoric rider — the control's instrument.
+const BARE_EXILE: &str = "Exile target creature.";
+
+/// CR 608.2b + CR 702.11b — CONTROL, and the falsifier for this fix's premise.
+/// A bare "Exile target creature." has no rider, so nothing can retain a
+/// propagated target: the head node's own re-validation is the whole story.
+/// This must pass at BASE_SHA as well as after the fix. If it FAILS at BASE,
+/// the resolution-time hexproof recheck is independently broken and the
+/// chain-retention fix is not sufficient.
+///
+/// The positive reach-guard that this control is not measuring a dead
+/// instrument lives in the sibling `bare_exile_exiles_legal_target`, which
+/// proves the very same `BARE_EXILE` text CAN exile. Without that sibling every
+/// assertion here is equally satisfied by "the spell resolved and did nothing"
+/// (e.g. the text lowering to `Effect::Unimplemented`), and a falsifier that
+/// passes when the instrument is dead falsifies nothing.
+#[test]
+fn bare_exile_fizzles_under_mid_stack_hexproof() {
+    let mut scenario = GameScenario::new_n_player(2, 42);
+    scenario.at_phase(Phase::PreCombatMain);
+
+    // P1's creature is the target; P0 casts the removal, so hexproof applies
+    // (CR 702.11b scopes hexproof to spells an OPPONENT controls).
+    let creature = scenario.add_creature(P1, "Hexproof Target", 2, 2).id();
+    let spell = scenario
+        .add_spell_to_hand_from_oracle(P0, "Bare Exile", true, BARE_EXILE)
+        .with_mana_cost(ManaCost::zero())
+        .id();
+
+    let mut runner = scenario.build();
+
+    // Put the spell on the stack WITHOUT resolving it.
+    runner.cast(spell).target_object(creature).commit();
+
+    // Reach-guard: the creature is a legal target at announcement.
+    assert_eq!(
+        runner.state().objects[&creature].zone,
+        Zone::Battlefield,
+        "reach-guard: the target must be on the battlefield when the spell is cast"
+    );
+
+    // Grant hexproof while the spell is on the stack. Both stores — see the
+    // CR 613.1 note in `issue_5965_hexproof_granted_mid_stack_fizzles_swords`;
+    // `layers.rs:2409` restores `keywords` from `base_keywords` on every pass.
+    // This push goes LAST (game_object.rs:2321-2322 back-fill guard).
+    let obj = runner.state_mut().objects.get_mut(&creature).unwrap();
+    obj.keywords.push(Keyword::Hexproof);
+    obj.base_keywords.push(Keyword::Hexproof);
+    evaluate_layers(runner.state_mut());
+
+    assert!(
+        runner.state().objects[&creature].has_keyword(&Keyword::Hexproof),
+        "reach-guard: the mid-stack grant must survive the CR 613.1 layers reseed \
+         (`seed_live_characteristics_from_base` restores `keywords` from \
+         `base_keywords` on every pass — layers.rs:2409 — which is why the grant \
+         must be written to BOTH stores) — without this, the fizzle assertion \
+         below could pass for the wrong reason"
+    );
+
+    runner.advance_until_stack_empty();
+
+    // Reach-guard (CR 608.2b): the assertion below is equally satisfied by "the
+    // spell never resolved". This pair pins that the spell LEFT THE STACK and
+    // reached its owner's graveyard, which distinguishes "fizzled" from "never
+    // resolved". That is ALL it proves: it does not prove countering, because an
+    // instant that resolves normally is also put into its owner's graveyard
+    // (CR 608.2n). What proves the effect did not happen is the assertion
+    // below — never delete that one on the strength of this pair.
+    assert!(
+        runner.state().stack.is_empty(),
+        "reach-guard: the spell must have left the stack"
+    );
+    assert_eq!(
+        runner.state().objects[&spell].zone,
+        Zone::Graveyard,
+        "CR 608.2b: a spell countered on resolution is removed from the stack and \
+         put into its owner's graveyard — this distinguishes 'fizzled' from \
+         'never resolved'"
+    );
+
+    assert_eq!(
+        runner.state().objects[&creature].zone,
+        Zone::Battlefield,
+        "CR 608.2b + CR 702.11b: with NO rider to retain a propagated target, the \
+         head node's own re-validation is the whole story — a hexproof creature \
+         is an illegal target for an opponent's spell, so the spell is countered \
+         on resolution and the creature is NOT exiled. If this is red at BASE, \
+         the resolution-time hexproof recheck is independently broken"
+    );
+}
+
+/// POSITIVE REACH-GUARD for `bare_exile_fizzles_under_mid_stack_hexproof`.
+/// Every assertion that control carries is equally satisfied by "the spell
+/// resolved and did nothing", so the negative result only means something if
+/// this exact `BARE_EXILE` text CAN exile a legal target. Identical fixture
+/// minus the hexproof grant.
+#[test]
+fn bare_exile_exiles_legal_target() {
+    let mut scenario = GameScenario::new_n_player(2, 42);
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let creature = scenario.add_creature(P1, "Hexproof Target", 2, 2).id();
+    let spell = scenario
+        .add_spell_to_hand_from_oracle(P0, "Bare Exile", true, BARE_EXILE)
+        .with_mana_cost(ManaCost::zero())
+        .id();
+
+    let mut runner = scenario.build();
+
+    runner.cast(spell).target_object(creature).commit();
+
+    assert_eq!(
+        runner.state().objects[&creature].zone,
+        Zone::Battlefield,
+        "reach-guard: the target must be on the battlefield when the spell is cast"
+    );
+
+    runner.advance_until_stack_empty();
+
+    assert!(
+        runner.state().stack.is_empty(),
+        "reach-guard: the spell must have left the stack"
+    );
+
+    assert_eq!(
+        runner.state().objects[&creature].zone,
+        Zone::Exile,
+        "instrument check: `Exile target creature.` must actually exile a LEGAL \
+         target, or the sibling control's negative result proves nothing"
+    );
+}

--- a/crates/engine/tests/integration/swords_target_legality_recheck.rs
+++ b/crates/engine/tests/integration/swords_target_legality_recheck.rs
@@ -153,6 +153,79 @@ fn issue_5965_hexproof_granted_mid_stack_fizzles_swords() {
     );
 }
 
+/// POSITIVE INSTRUMENT CONTROL for BOTH `SWORDS` regression pins above and
+/// below. Every assertion those two tests make is an ABSENCE — nothing exiled,
+/// no life gained, spell in the graveyard. If `SWORDS` ever stopped lowering to
+/// `ChangeZone` + the `GainLife` anaphor rider — a parse regression to
+/// `Effect::Unimplemented`, or a lost rider — all of those absences would still
+/// hold and both pins would rot silently to green. Nothing upstream catches it:
+/// `add_spell_to_hand_from_oracle` asserts nothing about the parse, and
+/// `SpellCast::try_commit` never checks that `.target_object(..)` was actually
+/// consumed by a surfaced slot (`CastCommit` has no `Drop`), so a target handed
+/// to a spell that surfaces no slot is discarded in silence.
+///
+/// This test is the only thing in the file that proves the instrument is alive
+/// for the PRIMARY card: `SWORDS` on a legal target really does exile it AND
+/// really does gain its controller life equal to its power.
+///
+/// NOTE FOR THE NEXT MAINTAINER — apply this to the CLASS, not the instance.
+/// The file already stated this doctrine and enforced it for the *control*
+/// (`bare_exile_exiles_legal_target`, below) while leaving the primary card
+/// uncovered. That instance-not-class gap is the single error shape that has
+/// recurred through this entire investigation. Every negative regression pin
+/// here needs a paired positive that proves its instrument still works — if you
+/// add one, add the pair.
+#[test]
+fn swords_exiles_and_gains_life_on_legal_target() {
+    let mut scenario = GameScenario::new_n_player(2, 42);
+    scenario.at_phase(Phase::PreCombatMain);
+
+    // Same fixture as the two pins, minus the hexproof grant and minus the
+    // death — so the ONLY difference is that the target stays legal.
+    let creature = scenario.add_creature(P1, "Legal Target", 2, 2).id();
+    let spell = scenario
+        .add_spell_to_hand_from_oracle(P0, "Swords to Plowshares", true, SWORDS)
+        .with_mana_cost(ManaCost::zero())
+        .id();
+
+    let mut runner = scenario.build();
+    let p1_life_before = runner.life(P1);
+
+    runner.cast(spell).target_object(creature).commit();
+
+    assert_eq!(
+        runner.state().objects[&creature].zone,
+        Zone::Battlefield,
+        "reach-guard: the target must be on the battlefield when the spell is cast"
+    );
+
+    runner.advance_until_stack_empty();
+
+    assert!(
+        runner.state().stack.is_empty(),
+        "reach-guard: the spell must have left the stack"
+    );
+
+    // CR 608.2b: a spell that resolves normally DOES both of its things. These
+    // two assertions are what prove the instrument is alive; if either goes red,
+    // the two fizzle pins in this file are no longer measuring anything.
+    assert_eq!(
+        runner.state().objects[&creature].zone,
+        Zone::Exile,
+        "instrument check: `SWORDS` must actually EXILE a legal target — if it \
+         does not, the ChangeZone head is gone and both fizzle pins in this file \
+         pass vacuously"
+    );
+    assert_eq!(
+        runner.life(P1),
+        p1_life_before + 2,
+        "instrument check: `SWORDS`'s anaphoric rider must actually fire on a \
+         legal target — the 2/2's controller gains life equal to its power. If \
+         this is red, the GainLife rider is gone and `issue_8058`'s and \
+         `issue_5965`'s life assertions pass vacuously"
+    );
+}
+
 /// CR 608.2b (issue #8058): the target dies before Swords resolves. The spell
 /// is countered on resolution, so the life-gain clause must NOT fire.
 #[test]


### PR DESCRIPTION
## Summary

A spell whose only target became illegal still resolved: Swords to Plowshares gained its controller life off a creature that had already died (#8058), and exiled a creature that had gained hexproof (#5965). CR 608.2b requires the spell to be countered on resolution with none of its effects happening. The fizzle check was counting targets the spell never specified.

## Files changed

- `crates/engine/src/game/ability_utils.rs` — new `flatten_specified_targets_in_chain`; inline unit tests V8-V11 + V10b
- `crates/engine/src/game/stack.rs` — both `check_fizzle` call sites use it, on both sides
- `crates/engine/tests/integration/swords_target_legality_recheck.rs` — new: two repro tests, two controls, one instrument control
- `crates/engine/tests/integration/main.rs` — module registration

## Track

Developer

## LLM

Model: claude-opus-5[1m] (Claude Opus 5, 1M context)
Tier: Frontier
Thinking: high

## Implementation method (required)

Method: /engine-implementer

## CR references

CR 608.2b (fizzle counts every instance of "target"; Sorin's Thirst example), CR 601.2c (one announcement per "target"), CR 115.10a (an anaphor is not a target), CR 608.2n (a normally-resolving instant also reaches its owner's graveyard — why the "left the stack" pair does not prove countering), CR 702.11b (hexproof scoped to opponents' spells), CR 613.1 (layers reseed), CR 702.103e (bestow), CR 603.7c, CR 603.12, CR 608.2d, CR 115.1.

## The defect

Not the target recheck — that is correct. For a hexproofed target the head node's validated target list is empty, exactly as CR 702.11b requires. Measured:

```
head_targets   = [Object(1)]      sub_targets   = [Object(1)]
validated_head = []               validated_sub = [Object(1)]
original = [Object(1), Object(1)] legal = [Object(1)]   fizzle = false
```

`flatten_targets_in_chain` concatenates targets from `sub_ability`/`else_ability` riders. "Its controller gains life" lowers to a context-ref rider (`GainLife { player: ParentTargetController }`) whose arm in `validate_targets_in_chain` returns its targets **unfiltered** — deliberately, so Flickerwisp-style delayed returns can reference an exiled card. The parent's chosen target is propagated into that rider at announcement, so when the head correctly drops an illegal target the rider still reports one, `check_fizzle` sees a non-empty legal list, and the spell resolves.

CR 608.2b counts "every instance of the word 'target'" — a question about targets the spell *specified* (CR 601.2c), not about every `TargetRef` the chain holds. CR 115.10a: "its controller" is not itself a target. The rule's own Sorin's Thirst example is this case: *"Its controller doesn't gain any life."*

## The fix

`flatten_specified_targets_in_chain` mirrors the **producer's own** propagation condition rather than re-deriving a discriminator, so the consumer cannot drift from the producer. Both `check_fizzle` sites use it on both sides — asymmetry there would cause spurious fizzles.

The two `defers_*` conjuncts are load-bearing, not defensive: removing either individually makes a deferred head's genuinely player-selected sub targets vanish from the count. Mutation-verified per conjunct.

Class-general: every "target X. \<anaphor rider\>" spell — Swords, Condemn, Solitude today, plus every future member, because the fix reads the same predicate that creates the propagation.

Announcement is unchanged; these spells still ask for one target. Flickerwisp's carve-out is unchanged. The other 64 `flatten_targets_in_chain` call sites are unchanged — they legitimately ask what the chain *holds*; only the two fizzle sites ask what it *specified*.

## Deliberately not fixed here

`change_zone::resolve`'s empty-target branch has no guard for "a target was specified and CR 608.2b re-validation dropped it", so it falls through to an untargeted zone-scan that never calls `can_target` — bypassing hexproof, shroud, protection and `CantBeTargeted`. After this change Swords is countered before resolution and never reaches it.

**The tests here pass because the spell fizzles, NOT because that branch handles dropped targets.** That is stated in the test file where a maintainer will see it, so the green assertion cannot be misread as coverage. Filed as #8656; reachable without this bug by any spell with two instances of "target" where one becomes illegal.

A second known gap: `stamp_other_batch_source_targets` is another announce-time snapshot writer this function does not yet exclude, affecting the pairwise "each of those creatures deals damage to the other" class. Pre-existing and out of scope; carries a `LOCKSTEP` note in the new function's doc so it is discoverable rather than latent.

## Anchored on

- `crates/engine/src/game/ability_utils.rs` — `flatten_targets_in_chain`, the existing chain-walk this mirrors; the new function is deliberately its narrower sibling rather than a change to it
- `crates/engine/src/game/ability_utils.rs` — `stamp_other_batch_source_targets`, the existing inner-`visit` recursion idiom at this same seam, directly above

## Verification

- [x] Required checks ran clean, or the exact CI-owned alternative is stated below.
- [x] Gate A output below is for the current committed head.
- [x] Final review-impl below is clean for the current committed head.
- [x] Both anchors cite existing analogous code at the same seam.

- `cargo test -p phase-engine --lib` — **20763 passed, 0 failed**, 7 ignored
- `cargo test -p phase-engine --test integration` — **6491 passed, 0 failed**, 3 ignored
- `cargo clippy -p phase-engine --all-targets -- -D warnings` — **exit 0, zero warnings**
- Per-conjunct mutation matrix — dropping `!defers_sub_ability_target_selection` ⇒ V10 **RED** / V10b **GREEN**; dropping `!defers_conditional_target_selection` ⇒ V10 **GREEN** / V10b **RED**. Each mutation kills exactly one test; V8/V9/V11 green under both. Both restores proven by `git hash-object` equality, not assumed.

Those gates ran at `10327302`, and the three source blobs were hash-verified byte-identical to that commit (`git hash-object` post-gate == `git rev-parse HEAD:<path>`), so they measure the commit rather than a working tree. The two commits after it are **comment-only**, mechanically verified: all 8 changed lines begin with `//`, so no compiled token differs. Behavior at `a909b4a` is identical to `10327302` by construction. Gate A was re-run against the final head with a clean tree.

Note: `cargo test -p phase-engine --doc` fails at BASE and after, on a pre-existing `SlotEnforcement` doc block that rustdoc compiles as a doctest. This PR's `ability_utils.rs` diff adds lines and deletes none, and the block is outside every added hunk — confirmed by `git show <base>:...`. Not introduced here, not fixed here.

Workspace-wide clippy could not run locally (`openssl-sys` build script, missing `openssl.pc`, unrelated non-engine crate); scoped to `-p phase-engine --all-targets`.

## Gate A

Gate A PASS head=a909b4ad05fed7eb8ccfd07eca0be1b31f1408da base=4075d46dce007a2ec932cc20a820d3c57d350f39

## Final review-impl

Final review-impl PASS head=10327302cb55688fbd4823e7a2adc12ae0b74a5f

Clean — no HIGH, no MED. Two LOW nits were raised and both are applied in the two comment-only commits that follow (`a909b4a`): the LOCKSTEP note now names #8684, and a reach-guard comment that claimed conjunct 3 "refuses first" now says what the guard actually does — conjunct 3 is evaluated last and `&&` short-circuits before reaching it.

Seven plan-review rounds and three implementation reviews preceded this. The reviews found, among other things: a false invariant in a doc comment, a fixture whose hexproof grant did not survive the layers reseed (so the original #5965 reproduction proved nothing), an absence-only assertion set with no live instrument, a mutation check that removed two conjuncts together and so could not tell which was load-bearing, and a doc block rustdoc silently compiled as a failing doctest.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved spell resolution so targets that become illegal before resolution are correctly rejected.
  - Fixed cases where protection gained mid-resolution or a target leaving play could incorrectly allow an effect to resolve.
  - Corrected target handling for chained abilities, preventing inherited targets from being counted as newly selected targets.
  - Preserved valid behavior for legal targets, deferred selections, conditional effects, and related ability riders.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->