### PR TITLE
feat(tournament): game-format label + "automatic + N" rounds (lobby protocol v7)

### DIFF
--- a/client/src/adapter/types.ts
+++ b/client/src/adapter/types.ts
@@ -4799,12 +4799,15 @@ export interface TournamentSummary {
   created_at: number;
   /**
    * The event's game-format label (Standard, Commander, …), a display label
-   * only — the tournament enforces no deck legality. `undefined` when the
-   * organizer named none, or when talking to a pre-v7 broker that omits the
-   * field (lobby protocol 7 added it). Mirrors the `format` a {@link LobbyGame}
-   * listing already carries; resolve its human label through `FORMAT_REGISTRY`.
+   * only — the tournament enforces no deck legality. Typed `| null` because the
+   * Rust field is `#[serde(default)] Option<GameFormat>` with NO
+   * `skip_serializing_if`, so `None` arrives as an explicit `"format": null`,
+   * not a missing key — the common "organizer named none" path. `undefined`
+   * only against a pre-v7 broker that omits the field entirely (lobby protocol
+   * 7 added it). Guard with `!= null` to cover both. Mirrors the `format` a
+   * {@link LobbyGame} listing carries; resolve its label through `FORMAT_REGISTRY`.
    */
-  format?: GameFormat;
+  format?: GameFormat | null;
 }
 
 /**

--- a/client/src/adapter/types.ts
+++ b/client/src/adapter/types.ts
@@ -4797,6 +4797,14 @@ export interface TournamentSummary {
    */
   total_rounds: number;
   created_at: number;
+  /**
+   * The event's game-format label (Standard, Commander, …), a display label
+   * only — the tournament enforces no deck legality. `undefined` when the
+   * organizer named none, or when talking to a pre-v7 broker that omits the
+   * field (lobby protocol 7 added it). Mirrors the `format` a {@link LobbyGame}
+   * listing already carries; resolve its human label through `FORMAT_REGISTRY`.
+   */
+  format?: GameFormat;
 }
 
 /**

--- a/client/src/adapter/ws-adapter.ts
+++ b/client/src/adapter/ws-adapter.ts
@@ -471,12 +471,13 @@ export const LOBBY_MIN_SUPPORTED_SERVER_PROTOCOL = PROTOCOL_VERSION - 1;
  * twice for GameState-only changes and the derived lobby window went disjoint
  * from the deployed broker's.
  *
- * 7 — Tournament game-format label and an "automatic + N" round option. Three
- *     fields added to CreateTournament, all optional (`#[serde(default)]`):
+ * 7 — Tournament game-format label and an "automatic + N" round option. Two
+ *     fields added to CreateTournament, both optional (`#[serde(default)]`):
  *     `format` (a GameFormat display label, mirroring the one a LobbyGame
- *     listing already carries), `plus_rounds` (add N to the auto-derived round
- *     count — the "Swiss plus N" shape, mutually exclusive with `total_rounds`),
- *     and `format` is echoed back resolved on TournamentSummary. Purely ADDITIVE
+ *     listing already carries) and `plus_rounds` (add N to the auto-derived
+ *     round count — the "Swiss plus N" shape, mutually exclusive with
+ *     `total_rounds`). Separately, the DIFFERENT TournamentSummary message
+ *     gains a `format` echoed back resolved (server → client). Purely ADDITIVE
  *     in BOTH directions, so MIN_SUPPORTED_SERVER_LOBBY_PROTOCOL below stays at
  *     2 and — unlike 6's scoring relaxation — NO client-side floor is needed:
  *     a client sending `format`/`plus_rounds` to a pre-7 broker has them

--- a/client/src/adapter/ws-adapter.ts
+++ b/client/src/adapter/ws-adapter.ts
@@ -471,6 +471,18 @@ export const LOBBY_MIN_SUPPORTED_SERVER_PROTOCOL = PROTOCOL_VERSION - 1;
  * twice for GameState-only changes and the derived lobby window went disjoint
  * from the deployed broker's.
  *
+ * 7 — Tournament game-format label and an "automatic + N" round option. Three
+ *     fields added to CreateTournament, all optional (`#[serde(default)]`):
+ *     `format` (a GameFormat display label, mirroring the one a LobbyGame
+ *     listing already carries), `plus_rounds` (add N to the auto-derived round
+ *     count — the "Swiss plus N" shape, mutually exclusive with `total_rounds`),
+ *     and `format` is echoed back resolved on TournamentSummary. Purely ADDITIVE
+ *     in BOTH directions, so MIN_SUPPORTED_SERVER_LOBBY_PROTOCOL below stays at
+ *     2 and — unlike 6's scoring relaxation — NO client-side floor is needed:
+ *     a client sending `format`/`plus_rounds` to a pre-7 broker has them
+ *     ignored as unknown fields (a silent capability loss, not a parse error),
+ *     and a pre-7 broker's summary omitting `format` is inert against this
+ *     client, whose consumer is `JSON.parse`.
  * 6 — Broker-owned tournament action legality, broker-owned default scoring,
  *     and expiring/rotating tournament credentials. Two lobby variants added —
  *     RenewTournamentCredential and TournamentCredentialRenewed — which alone
@@ -523,7 +535,7 @@ export const LOBBY_MIN_SUPPORTED_SERVER_PROTOCOL = PROTOCOL_VERSION - 1;
  * 1 — Initial lobby-owned version, covering the lobby variant set unchanged
  *     since #1880.
  */
-export const LOBBY_PROTOCOL_VERSION = 6;
+export const LOBBY_PROTOCOL_VERSION = 7;
 
 /**
  * Lowest broker LOBBY_PROTOCOL_VERSION this client accepts.

--- a/client/src/components/tournament/CreateTournamentForm.tsx
+++ b/client/src/components/tournament/CreateTournamentForm.tsx
@@ -1,8 +1,9 @@
 import { useId, useState } from "react";
 import { useTranslation } from "react-i18next";
 
-import type { BracketShape, MatchArity, ScoringPolicy } from "../../adapter/types";
+import type { BracketShape, GameFormat, MatchArity, ScoringPolicy } from "../../adapter/types";
 import type { CreateTournamentRequest } from "../../services/tournamentClient";
+import { FORMAT_REGISTRY } from "../../data/formatRegistry";
 import { defaultScoringForArity } from "../../pages/tournamentPageState";
 
 interface CreateTournamentFormProps {
@@ -34,7 +35,10 @@ export function CreateTournamentForm({
   const arityId = useId();
   const arityHintId = useId();
   const bracketId = useId();
+  const formatId = useId();
   const roundsId = useId();
+  const plusRoundsId = useId();
+  const plusRoundsHintId = useId();
   const winId = useId();
   const drawId = useId();
   const lossId = useId();
@@ -42,8 +46,17 @@ export function CreateTournamentForm({
   const [name, setName] = useState("");
   const [arity, setArity] = useState<MatchArity>(initialArity);
   const [bracket, setBracket] = useState<BracketShape>("Swiss");
+  /** Empty string means "no format named" — the wire's `format: null`. */
+  const [format, setFormat] = useState<GameFormat | "">("");
   /** Empty string means "Automatic" — the wire's `total_rounds: null`. */
   const [roundsInput, setRoundsInput] = useState("");
+  /**
+   * "Automatic + N": extra rounds added on top of the auto-derived count. Only
+   * meaningful while `roundsInput` is empty (Automatic) — an exact count and a
+   * plus-N addend are mutually exclusive, which the broker also enforces, so
+   * this is dropped rather than sent alongside an explicit round count.
+   */
+  const [plusRoundsInput, setPlusRoundsInput] = useState("");
   const [scoring, setScoring] = useState<ScoringPolicy>(() =>
     defaultScoringForArity(initialArity),
   );
@@ -74,12 +87,24 @@ export function CreateTournamentForm({
         // and an explicit round count of 0, refused at `:1524`. Both must reach
         // the wire so the server stays the single authority.
         const parsedRounds = Number.parseInt(roundsInput, 10);
+        const totalRounds = Number.isNaN(parsedRounds) ? null : parsedRounds;
+        // The plus-N addend is only sent when the round count is Automatic —
+        // an exact `total_rounds` wins outright and the two are mutually
+        // exclusive (the broker rejects both), so never put them on the wire
+        // together.
+        const parsedPlus = Number.parseInt(plusRoundsInput, 10);
+        const plusRounds =
+          totalRounds === null && !Number.isNaN(parsedPlus) ? parsedPlus : null;
         onSubmit({
           name,
           arity,
           scoring,
           bracket,
-          totalRounds: Number.isNaN(parsedRounds) ? null : parsedRounds,
+          totalRounds,
+          plusRounds,
+          // `""` is the "no format named" choice; everything else is a
+          // `GameFormat` submitted verbatim.
+          format: format === "" ? null : format,
         });
       }}
       className="flex flex-col gap-4 rounded-xl border border-white/10 bg-black/20 p-4"
@@ -133,6 +158,29 @@ export function CreateTournamentForm({
       </div>
 
       <div className="flex flex-col gap-1">
+        <label htmlFor={formatId} className="text-xs text-gray-400">
+          {t("create.formatLabel")}
+        </label>
+        {/* A display label only — the tournament enforces no deck legality.
+            Options come from the shared FORMAT_REGISTRY (the same list the game
+            host format picker renders), so a new engine format appears here
+            with no change to this component. */}
+        <select
+          id={formatId}
+          value={format}
+          onChange={(event) => setFormat(event.target.value as GameFormat | "")}
+          className="rounded-[6px] border border-white/10 bg-black/30 px-3 py-2 text-sm text-gray-100"
+        >
+          <option value="">{t("create.formatNone")}</option>
+          {FORMAT_REGISTRY.map((meta) => (
+            <option key={meta.format} value={meta.format}>
+              {meta.label}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <div className="flex flex-col gap-1">
         <label htmlFor={roundsId} className="text-xs text-gray-400">
           {t("create.totalRoundsLabel")}
         </label>
@@ -147,6 +195,26 @@ export function CreateTournamentForm({
           onChange={(event) => setRoundsInput(event.target.value)}
           className="rounded-[6px] border border-white/10 bg-black/30 px-3 py-2 text-sm text-gray-100"
         />
+      </div>
+
+      <div className="flex flex-col gap-1">
+        <label htmlFor={plusRoundsId} className="text-xs text-gray-400">
+          {t("create.plusRoundsLabel")}
+        </label>
+        {/* "Swiss plus N": extra rounds added on top of the automatic count.
+            Applies only while the round count above is left Automatic; an
+            explicit count and a plus-N addend are mutually exclusive. */}
+        <input
+          id={plusRoundsId}
+          type="number"
+          value={plusRoundsInput}
+          aria-describedby={plusRoundsHintId}
+          onChange={(event) => setPlusRoundsInput(event.target.value)}
+          className="rounded-[6px] border border-white/10 bg-black/30 px-3 py-2 text-sm text-gray-100"
+        />
+        <p id={plusRoundsHintId} className="text-xs text-gray-500">
+          {t("create.plusRoundsHint")}
+        </p>
       </div>
 
       <fieldset className="flex flex-col gap-2">

--- a/client/src/components/tournament/__tests__/CreateTournamentForm.test.tsx
+++ b/client/src/components/tournament/__tests__/CreateTournamentForm.test.tsx
@@ -107,6 +107,46 @@ describe("CreateTournamentForm", () => {
     expect(onSubmit.mock.calls[0][0].totalRounds).toBe(5);
   });
 
+  // Protocol v7: a chosen format is submitted verbatim; "Unspecified" is null.
+  it("submits the chosen game format, or null when unspecified", () => {
+    const onSubmit = vi.fn();
+    render(<CreateTournamentForm onSubmit={onSubmit} />);
+
+    // Default is "Unspecified".
+    fireEvent.click(submitButton());
+    expect(onSubmit.mock.calls[0][0].format).toBeNull();
+
+    fireEvent.change(screen.getByLabelText("Format"), {
+      target: { value: "Commander" },
+    });
+    fireEvent.click(submitButton());
+    expect(onSubmit.mock.calls[1][0].format).toBe("Commander");
+  });
+
+  // "Automatic + N": extra rounds ride as `plusRounds` while the count is
+  // automatic, and are dropped when an exact count is set (mutually exclusive).
+  it("submits extra rounds as plusRounds only while the count is automatic", () => {
+    const onSubmit = vi.fn();
+    render(<CreateTournamentForm onSubmit={onSubmit} />);
+
+    fireEvent.change(screen.getByLabelText("Extra rounds"), {
+      target: { value: "2" },
+    });
+    fireEvent.click(submitButton());
+    expect(onSubmit.mock.calls[0][0]).toMatchObject({
+      totalRounds: null,
+      plusRounds: 2,
+    });
+
+    // With an exact round count set, the addend is dropped, never sent both.
+    fireEvent.change(screen.getByLabelText("Rounds"), { target: { value: "5" } });
+    fireEvent.click(submitButton());
+    expect(onSubmit.mock.calls[1][0]).toMatchObject({
+      totalRounds: 5,
+      plusRounds: null,
+    });
+  });
+
   it("submits the name exactly as typed", () => {
     const onSubmit = vi.fn();
     render(<CreateTournamentForm onSubmit={onSubmit} />);

--- a/client/src/i18n/locales/de/tournament.json
+++ b/client/src/i18n/locales/de/tournament.json
@@ -52,6 +52,10 @@
     "winPointsLabel": "Sieg",
     "drawPointsLabel": "Unentschieden",
     "lossPointsLabel": "Niederlage",
+    "formatLabel": "Format",
+    "formatNone": "Nicht angegeben",
+    "plusRoundsLabel": "Zusätzliche Runden",
+    "plusRoundsHint": "Werden zur automatischen Rundenzahl addiert (Schweizer plus N). Gilt nur, wenn Runden auf automatisch bleibt.",
     "submit": "Turnier erstellen",
     "submitting": "Wird erstellt…"
   },

--- a/client/src/i18n/locales/en/tournament.json
+++ b/client/src/i18n/locales/en/tournament.json
@@ -52,6 +52,10 @@
     "winPointsLabel": "Win",
     "drawPointsLabel": "Draw",
     "lossPointsLabel": "Loss",
+    "formatLabel": "Format",
+    "formatNone": "Unspecified",
+    "plusRoundsLabel": "Extra rounds",
+    "plusRoundsHint": "Added on top of the automatic round count (Swiss plus N). Applies only when Rounds is left automatic.",
     "submit": "Create Tournament",
     "submitting": "Creating…"
   },

--- a/client/src/i18n/locales/es/tournament.json
+++ b/client/src/i18n/locales/es/tournament.json
@@ -52,6 +52,10 @@
     "winPointsLabel": "Victoria",
     "drawPointsLabel": "Empate",
     "lossPointsLabel": "Derrota",
+    "formatLabel": "Formato",
+    "formatNone": "Sin especificar",
+    "plusRoundsLabel": "Rondas adicionales",
+    "plusRoundsHint": "Se añaden al número de rondas automático (Suizo más N). Solo se aplica si Rondas se deja en automático.",
     "submit": "Crear torneo",
     "submitting": "Creando…"
   },

--- a/client/src/i18n/locales/fr/tournament.json
+++ b/client/src/i18n/locales/fr/tournament.json
@@ -52,6 +52,10 @@
     "winPointsLabel": "Victoire",
     "drawPointsLabel": "Égalité",
     "lossPointsLabel": "Défaite",
+    "formatLabel": "Format",
+    "formatNone": "Non spécifié",
+    "plusRoundsLabel": "Rondes supplémentaires",
+    "plusRoundsHint": "Ajoutées au nombre de rondes automatique (Suisse plus N). Ne s'applique que si Rondes est laissé automatique.",
     "submit": "Créer le tournoi",
     "submitting": "Création…"
   },

--- a/client/src/i18n/locales/it/tournament.json
+++ b/client/src/i18n/locales/it/tournament.json
@@ -52,6 +52,10 @@
     "winPointsLabel": "Vittoria",
     "drawPointsLabel": "Pareggio",
     "lossPointsLabel": "Sconfitta",
+    "formatLabel": "Formato",
+    "formatNone": "Non specificato",
+    "plusRoundsLabel": "Turni aggiuntivi",
+    "plusRoundsHint": "Aggiunti al numero di turni automatico (Svizzero più N). Si applica solo se Turni è lasciato automatico.",
     "submit": "Crea torneo",
     "submitting": "Creazione…"
   },

--- a/client/src/i18n/locales/pl/tournament.json
+++ b/client/src/i18n/locales/pl/tournament.json
@@ -52,6 +52,10 @@
     "winPointsLabel": "Wygrana",
     "drawPointsLabel": "Remis",
     "lossPointsLabel": "Przegrana",
+    "formatLabel": "Format",
+    "formatNone": "Nieokreślony",
+    "plusRoundsLabel": "Dodatkowe rundy",
+    "plusRoundsHint": "Dodawane do automatycznej liczby rund (Szwajcarski plus N). Obowiązuje tylko, gdy Rundy pozostają automatyczne.",
     "submit": "Utwórz turniej",
     "submitting": "Tworzenie…"
   },

--- a/client/src/i18n/locales/pt/tournament.json
+++ b/client/src/i18n/locales/pt/tournament.json
@@ -52,6 +52,10 @@
     "winPointsLabel": "Vitória",
     "drawPointsLabel": "Empate",
     "lossPointsLabel": "Derrota",
+    "formatLabel": "Formato",
+    "formatNone": "Não especificado",
+    "plusRoundsLabel": "Rodadas extras",
+    "plusRoundsHint": "Adicionadas à contagem automática de rodadas (Suíço mais N). Aplica-se apenas quando Rodadas fica automático.",
     "submit": "Criar torneio",
     "submitting": "A criar…"
   },

--- a/client/src/pages/TournamentPage.tsx
+++ b/client/src/pages/TournamentPage.tsx
@@ -9,6 +9,7 @@ import type {
   TournamentView,
 } from "../adapter/types";
 import { ScreenChrome } from "../components/chrome/ScreenChrome";
+import { formatMetadata } from "../data/formatRegistry";
 import { useInShell } from "../components/chrome/ShellContext";
 import { MenuParticles } from "../components/menu/MenuParticles";
 import { MenuPanel, MenuShell } from "../components/menu/MenuShell";
@@ -409,6 +410,16 @@ export function TournamentPage() {
                 <span className="rounded-[5px] border border-indigo-300/20 bg-indigo-500/15 px-1.5 py-0.5 font-semibold text-indigo-200">
                   {t(`bracket.${view.summary.bracket}`)}
                 </span>
+                {/* The game-format label, resolved to its human name through the
+                    shared registry (the engine is the source of truth for the
+                    list). Absent when the organizer named none, or against a
+                    pre-v7 broker. Never recomputed — a display label only. */}
+                {view.summary.format !== undefined && (
+                  <span className="rounded-[5px] border border-sky-300/20 bg-sky-500/15 px-1.5 py-0.5 font-semibold text-sky-200">
+                    {formatMetadata(view.summary.format)?.label ??
+                      view.summary.format}
+                  </span>
+                )}
                 <span className="text-slate-400">
                   {"seats" in arity
                     ? t(arity.key, { seats: arity.seats })

--- a/client/src/pages/TournamentPage.tsx
+++ b/client/src/pages/TournamentPage.tsx
@@ -414,7 +414,7 @@ export function TournamentPage() {
                     shared registry (the engine is the source of truth for the
                     list). Absent when the organizer named none, or against a
                     pre-v7 broker. Never recomputed — a display label only. */}
-                {view.summary.format !== undefined && (
+                {view.summary.format != null && (
                   <span className="rounded-[5px] border border-sky-300/20 bg-sky-500/15 px-1.5 py-0.5 font-semibold text-sky-200">
                     {formatMetadata(view.summary.format)?.label ??
                       view.summary.format}

--- a/client/src/pages/__tests__/TournamentPage.test.tsx
+++ b/client/src/pages/__tests__/TournamentPage.test.tsx
@@ -630,6 +630,42 @@ describe("TournamentPage broadcast scoping", () => {
   });
 });
 
+// The v7 format badge. The pill (a `bg-sky-500/15` chip) resolves the label
+// through the registry, and must NOT render on the no-format path — the wire
+// sends an explicit `null` there, not `undefined`.
+describe("TournamentPage format badge", () => {
+  it("renders the format label when the summary carries one", async () => {
+    const fake = makeFakeSocket();
+    primeSocket(fake);
+    const view = h2hView("TOUR01", {
+      summary: { ...summaryFor("TOUR01"), format: "Commander" },
+    });
+    const { container } = await mountWith(fake, view);
+
+    expect(screen.getByText("Commander")).toBeTruthy();
+    expect(container.querySelector(".bg-sky-500\\/15")).not.toBeNull();
+  });
+
+  it("renders no format pill when the summary format is null", async () => {
+    const fake = makeFakeSocket();
+    primeSocket(fake);
+    const view = h2hView("TOUR01", {
+      summary: { ...summaryFor("TOUR01"), format: null },
+    });
+    const { container } = await mountWith(fake, view);
+
+    expect(container.querySelector(".bg-sky-500\\/15")).toBeNull();
+  });
+
+  it("renders no format pill when the summary omits format (pre-v7 broker)", async () => {
+    const fake = makeFakeSocket();
+    primeSocket(fake);
+    const { container } = await mountWith(fake, h2hView());
+
+    expect(container.querySelector(".bg-sky-500\\/15")).toBeNull();
+  });
+});
+
 // ── V4 / V4b — organizer gating, and the §0.2 player-authority correction ──
 
 describe("TournamentPage organizer gating", () => {

--- a/client/src/services/__tests__/tournamentClient.test.ts
+++ b/client/src/services/__tests__/tournamentClient.test.ts
@@ -285,7 +285,7 @@ const HELPERS: HelperCase[] = [
         opts,
       ),
     frame:
-      '{"type":"CreateTournament","data":{"name":"Friday Night","arity":2,"scoring":{"win_points":3,"draw_points":1,"loss_points":0},"bracket":"Swiss","total_rounds":3}}',
+      '{"type":"CreateTournament","data":{"name":"Friday Night","arity":2,"scoring":{"win_points":3,"draw_points":1,"loss_points":0},"bracket":"Swiss","total_rounds":3,"plus_rounds":null,"format":null}}',
     gated: false,
     reply: CREATED_REPLY,
   },
@@ -394,7 +394,34 @@ describe("tournament request frames", () => {
 
     // `Option<u32>` with `#[serde(default)]` and no `skip_serializing_if`.
     expect(ws.send).toHaveBeenCalledWith(
-      '{"type":"CreateTournament","data":{"name":"Friday Night","arity":4,"scoring":{"win_points":7,"draw_points":1,"loss_points":0},"bracket":"Swiss","total_rounds":null}}',
+      '{"type":"CreateTournament","data":{"name":"Friday Night","arity":4,"scoring":{"win_points":7,"draw_points":1,"loss_points":0},"bracket":"Swiss","total_rounds":null,"plus_rounds":null,"format":null}}',
+    );
+
+    controller.abort();
+    await expect(promise).resolves.toMatchObject({ ok: false, reason: "aborted" });
+  });
+
+  // Protocol v7: an event-format label and an "automatic + N" round addend ride
+  // the frame as `format` and `plus_rounds`, in that declaration order.
+  it("puts format and plus_rounds on the wire when supplied", async () => {
+    const ws = new MockWebSocket();
+    const controller = new AbortController();
+    const promise = createTournamentOver(
+      makePhaseSocket(ws),
+      {
+        name: "Friday Night",
+        arity: 2,
+        scoring: { win_points: 3, draw_points: 1, loss_points: 0 },
+        bracket: "Swiss",
+        totalRounds: null,
+        plusRounds: 2,
+        format: "Commander",
+      },
+      { signal: controller.signal },
+    );
+
+    expect(ws.send).toHaveBeenCalledWith(
+      '{"type":"CreateTournament","data":{"name":"Friday Night","arity":2,"scoring":{"win_points":3,"draw_points":1,"loss_points":0},"bracket":"Swiss","total_rounds":null,"plus_rounds":2,"format":"Commander"}}',
     );
 
     controller.abort();

--- a/client/src/services/tournamentClient.ts
+++ b/client/src/services/tournamentClient.ts
@@ -1,5 +1,6 @@
 import type {
   BracketShape,
+  GameFormat,
   MatchArity,
   PairingId,
   PodOutcome,
@@ -539,6 +540,19 @@ export interface CreateTournamentRequest {
   scoring: ScoringPolicy;
   bracket: BracketShape;
   totalRounds?: number | null;
+  /**
+   * "Automatic + N": add N to the broker's auto-derived round count. Mutually
+   * exclusive with `totalRounds` (an exact count) — the broker rejects both.
+   * `null`/omitted adds nothing. Additive in lobby protocol 7; ignored by a
+   * pre-v7 broker.
+   */
+  plusRounds?: number | null;
+  /**
+   * The event's game-format label. Display metadata only — the tournament
+   * enforces no deck legality. `null`/omitted names no format. Additive in
+   * lobby protocol 7; ignored by a pre-v7 broker.
+   */
+  format?: GameFormat | null;
 }
 
 /** `CreateTournament` → `TournamentCreated` (point reply, carries the token). */
@@ -557,6 +571,8 @@ export function createTournamentOver(
         scoring: req.scoring,
         bracket: req.bracket,
         total_rounds: req.totalRounds ?? null,
+        plus_rounds: req.plusRounds ?? null,
+        format: req.format ?? null,
       },
     },
     matchReply<TournamentCreatedReply>("TournamentCreated", null),

--- a/crates/lobby-broker/src/broker.rs
+++ b/crates/lobby-broker/src/broker.rs
@@ -11,6 +11,7 @@
 //! dispatch (and the mode-agnostic Subscribe/Ping arms, whose behavior is
 //! identical across modes), so every entry the core sees is a P2P entry.
 
+use engine::types::format::GameFormat;
 use serde::{Deserialize, Serialize};
 use tracing::{debug, info, warn};
 
@@ -517,6 +518,8 @@ impl Broker {
                 scoring,
                 bracket,
                 total_rounds,
+                plus_rounds,
+                format,
             } => self.handle_create_tournament(
                 conn,
                 name,
@@ -524,6 +527,8 @@ impl Broker {
                 scoring,
                 bracket,
                 total_rounds,
+                plus_rounds,
+                format,
                 env,
             ),
 
@@ -1240,6 +1245,8 @@ impl Broker {
         scoring: Option<ScoringPolicy>,
         bracket: BracketShape,
         total_rounds: Option<u32>,
+        plus_rounds: Option<u32>,
+        format: Option<GameFormat>,
         env: &impl BrokerEnv,
     ) -> Vec<Outbound> {
         // Registry capacity, checked before a code or a token is minted and
@@ -1275,6 +1282,8 @@ impl Broker {
                 scoring,
                 bracket,
                 total_rounds,
+                plus_rounds,
+                format,
             },
             env,
         ) {
@@ -2529,6 +2538,8 @@ mod tests {
                 scoring: Some(ScoringPolicy::default()),
                 bracket,
                 total_rounds: None,
+                plus_rounds: None,
+                format: None,
             },
             env,
         );
@@ -2685,6 +2696,8 @@ mod tests {
                 scoring: Some(ScoringPolicy::default()),
                 bracket: BracketShape::Swiss,
                 total_rounds: None,
+                plus_rounds: None,
+                format: None,
             },
             &env,
         );
@@ -3063,6 +3076,8 @@ mod tests {
                 scoring: Some(ScoringPolicy::default_for_arity(arity)),
                 bracket: BracketShape::Swiss,
                 total_rounds: None,
+                plus_rounds: None,
+                format: None,
             },
             env,
         );
@@ -4235,6 +4250,8 @@ mod tests {
                 scoring: Some(ScoringPolicy::default()),
                 bracket: BracketShape::Swiss,
                 total_rounds: None,
+                plus_rounds: None,
+                format: None,
             },
             &env,
         );
@@ -4420,6 +4437,8 @@ mod tests {
                 scoring,
                 bracket: BracketShape::Swiss,
                 total_rounds: None,
+                plus_rounds: None,
+                format: None,
             },
             env,
         );

--- a/crates/lobby-broker/src/protocol.rs
+++ b/crates/lobby-broker/src/protocol.rs
@@ -427,6 +427,28 @@ pub const MIN_SUPPORTED_PROTOCOL: u32 = PROTOCOL_VERSION.saturating_sub(1);
 /// broker's window went disjoint from the shipped client's. This constant is
 /// the fix — it moves only for reasons the lobby can actually observe.
 ///
+/// 7 — Tournament game-format label and an "automatic + N" round option. Three
+///     fields are added, all `#[serde(default)]` and OPTIONAL, so this is the
+///     "a lobby field is added" trigger and nothing else. (a)
+///     `CreateTournament` gains `format: Option<GameFormat>` — a display label
+///     for the event's format, mirroring the `format: Option<GameFormat>`
+///     [`LobbyGame`] already carries — and (b) `plus_rounds: Option<u32>`,
+///     which adds N to the bracket- and arity-derived default round count for
+///     the "Swiss plus N" community shape (mutually exclusive with the existing
+///     `total_rounds` override, rejected at validation). (c) [`TournamentSummary`]
+///     gains `format: Option<GameFormat>`, server → client, so a browsing or
+///     spectating client sees the resolved label without recomputing it. This
+///     entry is one unbroken paragraph on purpose, for the reason entry 5 below
+///     spells out — a blank `///` line before 4-space-indented prose is a
+///     rustdoc code block. Purely ADDITIVE in BOTH directions, so
+///     [`MIN_SUPPORTED_LOBBY_PROTOCOL`] does **not** move and — unlike 6(c) — no
+///     client-side capability floor is needed. A new client's `format`/`plus_rounds`
+///     reaching a pre-7 broker deserialize away as unknown fields (no enum here
+///     sets `deny_unknown_fields`), so the event is created with no label and
+///     the auto round count, a silent capability loss rather than a parse error.
+///     A pre-7 broker's summary omitting `format` is inert against a new client
+///     whose consumer is `JSON.parse`. [`PROTOCOL_VERSION`] does **not** move:
+///     no variant here carries `GameState` or `GameAction`.
 /// 6 — Broker-owned tournament action legality, broker-owned default scoring,
 ///     and expiring/rotating tournament credentials. Three triggers fire at
 ///     once and any one of them alone would be mandatory. (a) Two
@@ -546,7 +568,7 @@ pub const MIN_SUPPORTED_PROTOCOL: u32 = PROTOCOL_VERSION.saturating_sub(1);
 ///     that direction can reject — into one legible handshake refusal.
 /// 1 — Initial lobby-owned version, covering the `LobbyClientMessage` /
 ///     `LobbyServerMessage` variant sets, unchanged since #1880.
-pub const LOBBY_PROTOCOL_VERSION: u32 = 6;
+pub const LOBBY_PROTOCOL_VERSION: u32 = 7;
 
 /// Lowest [`LOBBY_PROTOCOL_VERSION`] a broker accepts from a client.
 ///
@@ -759,6 +781,13 @@ pub struct TournamentSummary {
     /// fetching a full view, and because the summary already carries `status`,
     /// `current_round` and `total_rounds` — the very inputs the gate reads.
     pub open_actions: std::collections::BTreeSet<crate::tournament::TournamentAction>,
+    /// The event's game format, a display label only (Standard, Commander, …).
+    /// `None` when the organizer named none. Mirrors [`LobbyGame::format`]: the
+    /// tournament never touches `GameState`, so it carries the `GameFormat`
+    /// label rather than a full [`FormatConfig`], and enforces no deck legality.
+    /// Additive in lobby protocol 7; absent from a pre-7 broker's summary.
+    #[serde(default)]
+    pub format: Option<GameFormat>,
 }
 
 impl From<&crate::tournament::TournamentMeta> for TournamentSummary {
@@ -775,6 +804,7 @@ impl From<&crate::tournament::TournamentMeta> for TournamentSummary {
             created_at: meta.created_at,
             scoring: meta.scoring,
             open_actions: meta.open_actions(),
+            format: meta.format,
         }
     }
 }
@@ -942,10 +972,26 @@ pub enum LobbyClientMessage {
         #[serde(default)]
         scoring: Option<crate::tournament::ScoringPolicy>,
         bracket: crate::tournament::BracketShape,
-        /// Organizer override for the scheduled round count. `None` uses the
-        /// bracket- and arity-selected default.
+        /// Organizer override for the scheduled round count, an EXACT count that
+        /// wins outright. `None` uses the bracket- and arity-selected default.
+        /// Mutually exclusive with `plus_rounds` below — supplying both is
+        /// rejected at [`crate::validation`].
         #[serde(default)]
         total_rounds: Option<u32>,
+        /// "Automatic + N": add N to the bracket- and arity-derived default
+        /// round count (the "Swiss plus N" community shape). `None` adds
+        /// nothing. Kept a separate field from `total_rounds` rather than folded
+        /// into it because the broker still owns the base default — a client
+        /// that resolved `default + N` itself would be the recomputed rule the
+        /// resolver exists to keep server-side. Additive in lobby protocol 7.
+        #[serde(default)]
+        plus_rounds: Option<u32>,
+        /// The event's game-format label (Standard, Commander, …), sent back
+        /// resolved on [`TournamentSummary::format`]. Display metadata only: the
+        /// tournament never touches `GameState` and enforces no deck legality.
+        /// `None` names no format. Additive in lobby protocol 7.
+        #[serde(default)]
+        format: Option<GameFormat>,
     },
     /// Register as an entrant. `player_key` is **client-supplied** and opaque
     /// to the broker — the stable per-entrant identity, following
@@ -1373,7 +1419,7 @@ mod tests {
     /// rather than silently re-coupling the lobby to full-game churn.
     #[test]
     fn lobby_protocol_version_is_independent_of_the_full_game_one() {
-        assert_eq!(LOBBY_PROTOCOL_VERSION, 6);
+        assert_eq!(LOBBY_PROTOCOL_VERSION, 7);
         // Deliberately still 2, not 6: lobby versions 3, 4 and 5 are purely
         // additive, and 6 is additive in the only direction this floor governs
         // — its server → client fields are ignored by a consumer that does not
@@ -1492,6 +1538,8 @@ mod tests {
             bracket: BracketShape::Swiss,
             total_rounds_override: Some(3),
             resolved_total_rounds: None,
+            plus_rounds: None,
+            format: None,
             current_round: 1,
             status: TournamentStatus::InProgress,
             players: vec![
@@ -1540,15 +1588,17 @@ mod tests {
     /// correlation took 5. Retargeting its number alone would have left a test
     /// whose name states a relationship it no longer checks, so the span is
     /// what it pins now, and the name says so. The same reasoning applies
-    /// again at 6: the chain grows a step and the name grows with it, rather
-    /// than the tail constant being quietly re-pointed.
+    /// again at 6, and once more at 7 for the format label and the "automatic +
+    /// N" round option: the chain grows a step and the name grows with it,
+    /// rather than the tail constant being quietly re-pointed.
     #[test]
-    fn the_tournament_surface_spans_lobby_versions_four_through_six() {
+    fn the_tournament_surface_spans_lobby_versions_four_through_seven() {
         const PRE_TOURNAMENT_LOBBY_VERSION: u32 = 3;
         const TOURNAMENT_SET_LOBBY_VERSION: u32 = PRE_TOURNAMENT_LOBBY_VERSION + 1;
         const CORRELATED_SETTLEMENT_LOBBY_VERSION: u32 = TOURNAMENT_SET_LOBBY_VERSION + 1;
         const BROKER_OWNED_POLICY_LOBBY_VERSION: u32 = CORRELATED_SETTLEMENT_LOBBY_VERSION + 1;
-        assert_eq!(LOBBY_PROTOCOL_VERSION, BROKER_OWNED_POLICY_LOBBY_VERSION);
+        const FORMAT_AND_PLUS_ROUNDS_LOBBY_VERSION: u32 = BROKER_OWNED_POLICY_LOBBY_VERSION + 1;
+        assert_eq!(LOBBY_PROTOCOL_VERSION, FORMAT_AND_PLUS_ROUNDS_LOBBY_VERSION);
     }
 
     /// The guard for [`is_known_lobby_tag`], which is a string `matches!` and
@@ -1666,6 +1716,8 @@ mod tests {
                 scoring: Some(ScoringPolicy::default_for_arity(MatchArity::COMMANDER_POD)),
                 bracket: BracketShape::Swiss,
                 total_rounds: Some(4),
+                plus_rounds: None,
+                format: None,
             },
             LobbyClientMessage::JoinTournament {
                 code: "TOUR01".to_string(),
@@ -2052,6 +2104,8 @@ mod tests {
             scoring: Some(ScoringPolicy::default_for_arity(MatchArity::HEAD_TO_HEAD)),
             bracket: BracketShape::Swiss,
             total_rounds: Some(3),
+            plus_rounds: None,
+            format: None,
         };
         let json = serde_json::to_string(&msg).expect("serializes");
         assert!(
@@ -2067,6 +2121,8 @@ mod tests {
             scoring: None,
             bracket: BracketShape::Swiss,
             total_rounds: Some(3),
+            plus_rounds: None,
+            format: None,
         };
         let omitted_json = serde_json::to_string(&omitted).expect("serializes");
         assert!(!omitted_json.contains(r#""win_points""#), "{omitted_json}");

--- a/crates/lobby-broker/src/tournament.rs
+++ b/crates/lobby-broker/src/tournament.rs
@@ -40,6 +40,8 @@ use std::collections::{BTreeSet, HashMap, HashSet};
 
 use serde::{Deserialize, Serialize};
 
+use engine::types::format::GameFormat;
+
 use crate::env::BrokerEnv;
 
 // ---------------------------------------------------------------------------
@@ -737,6 +739,16 @@ pub struct CreateTournamentRequest {
     /// [`TournamentMeta::resolved_total_rounds`] once round 1 is paired, so
     /// a drop cannot shorten a schedule that is already being played.
     pub total_rounds: Option<u32>,
+    /// "Automatic + N": add N to the bracket- and arity-derived default round
+    /// count. Mutually exclusive with `total_rounds` (an EXACT override);
+    /// supplying both is rejected before this request is built. `None` adds
+    /// nothing. The base default stays server-owned — see
+    /// [`TournamentMeta::total_rounds`].
+    pub plus_rounds: Option<u32>,
+    /// The event's game-format label (display metadata only — the tournament
+    /// enforces no deck legality and never touches `GameState`). `None` names
+    /// no format.
+    pub format: Option<GameFormat>,
 }
 
 /// One tournament's durable record.
@@ -772,7 +784,22 @@ pub struct TournamentMeta {
     /// ceiling in [`TournamentManager::generate_pairings`] would then refuse
     /// the bracket's own final. The schedule an event started under is the
     /// schedule it finishes under.
+    ///
+    /// The latched value ALREADY folds in [`Self::plus_rounds`]: it is
+    /// [`Self::total_rounds`]'s live result at round 1, and that resolver adds
+    /// the "+N" to the base default. So the "+N" survives a mid-event drop for
+    /// the same reason the base does, with no special handling here.
     pub resolved_total_rounds: Option<u32>,
+    /// "Automatic + N": how many rounds to add on top of the bracket- and
+    /// arity-derived default. `None`/`Some(0)` add nothing. Ignored entirely
+    /// when [`Self::total_rounds_override`] is set — an exact count wins outright
+    /// (and the two are mutually exclusive at create-validation). Read through
+    /// [`Self::total_rounds`].
+    pub plus_rounds: Option<u32>,
+    /// The event's game-format label (Standard, Commander, …), or `None`.
+    /// Display metadata only: the tournament enforces no deck legality and
+    /// never touches `GameState`. Surfaced on [`crate::protocol::TournamentSummary::format`].
+    pub format: Option<GameFormat>,
     pub current_round: u32,
     pub status: TournamentStatus,
     pub players: Vec<TournamentPlayer>,
@@ -798,18 +825,24 @@ impl TournamentMeta {
     ///    must not shorten a schedule that is already being played (see that
     ///    field for the single-elimination case it would otherwise break).
     /// 3. Otherwise the live bracket- and arity-selected default for the
-    ///    current active-player count — the right answer for an event that
-    ///    has not started yet, whose field is still growing.
+    ///    current active-player count, plus [`Self::plus_rounds`] — the right
+    ///    answer for an event that has not started yet, whose field is still
+    ///    growing.
     ///
-    /// All three inputs to that last tier go through the single
+    /// The `plus_rounds` "+N" applies only to tier 3. An exact override (tier 1)
+    /// already names the total, and the tier-2 latch captured tier 3's result
+    /// (base + N) at round 1, so the "+N" is folded in there too.
+    ///
+    /// All three inputs to the base of that last tier go through the single
     /// [`default_total_rounds`] authority rather than being branched on here,
     /// so a caller holding a bare `(bracket, arity, player_count)` gets the
-    /// same answer this does.
+    /// same base this does.
     pub fn total_rounds(&self) -> u32 {
         self.total_rounds_override
             .or(self.resolved_total_rounds)
             .unwrap_or_else(|| {
                 default_total_rounds(self.bracket, self.arity, self.active_player_count())
+                    .saturating_add(self.plus_rounds.unwrap_or(0))
             })
     }
 
@@ -1860,6 +1893,8 @@ impl TournamentManager {
                 // Nothing is latched until round 1 is paired: no round has
                 // been scheduled yet, and the field is still empty.
                 resolved_total_rounds: None,
+                plus_rounds: req.plus_rounds,
+                format: req.format,
                 current_round: 0,
                 status: TournamentStatus::Registration,
                 players: Vec::new(),
@@ -2441,6 +2476,8 @@ mod tests {
                 scoring: ScoringPolicy::default_for_arity(a),
                 bracket,
                 total_rounds: None,
+                plus_rounds: None,
+                format: None,
             },
             env,
         )
@@ -2477,6 +2514,8 @@ mod tests {
                 scoring: ScoringPolicy::default_for_arity(a),
                 bracket: BracketShape::Swiss,
                 total_rounds: Some(total_rounds),
+                plus_rounds: None,
+                format: None,
             },
             env,
         )
@@ -2728,6 +2767,8 @@ mod tests {
                     scoring,
                     bracket: BracketShape::Swiss,
                     total_rounds: Some(4),
+                    plus_rounds: None,
+                    format: None,
                 },
                 &env,
             )
@@ -2766,6 +2807,8 @@ mod tests {
                     scoring: ScoringPolicy::default(),
                     bracket: BracketShape::Swiss,
                     total_rounds: None,
+                    plus_rounds: None,
+                    format: None,
                 },
                 &env,
             )
@@ -2800,6 +2843,8 @@ mod tests {
                 scoring: ScoringPolicy::default_for_arity(arity(seats)),
                 bracket: BracketShape::SingleElimination,
                 total_rounds: None,
+                plus_rounds: None,
+                format: None,
             };
             assert!(
                 mgr.create_tournament(&format!("SE{seats}"), request, &env)
@@ -2817,6 +2862,8 @@ mod tests {
                     scoring: ScoringPolicy::default(),
                     bracket: BracketShape::SingleElimination,
                     total_rounds: None,
+                    plus_rounds: None,
+                    format: None,
                 },
                 &env,
             )
@@ -2830,6 +2877,8 @@ mod tests {
                     scoring: ScoringPolicy::default_for_arity(MatchArity::COMMANDER_POD),
                     bracket: BracketShape::Swiss,
                     total_rounds: None,
+                    plus_rounds: None,
+                    format: None,
                 },
                 &env,
             )
@@ -4248,6 +4297,76 @@ mod tests {
         assert!(err.contains("already at round 4"), "{err}");
     }
 
+    /// "Automatic + N" adds N to the live default, and the round-1 latch carries
+    /// the "+N" the same way it carries the base — a later drop cannot strip it.
+    #[test]
+    fn plus_rounds_adds_to_the_default_and_latches_with_it() {
+        let env = FakeEnv::new();
+        let mut mgr = TournamentManager::new();
+        mgr.create_tournament(
+            "T",
+            CreateTournamentRequest {
+                name: "Plus".to_string(),
+                arity: MatchArity::HEAD_TO_HEAD,
+                scoring: ScoringPolicy::default(),
+                bracket: BracketShape::Swiss,
+                total_rounds: None,
+                plus_rounds: Some(2),
+                format: None,
+            },
+            &env,
+        )
+        .expect("create");
+        join_n(&mut mgr, "T", 8, &env);
+
+        let base = default_total_rounds(BracketShape::Swiss, MatchArity::HEAD_TO_HEAD, 8);
+        assert_eq!(
+            mgr.get("T").expect("t").total_rounds(),
+            base + 2,
+            "the live default carries the +N addend"
+        );
+
+        // Round 1 latches base + N; a later drop must not strip the +N.
+        mgr.generate_pairings("T", &env).expect("round 1");
+        mgr.drop_player("T", &key(7), &env).expect("drop");
+        assert_eq!(
+            mgr.get("T").expect("t").total_rounds(),
+            base + 2,
+            "the latched schedule keeps the +N across a drop"
+        );
+    }
+
+    /// The game-format label is stored on the meta and projected onto the
+    /// summary unchanged — the tournament carries the label, nothing more.
+    #[test]
+    fn format_is_stored_on_the_meta_and_projected_to_the_summary() {
+        let env = FakeEnv::new();
+        let mut mgr = TournamentManager::new();
+        mgr.create_tournament(
+            "T",
+            CreateTournamentRequest {
+                name: "Commander Night".to_string(),
+                arity: MatchArity::COMMANDER_POD,
+                scoring: ScoringPolicy::default_for_arity(MatchArity::COMMANDER_POD),
+                bracket: BracketShape::Swiss,
+                total_rounds: None,
+                plus_rounds: None,
+                format: Some(GameFormat::Commander),
+            },
+            &env,
+        )
+        .expect("create");
+
+        let meta = mgr.get("T").expect("t");
+        assert_eq!(meta.format, Some(GameFormat::Commander));
+        let summary = crate::protocol::TournamentSummary::from(meta);
+        assert_eq!(
+            summary.format,
+            Some(GameFormat::Commander),
+            "the From<&TournamentMeta> projection carries the label"
+        );
+    }
+
     /// The three resolution tiers, at the one point where they can disagree.
     /// The organizer's override outranks a latched default exactly as it
     /// outranks a live one, and an event created with an override latches
@@ -4547,6 +4666,8 @@ mod tests {
             bracket: BracketShape::Swiss,
             total_rounds_override: None,
             resolved_total_rounds: Some(3),
+            plus_rounds: None,
+            format: None,
             current_round: 1,
             status,
             players: undropped(&["a", "b"]),
@@ -4858,6 +4979,8 @@ mod tests {
                     scoring: ScoringPolicy::default_for_arity(MatchArity::HEAD_TO_HEAD),
                     bracket: BracketShape::Swiss,
                     total_rounds: None,
+                    plus_rounds: None,
+                    format: None,
                 },
                 &env,
             )
@@ -4896,6 +5019,8 @@ mod tests {
                     scoring: ScoringPolicy::default_for_arity(MatchArity::HEAD_TO_HEAD),
                     bracket: BracketShape::Swiss,
                     total_rounds: None,
+                    plus_rounds: None,
+                    format: None,
                 },
                 &env,
             )
@@ -4942,6 +5067,8 @@ mod tests {
                     scoring: ScoringPolicy::default_for_arity(MatchArity::HEAD_TO_HEAD),
                     bracket: BracketShape::Swiss,
                     total_rounds: None,
+                    plus_rounds: None,
+                    format: None,
                 },
                 &env,
             )
@@ -4976,6 +5103,8 @@ mod tests {
                     scoring: ScoringPolicy::default_for_arity(MatchArity::HEAD_TO_HEAD),
                     bracket: BracketShape::Swiss,
                     total_rounds: None,
+                    plus_rounds: None,
+                    format: None,
                 },
                 &env,
             )
@@ -5036,6 +5165,8 @@ mod tests {
                     scoring: ScoringPolicy::default_for_arity(MatchArity::HEAD_TO_HEAD),
                     bracket: BracketShape::Swiss,
                     total_rounds: None,
+                    plus_rounds: None,
+                    format: None,
                 },
                 &env,
             )

--- a/crates/lobby-broker/src/validation.rs
+++ b/crates/lobby-broker/src/validation.rs
@@ -259,18 +259,32 @@ pub const MAX_GAME_WINS_ENTRIES: usize = 128;
 
 pub struct CreateTournamentFields<'a> {
     pub name: &'a str,
+    /// The organizer's EXACT round-count override.
+    pub total_rounds: Option<u32>,
+    /// The "automatic + N" round addend.
+    pub plus_rounds: Option<u32>,
 }
 
 pub fn validate_create_tournament_fields(fields: CreateTournamentFields<'_>) -> Result<(), String> {
     // A tournament name is a display label broadcast to every subscriber in
     // `TournamentSummary`, so it gets the same treatment as a room name.
     validate_required_label("name", fields.name, MAX_ROOM_NAME_LEN)?;
-    // `total_rounds` is deliberately unbounded here beyond PR1's own
-    // `Some(0)` rejection in `TournamentManager::create_tournament`. It is a
-    // `u32` (no unbounded allocation to guard) and nothing loops over it: the
-    // round ceiling is compared against, never counted to, so even `u32::MAX`
-    // costs a comparison. A ceiling would be a tournament-policy judgment,
-    // which is `crate::tournament`'s to make, not this module's.
+    // `total_rounds` (an exact count) and `plus_rounds` (auto default + N) are
+    // two different answers to "how many rounds", so accepting both would leave
+    // the resolver to silently pick one and discard the other — a
+    // configuration the organizer cannot see the outcome of. Reject the
+    // contradiction at the boundary instead. Neither value is otherwise
+    // bounded: both are `u32` (no unbounded allocation to guard) and nothing
+    // loops over them — the round ceiling is compared against, never counted to,
+    // so even `u32::MAX` costs a comparison. A ceiling would be a
+    // tournament-policy judgment, which is `crate::tournament`'s to make.
+    if fields.total_rounds.is_some() && fields.plus_rounds.is_some() {
+        return Err(
+            "total_rounds and plus_rounds are mutually exclusive: set an exact \
+             round count or an automatic-plus-N addend, not both"
+                .to_string(),
+        );
+    }
     Ok(())
 }
 
@@ -451,8 +465,17 @@ pub fn validate_lobby_message(msg: &crate::protocol::LobbyClientMessage) -> Resu
         M::UnregisterLobby { game_code } => {
             validate_unregister_lobby_fields(game_code)?;
         }
-        M::CreateTournament { name, .. } => {
-            validate_create_tournament_fields(CreateTournamentFields { name })?;
+        M::CreateTournament {
+            name,
+            total_rounds,
+            plus_rounds,
+            ..
+        } => {
+            validate_create_tournament_fields(CreateTournamentFields {
+                name,
+                total_rounds: *total_rounds,
+                plus_rounds: *plus_rounds,
+            })?;
         }
         M::JoinTournament {
             code,
@@ -806,6 +829,8 @@ mod tests {
             scoring: Some(ScoringPolicy::default()),
             bracket: BracketShape::Swiss,
             total_rounds: None,
+            plus_rounds: None,
+            format: None,
         }
     }
 
@@ -909,6 +934,43 @@ mod tests {
     #[test]
     fn create_tournament_rejects_blank_name() {
         assert!(validate_lobby_message(&create_tournament_with("   ")).is_err());
+    }
+
+    #[test]
+    fn create_tournament_rejects_total_rounds_and_plus_rounds_together() {
+        // Each alone is accepted; only the contradiction is refused.
+        let exact = M::CreateTournament {
+            name: "Friday Night".to_string(),
+            arity: MatchArity::HEAD_TO_HEAD,
+            scoring: Some(ScoringPolicy::default()),
+            bracket: BracketShape::Swiss,
+            total_rounds: Some(5),
+            plus_rounds: None,
+            format: None,
+        };
+        let plus = M::CreateTournament {
+            name: "Friday Night".to_string(),
+            arity: MatchArity::HEAD_TO_HEAD,
+            scoring: Some(ScoringPolicy::default()),
+            bracket: BracketShape::Swiss,
+            total_rounds: None,
+            plus_rounds: Some(1),
+            format: None,
+        };
+        assert!(validate_lobby_message(&exact).is_ok());
+        assert!(validate_lobby_message(&plus).is_ok());
+
+        let both = M::CreateTournament {
+            name: "Friday Night".to_string(),
+            arity: MatchArity::HEAD_TO_HEAD,
+            scoring: Some(ScoringPolicy::default()),
+            bracket: BracketShape::Swiss,
+            total_rounds: Some(5),
+            plus_rounds: Some(1),
+            format: None,
+        };
+        let err = validate_lobby_message(&both).expect_err("both set is rejected");
+        assert!(err.contains("mutually exclusive"), "{err}");
     }
 
     #[test]

--- a/crates/phase-server/src/main.rs
+++ b/crates/phase-server/src/main.rs
@@ -15002,7 +15002,10 @@ mod mode_gate_tests {
                 bracket: BracketShape::Swiss,
                 total_rounds: Some(4),
                 plus_rounds: None,
-                format: None,
+                // A concrete label, so the round-trip cannot pass against a
+                // projection that hardcoded `format: None` instead of forwarding
+                // it — matching the server-direction fixture's treatment.
+                format: Some(engine::types::format::GameFormat::Commander),
             },
             ClientMessage::JoinTournament {
                 code: "TOUR01".into(),

--- a/crates/phase-server/src/main.rs
+++ b/crates/phase-server/src/main.rs
@@ -3255,6 +3255,8 @@ mod lifecycle_tests {
                 scoring: Some(ScoringPolicy::default()),
                 bracket: BracketShape::Swiss,
                 total_rounds: None,
+                plus_rounds: None,
+                format: None,
             },
             &env,
         );
@@ -4593,12 +4595,16 @@ fn to_lobby_client_message(msg: &ClientMessage) -> Option<lobby_broker::LobbyCli
             scoring,
             bracket,
             total_rounds,
+            plus_rounds,
+            format,
         } => L::CreateTournament {
             name: name.clone(),
             arity: *arity,
             scoring: *scoring,
             bracket: *bracket,
             total_rounds: *total_rounds,
+            plus_rounds: *plus_rounds,
+            format: *format,
         },
         ClientMessage::JoinTournament {
             code,
@@ -14995,6 +15001,8 @@ mod mode_gate_tests {
                 scoring: Some(ScoringPolicy::default_for_arity(MatchArity::COMMANDER_POD)),
                 bracket: BracketShape::Swiss,
                 total_rounds: Some(4),
+                plus_rounds: None,
+                format: None,
             },
             ClientMessage::JoinTournament {
                 code: "TOUR01".into(),
@@ -15079,6 +15087,8 @@ mod mode_gate_tests {
                     TournamentAction::EndTournament,
                     TournamentAction::Drop,
                 ]),
+                // A concrete label, so the round-trip cannot pass by dropping it.
+                format: Some(engine::types::format::GameFormat::Commander),
             },
             players: vec![alice.clone(), bob.clone()],
             // Every `PairingOutcome` shape, so the round-trip cannot pass by
@@ -15865,6 +15875,8 @@ mod handshake_tests {
                 scoring: Some(ScoringPolicy::default()),
                 bracket: BracketShape::Swiss,
                 total_rounds: None,
+                plus_rounds: None,
+                format: None,
             },
             &env,
         );

--- a/crates/server-core/src/client_message_wire_guard.rs
+++ b/crates/server-core/src/client_message_wire_guard.rs
@@ -193,9 +193,16 @@ pub fn guard_client_message_before_dispatch(
         // validation the broker crate cannot depend on. The identical calls
         // appear in `guard_broker_projection_inbound`; `both_inbound_guards_agree_
         // on_every_tournament_variant` is what keeps the two from drifting.
-        ClientMessage::CreateTournament { name, .. } => {
-            validate_create_tournament_fields(CreateTournamentFields { name })
-        }
+        ClientMessage::CreateTournament {
+            name,
+            total_rounds,
+            plus_rounds,
+            ..
+        } => validate_create_tournament_fields(CreateTournamentFields {
+            name,
+            total_rounds: *total_rounds,
+            plus_rounds: *plus_rounds,
+        }),
         ClientMessage::JoinTournament {
             code,
             player_key,
@@ -461,9 +468,16 @@ pub fn guard_broker_projection_inbound(msg: &ClientMessage) -> Result<(), String
         // map into the broker, so anything unbounded here is an unbounded
         // clone — the same hazard `UpdateLobbyMetadata`'s arm above exists to
         // prevent.
-        ClientMessage::CreateTournament { name, .. } => {
-            validate_create_tournament_fields(CreateTournamentFields { name })
-        }
+        ClientMessage::CreateTournament {
+            name,
+            total_rounds,
+            plus_rounds,
+            ..
+        } => validate_create_tournament_fields(CreateTournamentFields {
+            name,
+            total_rounds: *total_rounds,
+            plus_rounds: *plus_rounds,
+        }),
         ClientMessage::JoinTournament {
             code,
             player_key,
@@ -837,6 +851,8 @@ mod tests {
                     scoring: Some(ScoringPolicy::default()),
                     bracket: BracketShape::Swiss,
                     total_rounds: None,
+                    plus_rounds: None,
+                    format: None,
                 },
             ),
             (
@@ -919,6 +935,8 @@ mod tests {
                 scoring: Some(ScoringPolicy::default()),
                 bracket: BracketShape::Swiss,
                 total_rounds: Some(3),
+                plus_rounds: None,
+                format: None,
             },
             ClientMessage::JoinTournament {
                 code: "TOUR01".into(),

--- a/crates/server-core/src/protocol.rs
+++ b/crates/server-core/src/protocol.rs
@@ -5,7 +5,7 @@ use engine::types::ability::AbilityBlockEntry;
 use engine::types::action_rejection::ActionRejection;
 use engine::types::actions::GameAction;
 use engine::types::events::GameEvent;
-use engine::types::format::FormatConfig;
+use engine::types::format::{FormatConfig, GameFormat};
 use engine::types::game_state::GameState;
 use engine::types::identifiers::ObjectId;
 use engine::types::interaction::{
@@ -548,6 +548,17 @@ pub enum ClientMessage {
         bracket: BracketShape,
         #[serde(default)]
         total_rounds: Option<u32>,
+        /// "Automatic + N" round addend, mirroring
+        /// [`lobby_broker::LobbyClientMessage::CreateTournament`]'s field in the
+        /// same position with the same serde attribute (added in lockstep for
+        /// lobby protocol 7). Mutually exclusive with `total_rounds`.
+        #[serde(default)]
+        plus_rounds: Option<u32>,
+        /// The event's game-format label, mirroring
+        /// [`lobby_broker::LobbyClientMessage::CreateTournament`]'s field. A
+        /// display label only; the tournament enforces no deck legality.
+        #[serde(default)]
+        format: Option<GameFormat>,
     },
     JoinTournament {
         code: String,

--- a/scripts/check-protocol-version.mjs
+++ b/scripts/check-protocol-version.mjs
@@ -7,7 +7,7 @@ const EXPECTED_PROTOCOL_VERSION = 66;
 // The LOBBY message-set version, not derived from the full-game number above.
 // The classifier below refuses an expression only on the SOURCE constants; this
 // script never reads itself, so its own EXPECTED_* must stay literals.
-const EXPECTED_LOBBY_PROTOCOL_VERSION = 6;
+const EXPECTED_LOBBY_PROTOCOL_VERSION = 7;
 // The capability FLOOR for correlated tournament settlement — a different kind
 // of number from the other version constants here, and the reason it is pinned
 // separately. Those track a surface's current version; this one is frozen at the


### PR DESCRIPTION
Adds two organizer-facing options to the tournament create flow, bumping the lobby protocol **6→7**. Both are broker-authoritative (the tournament is shared, broadcast state) and **purely additive**, so `MIN_SUPPORTED_LOBBY_PROTOCOL` stays at 2 and — unlike v6's scoring relaxation — **no capability floor is needed**: a pre-v7 broker ignores the new client fields (a silent capability loss, not a parse error), and its summary omitting `format` is inert against a `JSON.parse` client.

## What it adds

- **Game format** — `CreateTournament.format: Option<GameFormat>`, a display label only (the tournament enforces no deck legality and never touches `GameState`), echoed back resolved on `TournamentSummary.format`. Mirrors the `format: Option<GameFormat>` a `LobbyGame` listing already carries. The create form renders a `<select>` from the shared `FORMAT_REGISTRY` (the same list the game-host picker uses); the detail page shows the resolved label.
- **Automatic + N rounds** — `CreateTournament.plus_rounds: Option<u32>` adds N to the bracket/arity-derived default round count (the "Swiss plus N" community shape). The resolver folds it into the live-default tier, and the round-1 latch captures `base + N`, so the "+N" survives a mid-event drop exactly as the base does. Mutually exclusive with the exact `total_rounds` override — rejected at validation.

## Mirror kept in lockstep

The tournament protocol is mirrored across `lobby-broker` and `server-core`, so both `LobbyClientMessage::CreateTournament` and `ClientMessage::CreateTournament` gain the two fields in the **same declaration order**, and `phase-server`'s projection threads them. The version bumped atomically across Rust (`LOBBY_PROTOCOL_VERSION`), TS (`ws-adapter.ts`), and `scripts/check-protocol-version.mjs`; the version-history doc entry and the `spans_lobby_versions_four_through_seven` test grew a step per the file's stated convention.

## Verification

- **Rust**: `cargo clippy` (lobby-broker + server-core + phase-server) clean; lobby-broker 221 lib/integration tests pass (incl. new resolver/latch, format-projection, and mutual-exclusion tests); phase-server both canonical mirror-roundtrip tests pass (the two enums *and* the view-with-`format` serialize identically across the projection).
- **Frontend**: type-check, eslint, 255 tests (incl. wire-frame, form-submission, and locale-parity — 4 new keys × 7 locales), and `check-protocol-version.mjs` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011BvCePEHnBgxPwsDPdYupM

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tournament creation now supports selecting an optional game format.
  * Added an “Automatic + N” option for configuring additional Swiss rounds.
  * Tournament details display the selected game format.
* **Bug Fixes**
  * Prevented conflicting fixed-round and additional-round settings from being submitted together.
* **Documentation**
  * Added localized labels and guidance for the new settings in English, German, Spanish, French, Italian, Polish, and Portuguese.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->