### PR TITLE
Add experimental tournaments setting

### DIFF
--- a/client/src/components/chrome/Rail.tsx
+++ b/client/src/components/chrome/Rail.tsx
@@ -2,8 +2,9 @@ import { useTranslation } from "react-i18next";
 import { Link, useLocation, useNavigate } from "react-router";
 
 import { BuildBadge } from "./BuildBadge";
-import { activeNavKey, NAV_ITEMS } from "./navItems";
+import { activeNavKey, navItemsFor } from "./navItems";
 import { SparkleIcon } from "./SparkleIcon";
+import { usePreferencesStore } from "../../stores/preferencesStore";
 
 /**
  * Desktop navigation rail (≥820px). Logo → the five primary destinations, and a
@@ -21,7 +22,9 @@ interface RailProps {
 export function Rail({ onSettings, onWhatsNew, hasUnread }: RailProps) {
   const { t } = useTranslation("menu");
   const navigate = useNavigate();
-  const active = activeNavKey(useLocation().pathname);
+  const experimentalTournamentsEnabled = usePreferencesStore((s) => s.experimentalTournamentsEnabled);
+  const navItems = navItemsFor(experimentalTournamentsEnabled);
+  const active = activeNavKey(useLocation().pathname, navItems);
 
   return (
     <nav
@@ -46,7 +49,7 @@ export function Rail({ onSettings, onWhatsNew, hasUnread }: RailProps) {
       </button>
 
       <div className="flex w-full flex-col gap-1">
-        {NAV_ITEMS.map(({ key, path, labelKey, Icon }) => {
+        {navItems.map(({ key, path, labelKey, Icon }) => {
           const on = active === key;
           return (
             <Link

--- a/client/src/components/chrome/TabBar.tsx
+++ b/client/src/components/chrome/TabBar.tsx
@@ -2,8 +2,9 @@ import { useTranslation } from "react-i18next";
 import { Link, useLocation } from "react-router";
 
 import { BuildBadge } from "./BuildBadge";
-import { activeNavKey, NAV_ITEMS } from "./navItems";
+import { activeNavKey, navItemsFor } from "./navItems";
 import { SparkleIcon } from "./SparkleIcon";
+import { usePreferencesStore } from "../../stores/preferencesStore";
 
 interface TabBarProps {
   onWhatsNew: () => void;
@@ -18,7 +19,9 @@ interface TabBarProps {
  */
 export function TabBar({ onWhatsNew, hasUnread }: TabBarProps) {
   const { t } = useTranslation("menu");
-  const active = activeNavKey(useLocation().pathname);
+  const experimentalTournamentsEnabled = usePreferencesStore((s) => s.experimentalTournamentsEnabled);
+  const navItems = navItemsFor(experimentalTournamentsEnabled);
+  const active = activeNavKey(useLocation().pathname, navItems);
 
   return (
     <nav
@@ -30,7 +33,7 @@ export function TabBar({ onWhatsNew, hasUnread }: TabBarProps) {
           bar's height. Absolutely positioned so it stays out of the nav's flex
           flow. */}
       <BuildBadge inline className="absolute bottom-full left-2 mb-2" />
-      {NAV_ITEMS.map(({ key, path, labelKey, Icon }) => {
+      {navItems.map(({ key, path, labelKey, Icon }) => {
         const on = active === key;
         return (
           <Link

--- a/client/src/components/chrome/__tests__/navItems.test.ts
+++ b/client/src/components/chrome/__tests__/navItems.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { activeNavKey, NAV_ITEMS } from "../navItems";
+import { activeNavKey, navItemsFor, NAV_ITEMS } from "../navItems";
 
 describe("activeNavKey", () => {
   it("matches Home only on the exact root path", () => {
@@ -9,12 +9,11 @@ describe("activeNavKey", () => {
     expect(activeNavKey("/setup")).not.toBe("home");
   });
 
-  it("lights the primary destinations on their own routes", () => {
+  it("lights the visible primary destinations on their own routes", () => {
     expect(activeNavKey("/setup")).toBe("play");
     expect(activeNavKey("/multiplayer")).toBe("online");
     expect(activeNavKey("/draft")).toBe("draft");
     expect(activeNavKey("/my-decks")).toBe("decks");
-    expect(activeNavKey("/tournament")).toBe("tournament");
   });
 
   it("keeps sub-routes under their section", () => {
@@ -24,22 +23,28 @@ describe("activeNavKey", () => {
     // The deck builder is a child of Decks.
     expect(activeNavKey("/deck-builder")).toBe("decks");
     expect(activeNavKey("/deck-builder?returnTo=%2Fmy-decks")).toBe("decks");
-    // A tournament's detail route stays under Tournaments.
-    expect(activeNavKey("/tournament/ABC123")).toBe("tournament");
+    // Tournament navigation is experimental and disabled in the default build.
+    expect(activeNavKey("/tournament/ABC123")).toBeNull();
   });
 
   it("returns null for routes with no primary nav item (e.g. coverage)", () => {
     expect(activeNavKey("/coverage")).toBeNull();
   });
 
-  it("exposes exactly the six primary destinations", () => {
+  it("hides the experimental tournament destination by default", () => {
     expect(NAV_ITEMS.map((n) => n.key)).toEqual([
       "home",
       "play",
       "online",
       "draft",
       "decks",
-      "tournament",
     ]);
+  });
+
+  it("includes tournaments when the experimental preference is enabled", () => {
+    const navItems = navItemsFor(true);
+
+    expect(navItems[navItems.length - 1]?.key).toBe("tournament");
+    expect(activeNavKey("/tournament/ABC123", navItems)).toBe("tournament");
   });
 });

--- a/client/src/components/chrome/navItems.tsx
+++ b/client/src/components/chrome/navItems.tsx
@@ -20,16 +20,36 @@ export interface NavItem {
   match: (pathname: string) => boolean;
 }
 
-export const NAV_ITEMS: NavItem[] = [
+const PRIMARY_NAV_ITEMS: NavItem[] = [
   { key: "home", path: "/", labelKey: "nav.home", Icon: HomeIcon, match: (p) => p === "/" },
   { key: "play", path: "/setup", labelKey: "nav.play", Icon: PlayNavIcon, match: (p) => p.startsWith("/setup") },
   { key: "online", path: "/multiplayer", labelKey: "nav.online", Icon: OnlineNavIcon, match: (p) => p.startsWith("/multiplayer") },
   { key: "draft", path: "/draft", labelKey: "nav.draft", Icon: DraftNavIcon, match: (p) => p.startsWith("/draft") },
   { key: "decks", path: "/my-decks", labelKey: "nav.decks", Icon: DecksNavIcon, match: (p) => p.startsWith("/my-decks") || p.startsWith("/deck-builder") },
-  { key: "tournament", path: "/tournament", labelKey: "nav.tournament", Icon: TournamentNavIcon, match: (p) => p.startsWith("/tournament") },
 ];
 
+const TOURNAMENT_NAV_ITEM: NavItem = {
+  key: "tournament",
+  path: "/tournament",
+  labelKey: "nav.tournament",
+  Icon: TournamentNavIcon,
+  match: (p) => p.startsWith("/tournament"),
+};
+
+/** Non-experimental primary navigation destinations. */
+export const NAV_ITEMS: NavItem[] = PRIMARY_NAV_ITEMS;
+
+/**
+ * Tournaments are still in development, so their navigation entry is opt-in.
+ * The routes remain available for testers using a direct tournament link.
+ */
+export function navItemsFor(experimentalTournamentsEnabled: boolean): NavItem[] {
+  return experimentalTournamentsEnabled
+    ? [...PRIMARY_NAV_ITEMS, TOURNAMENT_NAV_ITEM]
+    : PRIMARY_NAV_ITEMS;
+}
+
 /** The key of the nav item that should appear active for a given pathname. */
-export function activeNavKey(pathname: string): string | null {
-  return NAV_ITEMS.find((item) => item.match(pathname))?.key ?? null;
+export function activeNavKey(pathname: string, navItems = NAV_ITEMS): string | null {
+  return navItems.find((item) => item.match(pathname))?.key ?? null;
 }

--- a/client/src/components/settings/PreferencesModal.tsx
+++ b/client/src/components/settings/PreferencesModal.tsx
@@ -100,6 +100,7 @@ function formatSpeed(value: number, max: number, labels: { instant: string; slow
 }
 const SETTINGS_TABS = [
   { id: "gameplay" },
+  { id: "experimental" },
   { id: "visual" },
   { id: "combat" },
   { id: "audio" },
@@ -179,6 +180,7 @@ export function PreferencesModal({
   const multiplayerBoardLayout = usePreferencesStore((s) => s.multiplayerBoardLayout);
   const spellPaymentMode = usePreferencesStore((s) => s.spellPaymentMode);
   const priorityPassingMode = usePreferencesStore((s) => s.priorityPassingMode);
+  const experimentalTournamentsEnabled = usePreferencesStore((s) => s.experimentalTournamentsEnabled);
   const boardBackground = usePreferencesStore((s) => s.boardBackground);
   const vfxQuality = usePreferencesStore((s) => s.vfxQuality);
   const animationSpeedMultiplier = usePreferencesStore((s) => s.animationSpeedMultiplier);
@@ -190,6 +192,7 @@ export function PreferencesModal({
   const setMultiplayerBoardLayout = usePreferencesStore((s) => s.setMultiplayerBoardLayout);
   const setSpellPaymentMode = usePreferencesStore((s) => s.setSpellPaymentMode);
   const setPriorityPassingMode = usePreferencesStore((s) => s.setPriorityPassingMode);
+  const setExperimentalTournamentsEnabled = usePreferencesStore((s) => s.setExperimentalTournamentsEnabled);
   const setBoardBackground = usePreferencesStore((s) => s.setBoardBackground);
   const customBackgroundUrl = usePreferencesStore((s) => s.customBackgroundUrl);
   const setCustomBackgroundUrl = usePreferencesStore((s) => s.setCustomBackgroundUrl);
@@ -494,6 +497,27 @@ export function PreferencesModal({
                       )}
                     </SettingGroup>
                   </div>
+                </SettingsSection>
+              )}
+
+              {activeTab === "experimental" && (
+                <SettingsSection title={t("experimental.title")}>
+                  <SettingGroup label={t("experimental.tournaments")}>
+                    <label className="flex min-h-11 items-start gap-2">
+                      <input
+                        type="checkbox"
+                        checked={experimentalTournamentsEnabled}
+                        onChange={(event) => setExperimentalTournamentsEnabled(event.target.checked)}
+                        className="mt-1 accent-cyan-500"
+                      />
+                      <span className="text-sm text-slate-200">
+                        {t("experimental.showTournaments")}
+                        <span className="mt-0.5 block text-xs leading-relaxed text-slate-400">
+                          {t("experimental.showTournamentsDescription")}
+                        </span>
+                      </span>
+                    </label>
+                  </SettingGroup>
                 </SettingsSection>
               )}
 

--- a/client/src/components/settings/__tests__/PreferencesModal.priorityPassing.test.tsx
+++ b/client/src/components/settings/__tests__/PreferencesModal.priorityPassing.test.tsx
@@ -11,7 +11,10 @@ vi.mock("../../../services/backup", () => ({
 
 describe("PreferencesModal priority passing", () => {
   beforeEach(() => {
-    usePreferencesStore.setState({ priorityPassingMode: "Standard" });
+    usePreferencesStore.setState({
+      priorityPassingMode: "Standard",
+      experimentalTournamentsEnabled: false,
+    });
   });
 
   afterEach(() => cleanup());
@@ -40,5 +43,17 @@ describe("PreferencesModal priority passing", () => {
 
     expect(screen.getByText("Command Zone")).toBeInTheDocument();
     expect(screen.queryByText("GAMEPLAY.COMMANDZONE")).not.toBeInTheDocument();
+  });
+
+  it("offers an opt-in toggle for tournament navigation", () => {
+    render(<PreferencesModal onClose={vi.fn()} initialTab="experimental" />);
+
+    const checkbox = screen.getByRole("checkbox", {
+      name: /show tournaments in navigation/i,
+    });
+    expect(checkbox).not.toBeChecked();
+
+    fireEvent.click(checkbox);
+    expect(usePreferencesStore.getState().experimentalTournamentsEnabled).toBe(true);
   });
 });

--- a/client/src/i18n/locales/de/settings.json
+++ b/client/src/i18n/locales/de/settings.json
@@ -5,11 +5,18 @@
   },
   "tabs": {
     "gameplay": "Spielablauf",
+    "experimental": "Experimentell",
     "visual": "Grafik",
     "combat": "Tempo",
     "audio": "Audio",
     "multiplayer": "Mehrspieler",
     "data": "Daten"
+  },
+  "experimental": {
+    "title": "Experimentell",
+    "tournaments": "Turniere",
+    "showTournaments": "Turniere in der Navigation anzeigen",
+    "showTournamentsDescription": "Turniere befinden sich noch in Entwicklung und können sich ohne Ankündigung ändern."
   },
   "gameplay": {
     "collapseLands": "Lands einklappen",

--- a/client/src/i18n/locales/en/settings.json
+++ b/client/src/i18n/locales/en/settings.json
@@ -5,11 +5,18 @@
   },
   "tabs": {
     "gameplay": "Gameplay",
+    "experimental": "Experimental",
     "visual": "Visual",
     "combat": "Pacing",
     "audio": "Audio",
     "multiplayer": "Multiplayer",
     "data": "Data"
+  },
+  "experimental": {
+    "title": "Experimental",
+    "tournaments": "Tournaments",
+    "showTournaments": "Show Tournaments in navigation",
+    "showTournamentsDescription": "Tournaments are still in progress and may change without notice."
   },
   "gameplay": {
     "collapseLands": "Collapse Lands",

--- a/client/src/i18n/locales/es/settings.json
+++ b/client/src/i18n/locales/es/settings.json
@@ -5,11 +5,18 @@
   },
   "tabs": {
     "gameplay": "Jugabilidad",
+    "experimental": "Experimental",
     "visual": "Visual",
     "combat": "Ritmo",
     "audio": "Audio",
     "multiplayer": "Multijugador",
     "data": "Datos"
+  },
+  "experimental": {
+    "title": "Experimental",
+    "tournaments": "Torneos",
+    "showTournaments": "Mostrar torneos en la navegación",
+    "showTournamentsDescription": "Los torneos aún están en desarrollo y pueden cambiar sin previo aviso."
   },
   "gameplay": {
     "collapseLands": "Contraer Lands",

--- a/client/src/i18n/locales/fr/settings.json
+++ b/client/src/i18n/locales/fr/settings.json
@@ -5,11 +5,18 @@
   },
   "tabs": {
     "gameplay": "Jouabilité",
+    "experimental": "Expérimental",
     "visual": "Visuel",
     "combat": "Rythme",
     "audio": "Audio",
     "multiplayer": "Multijoueur",
     "data": "Données"
+  },
+  "experimental": {
+    "title": "Expérimental",
+    "tournaments": "Tournois",
+    "showTournaments": "Afficher les tournois dans la navigation",
+    "showTournamentsDescription": "Les tournois sont encore en cours de développement et peuvent changer sans préavis."
   },
   "gameplay": {
     "collapseLands": "Réduire Lands",

--- a/client/src/i18n/locales/it/settings.json
+++ b/client/src/i18n/locales/it/settings.json
@@ -5,11 +5,18 @@
   },
   "tabs": {
     "gameplay": "Giocabilità",
+    "experimental": "Sperimentale",
     "visual": "Grafica",
     "combat": "Ritmo",
     "audio": "Audio",
     "multiplayer": "Multigiocatore",
     "data": "Dati"
+  },
+  "experimental": {
+    "title": "Sperimentale",
+    "tournaments": "Tornei",
+    "showTournaments": "Mostra i tornei nella navigazione",
+    "showTournamentsDescription": "I tornei sono ancora in lavorazione e potrebbero cambiare senza preavviso."
   },
   "gameplay": {
     "collapseLands": "Comprimi Lands",

--- a/client/src/i18n/locales/pl/settings.json
+++ b/client/src/i18n/locales/pl/settings.json
@@ -5,11 +5,18 @@
   },
   "tabs": {
     "gameplay": "Rozgrywka",
+    "experimental": "Eksperymentalne",
     "visual": "Grafika",
     "combat": "Tempo",
     "audio": "Dźwięk",
     "multiplayer": "Tryb wieloosobowy",
     "data": "Dane"
+  },
+  "experimental": {
+    "title": "Eksperymentalne",
+    "tournaments": "Turnieje",
+    "showTournaments": "Pokazuj turnieje w nawigacji",
+    "showTournamentsDescription": "Turnieje są nadal w fazie rozwoju i mogą ulec zmianie bez uprzedzenia."
   },
   "gameplay": {
     "collapseLands": "Zwiń Lands",

--- a/client/src/i18n/locales/pt/settings.json
+++ b/client/src/i18n/locales/pt/settings.json
@@ -5,11 +5,18 @@
   },
   "tabs": {
     "gameplay": "Jogabilidade",
+    "experimental": "Experimental",
     "visual": "Visual",
     "combat": "Ritmo",
     "audio": "Áudio",
     "multiplayer": "Multijogador",
     "data": "Dados"
+  },
+  "experimental": {
+    "title": "Experimental",
+    "tournaments": "Torneios",
+    "showTournaments": "Mostrar torneios na navegação",
+    "showTournamentsDescription": "Os torneios ainda estão em desenvolvimento e podem mudar sem aviso prévio."
   },
   "gameplay": {
     "collapseLands": "Recolher Lands",

--- a/client/src/stores/__tests__/preferencesStore.test.ts
+++ b/client/src/stores/__tests__/preferencesStore.test.ts
@@ -20,6 +20,7 @@ describe("preferencesStore", () => {
         draftDoubleClickConfirmPick: true,
         pacingMultipliers: { effects: 1.0, combat: 1.0, banners: 1.0 },
         priorityPassingMode: "Standard",
+        experimentalTournamentsEnabled: false,
         masterVolume: 100,
         sfxVolume: 70,
         musicVolume: 40,
@@ -51,6 +52,7 @@ describe("preferencesStore", () => {
     expect(usePreferencesStore.getInitialState().multiplayerSplitLayoutNudgeDismissed).toBe(true);
     expect(state.aiSeats).toEqual([{ difficulty: "Medium", deckId: "Random" }]);
     expect(state.priorityPassingMode).toBe("Standard");
+    expect(state.experimentalTournamentsEnabled).toBe(false);
     expect(state.draftDoubleClickConfirmPick).toBe(true);
   });
 
@@ -110,6 +112,15 @@ describe("preferencesStore", () => {
     });
 
     expect(usePreferencesStore.getState().multiplayerBoardLayout).toBe("split");
+  });
+
+  it("persists the experimental tournaments navigation preference", () => {
+    act(() => {
+      usePreferencesStore.getState().setExperimentalTournamentsEnabled(true);
+    });
+
+    expect(usePreferencesStore.getState().experimentalTournamentsEnabled).toBe(true);
+    expect(JSON.parse(localStorage.getItem("phase-preferences")!).state.experimentalTournamentsEnabled).toBe(true);
   });
 
   it("updates the multiplayer split-layout nudge dismissal independently", () => {

--- a/client/src/stores/preferencesStore.ts
+++ b/client/src/stores/preferencesStore.ts
@@ -286,6 +286,7 @@ function buildDefaultPreferences(): PreferencesState {
     pacingMultipliers: defaultPacingMultipliers(),
     phaseStops: [],
     priorityPassingMode: "Standard",
+    experimentalTournamentsEnabled: false,
     masterVolume: 100,
     sfxVolume: 70,
     musicVolume: 40,
@@ -357,6 +358,8 @@ interface PreferencesState {
   pacingMultipliers: Record<PacingCategory, number>;
   phaseStops: PhaseStop[];
   priorityPassingMode: PriorityPassingMode;
+  /** Whether the in-progress tournament UI appears in app navigation. */
+  experimentalTournamentsEnabled: boolean;
   masterVolume: number;
   sfxVolume: number;
   musicVolume: number;
@@ -472,6 +475,7 @@ interface PreferencesActions {
   resetAllPreferences: () => void;
   setPhaseStops: (stops: PhaseStop[]) => void;
   setPriorityPassingMode: (mode: PriorityPassingMode) => void;
+  setExperimentalTournamentsEnabled: (enabled: boolean) => void;
   setMasterVolume: (vol: number) => void;
   setSfxVolume: (vol: number) => void;
   setMusicVolume: (vol: number) => void;
@@ -625,6 +629,7 @@ export const usePreferencesStore = create<PreferencesState & PreferencesActions>
       resetAllPreferences: () => set(buildDefaultPreferences()),
       setPhaseStops: (stops) => set({ phaseStops: stops }),
       setPriorityPassingMode: (mode) => set({ priorityPassingMode: mode }),
+      setExperimentalTournamentsEnabled: (enabled) => set({ experimentalTournamentsEnabled: enabled }),
       setMasterVolume: (vol) => set({ masterVolume: vol }),
       setSfxVolume: (vol) => set({ sfxVolume: vol }),
       setMusicVolume: (vol) => set({ musicVolume: vol }),
@@ -820,7 +825,7 @@ export const usePreferencesStore = create<PreferencesState & PreferencesActions>
     }),
     {
       name: "phase-preferences",
-      version: 34,
+      version: 35,
       // v0 → v1: flat aiDifficulty + aiDeckName become aiSeats[0].
       // v1 → v2: discrete animationSpeed/combatPacing enums become numeric
       //          animationSpeedMultiplier/combatPacingMultiplier.
@@ -903,6 +908,9 @@ export const usePreferencesStore = create<PreferencesState & PreferencesActions>
       //          once is now remembered. The legacy key is dropped so it cannot
       //          linger in the persisted blob. Mobile never auto-opens regardless,
       //          so this is a desktop-only behavior change.
+      // v34 → v35: Add experimentalTournamentsEnabled. Existing users retain
+      //          the hidden-by-default navigation because the shallow merge
+      //          supplies false.
       migrate: (persisted: unknown, version: number) => {
         if (!persisted || typeof persisted !== "object") return persisted;
         let migrated = persisted as Record<string, unknown>;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an Experimental settings tab with an option to show tournaments in the navigation.
  - Tournament navigation is hidden by default and appears when the setting is enabled.
  - The preference is saved and retained across sessions.
- **Localization**
  - Added translations for the Experimental settings and tournament visibility option in supported languages.
- **Bug Fixes**
  - Navigation now consistently reflects the tournament visibility preference across desktop layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->