### PR TITLE
fix(game): keep log rail separate from board layers

### DIFF
--- a/client/src/components/log/GameLogPanel.tsx
+++ b/client/src/components/log/GameLogPanel.tsx
@@ -1,5 +1,4 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
 import { useTranslation } from "react-i18next";
 
 import { LOG_CATEGORIES, type GameLogEntry, type LogCategory } from "../../adapter/types.ts";
@@ -61,7 +60,6 @@ export function GameLogPanel() {
   const setLogPanelOpenByUser = useUiStore((s) => s.setLogPanelOpenByUser);
   const inspectObjectSticky = useUiStore((s) => s.inspectObjectSticky);
   const gameSessionGeneration = useGameStore((s) => s.gameSessionGeneration);
-  const reduceMotion = useReducedMotion();
   const isMobile = useIsMobile();
 
   const [view, setView] = useState<LogView>("timeline");
@@ -228,17 +226,13 @@ export function GameLogPanel() {
 
   const filterSummary = t("log.filterSummary", { count: filteredEntries.length });
 
+  if (!isOpen) return null;
+
   return (
-    <AnimatePresence>
-      {isOpen && (
-        <motion.aside
+        <aside
           role="region"
           aria-label={t("log.panelLabel")}
           className="flex h-[min(50dvh,28rem)] w-full shrink-0 flex-col border-t border-gray-700 bg-gray-900/95 pb-[env(safe-area-inset-bottom)] shadow-2xl lg:h-full lg:w-80 lg:border-l lg:border-t-0"
-          initial={{ opacity: 0 }}
-          animate={{ opacity: 1 }}
-          exit={{ opacity: 0 }}
-          transition={reduceMotion ? { duration: 0 } : { type: "spring", stiffness: 300, damping: 30 }}
         >
           <div className="flex items-center justify-between border-b border-gray-700 px-3 py-2">
             <h3 className="text-xs font-semibold uppercase tracking-wider text-gray-300">{t("log.title")}</h3>
@@ -280,8 +274,6 @@ export function GameLogPanel() {
           </div>
           {unreadCount > 0 && <button type="button" onClick={jumpToLatest} className="m-2 min-h-11 rounded bg-cyan-700 px-3 text-xs font-medium text-white shadow focus-visible:outline focus-visible:outline-2 focus-visible:outline-cyan-200">{t("log.jumpToLatest", { count: unreadCount })}</button>}
           <p className="sr-only" aria-live="polite">{copyStatus === "success" ? t("log.copySuccess") : copyStatus === "failure" ? t("log.copyFailure") : filterSummary}</p>
-        </motion.aside>
-      )}
-    </AnimatePresence>
+        </aside>
   );
 }

--- a/client/src/components/log/__tests__/GameLogPanel.test.tsx
+++ b/client/src/components/log/__tests__/GameLogPanel.test.tsx
@@ -268,6 +268,14 @@ describe("GameLogPanel", () => {
     expect(useUiStore.getState().logPanelOpen).toBe(false);
   });
 
+  it("releases its flex-layout column immediately when closed", () => {
+    render(<GameLogPanel />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Close game log" }));
+
+    expect(screen.queryByRole("region", { name: "Game log panel" })).not.toBeInTheDocument();
+  });
+
   it("seeds the panel open on desktop from the shipped default", () => {
     // Driven from the store's REAL default rather than a literal "open": with a
     // literal this test would pass against the pre-change seed effect too and so

--- a/client/src/pages/GamePage.tsx
+++ b/client/src/pages/GamePage.tsx
@@ -1478,7 +1478,7 @@ function GamePageContent({
     >
       <div
         ref={containerRef}
-        className="relative min-h-0 min-w-0 flex-1 overflow-hidden"
+        className="relative z-0 isolate min-h-0 min-w-0 flex-1 overflow-hidden"
         style={gamePageStyle}
       onContextMenu={(e) => {
         e.preventDefault();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Closed game logs now release their layout space immediately.
  - Improved layering and stacking behavior for elements on the game board.

- **Style**
  - Simplified game log panel transitions for more predictable open and close behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->