### PR TITLE
test(engine): fix two vacuous assertions in the #8485 Maze of Ith suite

### DIFF
--- a/crates/engine/src/game/effects/create_damage_replacement.rs
+++ b/crates/engine/src/game/effects/create_damage_replacement.rs
@@ -695,12 +695,25 @@ mod tests {
         );
     }
 
-    /// CR 615.7 + CR 611.2c (issue #8485, matrix row 20): a `Next(n)` redirection
-    /// shield's DEPLETION survives a layer pass. This is the property dual-write
+    /// CR 611.2a + CR 611.2c (issue #8485, matrix row 20): a ONE-SHOT redirection
+    /// shield stays CONSUMED across a layer pass. This is the property dual-write
     /// cannot deliver — two copies plus mutable state means the pristine base twin
-    /// is re-seeded over the depleted live one on every pass.
+    /// is re-seeded over the spent live one on every pass.
+    ///
+    /// The fixture passes `redirect_amount: None`, which `resolve` turns into
+    /// `PreventionAmount::All` with `RedirectionLifetime::OneOpportunity`, so there
+    /// is no `Next(n)` depletion arithmetic here at all — the observable is
+    /// `is_consumed`, set once and never cleared. (This test previously claimed
+    /// `Next(n)` depletion and cited CR 615.7 for it; CR 615.7 is the *prevention*
+    /// shield-arithmetic rule and describes neither the shape nor the effect class.
+    /// CR 615.3 and CR 615.8, cited in the assertion below, are likewise scoped to
+    /// PREVENTION effects, while this is a REDIRECTION effect — CR 614.9. The rule
+    /// that actually governs the one-opportunity window is CR 611.2a: a continuous
+    /// effect from the resolution of a spell or ability "lasts as long as stated by
+    /// the spell or ability creating it", and "the next time" states exactly one
+    /// opportunity. One rule, used in both places.)
     #[test]
-    fn redirect_shield_depletion_survives_a_layer_pass() {
+    fn redirect_one_shot_stays_consumed_across_a_layer_pass() {
         let mut state = GameState::new_two_player(42);
         let source = create_creature(&mut state, PlayerId(0), "Redirector");
         let victim = create_creature(&mut state, PlayerId(1), "Victim");
@@ -742,7 +755,8 @@ mod tests {
         crate::game::layers::evaluate_layers(&mut state);
         assert!(
             state.objects[&source].replacement_definitions[0].is_consumed,
-            "CR 615.3: a layer pass must not un-spend the shield"
+            "CR 611.2a: the stated one-opportunity window is used up, and a layer \
+             pass has no authority to un-spend it"
         );
 
         let ctx = deal_damage::DamageContext::from_source(&state, source).unwrap();

--- a/crates/engine/tests/integration/issue_8485_maze_of_ith_defender.rs
+++ b/crates/engine/tests/integration/issue_8485_maze_of_ith_defender.rs
@@ -562,6 +562,23 @@ fn issue_8485_maze_prevents_both_double_strike_steps() {
         b.double_strike();
         b.id()
     };
+    // POSITIVE CONTROL for the second damage step. The Maze assertion below is an
+    // ABSENCE, and the driver's `saw_damage_step` latch is satisfied by a SINGLE
+    // `Phase::CombatDamage` observation — the engine runs both CR 510.4 steps inside
+    // one `Phase::CombatDamage` arm, so no phase-transition count can distinguish
+    // them either. Without this control the test would stay green while proving only
+    // the first-strike step: if the engine ever stopped raising the regular step for
+    // a double striker, the Mazed creature's damage would still be zero.
+    //
+    // An UN-MAZED double striker makes the second step observable. CR 702.4b: a
+    // creature with double strike deals combat damage in the first-strike step AND
+    // again in the regular step, so this 2/2 must take exactly 2 + 2 = 4 life off P0.
+    // A single step would take 2 and fail the assertion.
+    let control = {
+        let mut b = scenario.add_creature(P1, "Free Double Striker", 2, 2);
+        b.double_strike();
+        b.id()
+    };
 
     let mut runner = scenario.build();
     runner.state_mut().active_player = P1;
@@ -572,16 +589,33 @@ fn issue_8485_maze_prevents_both_double_strike_steps() {
         &mut runner,
         maze,
         mazed,
-        &[(mazed, AttackTarget::Player(P0))],
+        &[
+            (mazed, AttackTarget::Player(P0)),
+            (control, AttackTarget::Player(P0)),
+        ],
         &[],
         MazeTiming::BeforeBlockers,
     );
 
+    // CR 702.4b + CR 510.4: the control proves BOTH damage steps actually ran. This
+    // must be asserted before the prevention claim, because it is what stops that
+    // claim from being vacuous.
     assert_eq!(
         runner.life(P0),
-        p0_life_before,
-        "BOTH the first-strike and regular combat damage steps must be prevented"
+        p0_life_before - 4,
+        "CR 702.4b: the un-Mazed 2/2 double striker must connect in BOTH the \
+         first-strike and the regular combat damage step (2 + 2). Exactly 2 here \
+         means only ONE step ran, and the Mazed creature's prevention below would \
+         prove nothing about the second."
     );
+    // NOTE: no `damage_marked(mazed)` assertion here on purpose. The Mazed double
+    // striker is UNBLOCKED, so nothing deals damage to it in either step and such an
+    // assertion would be vacuously true — the exact defect this control exists to
+    // remove. The "dealt BY that creature" claim is already carried by the life
+    // assertion above: had the Maze failed, P0 would be down 4 (control) + 6 (the
+    // Mazed 3/3 striking twice) = 10, not 4. The blocked "dealt TO" direction is
+    // covered by `issue_8485_maze_prevents_both_directions_against_opposing_attacker`
+    // and `issue_8485_maze_to_shield_survives_layer_reevaluation_when_blocked`.
 }
 
 /// CR 615 + CR 806: the same defender-side orientation in a MULTIPLAYER game —


### PR DESCRIPTION
## Summary

Follow-up to #8601 (Maze of Ith, issue #8485). Two of that PR's regression tests do not test what they claim: one cites the wrong Comprehensive Rules section for the wrong effect class, and one would stay green if the engine stopped raising the regular combat damage step entirely. Test-only and doc-only — no engine behavior changes.

## Files changed

- `crates/engine/src/game/effects/create_damage_replacement.rs` — renamed one unit test, corrected its CR citations and header
- `crates/engine/tests/integration/issue_8485_maze_of_ith_defender.rs` — added a positive control to the double-strike test

## Track

Developer

## LLM

Model: claude-opus-5[1m] (Claude Opus 5, 1M context)
Tier: Frontier
Thinking: high

## Implementation method (required)

Method: not-applicable — test-accuracy and CR-citation corrections only. No parser, effect, resolver, targeting, or rules-behavior change; the two production files' compiled behavior is untouched.

## CR references

Corrected to CR 611.2a (a continuous effect from a resolving spell or ability lasts as long as stated) and CR 614.9 (redirection). Removed CR 615.3 / CR 615.7 / CR 615.8, which are prevention rules. Added CR 702.4b (double strike deals combat damage in both steps) and CR 510.4 in the integration control.

## What was wrong

**1. A test named for a rule it does not exercise, citing a section that does not govern it.**

`redirect_shield_depletion_survives_a_layer_pass` claimed to test `Next(n)` shield depletion and cited CR 615.7. Its fixture passes `redirect_amount: None`, which `resolve` turns into `PreventionAmount::All` with `RedirectionLifetime::OneOpportunity` — there is no depletion arithmetic in it at all. The observable is `is_consumed`, set once and never cleared.

The citation is wrong at the section level, not just the sub-rule: CR 615.3, 615.7 and 615.8 are all scoped to **prevention** effects, while this is a **redirection** effect (CR 614.9). The rule that actually bounds the window is CR 611.2a — a continuous effect from the resolution of a spell or ability "lasts as long as stated by the spell or ability creating it", and "the next time" states exactly one opportunity.

Renamed to `redirect_one_shot_stays_consumed_across_a_layer_pass` and re-cited. This matters because CLAUDE.md treats a wrong CR number as worse than none: it manufactures confidence that code was checked against a rule that does not apply to it.

**2. An absence assertion with no way to fail.**

`issue_8485_maze_prevents_both_double_strike_steps` asserted that both the first-strike and regular damage steps were prevented, but its evidence was an absence — the Mazed creature dealt zero damage — and the driver's `saw_damage_step` latch is satisfied by a **single** `Phase::CombatDamage` observation. The engine runs both CR 510.4 steps inside one `Phase::CombatDamage` arm, so no phase-transition count can distinguish them either.

Consequence: if the engine ever stopped raising the regular damage step for a double striker, the Mazed creature's damage would still be zero and this test would still pass, while proving only the first-strike step.

Fixed with a positive control — an **un-Mazed** double striker in the same fixture, which by CR 702.4b must take exactly 2 + 2 = 4 life. A single step takes 2 and fails. The second step is now observable, so the Maze assertion is a real negative.

## Anchored on

- `crates/engine/tests/integration/issue_8485_maze_of_ith_defender.rs` — the existing suite's own convention of pairing a Mazed subject against an unaffected one in the same fixture
- `crates/engine/src/game/effects/create_damage_replacement.rs` — the sibling one-shot/`Next(n)` tests in the same module, whose citations this brings into line

## Verification

- [x] Required checks ran clean, or the exact CI-owned alternative is stated below.
- [x] Gate A output below is for the current committed head.
- [ ] Final review-impl below is clean for the current committed head.
- [x] Both anchors cite existing analogous code at the same seam.

- `cargo test -p phase-engine --test integration issue_8485` — **14 passed, 0 failed**
- `cargo test -p phase-engine --lib redirect_one_shot` — **1 passed, 0 failed**
- `cargo test -p phase-engine --lib` — **20852 passed, 0 failed**
- `cargo test -p phase-engine --test integration` — **6576 passed, 0 failed**
- `cargo clippy -p phase-engine --all-targets -- -D warnings` — **clean, zero warnings**

Stated precisely: those gates ran on the identical patch applied to a **newer** base (`558dc1e0b`, upstream main at the time). This branch is based on `4075d46dc` because the fork's push token lacks `workflow` scope and a newer base pulls in `.github/workflows/ci.yml` changes. **The two changed files are byte-identical blobs across both** (`f3411fa9…` and `bf6b7608…`), so what was compiled and run is exactly what is proposed here; only the surrounding base differs, and CI will run against this head.

## Gate A

Gate A PASS head=56489a38cc879cb58c4caec6c34e252b489430d0 base=4075d46dce007a2ec932cc20a820d3c57d350f39

## Final review-impl

Not run — this is a test-accuracy and citation correction with no engine behavior change, arising from CodeRabbit review feedback on #8601 rather than from a new design. Happy to route it through the full loop if a maintainer would prefer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated coverage for one-opportunity damage replacement effects across layer processing.
  - Expanded Maze double-strike test coverage to verify that unaffected attackers deal damage in both combat-damage steps while Mazed attackers remain prevented.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->