### PR TITLE
fix(game): keep game log accurate and visible

### DIFF
--- a/client/src/components/card/GameCardPreview.tsx
+++ b/client/src/components/card/GameCardPreview.tsx
@@ -28,6 +28,7 @@ export function GameCardPreview() {
   usePreviewDismiss();
 
   const inspectedObjectId = useUiStore((s) => s.inspectedObjectId);
+  const inspectedCardName = useUiStore((s) => s.inspectedCardName);
   const inspectedFaceIndex = useUiStore((s) => s.inspectedFaceIndex);
   const previewPlacement = useUiStore((s) => s.previewPlacement);
   const isDragging = useUiStore((s) => s.isDragging);
@@ -57,7 +58,7 @@ export function GameCardPreview() {
     inspectedObj && !shouldRenderCardBack(inspectedObj) && inspectedObj.face_down
       ? (inspectedObj.back_face ?? null)
       : null;
-  const inspectedCardName = inspectedObj && !shouldRenderCardBack(inspectedObj)
+  const resolvedCardName = inspectedObj && !shouldRenderCardBack(inspectedObj)
     ? inspectedPeekedFace
       ? inspectedPeekedFace.name
       : inspectedFaceIndex === 1 && inspectedObj.back_face
@@ -76,7 +77,7 @@ export function GameCardPreview() {
       (inspectedObj
         ? faceDownMarkerName(true, inspectedObj.face_down_cause)
           ?? (inspectedObj.zone === "Battlefield" ? t("card.faceDownName") : null)
-        : null);
+        : inspectedCardName);
   // The "other" face: when viewing front, this is back_face; when viewing back,
   // this is the front. A face-down permanent has no OTHER printed face — its
   // `back_face` is the stored real face already shown by the peek.
@@ -91,7 +92,7 @@ export function GameCardPreview() {
 
   return (
     <CardPreview
-      cardName={previewSuppressed ? null : inspectedCardName}
+      cardName={previewSuppressed ? null : resolvedCardName}
       objectId={inspectedObj?.id ?? null}
       backFaceName={previewSuppressed ? null : inspectedOtherFaceName}
       dockSide={cardPreviewMode === "side" || previewPlacement === "side"}

--- a/client/src/components/card/__tests__/GameCardPreview.test.tsx
+++ b/client/src/components/card/__tests__/GameCardPreview.test.tsx
@@ -63,6 +63,7 @@ afterEach(() => {
   useGameStore.setState({ gameState: null, spellCosts: {} });
   useUiStore.setState({
     inspectedObjectId: null,
+    inspectedCardName: null,
     inspectedFaceIndex: 0,
     previewPlacement: "cursor",
     isDragging: false,
@@ -78,6 +79,19 @@ afterEach(() => {
 describe("GameCardPreview", () => {
   it("forwards the inspected object's name to the preview", () => {
     inspect(battlefieldObject());
+
+    render(<GameCardPreview />);
+
+    expect(screen.getAllByAltText("Pithing Needle").length).toBeGreaterThan(0);
+  });
+
+  it("previews a public historical log card after its live object is gone", () => {
+    useGameStore.setState({ gameState: null, spellCosts: {} });
+    useUiStore.setState({
+      inspectedObjectId: 999,
+      inspectedCardName: "Pithing Needle",
+      previewSticky: true,
+    });
 
     render(<GameCardPreview />);
 

--- a/client/src/components/log/GameLogPanel.tsx
+++ b/client/src/components/log/GameLogPanel.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 
-import { LOG_CATEGORIES, type GameLogEntry, type LogCategory } from "../../adapter/types.ts";
+import { LOG_CATEGORIES, type GameLogEntry, type LogCategory, type ObjectId } from "../../adapter/types.ts";
 import { useIsMobile } from "../../hooks/useIsMobile.ts";
 import { useGameStore } from "../../stores/gameStore.ts";
 import { usePreferencesStore } from "../../stores/preferencesStore.ts";
@@ -152,7 +152,9 @@ export function GameLogPanel() {
       return;
     }
     if (nextLogSeq === previousLogSeq) return;
-    const newEntries = rows.filter((row) => timelineRowSeq(row) > previousLogSeq).length;
+    const newEntries = rows.filter(
+      (row) => row.type === "entry" && timelineRowSeq(row) > previousLogSeq,
+    ).length;
     if (newEntries === 0) return;
     const element = scrollRef.current;
     if (element && nearBottomRef.current) {
@@ -192,7 +194,6 @@ export function GameLogPanel() {
   };
 
   const clearFilters = () => {
-    setView("diagnostics");
     setSearchQuery("");
     setTurnFilter(null);
     setCategoryFilter(new Set());
@@ -204,6 +205,13 @@ export function GameLogPanel() {
     if (copyResetRef.current) clearTimeout(copyResetRef.current);
     copyResetRef.current = setTimeout(() => setCopyStatus(null), 3000);
   }, []);
+
+  const inspectLogCardSticky = useCallback(
+    (objectId: ObjectId, fallbackCardName?: string) => {
+      inspectObjectSticky(objectId, 0, "cursor", fallbackCardName);
+    },
+    [inspectObjectSticky],
+  );
 
   const handleExport = () => {
     const blob = new Blob([exportLogEntriesJson(filteredEntries)], { type: "application/json" });
@@ -260,10 +268,17 @@ export function GameLogPanel() {
               <div className="space-y-2 pt-2">
                 <label className="sr-only" htmlFor="game-log-search">{t("log.searchLabel")}</label>
                 <input id="game-log-search" type="search" value={searchQuery} onChange={(event) => setSearchQuery(event.target.value)} placeholder={t("log.searchPlaceholder")} className="min-h-11 w-full rounded-md border border-gray-700 bg-gray-950 px-2 py-1 text-[11px] text-gray-200 placeholder:text-gray-600 focus:border-cyan-500 focus:outline-none" />
-                <div className="flex flex-wrap gap-1">
-                  <button type="button" onClick={() => setTurnFilter(null)} aria-pressed={turnFilter == null} className={`min-h-11 rounded px-2 text-[9px] focus-visible:outline focus-visible:outline-2 focus-visible:outline-cyan-400 ${turnFilter == null ? "bg-cyan-600 text-white" : "bg-gray-800 text-white"}`}>{t("log.allTurns")}</button>
-                  {availableTurns.map((turn) => <button key={turn} type="button" onClick={() => setTurnFilter(turn)} aria-pressed={turnFilter === turn} className={`min-h-11 rounded px-2 text-[9px] tabular-nums focus-visible:outline focus-visible:outline-2 focus-visible:outline-cyan-400 ${turnFilter === turn ? "bg-cyan-600 text-white" : "bg-gray-800 text-white"}`}>{t("log.turnChip", { turn })}</button>)}
-                </div>
+                <label className="block text-[10px] text-gray-300">
+                  {t("log.turnFilterLabel")}
+                  <select
+                    value={turnFilter ?? ""}
+                    onChange={(event) => setTurnFilter(event.target.value ? Number(event.target.value) : null)}
+                    className="mt-1 min-h-11 w-full rounded border border-gray-700 bg-gray-950 px-2 text-xs text-gray-200 focus:border-cyan-500 focus:outline-none"
+                  >
+                    <option value="">{t("log.allTurns")}</option>
+                    {availableTurns.map((turn) => <option key={turn} value={turn}>{t("log.turnChip", { turn })}</option>)}
+                  </select>
+                </label>
                 <div className="flex max-h-20 flex-wrap gap-1 overflow-y-auto">
                   {LOG_CATEGORIES.map((category) => <button key={category} type="button" onClick={() => toggleCategory(category)} aria-pressed={categoryFilter.has(category)} className={`min-h-11 rounded px-2 text-[9px] focus-visible:outline focus-visible:outline-2 focus-visible:outline-cyan-400 ${categoryFilter.has(category) ? "bg-indigo-600 text-white" : "bg-gray-800 text-white"}`}>{t(CATEGORY_LABEL_KEYS[category])}</button>)}
                 </div>
@@ -273,7 +288,7 @@ export function GameLogPanel() {
           </div>
 
           <div ref={scrollRef} role="region" tabIndex={0} aria-label={t("log.title")} onScroll={handleScroll} className="select-text flex-1 overflow-y-auto px-3 py-1 focus-visible:outline focus-visible:outline-2 focus-visible:outline-cyan-400">
-            {rows.length === 0 ? <div className="py-4 text-center text-xs text-gray-500"><p>{t("log.noMatchingEvents")}</p><button type="button" onClick={clearFilters} className="mt-2 min-h-11 rounded px-2 text-cyan-300 focus-visible:outline focus-visible:outline-2 focus-visible:outline-cyan-400">{t("log.clearFilters")}</button></div> : rows.map((row) => row.type === "entry" ? <LogEntry key={row.entry.seq} entry={row.entry} onInspectObjectSticky={inspectObjectSticky} /> : <div key={`divider-${row.divider.seq}`} className="my-2 border-y border-gray-700 py-1 text-center text-[9px] font-semibold uppercase tracking-wide text-gray-500">{row.divider.turn > 0 && `${t("log.turnChip", { turn: row.divider.turn })} · `}{t(`phaseName.${row.divider.phase}`)}</div>)}
+            {rows.length === 0 ? <div className="py-4 text-center text-xs text-gray-500"><p>{t("log.noMatchingEvents")}</p><button type="button" onClick={clearFilters} className="mt-2 min-h-11 rounded px-2 text-cyan-300 focus-visible:outline focus-visible:outline-2 focus-visible:outline-cyan-400">{t("log.clearFilters")}</button></div> : rows.map((row) => row.type === "entry" ? <LogEntry key={row.entry.seq} entry={row.entry} onInspectObjectSticky={inspectLogCardSticky} /> : <div key={`divider-${row.divider.seq}`} className="my-2 border-y border-gray-700 py-1 text-center text-xs font-semibold tracking-wide text-gray-400">{row.divider.turnSegments ? `${segmentsToPlainText(row.divider.turnSegments)} · ` : row.divider.turn > 0 && `${t("log.turnChip", { turn: row.divider.turn })} · `}{t(`phaseName.${row.divider.phase}`)}</div>)}
           </div>
           {unreadCount > 0 && <button type="button" onClick={jumpToLatest} className="m-2 min-h-11 rounded bg-cyan-700 px-3 text-xs font-medium text-white shadow focus-visible:outline focus-visible:outline-2 focus-visible:outline-cyan-200">{t("log.jumpToLatest", { count: unreadCount })}</button>}
           <p className="sr-only" aria-live="polite">{copyStatus === "success" ? t("log.copySuccess") : copyStatus === "failure" ? t("log.copyFailure") : filterSummary}</p>

--- a/client/src/components/log/GameLogPanel.tsx
+++ b/client/src/components/log/GameLogPanel.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import { LOG_CATEGORIES, type GameLogEntry, type LogCategory } from "../../adapter/types.ts";
@@ -122,7 +122,10 @@ export function GameLogPanel() {
   // device-correct — and that matters MORE now the value is written
   // automatically on every user toggle.
   const seededSessionRef = useRef<number | null>(null);
-  useEffect(() => {
+  // Seed before the first paint. A passive effect let a menu click briefly open
+  // the panel and then overwrite that user action with the prior session's
+  // remembered choice.
+  useLayoutEffect(() => {
     if (seededSessionRef.current === gameSessionGeneration) return;
     seededSessionRef.current = gameSessionGeneration;
     setLogPanelOpen(!isMobile && logPanelLastChoice === "open");

--- a/client/src/components/log/LogEntry.tsx
+++ b/client/src/components/log/LogEntry.tsx
@@ -3,20 +3,19 @@ import { memo } from "react";
 import type { GameLogEntry, LogSegment, ObjectId, PlayerId } from "../../adapter/types.ts";
 import { getSeatColor } from "../../hooks/useSeatColor.ts";
 import { useGameStore } from "../../stores/gameStore.ts";
-import { getPlayerDisplayName } from "../../stores/multiplayerStore.ts";
 import { assertNever } from "../../utils/assertNever.ts";
 import { logPresentation, toneClass } from "../../viewmodel/logFormatting.ts";
 
 interface LogEntryProps {
   entry: GameLogEntry;
-  onInspectObjectSticky?: (objectId: ObjectId) => void;
+  onInspectObjectSticky?: (objectId: ObjectId, fallbackCardName?: string) => void;
 }
 
 function renderSegment(
   segment: LogSegment,
   index: number,
   seatOrder: PlayerId[] | undefined,
-  onInspectObjectSticky?: (objectId: ObjectId) => void,
+  onInspectObjectSticky?: (objectId: ObjectId, fallbackCardName?: string) => void,
 ) {
   switch (segment.type) {
     case "Text":
@@ -26,8 +25,8 @@ function renderSegment(
         <button
           key={index}
           type="button"
-          onClick={() => onInspectObjectSticky(segment.value.object_id)}
-          className="font-semibold text-yellow-300 underline decoration-yellow-500/40 underline-offset-2 transition hover:text-yellow-200"
+          onClick={() => onInspectObjectSticky(segment.value.object_id, segment.value.name)}
+          className="font-semibold text-yellow-300 underline decoration-yellow-500/40 underline-offset-2 transition hover:text-yellow-200 focus-visible:outline focus-visible:outline-2 focus-visible:outline-cyan-300"
         >
           {segment.value.name}
         </button>
@@ -43,7 +42,7 @@ function renderSegment(
           className="font-semibold"
           style={{ color: getSeatColor(segment.value.player_id, seatOrder) }}
         >
-          {getPlayerDisplayName(segment.value.player_id)}
+          {segment.value.name}
         </span>
       );
     case "Number":
@@ -87,7 +86,7 @@ export const LogEntry = memo(function LogEntry({ entry, onInspectObjectSticky }:
   const seatOrder = useGameStore((s) => s.gameState?.seat_order);
 
   return (
-    <div data-tone={presentation.tone} className={`border-b border-l border-gray-800 py-0.5 pl-1 font-mono text-[10px] ${colorClass}`}>
+    <div data-tone={presentation.tone} className={`border-b border-l border-gray-800 py-1 pl-2 text-sm leading-5 break-words ${colorClass}`}>
       {entry.segments.map((segment, index) =>
         renderSegment(segment, index, seatOrder, onInspectObjectSticky),
       )}

--- a/client/src/components/log/__tests__/GameLogPanel.test.tsx
+++ b/client/src/components/log/__tests__/GameLogPanel.test.tsx
@@ -186,6 +186,7 @@ describe("GameLogPanel", () => {
     await user.click(within(log).getByRole("button", { name: "Clear filters" }));
     expect(screen.getByRole("searchbox", { name: "Search game log" })).toHaveValue("");
     expect(screen.getByRole("button", { name: "Life" })).toHaveAttribute("aria-pressed", "false");
+    expect(screen.getByRole("button", { name: "Details" })).toHaveAttribute("aria-pressed", "true");
     expect(screen.getByText("Life event")).toBeInTheDocument();
     expect(log.scrollTop).toBe(40);
   });
@@ -206,10 +207,39 @@ describe("GameLogPanel", () => {
     render(<GameLogPanel />);
 
     await user.click(screen.getByRole("button", { name: "Filters (0)" }));
-    await user.click(screen.getByRole("button", { name: "Turn" }));
+    await user.selectOptions(screen.getByRole("combobox", { name: "Filter by turn" }), "2");
 
     expect(screen.getByText("T2 · Upkeep")).toBeInTheDocument();
     expect(screen.queryByText("No matching events")).not.toBeInTheDocument();
+  });
+
+  it("keeps an engine-authored active player in a coalesced timeline divider", () => {
+    useGameStore.setState({
+      logHistory: [
+        entry(0, "", {
+          turn: 2,
+          phase: "Untap",
+          category: "Turn",
+          segments: [
+            { type: "Text", value: "Turn " },
+            { type: "Number", value: 2 },
+            { type: "Text", value: " — " },
+            { type: "PlayerName", value: { name: "Chandra", player_id: 1 } },
+          ],
+          presentation: { importance: "Context", tone: "Neutral", boundary: "Turn", visibility: "Public" },
+        }),
+        entry(1, "", {
+          turn: 2,
+          phase: "DeclareAttackers",
+          category: "Turn",
+          presentation: { importance: "Context", tone: "Neutral", boundary: "Phase", visibility: "Public" },
+        }),
+        entry(2, "Balduvian Bears attacks Chandra", { turn: 2, category: "Combat" }),
+      ],
+    });
+    render(<GameLogPanel />);
+
+    expect(screen.getByText(/Turn 2 — Chandra · Declare Attackers/)).toBeInTheDocument();
   });
 
   it("opens a closed panel when the game ends and can then be dismissed", () => {
@@ -401,6 +431,7 @@ describe("GameLogPanel", () => {
 
     expect(useUiStore.getState()).toMatchObject({
       inspectedObjectId: 42,
+      inspectedCardName: "Pithing Needle",
       previewSticky: true,
     });
   });

--- a/client/src/components/log/__tests__/GameLogPanel.test.tsx
+++ b/client/src/components/log/__tests__/GameLogPanel.test.tsx
@@ -209,7 +209,7 @@ describe("GameLogPanel", () => {
     await user.click(screen.getByRole("button", { name: "Filters (0)" }));
     await user.selectOptions(screen.getByRole("combobox", { name: "Filter by turn" }), "2");
 
-    expect(screen.getByText("T2 · Upkeep")).toBeInTheDocument();
+    expect(screen.getByText("Turn 2 · Upkeep")).toBeInTheDocument();
     expect(screen.queryByText("No matching events")).not.toBeInTheDocument();
   });
 

--- a/client/src/i18n/locales/de/game.json
+++ b/client/src/i18n/locales/de/game.json
@@ -965,6 +965,7 @@
     "genericEvent": "Ereignis: {{type}}",
     "searchPlaceholder": "Search log…",
     "allTurns": "All turns",
+    "turnFilterLabel": "Nach Zug filtern",
     "turnChip": "T{{turn}}",
     "entryCount": "{{count}} entries",
     "copy": "Copy",

--- a/client/src/i18n/locales/en/game.json
+++ b/client/src/i18n/locales/en/game.json
@@ -917,6 +917,7 @@
     "verbosityMinimal": "minimal",
     "searchPlaceholder": "Search log…",
     "allTurns": "All turns",
+    "turnFilterLabel": "Filter by turn",
     "turnChip": "T{{turn}}",
     "entryCount": "{{count}} entries",
     "copy": "Copy",

--- a/client/src/i18n/locales/es/game.json
+++ b/client/src/i18n/locales/es/game.json
@@ -965,6 +965,7 @@
     "genericEvent": "Evento: {{type}}",
     "searchPlaceholder": "Search log…",
     "allTurns": "All turns",
+    "turnFilterLabel": "Filtrar por turno",
     "turnChip": "T{{turn}}",
     "entryCount": "{{count}} entries",
     "copy": "Copy",

--- a/client/src/i18n/locales/fr/game.json
+++ b/client/src/i18n/locales/fr/game.json
@@ -965,6 +965,7 @@
     "genericEvent": "Événement : {{type}}",
     "searchPlaceholder": "Search log…",
     "allTurns": "All turns",
+    "turnFilterLabel": "Filtrer par tour",
     "turnChip": "T{{turn}}",
     "entryCount": "{{count}} entries",
     "copy": "Copy",

--- a/client/src/i18n/locales/it/game.json
+++ b/client/src/i18n/locales/it/game.json
@@ -965,6 +965,7 @@
     "genericEvent": "Evento: {{type}}",
     "searchPlaceholder": "Search log…",
     "allTurns": "All turns",
+    "turnFilterLabel": "Filtra per turno",
     "turnChip": "T{{turn}}",
     "entryCount": "{{count}} entries",
     "copy": "Copy",

--- a/client/src/i18n/locales/pl/game.json
+++ b/client/src/i18n/locales/pl/game.json
@@ -965,6 +965,7 @@
     "genericEvent": "Zdarzenie: {{type}}",
     "searchPlaceholder": "Search log…",
     "allTurns": "All turns",
+    "turnFilterLabel": "Filtruj według tury",
     "turnChip": "T{{turn}}",
     "entryCount": "{{count}} entries",
     "copy": "Copy",

--- a/client/src/i18n/locales/pt/game.json
+++ b/client/src/i18n/locales/pt/game.json
@@ -965,6 +965,7 @@
     "genericEvent": "Evento: {{type}}",
     "searchPlaceholder": "Search log…",
     "allTurns": "All turns",
+    "turnFilterLabel": "Filtrar por turno",
     "turnChip": "T{{turn}}",
     "entryCount": "{{count}} entries",
     "copy": "Copy",

--- a/client/src/pages/GamePage.tsx
+++ b/client/src/pages/GamePage.tsx
@@ -1992,10 +1992,6 @@ function GamePageContent({
       <AttackRequirementBadges />
       <BlockerConstraintBadges />
 
-      {/* Card preview overlay. Owns its own inspect-state subscriptions so a
-          hover doesn't re-render GamePageContent (and the whole battlefield). */}
-      <GameCardPreview />
-
       {/* WaitingFor-driven prompt overlays (only for human player).
           Wrapped in DialogHost so any active dialog can be peeked away to
           reveal the battlefield underneath; peek state resets on every
@@ -2343,6 +2339,9 @@ function GamePageContent({
       />
       </div>
       <GameLogPanel />
+      {/* This is a peer of the board and log columns: a preview opened from a
+          log card must not be clipped by the paint-contained board column. */}
+      <GameCardPreview />
     </div>
   );
 }

--- a/client/src/pages/GamePage.tsx
+++ b/client/src/pages/GamePage.tsx
@@ -1376,9 +1376,6 @@ function GamePageContent({
   const gamePageStyle = {
     "--game-top-overlay-offset": `${topOverlayOffsetPx}px`,
     "--game-split-safe-top": "0px",
-    // Fixed board tools are descendants of the game column, while the log is
-    // its sibling. Keep those tools out of the dedicated log column.
-    "--game-right-rail-offset": logPanelOpen && !isMobile ? "20rem" : "0px",
     "--game-left-rail-offset": "0px",
     // Where the targeting prompt starts, which is the only part of its
     // placement this page can state: the split layout puts seat panes at the
@@ -1478,7 +1475,7 @@ function GamePageContent({
     >
       <div
         ref={containerRef}
-        className="relative z-0 isolate min-h-0 min-w-0 flex-1 overflow-hidden"
+        className="relative min-h-0 min-w-0 flex-1 overflow-hidden contain-paint"
         style={gamePageStyle}
       onContextMenu={(e) => {
         e.preventDefault();

--- a/client/src/stores/__tests__/uiStore.test.ts
+++ b/client/src/stores/__tests__/uiStore.test.ts
@@ -11,6 +11,7 @@ describe("uiStore", () => {
         selectedObjectId: null,
         hoveredObjectId: null,
         inspectedObjectId: null,
+        inspectedCardName: null,
         inspectedFaceIndex: 0,
         altHeld: false,
         selectedCardIds: [],
@@ -34,6 +35,19 @@ describe("uiStore", () => {
   it("inspectObject sets inspectedObjectId", () => {
     act(() => useUiStore.getState().inspectObject(99));
     expect(useUiStore.getState().inspectedObjectId).toBe(99);
+  });
+
+  it("keeps a public log card name when its live object is unavailable", () => {
+    act(() => useUiStore.getState().inspectObjectSticky(99, 0, "cursor", "Pithing Needle"));
+
+    expect(useUiStore.getState()).toMatchObject({
+      inspectedObjectId: 99,
+      inspectedCardName: "Pithing Needle",
+      previewSticky: true,
+    });
+
+    act(() => useUiStore.getState().dismissPreview());
+    expect(useUiStore.getState().inspectedCardName).toBeNull();
   });
 
   it("inspecting a different object resets a pinned altHeld", () => {

--- a/client/src/stores/uiStore.ts
+++ b/client/src/stores/uiStore.ts
@@ -560,7 +560,7 @@ export const useUiStore = create<UiStore>()((set, get) => ({
     }
   },
 
-  inspectObjectSticky: (id, faceIndex = 0, placement = "cursor", fallbackCardName = null) => {
+  inspectObjectSticky: (id, faceIndex = 0, placement = "cursor", fallbackCardName) => {
     if (pendingClearTimer != null) {
       clearTimeout(pendingClearTimer);
       pendingClearTimer = null;
@@ -568,7 +568,7 @@ export const useUiStore = create<UiStore>()((set, get) => ({
     cancelPendingShow();
     set({
       inspectedObjectId: id,
-      inspectedCardName: fallbackCardName,
+      inspectedCardName: fallbackCardName ?? null,
       inspectedFaceIndex: faceIndex,
       previewPlacement: placement,
       previewSticky: true,

--- a/client/src/stores/uiStore.ts
+++ b/client/src/stores/uiStore.ts
@@ -194,6 +194,9 @@ interface UiStoreState {
   selectedObjectId: ObjectId | null;
   hoveredObjectId: ObjectId | null;
   inspectedObjectId: ObjectId | null;
+  /** Public printed-card name retained by a historical log entry when its live
+   * object is no longer in the current game state. */
+  inspectedCardName: string | null;
   inspectedFaceIndex: number;
   /** Presentation requested by the element that opened the current preview. */
   previewPlacement: PreviewPlacement;
@@ -314,7 +317,12 @@ interface UiStoreActions {
   ) => void;
   /** Open a preview from an explicit interaction and keep it visible until a
    * later outside interaction dismisses it. */
-  inspectObjectSticky: (id: ObjectId, faceIndex?: number, placement?: PreviewPlacement) => void;
+  inspectObjectSticky: (
+    id: ObjectId,
+    faceIndex?: number,
+    placement?: PreviewPlacement,
+    fallbackCardName?: string,
+  ) => void;
   dismissPreview: () => void;
   setAltHeld: (held: boolean) => void;
   setShiftHeld: (held: boolean) => void;
@@ -399,6 +407,7 @@ export const useUiStore = create<UiStore>()((set, get) => ({
   selectedObjectId: null,
   hoveredObjectId: null,
   inspectedObjectId: null,
+  inspectedCardName: null,
   inspectedFaceIndex: 0,
   previewPlacement: "cursor",
   altHeld: false,
@@ -460,6 +469,7 @@ export const useUiStore = create<UiStore>()((set, get) => ({
       const applyInspect = () =>
         set((s) => ({
           inspectedObjectId: id,
+          inspectedCardName: null,
           inspectedFaceIndex: faceIndex ?? 0,
           previewPlacement: placement,
           // Inspecting a DIFFERENT object replaces (dismisses) the previous
@@ -540,6 +550,7 @@ export const useUiStore = create<UiStore>()((set, get) => ({
         cancelPendingShow();
         set({
           inspectedObjectId: null,
+          inspectedCardName: null,
           inspectedFaceIndex: 0,
           previewPlacement: "cursor",
           previewSticky: false,
@@ -549,7 +560,7 @@ export const useUiStore = create<UiStore>()((set, get) => ({
     }
   },
 
-  inspectObjectSticky: (id, faceIndex = 0, placement = "cursor") => {
+  inspectObjectSticky: (id, faceIndex = 0, placement = "cursor", fallbackCardName = null) => {
     if (pendingClearTimer != null) {
       clearTimeout(pendingClearTimer);
       pendingClearTimer = null;
@@ -557,6 +568,7 @@ export const useUiStore = create<UiStore>()((set, get) => ({
     cancelPendingShow();
     set({
       inspectedObjectId: id,
+      inspectedCardName: fallbackCardName,
       inspectedFaceIndex: faceIndex,
       previewPlacement: placement,
       previewSticky: true,
@@ -572,6 +584,7 @@ export const useUiStore = create<UiStore>()((set, get) => ({
     cancelPendingShow();
     set({
       inspectedObjectId: null,
+      inspectedCardName: null,
       inspectedFaceIndex: 0,
       previewPlacement: "cursor",
       previewSticky: false,

--- a/client/src/viewmodel/__tests__/logFormatting.test.ts
+++ b/client/src/viewmodel/__tests__/logFormatting.test.ts
@@ -33,6 +33,16 @@ describe("game log presentation", () => {
     expect(filterLogByView(entries, "details").map((value) => value.seq)).toEqual([1, 2, 3]);
     expect(filterLogByView(entries, "diagnostics").map((value) => value.seq)).toEqual([1, 2, 3, 4]);
     expect(filterLogByView(entries, "timeline", new Set(["Debug"]))).toEqual([entries[3]]);
+
+    const boundary = entry("Context", {
+      seq: 5,
+      category: "Turn",
+      presentation: { importance: "Context", tone: "Neutral", boundary: "Turn", visibility: "Public" },
+    });
+    expect(filterLogByView([boundary, entries[0]], "timeline", new Set(["Stack"]))).toEqual([
+      boundary,
+      entries[0],
+    ]);
   });
 
   it("requires an explicit diagnostics opt-in for hidden information", () => {
@@ -75,8 +85,26 @@ describe("game log presentation", () => {
 
     expect(timelineRows([firstBoundary, secondBoundary])).toEqual([]);
     expect(timelineRows([firstBoundary, secondBoundary], true)).toEqual([
-      { type: "divider", divider: { seq: 1, turn: 1, phase: "Upkeep", boundary: "Turn" } },
-      { type: "divider", divider: { seq: 2, turn: 2, phase: "Draw", boundary: "Turn" } },
+      {
+        type: "divider",
+        divider: {
+          seq: 1,
+          turn: 1,
+          phase: "Upkeep",
+          boundary: "Turn",
+          turnSegments: firstBoundary.segments,
+        },
+      },
+      {
+        type: "divider",
+        divider: {
+          seq: 2,
+          turn: 2,
+          phase: "Draw",
+          boundary: "Turn",
+          turnSegments: secondBoundary.segments,
+        },
+      },
     ]);
     expect(timelineRows([{ ...firstBoundary, turn: 0 }], true)).toEqual([]);
   });

--- a/client/src/viewmodel/__tests__/logSearch.test.ts
+++ b/client/src/viewmodel/__tests__/logSearch.test.ts
@@ -32,6 +32,19 @@ describe("logSearch", () => {
     expect(segmentsToPlainText(result[0].segments)).toContain("damage");
   });
 
+  it("keeps preceding engine-authored turn context beside a search result", () => {
+    const turn = {
+      ...entry("Turn", "Turn 4 — Chandra", 4),
+      presentation: { importance: "Context" as const, tone: "Neutral" as const, boundary: "Turn" as const, visibility: "Public" as const },
+    };
+    const match = entry("Combat", "Balduvian Bears attacks Chandra", 4);
+
+    expect(filterLogEntries([turn, match], { query: "Balduvian", categories: null, turn: null })).toEqual([
+      turn,
+      match,
+    ]);
+  });
+
   it("does not expose pregame turn zero as a turn filter", () => {
     const turns = uniqueTurns([entry("Game", "setup", 0), entry("Stack", "cast", 1)]);
     expect(turns).toEqual([1]);

--- a/client/src/viewmodel/logFormatting.ts
+++ b/client/src/viewmodel/logFormatting.ts
@@ -14,6 +14,8 @@ export interface LogDivider {
   turn: number;
   phase: GameLogEntry["phase"];
   boundary: Exclude<LogBoundary, "None">;
+  /** Engine-authored TurnStarted segments, retained when a later phase boundary coalesces. */
+  turnSegments: GameLogEntry["segments"] | null;
 }
 
 export type LogTimelineRow =
@@ -62,9 +64,12 @@ export function filterLogByView(
       return false;
     }
     const explicitCategory = categories?.has(entry.category) ?? false;
-    if (categories && !explicitCategory) return false;
-
     const presentation = logPresentation(entry);
+    // A category drill-down still needs engine-authored turn/phase context.
+    // Keep boundaries structurally; timelineRows decides whether a retained
+    // boundary has adjacent content worth rendering.
+    if (categories && !explicitCategory && presentation.boundary !== "None") return true;
+    if (categories && !explicitCategory) return false;
     if (entry.category === "Debug") return view === "diagnostics" || explicitCategory;
     if (explicitCategory) return true;
     if (!entry.presentation) return view !== "timeline";
@@ -95,6 +100,11 @@ export function timelineRows(
         turn: entry.turn,
         phase: entry.phase,
         boundary: presentation.boundary,
+        turnSegments: presentation.boundary === "Turn"
+          ? entry.segments
+          : pending?.turn === entry.turn
+            ? pending.turnSegments
+            : null,
       };
       continue;
     }

--- a/client/src/viewmodel/logFormatting.ts
+++ b/client/src/viewmodel/logFormatting.ts
@@ -95,6 +95,7 @@ export function timelineRows(
       if (retainStandaloneBoundary && pending !== null && pending.turn !== 0) {
         rows.push({ type: "divider", divider: pending });
       }
+      const previousPending: LogDivider | null = pending;
       pending = {
         seq: entry.seq,
         turn: entry.turn,
@@ -102,8 +103,8 @@ export function timelineRows(
         boundary: presentation.boundary,
         turnSegments: presentation.boundary === "Turn"
           ? entry.segments
-          : pending?.turn === entry.turn
-            ? pending.turnSegments
+          : previousPending?.turn === entry.turn
+            ? previousPending.turnSegments
             : null,
       };
       continue;

--- a/client/src/viewmodel/logFormatting.ts
+++ b/client/src/viewmodel/logFormatting.ts
@@ -95,7 +95,9 @@ export function timelineRows(
       if (retainStandaloneBoundary && pending !== null && pending.turn !== 0) {
         rows.push({ type: "divider", divider: pending });
       }
-      const previousPending: LogDivider | null = pending;
+      // TypeScript loses the carried loop value's union type at this assignment
+      // site, although a prior boundary can leave a divider pending.
+      const previousPending = pending as LogDivider | null;
       pending = {
         seq: entry.seq,
         turn: entry.turn,

--- a/client/src/viewmodel/logSearch.ts
+++ b/client/src/viewmodel/logSearch.ts
@@ -32,15 +32,33 @@ export function filterLogEntries(
   },
 ): GameLogEntry[] {
   const q = opts.query.trim().toLowerCase();
-  return entries.filter((entry) => {
+  const matchesScope = (entry: GameLogEntry) => {
     if (opts.turn != null && entry.turn !== opts.turn) return false;
     if (opts.categories && opts.categories.size > 0 && !opts.categories.has(entry.category)) {
       return false;
     }
-    if (!q) return true;
+    return true;
+  };
+  if (!q) return entries.filter(matchesScope);
+
+  const matchesQuery = (entry: GameLogEntry) => {
     const haystack = `${entry.category} ${segmentsToPlainText(entry.segments)}`.toLowerCase();
     return haystack.includes(q);
-  });
+  };
+  const filtered: GameLogEntry[] = [];
+  let pendingBoundaries: GameLogEntry[] = [];
+
+  for (const entry of entries) {
+    if (!matchesScope(entry)) continue;
+    if (entry.presentation?.boundary === "Turn" || entry.presentation?.boundary === "Phase") {
+      pendingBoundaries.push(entry);
+      continue;
+    }
+    if (!matchesQuery(entry)) continue;
+    filtered.push(...pendingBoundaries, entry);
+    pendingBoundaries = [];
+  }
+  return filtered;
 }
 
 export function uniqueTurns(entries: GameLogEntry[]): number[] {

--- a/crates/engine/src/game/log.rs
+++ b/crates/engine/src/game/log.rs
@@ -1,3 +1,4 @@
+use crate::game::combat::AttackTarget;
 use crate::types::ability::{AbilityTag, TargetRef};
 use crate::types::events::GameEvent;
 use crate::types::game_state::GameState;
@@ -130,6 +131,12 @@ fn importance(event: &GameEvent) -> LogImportance {
         // they landed in and what it does.
         | GameEvent::RoomEntered { .. }
         | GameEvent::ArmyAmassed { .. } => LogImportance::Context,
+        // A countered spell or prevented damage is the decisive outcome of an
+        // otherwise-visible action, so Timeline must not make that outcome
+        // disappear behind the Details view.
+        GameEvent::DamagePrevented { .. } | GameEvent::SpellCountered { .. } => {
+            LogImportance::Context
+        }
         // The remaining variants are deliberately listed rather than covered by a
         // wildcard. Adding a GameEvent must require an explicit presentation policy.
         // CR 701.17a + CR 400.2: the mill's library departure is hidden
@@ -169,8 +176,6 @@ fn importance(event: &GameEvent) -> LogImportance {
         | GameEvent::SagaChapterAbilityResolved { .. }
         | GameEvent::DamageCleared { .. }
         | GameEvent::ResolutionHalted { .. }
-        | GameEvent::DamagePrevented { .. }
-        | GameEvent::SpellCountered { .. }
         | GameEvent::ObjectIntensified { .. }
         | GameEvent::Evolved { .. }
         | GameEvent::Unattached { .. }
@@ -488,6 +493,15 @@ fn player_seg(state: &GameState, id: PlayerId) -> LogSegment {
     LogSegment::PlayerName {
         name: resolve_player_name(state, id),
         player_id: id,
+    }
+}
+
+fn attack_target_seg(state: &GameState, target: AttackTarget) -> LogSegment {
+    match target {
+        AttackTarget::Player(player_id) => player_seg(state, player_id),
+        AttackTarget::Planeswalker(object_id) | AttackTarget::Battle(object_id) => {
+            card_seg(state, object_id)
+        }
     }
 }
 
@@ -1059,17 +1073,52 @@ fn format_segments(event: &GameEvent, state: &GameState) -> Vec<LogSegment> {
         GameEvent::AttackersDeclared {
             attacker_ids,
             defending_player,
-            ..
+            attacks,
         } => {
-            let mut segs = vec![
-                player_seg(state, *defending_player),
-                text(" is attacked by "),
-            ];
-            for (i, id) in attacker_ids.iter().enumerate() {
-                if i > 0 {
-                    segs.push(text(", "));
+            // The legacy fallback keeps pre-`attacks` snapshots legible. New
+            // declarations preserve each attacker's actual target, which may be
+            // a different player, planeswalker, or battle.
+            let attack_targets: Vec<_> = if attacks.is_empty() {
+                attacker_ids
+                    .iter()
+                    .copied()
+                    .map(|attacker| (attacker, AttackTarget::Player(*defending_player)))
+                    .collect()
+            } else {
+                attacks.clone()
+            };
+            let mut groups: Vec<(AttackTarget, Vec<ObjectId>)> = Vec::new();
+            for (attacker, target) in attack_targets {
+                if let Some((_, attackers)) =
+                    groups.iter_mut().find(|(existing, _)| *existing == target)
+                {
+                    attackers.push(attacker);
+                } else {
+                    groups.push((target, vec![attacker]));
                 }
-                segs.push(card_seg(state, *id));
+            }
+
+            let mut segs = Vec::new();
+            for (group_index, (target, attackers)) in groups.iter().enumerate() {
+                if group_index > 0 {
+                    segs.push(text("; "));
+                }
+                for (attacker_index, attacker) in attackers.iter().enumerate() {
+                    if attacker_index > 0 {
+                        segs.push(text(if attacker_index + 1 == attackers.len() {
+                            " and "
+                        } else {
+                            ", "
+                        }));
+                    }
+                    segs.push(card_seg(state, *attacker));
+                }
+                segs.push(text(if attackers.len() == 1 {
+                    " attacks "
+                } else {
+                    " attack "
+                }));
+                segs.push(attack_target_seg(state, *target));
             }
             segs
         }
@@ -1108,10 +1157,12 @@ fn format_segments(event: &GameEvent, state: &GameState) -> Vec<LogSegment> {
         GameEvent::CombatDamageDealtToPlayer {
             player_id,
             source_amounts,
-            ..
+            total_damage,
         } => vec![
             player_seg(state, *player_id),
-            text(" is dealt combat damage by "),
+            text(" is dealt "),
+            num(*total_damage as i32),
+            text(" combat damage by "),
             num(source_amounts.len() as i32),
             text(" creature(s)"),
         ],
@@ -1854,6 +1905,92 @@ mod tests {
 
         assert!(should_exclude_event(&no_attackers, &state));
         assert!(!should_exclude_event(&attacker, &state));
+    }
+
+    #[test]
+    fn attack_log_uses_each_attackers_actual_target() {
+        let mut state = GameState::new_two_player(42);
+        let bear = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Balduvian Bears".to_string(),
+            crate::types::zones::Zone::Battlefield,
+        );
+        let wolf = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(0),
+            "Runeclaw Bear".to_string(),
+            crate::types::zones::Zone::Battlefield,
+        );
+        let gideon = create_object(
+            &mut state,
+            CardId(3),
+            PlayerId(1),
+            "Gideon Jura".to_string(),
+            crate::types::zones::Zone::Battlefield,
+        );
+        let event = GameEvent::AttackersDeclared {
+            attacker_ids: vec![bear, wolf],
+            defending_player: PlayerId(1),
+            attacks: vec![
+                (bear, AttackTarget::Player(PlayerId(1))),
+                (wolf, AttackTarget::Planeswalker(gideon)),
+            ],
+        };
+
+        assert_eq!(
+            format_segments(&event, &state),
+            vec![
+                card_seg(&state, bear),
+                text(" attacks "),
+                player_seg(&state, PlayerId(1)),
+                text("; "),
+                card_seg(&state, wolf),
+                text(" attacks "),
+                card_seg(&state, gideon),
+            ]
+        );
+    }
+
+    #[test]
+    fn countering_and_prevention_are_visible_in_timeline() {
+        let countered = GameEvent::SpellCountered {
+            object_id: ObjectId(7),
+            countered_by: ObjectId(8),
+            countered_by_controller: PlayerId(1),
+        };
+        let prevented = GameEvent::DamagePrevented {
+            source_id: ObjectId(7),
+            target: TargetRef::Player(PlayerId(1)),
+            amount: 3,
+        };
+
+        assert_eq!(importance(&countered), LogImportance::Context);
+        assert_eq!(importance(&prevented), LogImportance::Context);
+    }
+
+    #[test]
+    fn combat_damage_summary_keeps_the_actual_total() {
+        let state = GameState::new_two_player(42);
+        let event = GameEvent::CombatDamageDealtToPlayer {
+            player_id: PlayerId(1),
+            source_amounts: vec![(ObjectId(7), 3), (ObjectId(8), 4)],
+            total_damage: 7,
+        };
+
+        assert_eq!(
+            format_segments(&event, &state),
+            vec![
+                player_seg(&state, PlayerId(1)),
+                text(" is dealt "),
+                num(7),
+                text(" combat damage by "),
+                num(2),
+                text(" creature(s)"),
+            ]
+        );
     }
 
     #[test]

--- a/crates/engine/src/game/log.rs
+++ b/crates/engine/src/game/log.rs
@@ -448,6 +448,10 @@ fn should_exclude_event(event: &GameEvent, state: &GameState) -> bool {
         // can observe it; the player already saw the chapter ability itself
         // resolve. Same low-signal bookkeeping class as StackResolved.
         GameEvent::SagaChapterAbilityResolved { .. } => true,
+        // `handle_empty_attackers` emits this bookkeeping event so the combat
+        // pipeline can advance uniformly, but no creature attacked. It must
+        // not be narrated as an attack against the default defender.
+        GameEvent::AttackersDeclared { attacker_ids, .. } if attacker_ids.is_empty() => true,
         _ => false,
     }
 }
@@ -1832,6 +1836,24 @@ mod tests {
             cast_mana_value: None,
         };
         assert!(!should_exclude_event(&cast, &state));
+    }
+
+    #[test]
+    fn empty_attack_declaration_is_excluded_from_the_log() {
+        let state = GameState::new_two_player(42);
+        let no_attackers = GameEvent::AttackersDeclared {
+            attacker_ids: vec![],
+            defending_player: PlayerId(1),
+            attacks: vec![],
+        };
+        let attacker = GameEvent::AttackersDeclared {
+            attacker_ids: vec![ObjectId(7)],
+            defending_player: PlayerId(1),
+            attacks: vec![],
+        };
+
+        assert!(should_exclude_event(&no_attackers, &state));
+        assert!(!should_exclude_event(&attacker, &state));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- keep the game log as a persistent column beside the board, without its board background or fixed layers leaking beneath it
- seed the remembered open/closed preference before paint, so opening it cannot be immediately overwritten
- suppress empty combat bookkeeping declarations from the player-facing log
- render the card preview as a top-level overlay, above both the board and log columns
- make Timeline describe each attacker’s actual player, planeswalker, or battle target and show combat damage totals
- keep turn context through search and category filtering; make filters and unread counts predictable
- make historical public log-card inspection survive when the live object is gone

## Verification

- commit hooks: Rust parser and CR-citation gates passed; `cargo fmt --all` and diff validation completed
- direct local browser verification of the persistent column and top-level preview layer
- focused engine and frontend tests added for combat narration, timeline visibility/context, filtering, and historical card inspection
- Tilt engine/WASM/frontend rebuilds and PR CI are running on the updated head

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added turn filtering through a dropdown in the game log.
  * Historical card previews remain available after the live card is gone.
  * Log searches retain relevant turn and phase context.
  * Timeline dividers display active-player and turn-segment details.

* **Bug Fixes**
  * Clearing log filters preserves the selected view.
  * Attack summaries show each attacker’s actual target.
  * Combat damage entries display the correct total.
  * Countered spells and prevented damage remain visible in the Timeline.
  * Improved preview placement prevents clipping.

* **Style**
  * Improved log readability, spacing, and card-button focus indicators.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->