### PR TITLE
fix(client): import authoritative game state exports

### DIFF
--- a/client/src/components/menu/LoadGameStateModal.tsx
+++ b/client/src/components/menu/LoadGameStateModal.tsx
@@ -4,7 +4,7 @@ import { motion, AnimatePresence } from "framer-motion";
 import { useTranslation } from "react-i18next";
 
 import { menuButtonClass } from "./buttonStyles";
-import type { GameState } from "../../adapter/types";
+import type { PersistedGameState } from "../../adapter/types";
 import {
   gameStateFromImportText,
   readImportFile,
@@ -15,9 +15,9 @@ type LoadTab = "paste" | "file";
 interface LoadGameStateModalProps {
   open: boolean;
   onClose: () => void;
-  /** Invoked with a validated GameState once parsing succeeds. The caller owns
+  /** Invoked with a validated persisted game state once parsing succeeds. The caller owns
    *  persistence + navigation into the game. */
-  onLoaded: (state: GameState) => void;
+  onLoaded: (state: PersistedGameState) => void;
 }
 
 export function LoadGameStateModal({ open, onClose, onLoaded }: LoadGameStateModalProps) {

--- a/client/src/game/dispatch.ts
+++ b/client/src/game/dispatch.ts
@@ -1,4 +1,4 @@
-import type { AiActionProposal, EngineAdapter, EngineSnapshot, GameAction, GameEvent, GameLogEntry, GameState, RewindOption, WaitingFor } from "../adapter/types";
+import type { AiActionProposal, EngineAdapter, EngineSnapshot, GameAction, GameEvent, GameLogEntry, GameState, PersistedGameState, RewindOption, WaitingFor } from "../adapter/types";
 import type {
   InteractionPreview,
   InteractionPreviewRequest,
@@ -986,11 +986,11 @@ export async function processRemoteUpdate(
 }
 
 /**
- * Restore a previously captured GameState snapshot.
+ * Restore a previously captured game-state snapshot or trusted persistence envelope.
  * Returns null on success, or an error message string on failure.
  */
 export async function restoreGameState(
-  state: GameState,
+  state: PersistedGameState,
   options: { preserveCheckpoints?: boolean } = {},
 ): Promise<string | null> {
   const { adapter, gameId } = useGameStore.getState();

--- a/client/src/pages/MenuPage.tsx
+++ b/client/src/pages/MenuPage.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router";
 
-import type { GameState } from "../adapter/types";
+import { persistedGameStateView, type PersistedGameState } from "../adapter/types";
 import { useAudioContext } from "../audio/useAudioContext";
 import { PreviewBadge } from "../components/chrome/PreviewBadge";
 import { LoadGameStateModal } from "../components/menu/LoadGameStateModal";
@@ -45,15 +45,15 @@ export function MenuPage() {
     }).catch(() => {/* prewarm is best-effort */});
   }, [cardStatus, lastFormat, lastMatchType]);
 
-  // Load an externally-provided GameState (pasted JSON / exported .zip): persist
+  // Load an externally-provided state (pasted JSON / exported .zip): persist
   // under a fresh gameId, record AI active-game meta, navigate into the game.
   const handleLoadState = useCallback(
-    async (state: GameState) => {
+    async (state: PersistedGameState) => {
       const gameId = crypto.randomUUID();
       await saveGame(gameId, state);
       saveActiveGame({ id: gameId, mode: "ai", difficulty: "Medium" });
       useGameStore.setState({ gameId });
-      const playerCount = state.players?.length ?? 0;
+      const playerCount = persistedGameStateView(state).players.length;
       const playersParam = playerCount > 2 ? `&players=${playerCount}` : "";
       navigate(`/game/${gameId}?mode=ai&difficulty=Medium${playersParam}`);
     },

--- a/client/src/services/__tests__/gameStateExport.test.ts
+++ b/client/src/services/__tests__/gameStateExport.test.ts
@@ -111,6 +111,12 @@ describe("gameStateExport", () => {
     expect(imported).toEqual(trustedEnvelope);
   });
 
+  it("rejects an incomplete game state import", () => {
+    expect(gameStateFromImportText(JSON.stringify({ waiting_for: { type: "Priority" } }))).toBe(
+      "JSON does not look like a GameState (missing waiting_for)",
+    );
+  });
+
   it("exports the trusted envelope from the P2P host", async () => {
     const trustedState = JSON.stringify({ state: { players: [{ hand: ["host-only-card"] }] } });
     const adapter = buildEngineAdapterMock(undefined, {

--- a/client/src/services/__tests__/gameStateExport.test.ts
+++ b/client/src/services/__tests__/gameStateExport.test.ts
@@ -9,6 +9,7 @@ import {
   exportAuthoritativeGameStateZip,
   serializeGameStateDebugSnapshot,
 } from "../gameStateExport.ts";
+import { gameStateFromImportText, readImportFile } from "../gameStateImport.ts";
 
 describe("gameStateExport", () => {
   afterEach(() => {
@@ -73,11 +74,13 @@ describe("gameStateExport", () => {
     expect(JSON.parse(json).gameState.turn_number).toBe(7);
   });
 
-  it("writes the trusted engine envelope, not the client snapshot", async () => {
-    const trustedState = JSON.stringify({
-      state: { stack_resolution_session: { policy: "RecheckNoMeaningfulPriorityAction" } },
-      schema_version: 1,
-    });
+  it("imports an authoritative state ZIP without discarding its trusted envelope", async () => {
+    const gameState = buildGameState({ turn_number: 7 });
+    const trustedEnvelope = {
+      state: gameState,
+      precast_shortcut_runtime: { nonce: "trusted-runtime" },
+    };
+    const trustedState = JSON.stringify(trustedEnvelope);
     let writtenBlob: Blob | null = null;
     const write = vi.fn(async (blob: Blob) => {
       writtenBlob = blob;
@@ -101,6 +104,11 @@ describe("gameStateExport", () => {
     const [entryName] = Object.keys(entries);
     expect(entryName).toMatch(/^authoritative-game-state-.*\.json$/);
     expect(strFromU8(entries[entryName])).toBe(trustedState);
+
+    const imported = gameStateFromImportText(
+      await readImportFile(new File([writtenBlob!], filename, { type: "application/zip" })),
+    );
+    expect(imported).toEqual(trustedEnvelope);
   });
 
   it("exports the trusted envelope from the P2P host", async () => {

--- a/client/src/services/__tests__/gameStateExport.test.ts
+++ b/client/src/services/__tests__/gameStateExport.test.ts
@@ -113,7 +113,7 @@ describe("gameStateExport", () => {
 
   it("rejects an incomplete game state import", () => {
     expect(gameStateFromImportText(JSON.stringify({ waiting_for: { type: "Priority" } }))).toBe(
-      "JSON does not look like a GameState (missing waiting_for)",
+      "JSON does not look like a GameState (missing waiting_for or players)",
     );
   });
 

--- a/client/src/services/gameStateImport.ts
+++ b/client/src/services/gameStateImport.ts
@@ -34,7 +34,12 @@ export function gameStateFromImportText(importText: string): PersistedGameState 
   }
   const state = persistedGameStateView(persistedState);
 
-  if (!state || typeof state !== "object" || !("waiting_for" in state)) {
+  if (
+    !state
+    || typeof state !== "object"
+    || !("waiting_for" in state)
+    || !Array.isArray(state.players)
+  ) {
     return "JSON does not look like a GameState (missing waiting_for)";
   }
 

--- a/client/src/services/gameStateImport.ts
+++ b/client/src/services/gameStateImport.ts
@@ -30,7 +30,7 @@ export function gameStateFromImportText(importText: string): PersistedGameState 
       : parsed
   ) as PersistedGameState;
   if (!persistedState || typeof persistedState !== "object") {
-    return "JSON does not look like a GameState (missing waiting_for)";
+    return "JSON does not look like a GameState (missing waiting_for or players)";
   }
   const state = persistedGameStateView(persistedState);
 
@@ -40,7 +40,7 @@ export function gameStateFromImportText(importText: string): PersistedGameState 
     || !("waiting_for" in state)
     || !Array.isArray(state.players)
   ) {
-    return "JSON does not look like a GameState (missing waiting_for)";
+    return "JSON does not look like a GameState (missing waiting_for or players)";
   }
 
   return persistedState;

--- a/client/src/services/gameStateImport.ts
+++ b/client/src/services/gameStateImport.ts
@@ -1,16 +1,20 @@
 import { strFromU8, unzipSync } from "fflate";
 
-import type { GameState } from "../adapter/types.ts";
+import {
+  persistedGameStateView,
+  type PersistedGameState,
+} from "../adapter/types.ts";
 
 /**
  * Parse import text into a `GameState`, or return a human-readable error string.
  *
- * Accepts either a bare `GameState` or the full debug-export wrapper
- * (`{ gameState, waitingFor, ... }`) produced by `gameStateExport.ts`. The
- * presence of `waiting_for` on the resolved object is the structural marker
- * that distinguishes a GameState from arbitrary JSON.
+ * Accepts a bare `GameState`, the full debug-export wrapper
+ * (`{ gameState, waitingFor, ... }`), or a trusted persistence envelope
+ * (`{ state, ... }`) produced by `gameStateExport.ts`. The presence of
+ * `waiting_for` on the resolved public state is the structural marker that
+ * distinguishes a game state from arbitrary JSON.
  */
-export function gameStateFromImportText(importText: string): GameState | string {
+export function gameStateFromImportText(importText: string): PersistedGameState | string {
   let parsed: unknown;
   try {
     parsed = JSON.parse(importText);
@@ -18,18 +22,23 @@ export function gameStateFromImportText(importText: string): GameState | string 
     return "Invalid JSON";
   }
 
-  // Accept either a bare GameState or the full debug export format {gameState, ...}
-  const state = (
+  // The debug export nests a raw state under `gameState`; a trusted persistence
+  // envelope must stay intact so the engine can restore its private runtime.
+  const persistedState = (
     parsed && typeof parsed === "object" && "gameState" in parsed
-      ? (parsed as { gameState: GameState }).gameState
+      ? (parsed as { gameState: PersistedGameState }).gameState
       : parsed
-  ) as GameState;
+  ) as PersistedGameState;
+  if (!persistedState || typeof persistedState !== "object") {
+    return "JSON does not look like a GameState (missing waiting_for)";
+  }
+  const state = persistedGameStateView(persistedState);
 
   if (!state || typeof state !== "object" || !("waiting_for" in state)) {
     return "JSON does not look like a GameState (missing waiting_for)";
   }
 
-  return state;
+  return persistedState;
 }
 
 /**


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved game state importing to correctly recognize and restore persisted game data from supported export formats.
  * Preserved authoritative game state details during export and re-import, including runtime information.
  * Loading an imported game state now maintains the persisted state structure and accurately derives the player count.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->