### PR TITLE
Improve multiplayer AI threat targeting

### DIFF
--- a/crates/phase-ai/src/combat_ai.rs
+++ b/crates/phase-ai/src/combat_ai.rs
@@ -745,6 +745,7 @@ thread_local! {
 struct ProposalAccounting {
     defender: PlayerId,
     attackers: Vec<ObjectId>,
+    blocked_damage: i32,
     opposing_losses: f64,
     own_losses: f64,
     pre_finish_utility: f64,
@@ -1155,6 +1156,7 @@ fn expanded_multiplayer_choice(
             accounting.borrow_mut().push(ProposalAccounting {
                 defender,
                 attackers: attackers.clone(),
+                blocked_damage,
                 opposing_losses,
                 own_losses,
                 pre_finish_utility,
@@ -4072,12 +4074,39 @@ mod tests {
             vec![Keyword::Menace],
         );
         let blocker = add_creature(&mut state, PlayerId(1), "Lone 5/5", 5, 5, vec![]);
+        state.phase = engine::types::phase::Phase::DeclareAttackers;
+        state.waiting_for = engine::game::combat::build_declare_attackers_waiting_for(&state);
         let slices = BlockLegalitySlices::collect(&state);
+        let WaitingFor::DeclareAttackers {
+            valid_attacker_ids,
+            valid_attack_targets,
+            ..
+        } = &state.waiting_for
+        else {
+            panic!("fixture must reach DeclareAttackers")
+        };
+        assert_eq!(valid_attacker_ids, &vec![attacker]);
+        assert!(valid_attack_targets.contains(&AttackTarget::Player(PlayerId(1))));
+        assert!(valid_attack_targets.contains(&AttackTarget::Player(PlayerId(2))));
+        let attackable = engine::game::combat::attackable_defender_targets(&state);
+        assert!(
+            !engine::game::combat::creature_must_attack_with_attackable_targets(
+                &state,
+                attacker,
+                &attackable,
+            ),
+            "the hostile attacker must remain voluntary"
+        );
+        let eligible: Vec<_> = [blocker]
+            .into_iter()
+            .filter(|&id| slices.can_block_pair(&state, id, attacker))
+            .collect();
+        assert_eq!(eligible, vec![blocker]);
         let lone_block = defender_best_block_from_eligible(
             &state,
             attacker,
             evaluate_creature(&state, attacker),
-            &[blocker],
+            &eligible,
             |id| evaluate_creature(&state, id),
         )
         .expect("the hostile hypothetical block exists");
@@ -4106,37 +4135,103 @@ mod tests {
         );
 
         reset_expanded_comparison_counters();
-        let attacks = choose_attackers_with_targets(&state, PlayerId(0));
+        let config = create_config(AiDifficulty::Hard, Platform::Native);
+        let mut rng = SmallRng::seed_from_u64(42);
+        let action = crate::search::choose_action(&state, PlayerId(0), &config, &mut rng)
+            .expect("engine-issued DeclareAttackers decision");
         let p1 = expanded_proposal_accounting()
             .into_iter()
             .find(|proposal| proposal.defender == PlayerId(1))
             .expect("P1 proposal completed");
         assert_eq!(p1.attackers, vec![attacker]);
+        assert_eq!(p1.blocked_damage, 3);
         assert_eq!(p1.own_losses, 0.0);
         assert_eq!(p1.opposing_losses, 0.0);
         assert!(p1.finishes);
-        assert_eq!(attacks, vec![(attacker, AttackTarget::Player(PlayerId(1)))]);
+        let p2 = expanded_proposal_accounting()
+            .into_iter()
+            .find(|proposal| proposal.defender == PlayerId(2))
+            .expect("P2 proposal completed");
+        assert_eq!(p2.attackers, vec![attacker]);
+        assert_eq!(p2.blocked_damage, 3);
+        assert!(!p2.finishes);
+        assert!(p2.utility > 0.0);
         let mut engine_state = state.clone();
-        engine_state.phase = engine::types::phase::Phase::DeclareAttackers;
-        engine_state.waiting_for =
-            engine::game::combat::build_declare_attackers_waiting_for(&engine_state);
-        engine::game::engine::apply_as_current(
-            &mut engine_state,
-            engine::types::actions::GameAction::DeclareAttackers {
-                attacks: attacks.clone(),
-                bands: vec![],
-            },
-        )
-        .expect("the real three-player declaration is engine legal");
+        assert!(matches!(
+            &action,
+            engine::types::actions::GameAction::DeclareAttackers { attacks, .. }
+                if attacks == &vec![(attacker, AttackTarget::Player(PlayerId(1)))]
+        ));
+        engine::game::engine::apply_as_current(&mut engine_state, action)
+            .expect("the real three-player declaration is engine legal");
 
         let second = add_creature(&mut state, PlayerId(1), "Second 5/5", 5, 5, vec![]);
-        reset_expanded_comparison_counters();
-        assert_eq!(
-            choose_attackers_with_targets(&state, PlayerId(0)),
-            vec![(attacker, AttackTarget::Player(PlayerId(2)))],
-            "a sufficient two-block floor keeps the open P2 proposal as the positive choice"
+        state.waiting_for = engine::game::combat::build_declare_attackers_waiting_for(&state);
+        let refreshed_slices = BlockLegalitySlices::collect(&state);
+        let WaitingFor::DeclareAttackers {
+            valid_attacker_ids,
+            valid_attack_targets,
+            ..
+        } = &state.waiting_for
+        else {
+            panic!("refreshed fixture must reach DeclareAttackers")
+        };
+        assert_eq!(valid_attacker_ids, &vec![attacker]);
+        assert!(valid_attack_targets.contains(&AttackTarget::Player(PlayerId(1))));
+        assert!(valid_attack_targets.contains(&AttackTarget::Player(PlayerId(2))));
+        let refreshed_attackable = engine::game::combat::attackable_defender_targets(&state);
+        assert!(
+            !engine::game::combat::creature_must_attack_with_attackable_targets(
+                &state,
+                attacker,
+                &refreshed_attackable,
+            ),
+            "the sufficient-floor sibling remains voluntary"
         );
-        assert!(state.battlefield.contains(&second));
+        let refreshed_eligible: Vec<_> = [blocker, second]
+            .into_iter()
+            .filter(|&id| refreshed_slices.can_block_pair(&state, id, attacker))
+            .collect();
+        assert_eq!(refreshed_eligible, vec![blocker, second]);
+        assert_eq!(
+            engine::game::combat::min_blockers_required_from_precomputed(
+                &state,
+                attacker,
+                &refreshed_slices.block_restriction,
+            ),
+            2,
+        );
+        reset_expanded_comparison_counters();
+        let mut refreshed_rng = SmallRng::seed_from_u64(42);
+        let refreshed_action =
+            crate::search::choose_action(&state, PlayerId(0), &config, &mut refreshed_rng)
+                .expect("refreshed engine-issued DeclareAttackers decision");
+        let refreshed_accounting = expanded_proposal_accounting();
+        let p1 = refreshed_accounting
+            .iter()
+            .find(|proposal| proposal.defender == PlayerId(1))
+            .expect("blocked P1 proposal completed");
+        assert_eq!(p1.attackers, Vec::<ObjectId>::new());
+        assert_eq!(p1.blocked_damage, 0);
+        assert!(!p1.finishes);
+        let p2 = refreshed_accounting
+            .iter()
+            .find(|proposal| proposal.defender == PlayerId(2))
+            .expect("open P2 proposal completed");
+        assert_eq!(p2.attackers, vec![attacker]);
+        assert_eq!(p2.blocked_damage, 3);
+        assert!(!p2.finishes);
+        assert!(p2.utility > 0.0);
+        assert!(matches!(
+            &refreshed_action,
+            engine::types::actions::GameAction::DeclareAttackers { attacks, .. }
+                if attacks == &vec![(attacker, AttackTarget::Player(PlayerId(2)))]
+        ));
+        let mut refreshed_engine_state = state.clone();
+        engine::game::engine::apply_as_current(&mut refreshed_engine_state, refreshed_action)
+            .expect(
+                "a sufficient two-block floor keeps the open P2 proposal as the positive choice",
+            );
     }
 
     #[test]
@@ -4175,7 +4270,17 @@ mod tests {
         assert!(accounting
             .iter()
             .all(|proposal| proposal.attackers.is_empty()));
-        assert_eq!(expanded_comparison_receipt().completed_proposals, 2);
+        assert_eq!(
+            expanded_comparison_receipt(),
+            ExpandedComparisonReceipt {
+                entries: 1,
+                attacker_evaluations: 2,
+                pairs: 2,
+                completed_proposals: 2,
+                grouping_passes: 0,
+                cached_value_evaluations: 3,
+            }
+        );
     }
 
     #[test]
@@ -5206,10 +5311,21 @@ mod tests {
     /// Manual runtime receipt for the bounded free-for-all comparator. Run with
     /// `--ignored --nocapture` on a release binary and compare its p50/p95 output
     /// with the matching baseline checkout. It deliberately uses the production
-    /// Medium and Hard profiles and repeats the same public board 100 times.
+    /// Medium and Hard profiles and repeats the same public board 100 times by
+    /// default. `PHASE_AI_THREAT_TIMING_ITERATIONS` is a test-only diagnostic
+    /// override for collecting a single iteration's work receipt.
     #[test]
     #[ignore = "manual multiplayer timing receipt"]
     fn multiplayer_comparison_timing_harness() {
+        let iterations = std::env::var("PHASE_AI_THREAT_TIMING_ITERATIONS").map_or(100, |value| {
+            value
+                .parse::<usize>()
+                .expect("PHASE_AI_THREAT_TIMING_ITERATIONS must be a positive integer")
+        });
+        assert!(
+            iterations > 0,
+            "PHASE_AI_THREAT_TIMING_ITERATIONS must be a positive integer"
+        );
         let fixtures = [
             ("small", 2, 2),
             ("typical_four_player", 12, 8),
@@ -5236,12 +5352,12 @@ mod tests {
                 )
                 .expect("timing state writes to the temporary directory");
 
-                let mut elapsed_us = Vec::with_capacity(100);
+                let mut elapsed_us = Vec::with_capacity(iterations);
                 let mut attacker_evaluations = 0;
                 let mut pair_count = 0;
                 let mut grouping_passes = 0;
                 let mut cached_value_evaluations = 0;
-                for _ in 0..100 {
+                for _ in 0..iterations {
                     reset_expanded_comparison_counters();
                     let started = Instant::now();
                     let _ = choose_attackers_with_targets_with_profile_and_deadline(
@@ -5260,13 +5376,14 @@ mod tests {
                     cached_value_evaluations += receipt.cached_value_evaluations;
                 }
                 elapsed_us.sort_unstable();
-                let p50 = elapsed_us[49];
-                let p95 = elapsed_us[94];
+                let p50 = elapsed_us[(iterations - 1) / 2];
+                let p95 = elapsed_us[(iterations * 95).div_ceil(100) - 1];
                 assert!(
-                    attacker_evaluations + pair_count <= 100 * MULTIPLAYER_COMPARISON_WORK_LIMIT
+                    attacker_evaluations + pair_count
+                        <= iterations * MULTIPLAYER_COMPARISON_WORK_LIMIT
                 );
                 println!(
-                    "multiplayer-comparison {difficulty:?} {name}: p50={p50}us p95={p95}us E={attacker_evaluations} P={pair_count} W={} groups={grouping_passes} values={cached_value_evaluations} reducers=0 projections=0",
+                    "multiplayer-comparison {difficulty:?} {name}: iterations={iterations} p50={p50}us p95={p95}us E={attacker_evaluations} P={pair_count} W={} groups={grouping_passes} values={cached_value_evaluations} reducers=0 projections=0",
                     attacker_evaluations + pair_count,
                 );
             }

--- a/crates/phase-ai/src/combat_ai.rs
+++ b/crates/phase-ai/src/combat_ai.rs
@@ -392,99 +392,121 @@ pub(crate) fn choose_attackers_with_targets_with_profile_and_deadline(
         })
     });
     let selected_defender = expanded_choice.as_ref().map(|choice| choice.defender);
-    let opponent_blockers = selected_defender
-        .and_then(|defender| {
-            blocker_groups
-                .as_ref()
-                .and_then(|groups| groups.get(&defender).cloned())
-        })
-        .unwrap_or_else(|| {
-            preferred_attack_opponent(state, player, &opponents, &candidates)
-                .map(|opponent| untapped_creature_blockers(state, opponent))
-                .unwrap_or_default()
-        });
+    let opponent_blockers = if let Some(defender) = selected_defender {
+        // The expanded choice's defender provenance includes an open board: a
+        // missing group is that defender's empty blocker slice, not a reason to
+        // reselect a legacy defender and borrow its blockers.
+        blocker_groups
+            .as_ref()
+            .and_then(|groups| groups.get(&defender).cloned())
+            .unwrap_or_default()
+    } else {
+        preferred_attack_opponent(state, player, &opponents, &candidates)
+            .map(|opponent| untapped_creature_blockers(state, opponent))
+            .unwrap_or_default()
+    };
 
-    let mut objective = determine_attack_objective(
-        state,
-        player,
-        &opponents,
-        &candidates,
-        &opponent_blockers,
-        profile,
-    );
-    // A raw lowest-life check is not a lethal certificate in a free-for-all.
-    // The bounded comparison below accounts for the selected defender's blocks.
-    if selected_defender.is_some() && matches!(objective, CombatObjective::PushLethal) {
-        objective = CombatObjective::Race;
-    }
+    // A completed comparison is already a Race-scored, defender-specific
+    // declaration. Keep that marker for crackback pruning; only fallback
+    // selection needs the ordinary objective calculation.
+    let completed_attackers = expanded_choice.and_then(|choice| choice.attackers);
+    let objective = if completed_attackers.is_some() {
+        CombatObjective::Race
+    } else {
+        let objective = determine_attack_objective(
+            state,
+            player,
+            &opponents,
+            &candidates,
+            &opponent_blockers,
+            profile,
+        );
+        // A raw lowest-life check is not a lethal certificate in a free-for-all.
+        // The bounded comparison below accounts for the selected defender's blocks.
+        if selected_defender.is_some() && matches!(objective, CombatObjective::PushLethal) {
+            CombatObjective::Race
+        } else {
+            objective
+        }
+    };
 
     // A completed proposal owns its exact voluntary declaration. `Some(empty)`
     // is an evaluated decline; only an inner `None` invokes the legacy fallback.
-    let mut attacking_ids = expanded_choice
-        .and_then(|choice| choice.attackers)
-        .unwrap_or_else(|| {
-            let mut selected = Vec::new();
-            for &id in &candidates {
-                if selected_defender.is_some()
-                    && targeting.valid_attack_targets_by_attacker.is_some_and(
-                        |targets_by_attacker| {
-                            !targets_by_attacker.get(&id).is_some_and(|targets| {
-                                targets.contains(&AttackTarget::Player(selected_defender.unwrap()))
-                            })
-                        },
-                    )
-                {
-                    continue;
-                }
-                let obj = match state.objects.get(&id) {
-                    Some(o) => o,
-                    None => continue,
-                };
+    #[cfg(test)]
+    let comparison_completed = completed_attackers.is_some();
+    let mut attacking_ids = completed_attackers.unwrap_or_else(|| {
+        let mut selected = Vec::new();
+        for &id in &candidates {
+            if selected_defender.is_some()
+                && targeting
+                    .valid_attack_targets_by_attacker
+                    .is_some_and(|targets_by_attacker| {
+                        !targets_by_attacker.get(&id).is_some_and(|targets| {
+                            targets.contains(&AttackTarget::Player(selected_defender.unwrap()))
+                        })
+                    })
+            {
+                continue;
+            }
+            let obj = match state.objects.get(&id) {
+                Some(o) => o,
+                None => continue,
+            };
 
-                let my_value = evaluate_creature(state, id);
-                let my_power = obj.power.unwrap_or(0);
+            let my_value = evaluate_creature(state, id);
+            let my_power = obj.power.unwrap_or(0);
 
-                let is_unblockable = has_cant_be_blocked(state, obj);
-                let has_lifelink = obj.has_keyword(&Keyword::Lifelink);
-                let is_commander = obj.is_commander;
+            let is_unblockable = has_cant_be_blocked(state, obj);
+            let has_lifelink = obj.has_keyword(&Keyword::Lifelink);
+            let is_commander = obj.is_commander;
 
-                if is_unblockable || opponent_blockers.is_empty() {
-                    selected.push(id);
-                    continue;
-                }
+            if is_unblockable || opponent_blockers.is_empty() {
+                selected.push(id);
+                continue;
+            }
 
-                // CR 509.1a: Evaluate the attack against the defender's *best* block, not
-                // its cheapest creature. Assuming the defender chump-trades with its
-                // weakest body let the AI swing doomed creatures into a "favorable trade"
-                // the defender would never offer — it instead kills the attacker for free
-                // with a first-striker or a larger body (gamestate1: a 1/1 animated land
-                // sent into a 2/1 first strike).
-                match defender_best_block(state, id, my_value, &opponent_blockers, &slices) {
-                    None => selected.push(id),
-                    Some(DefenderBlock {
-                        blocker_value,
-                        kills_blocker,
+            // CR 509.1a: Evaluate the attack against the defender's *best* block, not
+            // its cheapest creature. Assuming the defender chump-trades with its
+            // weakest body let the AI swing doomed creatures into a "favorable trade"
+            // the defender would never offer — it instead kills the attacker for free
+            // with a first-striker or a larger body (gamestate1: a 1/1 animated land
+            // sent into a 2/1 first strike).
+            match defender_best_block(state, id, my_value, &opponent_blockers, &slices) {
+                None => selected.push(id),
+                Some(DefenderBlock {
+                    blocker_value,
+                    kills_blocker,
+                    attacker_survives,
+                    ..
+                }) => {
+                    let free_damage = kills_blocker && attacker_survives;
+                    let favorable_trade = kills_blocker && my_value <= blocker_value;
+                    if should_attack_given_objective(
+                        objective,
+                        free_damage,
+                        favorable_trade,
+                        has_lifelink,
+                        my_power,
                         attacker_survives,
-                        ..
-                    }) => {
-                        let free_damage = kills_blocker && attacker_survives;
-                        let favorable_trade = kills_blocker && my_value <= blocker_value;
-                        if should_attack_given_objective(
-                            objective,
-                            free_damage,
-                            favorable_trade,
-                            has_lifelink,
-                            my_power,
-                            attacker_survives,
-                            is_commander,
-                        ) {
-                            selected.push(id);
-                        }
+                        is_commander,
+                    ) {
+                        selected.push(id);
                     }
                 }
             }
-            selected
+        }
+        selected
+    });
+
+    #[cfg(test)]
+    if comparison_completed {
+        EXPANDED_PRE_MANDATORY_SELECTION.with(|selection| {
+            *selection.borrow_mut() = selected_defender.map(|defender| ExpandedSelectionReceipt {
+                defender,
+                attackers: attacking_ids.clone(),
+            });
         });
+    }
 
     // CR 508.1d / CR 701.15b: union the mandatory must-attack set. These
     // creatures are declared regardless of the value heuristic's verdict.
@@ -737,6 +759,7 @@ thread_local! {
     static EXPANDED_COMPARISON_VALUE_EVALUATIONS: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
     static EXPANDED_COMPARISON_GROUPED_BLOCKERS: std::cell::RefCell<HashMap<PlayerId, Vec<ObjectId>>> = std::cell::RefCell::new(HashMap::new());
     static EXPANDED_PROPOSAL_ACCOUNTING: std::cell::RefCell<Vec<ProposalAccounting>> = const { std::cell::RefCell::new(Vec::new()) };
+    static EXPANDED_PRE_MANDATORY_SELECTION: std::cell::RefCell<Option<ExpandedSelectionReceipt>> = const { std::cell::RefCell::new(None) };
     static EXPANDED_COMPARISON_FORCE_EXPIRE_AT_WORK: std::cell::Cell<Option<usize>> = const { std::cell::Cell::new(None) };
 }
 
@@ -755,6 +778,13 @@ struct ProposalAccounting {
 }
 
 #[cfg(test)]
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct ExpandedSelectionReceipt {
+    defender: PlayerId,
+    attackers: Vec<ObjectId>,
+}
+
+#[cfg(test)]
 pub(crate) fn reset_expanded_comparison_counters() {
     EXPANDED_COMPARISON_ENTRIES.with(|counter| counter.set(0));
     EXPANDED_COMPARISON_EVALUATIONS.with(|counter| counter.set(0));
@@ -764,6 +794,7 @@ pub(crate) fn reset_expanded_comparison_counters() {
     EXPANDED_COMPARISON_VALUE_EVALUATIONS.with(|counter| counter.set(0));
     EXPANDED_COMPARISON_GROUPED_BLOCKERS.with(|groups| groups.borrow_mut().clear());
     EXPANDED_PROPOSAL_ACCOUNTING.with(|accounting| accounting.borrow_mut().clear());
+    EXPANDED_PRE_MANDATORY_SELECTION.with(|selection| *selection.borrow_mut() = None);
     EXPANDED_COMPARISON_FORCE_EXPIRE_AT_WORK.with(|limit| limit.set(None));
 }
 
@@ -781,6 +812,11 @@ fn force_expanded_comparison_expiry_after_work(work: usize) {
 #[cfg(test)]
 fn expanded_proposal_accounting() -> Vec<ProposalAccounting> {
     EXPANDED_PROPOSAL_ACCOUNTING.with(|accounting| accounting.borrow().clone())
+}
+
+#[cfg(test)]
+fn expanded_pre_mandatory_selection() -> Option<ExpandedSelectionReceipt> {
+    EXPANDED_PRE_MANDATORY_SELECTION.with(|selection| selection.borrow().clone())
 }
 
 #[cfg(test)]
@@ -4369,18 +4405,22 @@ mod tests {
     }
 
     #[test]
-    fn proposal_deduplicates_reused_blocker_credit_and_caps_at_open_pressure() {
+    fn proposal_deduplication_flips_the_competing_public_defender() {
         let mut state = setup_multiplayer(3);
         let attackers: Vec<_> = (0..5)
             .map(|_| add_creature(&mut state, PlayerId(0), "Attacker", 5, 5, vec![]))
             .collect();
         let blocker = add_creature(&mut state, PlayerId(1), "Blocker", 2, 2, vec![]);
+        for _ in 0..3 {
+            let threat = add_creature(&mut state, PlayerId(1), "Tapped threat", 10, 10, vec![]);
+            state.objects.get_mut(&threat).unwrap().tapped = true;
+        }
         state.players[1].life = 30;
         state.players[2].life = 30;
         let slices = BlockLegalitySlices::collect(&state);
         reset_expanded_comparison_counters();
 
-        let _ = expanded_multiplayer_choice(
+        let choice = expanded_multiplayer_choice(
             &state,
             PlayerId(0),
             ExpandedComparisonInput {
@@ -4398,12 +4438,18 @@ mod tests {
                 shared_deadline: Deadline::none(),
                 local_deadline: None,
             },
-        );
+        )
+        .expect("the competing defender proposals complete");
 
-        let p1 = expanded_proposal_accounting()
-            .into_iter()
+        let accounting = expanded_proposal_accounting();
+        let p1 = accounting
+            .iter()
             .find(|proposal| proposal.defender == PlayerId(1))
             .expect("the blocked defender has a complete proposal");
+        let p2 = accounting
+            .iter()
+            .find(|proposal| proposal.defender == PlayerId(2))
+            .expect("the open defender has a complete proposal");
         assert_eq!(p1.own_losses, 0.0);
         assert_eq!(
             p1.opposing_losses,
@@ -4414,6 +4460,31 @@ mod tests {
             p1.pre_finish_utility <= p1.open_pressure,
             "optional block credit is bounded by the defender declining every block"
         );
+        let fictional_repeated_credit =
+            (p1.opposing_losses * attackers.len() as f64).min(p1.open_pressure);
+        assert!(
+            p1.pre_finish_utility < p2.utility && p2.utility < fictional_repeated_credit,
+            "the open defender is between the deduplicated and fictional repeated-credit proposals"
+        );
+        assert_eq!(choice.defender, PlayerId(2));
+        assert_eq!(choice.attackers.as_deref(), Some(attackers.as_slice()));
+
+        state.phase = engine::types::phase::Phase::DeclareAttackers;
+        state.waiting_for = engine::game::combat::build_declare_attackers_waiting_for(&state);
+        reset_expanded_comparison_counters();
+        let config = create_config(AiDifficulty::Hard, Platform::Native);
+        let mut rng = SmallRng::seed_from_u64(42);
+        let action = crate::search::choose_action(&state, PlayerId(0), &config, &mut rng)
+            .expect("engine-issued public attacker selection");
+        assert!(matches!(
+            &action,
+            engine::types::actions::GameAction::DeclareAttackers { attacks, .. }
+                if attacks.len() == attackers.len()
+                    && attacks.iter().all(|(id, target)| attackers.contains(id)
+                        && *target == AttackTarget::Player(PlayerId(2)))
+        ));
+        engine::game::engine::apply_as_current(&mut state, action)
+            .expect("the deduplicated public selection is engine legal");
     }
 
     #[test]
@@ -4573,18 +4644,33 @@ mod tests {
         add_creature(&mut state, PlayerId(1), "Trade blocker", 2, 3, vec![]);
         let threat = add_creature(&mut state, PlayerId(2), "Crackback", 6, 6, vec![]);
         state.objects.get_mut(&threat).unwrap().tapped = true;
+        add_creature(&mut state, PlayerId(2), "Withholding blocker", 0, 4, vec![]);
+        let defender = add_creature(&mut state, PlayerId(0), "Defender", 0, 4, vec![]);
+        state
+            .objects
+            .get_mut(&defender)
+            .unwrap()
+            .keywords
+            .push(Keyword::Defender);
         state.phase = engine::types::phase::Phase::DeclareAttackers;
+        state.waiting_for = engine::game::combat::build_declare_attackers_waiting_for(&state);
         let p1 = AttackTarget::Player(PlayerId(1));
         let p2 = AttackTarget::Player(PlayerId(2));
-        let mut targets_by_attacker = HashMap::new();
-        targets_by_attacker.insert(attacker, vec![p1]);
-        state.waiting_for = engine::types::game_state::WaitingFor::DeclareAttackers {
-            player: PlayerId(0),
-            valid_attacker_ids: vec![attacker],
-            valid_attack_targets: vec![p1, p2],
-            valid_attack_targets_by_attacker: Some(targets_by_attacker),
-            attacker_constraints: Default::default(),
+        let engine::types::game_state::WaitingFor::DeclareAttackers {
+            valid_attacker_ids,
+            valid_attack_targets,
+            valid_attack_targets_by_attacker,
+            ..
+        } = &state.waiting_for
+        else {
+            panic!("engine must issue a DeclareAttackers domain")
         };
+        assert!(valid_attacker_ids.contains(&attacker));
+        assert!(valid_attack_targets.contains(&p1) && valid_attack_targets.contains(&p2));
+        assert!(valid_attack_targets_by_attacker
+            .as_ref()
+            .and_then(|targets| targets.get(&attacker))
+            .is_some_and(|targets| targets.contains(&p1) && targets.contains(&p2)));
         let blockers = group_untapped_creature_blockers(
             &state,
             PlayerId(0),
@@ -4631,9 +4717,20 @@ mod tests {
             engine::types::actions::GameAction::DeclareAttackers { attacks, .. }
                 if attacks == &vec![(attacker, p1)]
         ));
-        assert!(expanded_proposal_accounting().iter().any(|proposal| {
-            proposal.defender == PlayerId(1) && proposal.attackers == vec![attacker]
-        }));
+        let winning_proposal = expanded_proposal_accounting()
+            .into_iter()
+            .find(|proposal| proposal.defender == PlayerId(1))
+            .expect("P1 proposal completes");
+        assert!(winning_proposal.utility > 0.0);
+        assert_eq!(winning_proposal.attackers, vec![attacker]);
+        assert_eq!(
+            expanded_pre_mandatory_selection(),
+            Some(ExpandedSelectionReceipt {
+                defender: PlayerId(1),
+                attackers: winning_proposal.attackers,
+            }),
+            "the public action uses the same-call pre-mandatory/pre-crackback proposal"
+        );
         engine::game::engine::apply_as_current(&mut state, action)
             .expect("engine completion accepts the preserved proposal");
     }
@@ -4866,6 +4963,105 @@ mod tests {
             vec![(attacker, AttackTarget::Player(PlayerId(2)))],
             "the expired fallback stays within the engine-issued per-attacker domain"
         );
+    }
+
+    #[test]
+    fn expired_open_defender_uses_its_empty_group_not_a_protected_sibling() {
+        let mut state = setup_multiplayer(3);
+        state.players[1].life = 3;
+        state.players[2].life = 20;
+        let attacker = add_creature(&mut state, PlayerId(0), "Attacker", 4, 4, vec![]);
+        add_creature(&mut state, PlayerId(1), "Protected blocker", 5, 5, vec![]);
+        let threat = add_creature(&mut state, PlayerId(2), "Tapped threat", 5, 5, vec![]);
+        state.objects.get_mut(&threat).unwrap().tapped = true;
+        state.phase = engine::types::phase::Phase::DeclareAttackers;
+        state.waiting_for = engine::game::combat::build_declare_attackers_waiting_for(&state);
+        let engine::types::game_state::WaitingFor::DeclareAttackers {
+            valid_attacker_ids,
+            valid_attack_targets,
+            valid_attack_targets_by_attacker,
+            ..
+        } = &state.waiting_for
+        else {
+            panic!("engine must issue DeclareAttackers")
+        };
+        let valid_attacker_ids = valid_attacker_ids.clone();
+        let valid_attack_targets = valid_attack_targets.clone();
+        let valid_attack_targets_by_attacker = valid_attack_targets_by_attacker.clone();
+        assert_eq!(valid_attacker_ids, vec![attacker]);
+        assert!(valid_attack_targets.contains(&AttackTarget::Player(PlayerId(1))));
+        assert!(valid_attack_targets.contains(&AttackTarget::Player(PlayerId(2))));
+        assert!(valid_attack_targets_by_attacker
+            .as_ref()
+            .and_then(|targets| targets.get(&attacker))
+            .is_some_and(|targets| {
+                targets.contains(&AttackTarget::Player(PlayerId(1)))
+                    && targets.contains(&AttackTarget::Player(PlayerId(2)))
+            }));
+
+        reset_expanded_comparison_counters();
+        let unexpired = choose_attackers_with_targets_with_profile_and_deadline(
+            &state,
+            PlayerId(0),
+            &AiProfile::default(),
+            CombatLookahead::Disabled,
+            None,
+            AttackTargetingContext {
+                valid_attacker_ids: Some(&valid_attacker_ids),
+                valid_attack_targets: Some(&valid_attack_targets),
+                valid_attack_targets_by_attacker: valid_attack_targets_by_attacker.as_ref(),
+                comparison_deadline: Some(Deadline::none()),
+            },
+        );
+        assert_eq!(
+            unexpired,
+            vec![(attacker, AttackTarget::Player(PlayerId(2)))],
+            "the same engine-issued board has a positive open-defender control"
+        );
+        assert!(
+            expanded_comparison_receipt().completed_proposals >= 2,
+            "the unexpired control completes both reachable defender proposals"
+        );
+
+        reset_expanded_comparison_counters();
+        let attacks = choose_attackers_with_targets_with_profile_and_deadline(
+            &state,
+            PlayerId(0),
+            &AiProfile::default(),
+            CombatLookahead::Disabled,
+            None,
+            AttackTargetingContext {
+                valid_attacker_ids: Some(&valid_attacker_ids),
+                valid_attack_targets: Some(&valid_attack_targets),
+                valid_attack_targets_by_attacker: valid_attack_targets_by_attacker.as_ref(),
+                comparison_deadline: Some(Deadline::after(0)),
+            },
+        );
+        assert_eq!(
+            expanded_comparison_receipt(),
+            ExpandedComparisonReceipt {
+                entries: 1,
+                attacker_evaluations: 0,
+                pairs: 0,
+                completed_proposals: 0,
+                grouping_passes: 1,
+                cached_value_evaluations: 0,
+            },
+            "the hostile fallback expires before comparison work"
+        );
+        assert_eq!(
+            attacks,
+            vec![(attacker, AttackTarget::Player(PlayerId(2)))],
+            "P2 is the selected threat fallback and has no blocker group"
+        );
+        engine::game::engine::apply_as_current(
+            &mut state,
+            engine::types::actions::GameAction::DeclareAttackers {
+                attacks,
+                bands: vec![],
+            },
+        )
+        .expect("the engine accepts the open-defender expired fallback");
     }
 
     #[test]

--- a/crates/phase-ai/src/combat_ai.rs
+++ b/crates/phase-ai/src/combat_ai.rs
@@ -269,6 +269,13 @@ pub(crate) fn choose_attackers_with_targets_with_profile_and_deadline(
             })
             .collect()
     };
+    // The engine accepts an empty declaration when no attacker is eligible.
+    // Return before the free-for-all comparison's static/blocker/value setup:
+    // a wide opposing board must not turn an empty legal choice into unbounded
+    // comparison work.
+    if candidates.is_empty() {
+        return Vec::new();
+    }
     // CR 508.1d / CR 701.15b: creatures with a live must-attack requirement
     // (goad, "attacks each combat if able", lure statics) MUST be declared as
     // attackers or the engine rejects the whole declaration. Partition them out
@@ -304,6 +311,17 @@ pub(crate) fn choose_attackers_with_targets_with_profile_and_deadline(
             FormatTopology::IndividualSeats
         )
         && opponents.len() > 1;
+
+    // This local budget covers comparison-specific setup as well as the charged
+    // proposal loops. Start it before collecting static/blocker data, then pass
+    // it through to the comparison for checks before value hoisting and work.
+    let comparison_local_deadline = comparison_enabled
+        .then(|| {
+            targeting
+                .comparison_deadline
+                .and_then(|deadline| deadline.remaining().map(|_| Deadline::after(10)))
+        })
+        .flatten();
 
     // CR 508.1 / CR 509.1 / CR 510.1: promote only an exact lethal
     // declaration the engine has reducer-replayed against every bounded legal
@@ -368,6 +386,7 @@ pub(crate) fn choose_attackers_with_targets_with_profile_and_deadline(
                     valid_attack_targets: targeting.valid_attack_targets,
                     valid_attack_targets_by_attacker: targeting.valid_attack_targets_by_attacker,
                     shared_deadline: deadline,
+                    local_deadline: comparison_local_deadline,
                 },
             )
         })
@@ -716,6 +735,7 @@ thread_local! {
     static EXPANDED_COMPARISON_COMPLETED_PROPOSALS: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
     static EXPANDED_COMPARISON_GROUPING_PASSES: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
     static EXPANDED_COMPARISON_VALUE_EVALUATIONS: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+    static EXPANDED_COMPARISON_GROUPED_BLOCKERS: std::cell::RefCell<HashMap<PlayerId, Vec<ObjectId>>> = std::cell::RefCell::new(HashMap::new());
     static EXPANDED_PROPOSAL_ACCOUNTING: std::cell::RefCell<Vec<ProposalAccounting>> = const { std::cell::RefCell::new(Vec::new()) };
     static EXPANDED_COMPARISON_FORCE_EXPIRE_AT_WORK: std::cell::Cell<Option<usize>> = const { std::cell::Cell::new(None) };
 }
@@ -741,6 +761,7 @@ pub(crate) fn reset_expanded_comparison_counters() {
     EXPANDED_COMPARISON_COMPLETED_PROPOSALS.with(|counter| counter.set(0));
     EXPANDED_COMPARISON_GROUPING_PASSES.with(|counter| counter.set(0));
     EXPANDED_COMPARISON_VALUE_EVALUATIONS.with(|counter| counter.set(0));
+    EXPANDED_COMPARISON_GROUPED_BLOCKERS.with(|groups| groups.borrow_mut().clear());
     EXPANDED_PROPOSAL_ACCOUNTING.with(|accounting| accounting.borrow_mut().clear());
     EXPANDED_COMPARISON_FORCE_EXPIRE_AT_WORK.with(|limit| limit.set(None));
 }
@@ -793,6 +814,11 @@ pub(crate) fn expanded_comparison_receipt() -> ExpandedComparisonReceipt {
     }
 }
 
+#[cfg(test)]
+fn expanded_grouped_blockers() -> HashMap<PlayerId, Vec<ObjectId>> {
+    EXPANDED_COMPARISON_GROUPED_BLOCKERS.with(|groups| groups.borrow().clone())
+}
+
 struct ExpandedMultiplayerChoice {
     defender: PlayerId,
     attackers: Option<Vec<ObjectId>>,
@@ -814,6 +840,7 @@ struct ExpandedComparisonInput<'a> {
     valid_attack_targets: Option<&'a [AttackTarget]>,
     valid_attack_targets_by_attacker: Option<&'a HashMap<ObjectId, Vec<AttackTarget>>>,
     shared_deadline: Deadline,
+    local_deadline: Option<Deadline>,
 }
 
 #[derive(Clone, Copy)]
@@ -845,6 +872,8 @@ fn group_untapped_creature_blockers(
                 .push(id);
         }
     }
+    #[cfg(test)]
+    EXPANDED_COMPARISON_GROUPED_BLOCKERS.with(|recorded| *recorded.borrow_mut() = groups.clone());
     groups
 }
 
@@ -884,6 +913,19 @@ fn expanded_multiplayer_choice(
         return None;
     }
 
+    if input.shared_deadline.expired()
+        || input
+            .local_deadline
+            .is_some_and(|deadline| deadline.expired())
+    {
+        return fallback_multiplayer_defender(state, player, &reachable_opponents).map(
+            |defender| ExpandedMultiplayerChoice {
+                defender,
+                attackers: None,
+            },
+        );
+    }
+
     let work_upper_bound = input
         .candidates
         .len()
@@ -906,10 +948,17 @@ fn expanded_multiplayer_choice(
         );
     }
 
-    let local_deadline = input
-        .shared_deadline
-        .remaining()
-        .map(|_| Deadline::after(10));
+    if input
+        .local_deadline
+        .is_some_and(|deadline| deadline.expired())
+    {
+        return fallback_multiplayer_defender(state, player, &reachable_opponents).map(
+            |defender| ExpandedMultiplayerChoice {
+                defender,
+                attackers: None,
+            },
+        );
+    }
     let mut values = HashMap::new();
     for &id in input
         .candidates
@@ -942,7 +991,9 @@ fn expanded_multiplayer_choice(
             break;
         }
         if input.shared_deadline.expired()
-            || local_deadline.is_some_and(|deadline| deadline.expired())
+            || input
+                .local_deadline
+                .is_some_and(|deadline| deadline.expired())
         {
             break;
         }
@@ -966,7 +1017,9 @@ fn expanded_multiplayer_choice(
                 break;
             }
             if input.shared_deadline.expired()
-                || local_deadline.is_some_and(|deadline| deadline.expired())
+                || input
+                    .local_deadline
+                    .is_some_and(|deadline| deadline.expired())
                 || attacker_evaluations + inspected_pairs >= MULTIPLAYER_COMPARISON_WORK_LIMIT
             {
                 complete = false;
@@ -999,7 +1052,9 @@ fn expanded_multiplayer_choice(
                     break;
                 }
                 if input.shared_deadline.expired()
-                    || local_deadline.is_some_and(|deadline| deadline.expired())
+                    || input
+                        .local_deadline
+                        .is_some_and(|deadline| deadline.expired())
                     || attacker_evaluations + inspected_pairs >= MULTIPLAYER_COMPARISON_WORK_LIMIT
                 {
                     complete = false;
@@ -3928,6 +3983,7 @@ mod tests {
                 valid_attack_targets: None,
                 valid_attack_targets_by_attacker: None,
                 shared_deadline: Deadline::none(),
+                local_deadline: None,
             },
         );
         let accounting = expanded_proposal_accounting();
@@ -4003,6 +4059,211 @@ mod tests {
     }
 
     #[test]
+    fn voluntary_menace_uses_no_block_treatment_before_race_selection() {
+        let mut state = setup_multiplayer(3);
+        state.players[1].life = 3;
+        state.players[2].life = 20;
+        let attacker = add_creature(
+            &mut state,
+            PlayerId(0),
+            "Voluntary menace",
+            3,
+            3,
+            vec![Keyword::Menace],
+        );
+        let blocker = add_creature(&mut state, PlayerId(1), "Lone 5/5", 5, 5, vec![]);
+        let slices = BlockLegalitySlices::collect(&state);
+        let lone_block = defender_best_block_from_eligible(
+            &state,
+            attacker,
+            evaluate_creature(&state, attacker),
+            &[blocker],
+            |id| evaluate_creature(&state, id),
+        )
+        .expect("the hostile hypothetical block exists");
+        assert_eq!(
+            engine::game::combat::min_blockers_required_from_precomputed(
+                &state,
+                attacker,
+                &slices.block_restriction,
+            ),
+            2,
+            "menace requires two blockers"
+        );
+        assert!(!lone_block.attacker_survives && lone_block.blocker_value > 0.0);
+        assert!(
+            !should_attack_given_objective(
+                CombatObjective::Race,
+                lone_block.kills_blocker && lone_block.attacker_survives,
+                lone_block.kills_blocker
+                    && evaluate_creature(&state, attacker) <= lone_block.blocker_value,
+                false,
+                3,
+                lone_block.attacker_survives,
+                false,
+            ),
+            "the illegal one-block hypothetical would reject Race"
+        );
+
+        reset_expanded_comparison_counters();
+        let attacks = choose_attackers_with_targets(&state, PlayerId(0));
+        let p1 = expanded_proposal_accounting()
+            .into_iter()
+            .find(|proposal| proposal.defender == PlayerId(1))
+            .expect("P1 proposal completed");
+        assert_eq!(p1.attackers, vec![attacker]);
+        assert_eq!(p1.own_losses, 0.0);
+        assert_eq!(p1.opposing_losses, 0.0);
+        assert!(p1.finishes);
+        assert_eq!(attacks, vec![(attacker, AttackTarget::Player(PlayerId(1)))]);
+        let mut engine_state = state.clone();
+        engine_state.phase = engine::types::phase::Phase::DeclareAttackers;
+        engine_state.waiting_for =
+            engine::game::combat::build_declare_attackers_waiting_for(&engine_state);
+        engine::game::engine::apply_as_current(
+            &mut engine_state,
+            engine::types::actions::GameAction::DeclareAttackers {
+                attacks: attacks.clone(),
+                bands: vec![],
+            },
+        )
+        .expect("the real three-player declaration is engine legal");
+
+        let second = add_creature(&mut state, PlayerId(1), "Second 5/5", 5, 5, vec![]);
+        reset_expanded_comparison_counters();
+        assert_eq!(
+            choose_attackers_with_targets(&state, PlayerId(0)),
+            vec![(attacker, AttackTarget::Player(PlayerId(2)))],
+            "a sufficient two-block floor keeps the open P2 proposal as the positive choice"
+        );
+        assert!(state.battlefield.contains(&second));
+    }
+
+    #[test]
+    fn completed_decline_is_distinct_from_fallback_and_records_empty_proposals() {
+        let mut state = setup_multiplayer(3);
+        let attacker = add_creature(&mut state, PlayerId(0), "Attacker", 1, 1, vec![]);
+        add_creature(&mut state, PlayerId(1), "Wall", 8, 8, vec![]);
+        add_creature(&mut state, PlayerId(2), "Wall", 8, 8, vec![]);
+        let opponents = players::opponents(&state, PlayerId(0));
+        let slices = BlockLegalitySlices::collect(&state);
+        let groups = group_untapped_creature_blockers(&state, PlayerId(0), &opponents);
+        reset_expanded_comparison_counters();
+        let choice = expanded_multiplayer_choice(
+            &state,
+            PlayerId(0),
+            ExpandedComparisonInput {
+                opponents: &opponents,
+                candidates: &[attacker],
+                mandatory: &[],
+                slices: &slices,
+                blockers_by_controller: &groups,
+                valid_attack_targets: None,
+                valid_attack_targets_by_attacker: None,
+                shared_deadline: Deadline::none(),
+                local_deadline: None,
+            },
+        )
+        .expect("the comparator reaches a completed decline");
+        assert!(matches!(choice.attackers, Some(ref ids) if ids.is_empty()));
+        let accounting = expanded_proposal_accounting();
+        assert_eq!(
+            accounting.len(),
+            2,
+            "both defender proposals completed before declining"
+        );
+        assert!(accounting
+            .iter()
+            .all(|proposal| proposal.attackers.is_empty()));
+        assert_eq!(expanded_comparison_receipt().completed_proposals, 2);
+    }
+
+    #[test]
+    fn mandatory_union_and_crackback_pruning_preserve_their_distinct_authorities() {
+        let mut mandatory_state = setup_multiplayer(3);
+        let voluntary = add_creature(&mut mandatory_state, PlayerId(0), "Voluntary", 1, 1, vec![]);
+        let mandatory = add_creature(&mut mandatory_state, PlayerId(0), "Mandatory", 3, 3, vec![]);
+        add_creature(&mut mandatory_state, PlayerId(1), "P1 wall", 8, 8, vec![]);
+        add_creature(&mut mandatory_state, PlayerId(2), "P2 wall", 8, 8, vec![]);
+        let battle_card_id = CardId(mandatory_state.next_object_id);
+        let battle = create_object(
+            &mut mandatory_state,
+            battle_card_id,
+            PlayerId(1),
+            "Battle".to_string(),
+            Zone::Battlefield,
+        );
+        let battle_object = mandatory_state
+            .objects
+            .get_mut(&battle)
+            .expect("battle exists");
+        battle_object.card_types.core_types.push(CoreType::Battle);
+        battle_object
+            .chosen_attributes
+            .push(engine::types::ability::ChosenAttribute::Player(PlayerId(1)));
+        let permanent = engine::types::identifiers::ObjectIncarnationRef::from_object(
+            mandatory_state.objects.get(&battle).expect("battle exists"),
+        );
+        mandatory_state
+            .objects
+            .get_mut(&mandatory)
+            .expect("mandatory creature exists")
+            .static_definitions
+            .push(
+                StaticDefinition::new(engine::types::statics::StaticMode::MustAttackDefender {
+                    defender: engine::types::statics::RequiredDefender::Permanent { permanent },
+                })
+                .affected(engine::types::ability::TargetFilter::SelfRef),
+            );
+        mandatory_state.phase = engine::types::phase::Phase::DeclareAttackers;
+        mandatory_state.waiting_for =
+            engine::game::combat::build_declare_attackers_waiting_for(&mandatory_state);
+        reset_expanded_comparison_counters();
+        let config = create_config(AiDifficulty::Hard, Platform::Native);
+        let mut rng = SmallRng::seed_from_u64(42);
+        let action = crate::search::choose_action(&mandatory_state, PlayerId(0), &config, &mut rng)
+            .expect("engine-issued declaration has an action");
+        let accounting = expanded_proposal_accounting();
+        assert!(
+            accounting
+                .iter()
+                .all(|proposal| !proposal.attackers.contains(&mandatory)),
+            "the nonplayer-required ID is absent from every pre-mandatory voluntary proposal"
+        );
+        assert!(
+            accounting
+                .iter()
+                .all(|proposal| !proposal.attackers.contains(&voluntary)),
+            "the walls make the scored voluntary set empty"
+        );
+        assert!(matches!(
+            action,
+            engine::types::actions::GameAction::DeclareAttackers { ref attacks, .. }
+                if attacks.contains(&(mandatory, AttackTarget::Battle(battle)))
+        ));
+        engine::game::engine::apply_as_current(&mut mandatory_state, action)
+            .expect("engine completion retains the mandatory nonplayer target");
+
+        let mut crackback_state = setup_multiplayer(3);
+        crackback_state.players[0].life = 3;
+        let scored = add_creature(&mut crackback_state, PlayerId(0), "Scored", 4, 4, vec![]);
+        add_creature(&mut crackback_state, PlayerId(2), "Crackback", 5, 5, vec![]);
+        reset_expanded_comparison_counters();
+        let attacks = choose_attackers_with_targets(&crackback_state, PlayerId(0));
+        assert!(
+            expanded_proposal_accounting()
+                .iter()
+                .any(|proposal| proposal.defender == PlayerId(1)
+                    && proposal.attackers.contains(&scored)),
+            "P1 receives a positive completed scorer-owned proposal before crackback"
+        );
+        assert!(
+            attacks.iter().all(|(id, _)| *id != scored),
+            "positive crackback prunes the scored nonmandatory attacker without rescoring"
+        );
+    }
+
+    #[test]
     fn proposal_deduplicates_reused_blocker_credit_and_caps_at_open_pressure() {
         let mut state = setup_multiplayer(3);
         let attackers: Vec<_> = (0..5)
@@ -4030,6 +4291,7 @@ mod tests {
                 valid_attack_targets: None,
                 valid_attack_targets_by_attacker: None,
                 shared_deadline: Deadline::none(),
+                local_deadline: None,
             },
         );
 
@@ -4074,6 +4336,7 @@ mod tests {
                 valid_attack_targets: None,
                 valid_attack_targets_by_attacker: None,
                 shared_deadline: Deadline::none(),
+                local_deadline: None,
             },
         );
 
@@ -4112,6 +4375,7 @@ mod tests {
                 valid_attack_targets: None,
                 valid_attack_targets_by_attacker: None,
                 shared_deadline: Deadline::none(),
+                local_deadline: None,
             },
         );
         let proposal = expanded_proposal_accounting()
@@ -4294,6 +4558,7 @@ mod tests {
                 valid_attack_targets: None,
                 valid_attack_targets_by_attacker: None,
                 shared_deadline: Deadline::none(),
+                local_deadline: None,
             },
         );
         let protected = expanded_proposal_accounting()
@@ -4334,6 +4599,7 @@ mod tests {
                 valid_attack_targets: None,
                 valid_attack_targets_by_attacker: None,
                 shared_deadline: Deadline::none(),
+                local_deadline: None,
             },
         );
         let open = expanded_proposal_accounting()
@@ -4498,6 +4764,126 @@ mod tests {
     }
 
     #[test]
+    fn mixed_and_restricted_comparisons_charge_attacker_and_pair_work_separately() {
+        let mut mixed = setup_multiplayer(3);
+        let first = add_creature(&mut mixed, PlayerId(0), "First", 4, 4, vec![]);
+        let second = add_creature(&mut mixed, PlayerId(0), "Second", 4, 4, vec![]);
+        add_creature(&mut mixed, PlayerId(1), "P1 blocker", 2, 2, vec![]);
+        add_creature(&mut mixed, PlayerId(2), "P2 blocker one", 2, 2, vec![]);
+        add_creature(&mut mixed, PlayerId(2), "P2 blocker two", 2, 2, vec![]);
+        reset_expanded_comparison_counters();
+        let mixed_attacks = choose_attackers_with_targets(&mixed, PlayerId(0));
+        let mixed_receipt = expanded_comparison_receipt();
+        assert!(
+            !mixed_attacks.is_empty(),
+            "the mixed board reaches a positive proposal"
+        );
+        assert_eq!(mixed_receipt.attacker_evaluations, 4);
+        assert_eq!(mixed_receipt.pairs, 6);
+        assert_eq!(
+            mixed_receipt.attacker_evaluations + mixed_receipt.pairs,
+            10,
+            "A=2, B={{1,2}} charges aggregate work rather than a pair-only bound"
+        );
+
+        let mut restricted = setup_multiplayer(3);
+        let restricted_first = add_creature(&mut restricted, PlayerId(0), "First", 4, 4, vec![]);
+        let restricted_second = add_creature(&mut restricted, PlayerId(0), "Second", 4, 4, vec![]);
+        add_creature(&mut restricted, PlayerId(1), "P1 blocker", 2, 2, vec![]);
+        add_creature(&mut restricted, PlayerId(2), "P2 blocker", 2, 2, vec![]);
+        let mut targets = HashMap::new();
+        targets.insert(restricted_first, vec![AttackTarget::Player(PlayerId(1))]);
+        targets.insert(restricted_second, vec![AttackTarget::Player(PlayerId(2))]);
+        reset_expanded_comparison_counters();
+        let restricted_attacks = choose_attackers_with_targets_with_profile_and_deadline(
+            &restricted,
+            PlayerId(0),
+            &AiProfile::default(),
+            CombatLookahead::Disabled,
+            None,
+            AttackTargetingContext {
+                valid_attacker_ids: Some(&[restricted_first, restricted_second]),
+                valid_attack_targets: Some(&[
+                    AttackTarget::Player(PlayerId(1)),
+                    AttackTarget::Player(PlayerId(2)),
+                ]),
+                valid_attack_targets_by_attacker: Some(&targets),
+                comparison_deadline: Some(Deadline::none()),
+            },
+        );
+        let restricted_receipt = expanded_comparison_receipt();
+        assert!(!restricted_attacks.is_empty());
+        assert_eq!(restricted_receipt.attacker_evaluations, 4);
+        assert_eq!(restricted_receipt.pairs, 2);
+        assert_eq!(
+            restricted_receipt.attacker_evaluations + restricted_receipt.pairs,
+            6
+        );
+        assert!(
+            [first, second]
+                .iter()
+                .all(|id| mixed.battlefield.contains(id)),
+            "the mixed fixture's concrete candidate IDs remain live"
+        );
+    }
+
+    #[test]
+    fn grouping_uses_live_controller_and_excludes_tapped_and_eliminated_blockers() {
+        let mut state = setup_multiplayer(4);
+        let attacker = add_creature(&mut state, PlayerId(0), "Attacker", 4, 4, vec![]);
+        let moved = add_creature(&mut state, PlayerId(1), "Moved", 2, 2, vec![]);
+        let tapped = add_creature(&mut state, PlayerId(2), "Tapped", 2, 2, vec![]);
+        let live = add_creature(&mut state, PlayerId(2), "Live", 2, 2, vec![]);
+        let eliminated = add_creature(&mut state, PlayerId(3), "Eliminated", 2, 2, vec![]);
+        state.objects.get_mut(&moved).unwrap().controller = PlayerId(2);
+        state.objects.get_mut(&tapped).unwrap().tapped = true;
+        state.players[3].is_eliminated = true;
+        reset_expanded_comparison_counters();
+        let attacks = choose_attackers_with_targets(&state, PlayerId(0));
+        let groups = expanded_grouped_blockers();
+        let receipt = expanded_comparison_receipt();
+        assert_eq!(groups.get(&PlayerId(1)), None);
+        assert_eq!(groups.get(&PlayerId(2)), Some(&vec![moved, live]));
+        assert!(
+            groups
+                .values()
+                .flatten()
+                .all(|id| *id != tapped && *id != eliminated),
+            "only actual live, untapped controller-owned blockers are grouped"
+        );
+        assert_eq!(
+            receipt.cached_value_evaluations, 3,
+            "one attacker plus the two grouped blockers"
+        );
+        assert_eq!(attacks, vec![(attacker, AttackTarget::Player(PlayerId(1)))]);
+    }
+
+    #[test]
+    fn open_board_expiry_charges_evaluation_work_without_pairs() {
+        let mut state = setup_multiplayer(3);
+        let attacker = add_creature(&mut state, PlayerId(0), "Attacker", 4, 4, vec![]);
+        reset_expanded_comparison_counters();
+        force_expanded_comparison_expiry_after_work(1);
+        let expired = choose_attackers_with_targets(&state, PlayerId(0));
+        let expired_receipt = expanded_comparison_receipt();
+        assert_eq!(expired_receipt.attacker_evaluations, 1);
+        assert_eq!(expired_receipt.pairs, 0);
+        assert_eq!(expired_receipt.completed_proposals, 1);
+        assert_eq!(expired, vec![(attacker, AttackTarget::Player(PlayerId(1)))]);
+
+        reset_expanded_comparison_counters();
+        let unexpired = choose_attackers_with_targets(&state, PlayerId(0));
+        let unexpired_receipt = expanded_comparison_receipt();
+        assert_eq!(unexpired_receipt.attacker_evaluations, 2);
+        assert_eq!(unexpired_receipt.pairs, 0);
+        assert_eq!(unexpired_receipt.completed_proposals, 2);
+        assert!(
+            !unexpired.is_empty(),
+            "the open-board comparison reaches both defenders without expiry"
+        );
+    }
+
+    #[test]
     fn partial_multiplayer_proposal_cannot_win_after_deterministic_expiry() {
         let mut state = setup_multiplayer(3);
         state.players[1].life = 20;
@@ -4648,6 +5034,144 @@ mod tests {
                 .all(|(_, target)| { *target == AttackTarget::Player(PlayerId(2)) }),
             "the above-cap fallback uses the aggregate issued target domain when no per-attacker map exists"
         );
+    }
+
+    #[test]
+    fn open_board_exact_limit_completes_and_next_attacker_falls_back_without_work() {
+        let mut exact_state = setup_multiplayer(3);
+        let exact_attackers: Vec<_> = (0..2048)
+            .map(|_| add_creature(&mut exact_state, PlayerId(0), "Attacker", 2, 2, vec![]))
+            .collect();
+        let exact_opponents = players::opponents(&exact_state, PlayerId(0));
+        let exact_slices = BlockLegalitySlices::collect(&exact_state);
+        let exact_groups =
+            group_untapped_creature_blockers(&exact_state, PlayerId(0), &exact_opponents);
+        reset_expanded_comparison_counters();
+        let exact = expanded_multiplayer_choice(
+            &exact_state,
+            PlayerId(0),
+            ExpandedComparisonInput {
+                opponents: &exact_opponents,
+                candidates: &exact_attackers,
+                mandatory: &[],
+                slices: &exact_slices,
+                blockers_by_controller: &exact_groups,
+                valid_attack_targets: None,
+                valid_attack_targets_by_attacker: None,
+                shared_deadline: Deadline::none(),
+                local_deadline: None,
+            },
+        )
+        .expect("4096 open-board units are admitted");
+        let exact_receipt = expanded_comparison_receipt();
+        assert!(matches!(exact.attackers, Some(ref ids) if !ids.is_empty()));
+        assert_eq!(exact_receipt.attacker_evaluations, 4096);
+        assert_eq!(exact_receipt.pairs, 0);
+        assert_eq!(exact_receipt.completed_proposals, 2);
+
+        let mut above_state = setup_multiplayer(3);
+        let above_attackers: Vec<_> = (0..2049)
+            .map(|_| add_creature(&mut above_state, PlayerId(0), "Attacker", 2, 2, vec![]))
+            .collect();
+        let above_opponents = players::opponents(&above_state, PlayerId(0));
+        let above_slices = BlockLegalitySlices::collect(&above_state);
+        let above_groups =
+            group_untapped_creature_blockers(&above_state, PlayerId(0), &above_opponents);
+        reset_expanded_comparison_counters();
+        let above = expanded_multiplayer_choice(
+            &above_state,
+            PlayerId(0),
+            ExpandedComparisonInput {
+                opponents: &above_opponents,
+                candidates: &above_attackers,
+                mandatory: &[],
+                slices: &above_slices,
+                blockers_by_controller: &above_groups,
+                valid_attack_targets: None,
+                valid_attack_targets_by_attacker: None,
+                shared_deadline: Deadline::none(),
+                local_deadline: None,
+            },
+        )
+        .expect("above-limit comparison supplies an ordinary fallback defender");
+        assert!(above.attackers.is_none());
+        assert_eq!(
+            expanded_comparison_receipt(),
+            ExpandedComparisonReceipt {
+                entries: 1,
+                attacker_evaluations: 0,
+                pairs: 0,
+                completed_proposals: 0,
+                grouping_passes: 0,
+                cached_value_evaluations: 0,
+            }
+        );
+        reset_expanded_comparison_counters();
+        let public_fallback = choose_attackers_with_targets(&above_state, PlayerId(0));
+        assert_eq!(
+            public_fallback.len(),
+            2049,
+            "the public fallback retains every legal open attacker"
+        );
+        assert_eq!(
+            expanded_comparison_receipt().attacker_evaluations
+                + expanded_comparison_receipt().pairs,
+            0,
+            "the public 4098-unit admission rejection still performs no comparison work"
+        );
+        above_state.phase = engine::types::phase::Phase::DeclareAttackers;
+        above_state.waiting_for = WaitingFor::DeclareAttackers {
+            player: PlayerId(0),
+            valid_attacker_ids: above_attackers,
+            valid_attack_targets: vec![
+                AttackTarget::Player(PlayerId(1)),
+                AttackTarget::Player(PlayerId(2)),
+            ],
+            valid_attack_targets_by_attacker: None,
+            attacker_constraints: Default::default(),
+        };
+        engine::game::engine::apply_as_current(
+            &mut above_state,
+            engine::types::actions::GameAction::DeclareAttackers {
+                attacks: public_fallback,
+                bands: vec![],
+            },
+        )
+        .expect("the above-limit public fallback is engine legal");
+    }
+
+    #[test]
+    fn empty_attacker_declaration_skips_wide_comparison_setup_and_is_engine_legal() {
+        let mut state = setup_multiplayer(3);
+        for _ in 0..2049 {
+            add_creature(&mut state, PlayerId(1), "Wide blocker", 1, 1, vec![]);
+            add_creature(&mut state, PlayerId(2), "Wide blocker", 1, 1, vec![]);
+        }
+        state.phase = engine::types::phase::Phase::DeclareAttackers;
+        state.waiting_for = engine::game::combat::build_declare_attackers_waiting_for(&state);
+        reset_expanded_comparison_counters();
+        let attacks = choose_attackers_with_targets(&state, PlayerId(0));
+        assert!(attacks.is_empty());
+        assert_eq!(
+            expanded_comparison_receipt(),
+            ExpandedComparisonReceipt {
+                entries: 0,
+                attacker_evaluations: 0,
+                pairs: 0,
+                completed_proposals: 0,
+                grouping_passes: 0,
+                cached_value_evaluations: 0,
+            },
+            "an empty candidate domain performs no comparison grouping or value work"
+        );
+        engine::game::engine::apply_as_current(
+            &mut state,
+            engine::types::actions::GameAction::DeclareAttackers {
+                attacks,
+                bands: vec![],
+            },
+        )
+        .expect("the engine accepts the empty declaration on a wide public board");
     }
 
     fn multiplayer_comparison_fixture(attacker_count: usize, blocker_count: usize) -> GameState {

--- a/crates/phase-ai/src/combat_ai.rs
+++ b/crates/phase-ai/src/combat_ai.rs
@@ -38,6 +38,28 @@ pub(crate) struct BlockLegalitySlices {
     can_block_shadow_exists: bool,
 }
 
+/// Engine-issued attack domain and the bounded root-comparison allowance.
+/// Keeping these inputs together prevents callers from accidentally threading
+/// aggregate targets without the per-attacker support that constrains them.
+pub(crate) struct AttackTargetingContext<'a> {
+    pub(crate) valid_attacker_ids: Option<&'a [ObjectId]>,
+    pub(crate) valid_attack_targets: Option<&'a [AttackTarget]>,
+    pub(crate) valid_attack_targets_by_attacker: Option<&'a HashMap<ObjectId, Vec<AttackTarget>>>,
+    pub(crate) comparison_deadline: Option<Deadline>,
+}
+
+impl<'a> AttackTargetingContext<'a> {
+    #[cfg(test)]
+    fn unrestricted() -> Self {
+        Self {
+            valid_attacker_ids: None,
+            valid_attack_targets: None,
+            valid_attack_targets_by_attacker: None,
+            comparison_deadline: Some(Deadline::none()),
+        }
+    }
+}
+
 impl BlockLegalitySlices {
     pub(crate) fn collect(state: &GameState) -> Self {
         Self {
@@ -204,10 +226,13 @@ pub fn choose_attackers_with_targets_with_profile(
         player,
         profile,
         lookahead,
-        valid_attacker_ids,
-        valid_attack_targets,
         session,
-        Some(Deadline::none()),
+        AttackTargetingContext {
+            valid_attacker_ids,
+            valid_attack_targets,
+            valid_attack_targets_by_attacker: None,
+            comparison_deadline: Some(Deadline::none()),
+        },
     )
 }
 
@@ -218,10 +243,8 @@ pub(crate) fn choose_attackers_with_targets_with_profile_and_deadline(
     player: PlayerId,
     profile: &AiProfile,
     lookahead: CombatLookahead,
-    valid_attacker_ids: Option<&[ObjectId]>,
-    valid_attack_targets: Option<&[AttackTarget]>,
     session: Option<&AiSession>,
-    comparison_deadline: Option<Deadline>,
+    targeting: AttackTargetingContext<'_>,
 ) -> Vec<(ObjectId, AttackTarget)> {
     let opponents = players::opponents(state, player);
     if opponents.is_empty() {
@@ -230,7 +253,7 @@ pub(crate) fn choose_attackers_with_targets_with_profile_and_deadline(
 
     // Use engine-provided valid attacker list when available; fall back to
     // local can_attack() for tests and hypothetical scenarios.
-    let candidates: Vec<ObjectId> = if let Some(ids) = valid_attacker_ids {
+    let candidates: Vec<ObjectId> = if let Some(ids) = targeting.valid_attacker_ids {
         ids.to_vec()
     } else {
         state
@@ -326,15 +349,18 @@ pub(crate) fn choose_attackers_with_targets_with_profile_and_deadline(
     // statics O(candidates × blockers) times.
     let slices = BlockLegalitySlices::collect(state);
 
-    let expanded_choice = comparison_deadline.and_then(|deadline| {
+    let expanded_choice = targeting.comparison_deadline.and_then(|deadline| {
         expanded_multiplayer_choice(
             state,
             player,
-            &opponents,
-            &candidates,
-            &mandatory,
-            &slices,
-            deadline,
+            ExpandedComparisonInput {
+                opponents: &opponents,
+                candidates: &candidates,
+                mandatory: &mandatory,
+                slices: &slices,
+                valid_attack_targets_by_attacker: targeting.valid_attack_targets_by_attacker,
+                shared_deadline: deadline,
+            },
         )
     });
     if let Some(choice) = expanded_choice {
@@ -358,6 +384,17 @@ pub(crate) fn choose_attackers_with_targets_with_profile_and_deadline(
     // Determine which creatures should attack (same logic as before)
     let mut attacking_ids = Vec::new();
     for &id in &candidates {
+        if expanded_choice.is_some()
+            && targeting
+                .valid_attack_targets_by_attacker
+                .is_some_and(|targets_by_attacker| {
+                    !targets_by_attacker.get(&id).is_some_and(|targets| {
+                        targets.contains(&AttackTarget::Player(expanded_choice.unwrap().defender))
+                    })
+                })
+        {
+            continue;
+        }
         let obj = match state.objects.get(&id) {
             Some(o) => o,
             None => continue,
@@ -520,7 +557,7 @@ pub(crate) fn choose_attackers_with_targets_with_profile_and_deadline(
         let assignments = redirect_attackers_to_planeswalker(
             state,
             &attacking_ids,
-            valid_attack_targets,
+            targeting.valid_attack_targets,
             objective,
             opp,
             opponent_life,
@@ -534,6 +571,15 @@ pub(crate) fn choose_attackers_with_targets_with_profile_and_deadline(
     let assignments = if let Some(choice) = expanded_choice {
         attacking_ids
             .into_iter()
+            .filter(|id| {
+                targeting
+                    .valid_attack_targets_by_attacker
+                    .is_none_or(|targets_by_attacker| {
+                        targets_by_attacker.get(id).is_some_and(|targets| {
+                            targets.contains(&AttackTarget::Player(choice.defender))
+                        })
+                    })
+            })
             .map(|id| (id, AttackTarget::Player(choice.defender)))
             .collect()
     } else {
@@ -639,11 +685,44 @@ const MULTIPLAYER_COMPARISON_PAIR_LIMIT: usize = 4096;
 const MULTIPLAYER_COMPARISON_TIE_BAND: f64 = 0.25;
 
 #[cfg(test)]
-static EXPANDED_COMPARISON_ENTRIES: std::sync::atomic::AtomicUsize =
-    std::sync::atomic::AtomicUsize::new(0);
+thread_local! {
+    static EXPANDED_COMPARISON_ENTRIES: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+    static EXPANDED_COMPARISON_PAIRS: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+    static EXPANDED_COMPARISON_COMPLETED_PROPOSALS: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+    static EXPANDED_PROPOSAL_ACCOUNTING: std::cell::RefCell<Vec<ProposalAccounting>> = const { std::cell::RefCell::new(Vec::new()) };
+}
+
 #[cfg(test)]
-static EXPANDED_COMPARISON_PAIRS: std::sync::atomic::AtomicUsize =
-    std::sync::atomic::AtomicUsize::new(0);
+#[derive(Clone, Copy, Debug)]
+struct ProposalAccounting {
+    defender: PlayerId,
+    opposing_losses: f64,
+    own_losses: f64,
+    pre_finish_utility: f64,
+    open_pressure: f64,
+}
+
+#[cfg(test)]
+pub(crate) fn reset_expanded_comparison_counters() {
+    EXPANDED_COMPARISON_ENTRIES.with(|counter| counter.set(0));
+    EXPANDED_COMPARISON_PAIRS.with(|counter| counter.set(0));
+    EXPANDED_COMPARISON_COMPLETED_PROPOSALS.with(|counter| counter.set(0));
+    EXPANDED_PROPOSAL_ACCOUNTING.with(|accounting| accounting.borrow_mut().clear());
+}
+
+#[cfg(test)]
+fn expanded_proposal_accounting() -> Vec<ProposalAccounting> {
+    EXPANDED_PROPOSAL_ACCOUNTING.with(|accounting| accounting.borrow().clone())
+}
+
+#[cfg(test)]
+pub(crate) fn expanded_comparison_counters() -> (usize, usize, usize) {
+    (
+        EXPANDED_COMPARISON_ENTRIES.with(std::cell::Cell::get),
+        EXPANDED_COMPARISON_PAIRS.with(std::cell::Cell::get),
+        EXPANDED_COMPARISON_COMPLETED_PROPOSALS.with(std::cell::Cell::get),
+    )
+}
 
 #[derive(Clone, Copy)]
 struct ExpandedMultiplayerChoice {
@@ -654,6 +733,15 @@ struct CombatProposal {
     defender: PlayerId,
     utility: f64,
     finishes: bool,
+}
+
+struct ExpandedComparisonInput<'a> {
+    opponents: &'a [PlayerId],
+    candidates: &'a [ObjectId],
+    mandatory: &'a [ObjectId],
+    slices: &'a BlockLegalitySlices,
+    valid_attack_targets_by_attacker: Option<&'a HashMap<ObjectId, Vec<AttackTarget>>>,
+    shared_deadline: Deadline,
 }
 
 fn untapped_creature_blockers(state: &GameState, defender: PlayerId) -> Vec<ObjectId> {
@@ -675,40 +763,41 @@ fn untapped_creature_blockers(state: &GameState, defender: PlayerId) -> Vec<Obje
 fn expanded_multiplayer_choice(
     state: &GameState,
     player: PlayerId,
-    opponents: &[PlayerId],
-    candidates: &[ObjectId],
-    mandatory: &[ObjectId],
-    slices: &BlockLegalitySlices,
-    shared_deadline: Deadline,
+    input: ExpandedComparisonInput<'_>,
 ) -> Option<ExpandedMultiplayerChoice> {
     if !matches!(
         state.format_config.topology(),
         FormatTopology::IndividualSeats
-    ) || opponents.len() < 2
-        || shared_deadline.expired()
+    ) || input.opponents.len() < 2
     {
         return None;
     }
     #[cfg(test)]
-    EXPANDED_COMPARISON_ENTRIES.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    EXPANDED_COMPARISON_ENTRIES.with(|counter| counter.set(counter.get() + 1));
 
-    let pair_upper_bound = candidates.len().saturating_mul(
-        opponents
+    let pair_upper_bound = input.candidates.len().saturating_mul(
+        input
+            .opponents
             .iter()
             .map(|&opponent| untapped_creature_blockers(state, opponent).len())
             .sum::<usize>(),
     );
-    if pair_upper_bound > MULTIPLAYER_COMPARISON_PAIR_LIMIT {
+    if input.shared_deadline.expired() || pair_upper_bound > MULTIPLAYER_COMPARISON_PAIR_LIMIT {
         return Some(ExpandedMultiplayerChoice {
-            defender: fallback_multiplayer_defender(state, player, opponents),
+            defender: fallback_multiplayer_defender(state, player, input.opponents),
         });
     }
 
-    let local_deadline = shared_deadline.remaining().map(|_| Deadline::after(10));
+    let local_deadline = input
+        .shared_deadline
+        .remaining()
+        .map(|_| Deadline::after(10));
     let mut inspected_pairs = 0usize;
     let mut proposals = Vec::new();
-    for &defender in opponents {
-        if shared_deadline.expired() || local_deadline.is_some_and(|deadline| deadline.expired()) {
+    for &defender in input.opponents {
+        if input.shared_deadline.expired()
+            || local_deadline.is_some_and(|deadline| deadline.expired())
+        {
             break;
         }
         let blockers = untapped_creature_blockers(state, defender);
@@ -719,30 +808,55 @@ fn expanded_multiplayer_choice(
         let mut blocked_damage = 0;
         let mut open_damage = 0;
         let mut commander_finish = false;
+        let mut complete = true;
 
-        for &attacker_id in candidates {
-            if shared_deadline.expired()
+        for &attacker_id in input.candidates {
+            if input.shared_deadline.expired()
                 || local_deadline.is_some_and(|deadline| deadline.expired())
                 || inspected_pairs >= MULTIPLAYER_COMPARISON_PAIR_LIMIT
             {
+                complete = false;
                 break;
+            }
+            if input
+                .valid_attack_targets_by_attacker
+                .is_some_and(|targets_by_attacker| {
+                    !targets_by_attacker
+                        .get(&attacker_id)
+                        .is_some_and(|targets| targets.contains(&AttackTarget::Player(defender)))
+                })
+            {
+                continue;
             }
             let Some(attacker) = state.objects.get(&attacker_id) else {
                 continue;
             };
             let attacker_value = (evaluate_creature(state, attacker_id).max(0.0)) / 5.0;
-            let eligible: Vec<_> = blockers
-                .iter()
-                .copied()
-                .filter(|&blocker_id| {
-                    inspected_pairs += 1;
-                    #[cfg(test)]
-                    EXPANDED_COMPARISON_PAIRS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-                    slices.can_block_pair(state, blocker_id, attacker_id)
-                })
-                .collect();
-            let best_block =
-                defender_best_block(state, attacker_id, attacker_value * 5.0, &blockers, slices);
+            let mut eligible = Vec::new();
+            for &blocker_id in &blockers {
+                if input.shared_deadline.expired()
+                    || local_deadline.is_some_and(|deadline| deadline.expired())
+                    || inspected_pairs >= MULTIPLAYER_COMPARISON_PAIR_LIMIT
+                {
+                    complete = false;
+                    break;
+                }
+                inspected_pairs += 1;
+                #[cfg(test)]
+                EXPANDED_COMPARISON_PAIRS.with(|counter| counter.set(counter.get() + 1));
+                if input.slices.can_block_pair(state, blocker_id, attacker_id) {
+                    eligible.push(blocker_id);
+                }
+            }
+            if !complete {
+                break;
+            }
+            let best_block = defender_best_block_from_eligible(
+                state,
+                attacker_id,
+                attacker_value * 5.0,
+                &eligible,
+            );
             let is_unblockable = has_cant_be_blocked(state, attacker);
             let should_attack = if is_unblockable || eligible.is_empty() {
                 true
@@ -759,18 +873,20 @@ fn expanded_multiplayer_choice(
             } else {
                 true
             };
-            if !should_attack && !mandatory.contains(&attacker_id) {
+            if !should_attack && !input.mandatory.contains(&attacker_id) {
                 continue;
             }
             attackers.push(attacker_id);
             let required = engine::game::combat::min_blockers_required_from_precomputed(
                 state,
                 attacker_id,
-                &slices.block_restriction,
+                &input.slices.block_restriction,
             ) as usize;
-            let damage_blockers = (eligible.len() >= required)
-                .then_some(eligible.as_slice())
-                .unwrap_or(&[]);
+            let damage_blockers = if eligible.len() >= required {
+                eligible.as_slice()
+            } else {
+                &[]
+            };
             let attacker_blocked_damage = engine::game::combat_damage::combat_damage_to_defender(
                 state,
                 attacker_id,
@@ -779,30 +895,48 @@ fn expanded_multiplayer_choice(
             blocked_damage += attacker_blocked_damage;
             open_damage +=
                 engine::game::combat_damage::combat_damage_to_defender(state, attacker_id, &[]);
-            if let Some(block) = best_block {
-                if !block.attacker_survives {
-                    own_losses += attacker_value;
-                }
-                if block.kills_blocker && credited_blockers.insert(block.blocker_id) {
-                    opposing_losses += block.blocker_value / 5.0;
+            // A one-block exchange does not model menace or any other minimum
+            // multi-block requirement. Keep its positive trade credit at zero
+            // unless the single-block model is itself a legal block.
+            if required <= 1 {
+                if let Some(block) = best_block {
+                    if !block.attacker_survives {
+                        own_losses += attacker_value;
+                    }
+                    if block.kills_blocker && credited_blockers.insert(block.blocker_id) {
+                        opposing_losses += block.blocker_value / 5.0;
+                    }
                 }
             }
             if commander_attack_finishes(state, defender, attacker_id, attacker_blocked_damage) {
                 commander_finish = true;
             }
         }
-        if attackers.is_empty() || inspected_pairs >= MULTIPLAYER_COMPARISON_PAIR_LIMIT {
+        if !complete || attackers.is_empty() {
             continue;
         }
+        #[cfg(test)]
+        EXPANDED_COMPARISON_COMPLETED_PROPOSALS.with(|counter| counter.set(counter.get() + 1));
         let defender_life = state.players[defender.0 as usize].life.max(0);
         let pressure = |damage: i32| {
             0.25 * f64::from(damage.max(0).min(defender_life))
                 * (0.5 + threat_level(state, player, defender))
         };
         let finishes = blocked_damage >= defender_life && defender_life > 0 || commander_finish;
-        let utility = (opposing_losses - own_losses + pressure(blocked_damage))
-            .min(pressure(open_damage))
-            + if finishes { 2.0 } else { 0.0 };
+        let open_pressure = pressure(open_damage);
+        let pre_finish_utility =
+            (opposing_losses - own_losses + pressure(blocked_damage)).min(open_pressure);
+        let utility = pre_finish_utility + if finishes { 2.0 } else { 0.0 };
+        #[cfg(test)]
+        EXPANDED_PROPOSAL_ACCOUNTING.with(|accounting| {
+            accounting.borrow_mut().push(ProposalAccounting {
+                defender,
+                opposing_losses,
+                own_losses,
+                pre_finish_utility,
+                open_pressure,
+            });
+        });
         proposals.push(CombatProposal {
             defender,
             utility,
@@ -810,11 +944,18 @@ fn expanded_multiplayer_choice(
         });
     }
 
-    let best = proposals
+    let Some(best) = proposals
         .iter()
-        .max_by(|left, right| left.utility.total_cmp(&right.utility))?;
+        .max_by(|left, right| left.utility.total_cmp(&right.utility))
+    else {
+        return Some(ExpandedMultiplayerChoice {
+            defender: fallback_multiplayer_defender(state, player, input.opponents),
+        });
+    };
     if best.utility <= 0.0 {
-        return None;
+        return Some(ExpandedMultiplayerChoice {
+            defender: fallback_multiplayer_defender(state, player, input.opponents),
+        });
     }
     let mut tied: Vec<_> = proposals
         .iter()
@@ -2363,10 +2504,26 @@ fn defender_best_block(
     blockers: &[ObjectId],
     slices: &BlockLegalitySlices,
 ) -> Option<DefenderBlock> {
-    let attacker = state.objects.get(&attacker_id)?;
-    blockers
+    let eligible: Vec<_> = blockers
         .iter()
-        .filter(|&&bid| slices.can_block_pair(state, bid, attacker_id))
+        .copied()
+        .filter(|&bid| slices.can_block_pair(state, bid, attacker_id))
+        .collect();
+    defender_best_block_from_eligible(state, attacker_id, attacker_value, &eligible)
+}
+
+/// Chooses the best single blocker from a legality-filtered list. The expanded
+/// multiplayer comparison performs the expensive legality sweep under its
+/// operation ceiling, so it must reuse that exact result here.
+fn defender_best_block_from_eligible(
+    state: &GameState,
+    attacker_id: ObjectId,
+    attacker_value: f64,
+    eligible_blockers: &[ObjectId],
+) -> Option<DefenderBlock> {
+    let attacker = state.objects.get(&attacker_id)?;
+    eligible_blockers
+        .iter()
         .filter_map(|&bid| {
             let blocker = state.objects.get(&bid)?;
             let blocker_value = evaluate_creature(state, bid);
@@ -2469,11 +2626,13 @@ fn evaluate_block_outcome(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::{create_config, AiDifficulty, Platform};
     use crate::planner::quick_state_hash;
     use crate::projection::ProjectionKey;
     use engine::game::zones::create_object;
     use engine::types::game_state::WaitingFor;
     use engine::types::identifiers::CardId;
+    use std::time::Instant;
 
     fn setup() -> GameState {
         let mut state = GameState::new_two_player(42);
@@ -3196,40 +3355,203 @@ mod tests {
     }
 
     #[test]
-    fn free_for_all_comparison_is_entered_once_and_honors_expired_deadline() {
-        use std::sync::atomic::Ordering;
+    fn free_for_all_comparison_respects_per_attacker_player_targets() {
+        let mut state = setup_multiplayer(3);
+        let attacker = add_creature(&mut state, PlayerId(0), "Attacker", 4, 4, vec![]);
+        // This is deliberately the more threatening player, but the engine-issued
+        // per-attacker support only permits the other opponent.
+        add_creature(&mut state, PlayerId(1), "Threat", 6, 6, vec![]);
+        let mut targets_by_attacker = HashMap::new();
+        targets_by_attacker.insert(attacker, vec![AttackTarget::Player(PlayerId(2))]);
 
+        let attacks = choose_attackers_with_targets_with_profile_and_deadline(
+            &state,
+            PlayerId(0),
+            &AiProfile::default(),
+            CombatLookahead::Disabled,
+            None,
+            AttackTargetingContext {
+                valid_attacker_ids: Some(&[attacker]),
+                valid_attack_targets: Some(&[
+                    AttackTarget::Player(PlayerId(1)),
+                    AttackTarget::Player(PlayerId(2)),
+                ]),
+                valid_attack_targets_by_attacker: Some(&targets_by_attacker),
+                comparison_deadline: Some(Deadline::none()),
+            },
+        );
+
+        assert_eq!(attacks, vec![(attacker, AttackTarget::Player(PlayerId(2)))]);
+    }
+
+    #[test]
+    fn multi_block_floor_does_not_credit_a_single_block_exchange() {
+        let mut state = setup_multiplayer(3);
+        let attacker = add_creature(
+            &mut state,
+            PlayerId(0),
+            "Menace",
+            3,
+            1,
+            vec![Keyword::Menace],
+        );
+        let blocker = add_creature(&mut state, PlayerId(1), "Blocker", 2, 3, vec![]);
+        let slices = BlockLegalitySlices::collect(&state);
+        let eligible = vec![blocker];
+        let single = defender_best_block_from_eligible(
+            &state,
+            attacker,
+            evaluate_creature(&state, attacker),
+            &eligible,
+        )
+        .expect("the lone blocker has a one-block outcome");
+        assert!(
+            single.kills_blocker,
+            "the one-block model would produce positive credit"
+        );
+        assert_eq!(
+            engine::game::combat::min_blockers_required_from_precomputed(
+                &state,
+                attacker,
+                &slices.block_restriction,
+            ),
+            2,
+        );
+
+        reset_expanded_comparison_counters();
+        let _ = expanded_multiplayer_choice(
+            &state,
+            PlayerId(0),
+            ExpandedComparisonInput {
+                opponents: &players::opponents(&state, PlayerId(0)),
+                candidates: &[attacker],
+                mandatory: &[attacker],
+                slices: &slices,
+                valid_attack_targets_by_attacker: None,
+                shared_deadline: Deadline::none(),
+            },
+        );
+        let accounting = expanded_proposal_accounting();
+        let p1 = accounting
+            .iter()
+            .find(|proposal| proposal.defender == PlayerId(1))
+            .expect("the targeted defender has a complete proposal");
+        assert_eq!(
+            p1.opposing_losses, 0.0,
+            "a single-block model cannot credit a menace exchange"
+        );
+    }
+
+    #[test]
+    fn proposal_deduplicates_reused_blocker_credit_and_caps_at_open_pressure() {
+        let mut state = setup_multiplayer(3);
+        let attackers: Vec<_> = (0..5)
+            .map(|_| add_creature(&mut state, PlayerId(0), "Attacker", 5, 5, vec![]))
+            .collect();
+        let blocker = add_creature(&mut state, PlayerId(1), "Blocker", 2, 2, vec![]);
+        state.players[1].life = 30;
+        state.players[2].life = 30;
+        let slices = BlockLegalitySlices::collect(&state);
+        reset_expanded_comparison_counters();
+
+        let _ = expanded_multiplayer_choice(
+            &state,
+            PlayerId(0),
+            ExpandedComparisonInput {
+                opponents: &players::opponents(&state, PlayerId(0)),
+                candidates: &attackers,
+                mandatory: &[],
+                slices: &slices,
+                valid_attack_targets_by_attacker: None,
+                shared_deadline: Deadline::none(),
+            },
+        );
+
+        let p1 = expanded_proposal_accounting()
+            .into_iter()
+            .find(|proposal| proposal.defender == PlayerId(1))
+            .expect("the blocked defender has a complete proposal");
+        assert_eq!(p1.own_losses, 0.0);
+        assert_eq!(
+            p1.opposing_losses,
+            evaluate_creature(&state, blocker) / 5.0,
+            "five hypothetical blocks by one ObjectId may earn its value only once"
+        );
+        assert!(
+            p1.pre_finish_utility <= p1.open_pressure,
+            "optional block credit is bounded by the defender declining every block"
+        );
+    }
+
+    #[test]
+    fn optional_block_credit_is_capped_by_the_all_no_block_alternative() {
+        let mut state = setup_multiplayer(3);
+        let attacker = add_creature(&mut state, PlayerId(0), "Attacker", 10, 10, vec![]);
+        add_creature(&mut state, PlayerId(1), "Chump", 4, 4, vec![]);
+        state.players[1].life = 30;
+        let slices = BlockLegalitySlices::collect(&state);
+        reset_expanded_comparison_counters();
+
+        let _ = expanded_multiplayer_choice(
+            &state,
+            PlayerId(0),
+            ExpandedComparisonInput {
+                opponents: &players::opponents(&state, PlayerId(0)),
+                candidates: &[attacker],
+                mandatory: &[],
+                slices: &slices,
+                valid_attack_targets_by_attacker: None,
+                shared_deadline: Deadline::none(),
+            },
+        );
+
+        let p1 = expanded_proposal_accounting()
+            .into_iter()
+            .find(|proposal| proposal.defender == PlayerId(1))
+            .expect("the chump defender has a complete proposal");
+        assert!(
+            p1.opposing_losses > p1.open_pressure,
+            "reach guard: without the cap, optional chump credit would exceed the no-block line"
+        );
+        assert_eq!(p1.pre_finish_utility, p1.open_pressure);
+    }
+
+    #[test]
+    fn free_for_all_comparison_is_entered_once_and_honors_expired_deadline() {
         let mut state = setup_multiplayer(3);
         let attacker = add_creature(&mut state, PlayerId(0), "Attacker", 4, 4, vec![]);
         add_creature(&mut state, PlayerId(1), "Blocker", 2, 2, vec![]);
 
-        EXPANDED_COMPARISON_ENTRIES.store(0, Ordering::Relaxed);
-        EXPANDED_COMPARISON_PAIRS.store(0, Ordering::Relaxed);
+        reset_expanded_comparison_counters();
         let attacks = choose_attackers_with_targets(&state, PlayerId(0));
-        assert_eq!(EXPANDED_COMPARISON_ENTRIES.load(Ordering::Relaxed), 1);
-        assert!(EXPANDED_COMPARISON_PAIRS.load(Ordering::Relaxed) > 0);
+        let (entries, pairs, completed) = expanded_comparison_counters();
+        assert_eq!(entries, 1);
+        assert!(pairs > 0);
+        assert!(completed >= 2);
         assert!(attacks.iter().any(|(id, _)| *id == attacker));
 
-        EXPANDED_COMPARISON_ENTRIES.store(0, Ordering::Relaxed);
-        EXPANDED_COMPARISON_PAIRS.store(0, Ordering::Relaxed);
+        reset_expanded_comparison_counters();
         let _ = choose_attackers_with_targets_with_profile_and_deadline(
             &state,
             PlayerId(0),
             &AiProfile::default(),
             CombatLookahead::Disabled,
             None,
-            None,
-            None,
-            Some(Deadline::after(0)),
+            AttackTargetingContext {
+                valid_attacker_ids: None,
+                valid_attack_targets: None,
+                valid_attack_targets_by_attacker: None,
+                comparison_deadline: Some(Deadline::after(0)),
+            },
         );
-        assert_eq!(EXPANDED_COMPARISON_ENTRIES.load(Ordering::Relaxed), 0);
-        assert_eq!(EXPANDED_COMPARISON_PAIRS.load(Ordering::Relaxed), 0);
+        let (entries, pairs, completed) = expanded_comparison_counters();
+        assert_eq!(entries, 1, "expired comparison selects the threat fallback");
+        assert_eq!(pairs, 0);
+        assert_eq!(completed, 0);
     }
 
     #[test]
     fn shared_team_topology_keeps_the_legacy_combat_path() {
-        use std::sync::atomic::Ordering;
-
         let mut state = GameState::new(
             engine::types::format::FormatConfig::two_headed_giant(),
             4,
@@ -3239,12 +3561,35 @@ mod tests {
         state.active_player = PlayerId(0);
         add_creature(&mut state, PlayerId(0), "Attacker", 4, 4, vec![]);
         add_creature(&mut state, PlayerId(2), "Enemy", 2, 2, vec![]);
-        EXPANDED_COMPARISON_ENTRIES.store(0, Ordering::Relaxed);
+        reset_expanded_comparison_counters();
 
         let attacks = choose_attackers_with_targets(&state, PlayerId(0));
 
-        assert_eq!(EXPANDED_COMPARISON_ENTRIES.load(Ordering::Relaxed), 0);
+        assert_eq!(expanded_comparison_counters().0, 0);
         assert!(!attacks.is_empty(), "legacy team combat remains reachable");
+    }
+
+    #[test]
+    fn non_individual_topologies_bypass_the_free_for_all_comparison() {
+        for config in [
+            engine::types::format::FormatConfig::two_headed_giant(),
+            engine::types::format::FormatConfig::archenemy(),
+        ] {
+            let mut state = GameState::new(config, 4, 42);
+            state.turn_number = 2;
+            state.active_player = PlayerId(0);
+            add_creature(&mut state, PlayerId(0), "Attacker", 4, 4, vec![]);
+            reset_expanded_comparison_counters();
+
+            let _ = choose_attackers_with_targets(&state, PlayerId(0));
+
+            assert_eq!(
+                expanded_comparison_counters().0,
+                0,
+                "{:?} must retain the engine's team-aware legacy combat path",
+                state.format_config.topology()
+            );
+        }
     }
 
     #[test]
@@ -3259,49 +3604,131 @@ mod tests {
 
     #[test]
     fn above_pair_ceiling_uses_bounded_fallback() {
-        use std::sync::atomic::Ordering;
-
         let mut state = setup_multiplayer(3);
         for _ in 0..65 {
             add_creature(&mut state, PlayerId(0), "Attacker", 2, 2, vec![]);
             add_creature(&mut state, PlayerId(1), "Blocker", 2, 2, vec![]);
             add_creature(&mut state, PlayerId(2), "Blocker", 2, 2, vec![]);
         }
-        EXPANDED_COMPARISON_ENTRIES.store(0, Ordering::Relaxed);
-        EXPANDED_COMPARISON_PAIRS.store(0, Ordering::Relaxed);
+        reset_expanded_comparison_counters();
 
         let attacks = choose_attackers_with_targets(&state, PlayerId(0));
 
-        assert_eq!(EXPANDED_COMPARISON_ENTRIES.load(Ordering::Relaxed), 1);
-        assert_eq!(EXPANDED_COMPARISON_PAIRS.load(Ordering::Relaxed), 0);
+        let (entries, pairs, completed) = expanded_comparison_counters();
+        assert_eq!(entries, 1);
+        assert_eq!(pairs, 0);
+        assert_eq!(completed, 0);
+        assert_eq!(
+            fallback_multiplayer_defender(
+                &state,
+                PlayerId(0),
+                &players::opponents(&state, PlayerId(0)),
+            ),
+            PlayerId(1),
+            "above the ceiling uses the same threat-based defender fallback"
+        );
         assert!(
-            !attacks.is_empty(),
-            "fallback retains a legal attack heuristic"
+            attacks.is_empty()
+                || attacks
+                    .iter()
+                    .all(|(_, target)| { *target == AttackTarget::Player(PlayerId(1)) })
         );
     }
 
+    /// Manual runtime receipt for the bounded free-for-all comparator. Run with
+    /// `--ignored --nocapture` on a release binary and compare its p50/p95 output
+    /// with the matching baseline checkout. It deliberately uses the production
+    /// Medium and Hard profiles and repeats the same public board 100 times.
     #[test]
-    fn four_player_bots_do_not_all_focus_same_seat_on_equal_threat() {
+    #[ignore = "manual multiplayer timing receipt"]
+    fn multiplayer_comparison_timing_harness() {
+        let fixtures = [
+            ("small", 2, 2),
+            ("typical_four_player", 12, 8),
+            ("above_cap", 65, 65),
+        ];
+        for (difficulty, profile) in [
+            (
+                AiDifficulty::Medium,
+                create_config(AiDifficulty::Medium, Platform::Native).profile,
+            ),
+            (
+                AiDifficulty::Hard,
+                create_config(AiDifficulty::Hard, Platform::Native).profile,
+            ),
+        ] {
+            for (name, attacker_count, blocker_count) in fixtures {
+                let mut state = setup_multiplayer(4);
+                for _ in 0..attacker_count {
+                    add_creature(&mut state, PlayerId(0), "Attacker", 2, 2, vec![]);
+                }
+                for defender in [PlayerId(1), PlayerId(2), PlayerId(3)] {
+                    for _ in 0..blocker_count {
+                        add_creature(&mut state, defender, "Blocker", 2, 2, vec![]);
+                    }
+                }
+                state.phase = engine::types::phase::Phase::DeclareAttackers;
+                state.waiting_for =
+                    engine::game::combat::build_declare_attackers_waiting_for(&state);
+                let path = std::env::temp_dir().join(format!("ai-threat-{name}.json"));
+                std::fs::write(
+                    &path,
+                    serde_json::to_vec(&state).expect("timing state serializes"),
+                )
+                .expect("timing state writes to the temporary directory");
+
+                let mut elapsed_us = Vec::with_capacity(100);
+                let mut pair_count = 0;
+                for _ in 0..100 {
+                    reset_expanded_comparison_counters();
+                    let started = Instant::now();
+                    let _ = choose_attackers_with_targets_with_profile_and_deadline(
+                        &state,
+                        PlayerId(0),
+                        &profile,
+                        CombatLookahead::Disabled,
+                        None,
+                        AttackTargetingContext::unrestricted(),
+                    );
+                    elapsed_us.push(started.elapsed().as_micros());
+                    pair_count += expanded_comparison_counters().1;
+                }
+                elapsed_us.sort_unstable();
+                let p50 = elapsed_us[49];
+                let p95 = elapsed_us[94];
+                assert!(pair_count <= 100 * MULTIPLAYER_COMPARISON_PAIR_LIMIT);
+                println!(
+                    "multiplayer-comparison {difficulty:?} {name}: p50={p50}us p95={p95}us pairs={pair_count} reducers=0 projections=0"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn equal_free_for_all_proposals_are_stable_and_cycle_by_turn() {
         let mut state = setup_multiplayer(4);
-        let p1_attacker = add_creature(&mut state, PlayerId(1), "P1 Bear", 2, 2, vec![]);
-        let p2_attacker = add_creature(&mut state, PlayerId(2), "P2 Bear", 2, 2, vec![]);
-        let p3_attacker = add_creature(&mut state, PlayerId(3), "P3 Bear", 2, 2, vec![]);
+        let attacker = add_creature(&mut state, PlayerId(0), "Bear", 2, 2, vec![]);
 
-        let p1_attacks = choose_attackers_with_targets(&state, PlayerId(1));
-        let p2_attacks = choose_attackers_with_targets(&state, PlayerId(2));
-        let p3_attacks = choose_attackers_with_targets(&state, PlayerId(3));
+        let first = choose_attackers_with_targets(&state, PlayerId(0));
+        assert_eq!(first, choose_attackers_with_targets(&state, PlayerId(0)));
+        assert_eq!(first.len(), 1);
+        assert_eq!(first[0].0, attacker);
 
+        let mut defenders = std::collections::HashSet::new();
+        for turn in 2..5 {
+            state.turn_number = turn;
+            let attacks = choose_attackers_with_targets(&state, PlayerId(0));
+            assert_eq!(attacks.len(), 1, "every tied turn has one attacker");
+            let AttackTarget::Player(defender) = attacks[0].1 else {
+                panic!("free-for-all comparison only chooses player defenders");
+            };
+            assert_ne!(defender, PlayerId(0));
+            defenders.insert(defender);
+        }
         assert_eq!(
-            p1_attacks,
-            vec![(p1_attacker, AttackTarget::Player(PlayerId(2)))]
-        );
-        assert_eq!(
-            p2_attacks,
-            vec![(p2_attacker, AttackTarget::Player(PlayerId(3)))]
-        );
-        assert_eq!(
-            p3_attacks,
-            vec![(p3_attacker, AttackTarget::Player(PlayerId(0)))]
+            defenders.len(),
+            3,
+            "the tie offset visits every living opponent"
         );
     }
 

--- a/crates/phase-ai/src/combat_ai.rs
+++ b/crates/phase-ai/src/combat_ai.rs
@@ -10,12 +10,14 @@ use engine::game::commander::commander_lethal_headroom;
 use engine::game::players;
 use engine::types::ability::StaticDefinition;
 use engine::types::card_type::CoreType;
+use engine::types::format::FormatTopology;
 use engine::types::game_state::GameState;
 use engine::types::identifiers::ObjectId;
 use engine::types::keywords::Keyword;
 use engine::types::player::PlayerId;
 use engine::types::statics::StaticMode;
 use engine::types::zones::Zone;
+use engine::util::Deadline;
 
 use crate::config::{AiConfig, AiProfile, ExecutionMode};
 use crate::damage_reflection::has_damage_reflection_to_controller;
@@ -197,6 +199,30 @@ pub fn choose_attackers_with_targets_with_profile(
     valid_attack_targets: Option<&[AttackTarget]>,
     session: Option<&AiSession>,
 ) -> Vec<(ObjectId, AttackTarget)> {
+    choose_attackers_with_targets_with_profile_and_deadline(
+        state,
+        player,
+        profile,
+        lookahead,
+        valid_attacker_ids,
+        valid_attack_targets,
+        session,
+        Some(Deadline::none()),
+    )
+}
+
+/// The root combat path supplies its normalized shared deadline. Lookahead
+/// callers pass `None`, which retains their existing inexpensive heuristic.
+pub(crate) fn choose_attackers_with_targets_with_profile_and_deadline(
+    state: &GameState,
+    player: PlayerId,
+    profile: &AiProfile,
+    lookahead: CombatLookahead,
+    valid_attacker_ids: Option<&[ObjectId]>,
+    valid_attack_targets: Option<&[AttackTarget]>,
+    session: Option<&AiSession>,
+    comparison_deadline: Option<Deadline>,
+) -> Vec<(ObjectId, AttackTarget)> {
     let opponents = players::opponents(state, player);
     if opponents.is_empty() {
         return Vec::new();
@@ -251,21 +277,9 @@ pub fn choose_attackers_with_targets_with_profile(
 
     let preferred_opponent = preferred_attack_opponent(state, player, &opponents, &candidates);
     // Collect blockers for the most likely attack target rather than the whole table.
-    let opponent_blockers: Vec<ObjectId> = state
-        .battlefield
-        .iter()
-        .filter_map(|&id| {
-            let obj = state.objects.get(&id)?;
-            if Some(obj.controller) == preferred_opponent
-                && obj.card_types.core_types.contains(&CoreType::Creature)
-                && !obj.tapped
-            {
-                Some(id)
-            } else {
-                None
-            }
-        })
-        .collect();
+    let mut opponent_blockers = preferred_opponent
+        .map(|opponent| untapped_creature_blockers(state, opponent))
+        .unwrap_or_default();
 
     // CR 508.1 / CR 509.1 / CR 510.1: promote only an exact lethal
     // declaration the engine has reducer-replayed against every bounded legal
@@ -306,7 +320,28 @@ pub fn choose_attackers_with_targets_with_profile(
         }
     }
 
-    let objective = determine_attack_objective(
+    // Hoist the block-legality static slices once for the whole candidate sweep —
+    // `defender_best_block` runs an O(blockers) `can_block_pair` filter per
+    // candidate, so collecting these per call would re-walk the battlefield's
+    // statics O(candidates × blockers) times.
+    let slices = BlockLegalitySlices::collect(state);
+
+    let expanded_choice = comparison_deadline.and_then(|deadline| {
+        expanded_multiplayer_choice(
+            state,
+            player,
+            &opponents,
+            &candidates,
+            &mandatory,
+            &slices,
+            deadline,
+        )
+    });
+    if let Some(choice) = expanded_choice {
+        opponent_blockers = untapped_creature_blockers(state, choice.defender);
+    }
+
+    let mut objective = determine_attack_objective(
         state,
         player,
         &opponents,
@@ -314,12 +349,11 @@ pub fn choose_attackers_with_targets_with_profile(
         &opponent_blockers,
         profile,
     );
-
-    // Hoist the block-legality static slices once for the whole candidate sweep —
-    // `defender_best_block` runs an O(blockers) `can_block_pair` filter per
-    // candidate, so collecting these per call would re-walk the battlefield's
-    // statics O(candidates × blockers) times.
-    let slices = BlockLegalitySlices::collect(state);
+    // A raw lowest-life check is not a lethal certificate in a free-for-all.
+    // The bounded comparison below accounts for the selected defender's blocks.
+    if expanded_choice.is_some() && matches!(objective, CombatObjective::PushLethal) {
+        objective = CombatObjective::Race;
+    }
 
     // Determine which creatures should attack (same logic as before)
     let mut attacking_ids = Vec::new();
@@ -353,6 +387,7 @@ pub fn choose_attackers_with_targets_with_profile(
                 blocker_value,
                 kills_blocker,
                 attacker_survives,
+                ..
             }) => {
                 let free_damage = kills_blocker && attacker_survives;
                 let favorable_trade = kills_blocker && my_value <= blocker_value;
@@ -494,8 +529,16 @@ pub fn choose_attackers_with_targets_with_profile(
         return assignments;
     }
 
-    // Multi-opponent: assign attack targets (planeswalker redirect deferred).
-    let assignments = assign_attack_targets(state, player, &opponents, attacking_ids);
+    // The expanded free-for-all path keeps its chosen defender attached through
+    // crackback pruning; legacy topologies retain their existing assignment path.
+    let assignments = if let Some(choice) = expanded_choice {
+        attacking_ids
+            .into_iter()
+            .map(|id| (id, AttackTarget::Player(choice.defender)))
+            .collect()
+    } else {
+        assign_attack_targets(state, player, &opponents, attacking_ids)
+    };
     emit_attack_trace(player, &candidates, &assignments);
     assignments
 }
@@ -590,6 +633,234 @@ fn redirect_attackers_to_planeswalker(
             }
         })
         .collect()
+}
+
+const MULTIPLAYER_COMPARISON_PAIR_LIMIT: usize = 4096;
+const MULTIPLAYER_COMPARISON_TIE_BAND: f64 = 0.25;
+
+#[cfg(test)]
+static EXPANDED_COMPARISON_ENTRIES: std::sync::atomic::AtomicUsize =
+    std::sync::atomic::AtomicUsize::new(0);
+#[cfg(test)]
+static EXPANDED_COMPARISON_PAIRS: std::sync::atomic::AtomicUsize =
+    std::sync::atomic::AtomicUsize::new(0);
+
+#[derive(Clone, Copy)]
+struct ExpandedMultiplayerChoice {
+    defender: PlayerId,
+}
+
+struct CombatProposal {
+    defender: PlayerId,
+    utility: f64,
+    finishes: bool,
+}
+
+fn untapped_creature_blockers(state: &GameState, defender: PlayerId) -> Vec<ObjectId> {
+    state
+        .battlefield
+        .iter()
+        .filter_map(|&id| {
+            let object = state.objects.get(&id)?;
+            (object.controller == defender
+                && object.card_types.core_types.contains(&CoreType::Creature)
+                && !object.tapped)
+                .then_some(id)
+        })
+        .collect()
+}
+
+/// Compares coherent, single-defender free-for-all attacks. This is deliberately
+/// a bounded estimate: block legality and combat damage remain engine-owned.
+fn expanded_multiplayer_choice(
+    state: &GameState,
+    player: PlayerId,
+    opponents: &[PlayerId],
+    candidates: &[ObjectId],
+    mandatory: &[ObjectId],
+    slices: &BlockLegalitySlices,
+    shared_deadline: Deadline,
+) -> Option<ExpandedMultiplayerChoice> {
+    if !matches!(
+        state.format_config.topology(),
+        FormatTopology::IndividualSeats
+    ) || opponents.len() < 2
+        || shared_deadline.expired()
+    {
+        return None;
+    }
+    #[cfg(test)]
+    EXPANDED_COMPARISON_ENTRIES.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+
+    let pair_upper_bound = candidates.len().saturating_mul(
+        opponents
+            .iter()
+            .map(|&opponent| untapped_creature_blockers(state, opponent).len())
+            .sum::<usize>(),
+    );
+    if pair_upper_bound > MULTIPLAYER_COMPARISON_PAIR_LIMIT {
+        return Some(ExpandedMultiplayerChoice {
+            defender: fallback_multiplayer_defender(state, player, opponents),
+        });
+    }
+
+    let local_deadline = shared_deadline.remaining().map(|_| Deadline::after(10));
+    let mut inspected_pairs = 0usize;
+    let mut proposals = Vec::new();
+    for &defender in opponents {
+        if shared_deadline.expired() || local_deadline.is_some_and(|deadline| deadline.expired()) {
+            break;
+        }
+        let blockers = untapped_creature_blockers(state, defender);
+        let mut attackers = Vec::new();
+        let mut own_losses = 0.0;
+        let mut opposing_losses = 0.0;
+        let mut credited_blockers = HashSet::new();
+        let mut blocked_damage = 0;
+        let mut open_damage = 0;
+        let mut commander_finish = false;
+
+        for &attacker_id in candidates {
+            if shared_deadline.expired()
+                || local_deadline.is_some_and(|deadline| deadline.expired())
+                || inspected_pairs >= MULTIPLAYER_COMPARISON_PAIR_LIMIT
+            {
+                break;
+            }
+            let Some(attacker) = state.objects.get(&attacker_id) else {
+                continue;
+            };
+            let attacker_value = (evaluate_creature(state, attacker_id).max(0.0)) / 5.0;
+            let eligible: Vec<_> = blockers
+                .iter()
+                .copied()
+                .filter(|&blocker_id| {
+                    inspected_pairs += 1;
+                    #[cfg(test)]
+                    EXPANDED_COMPARISON_PAIRS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                    slices.can_block_pair(state, blocker_id, attacker_id)
+                })
+                .collect();
+            let best_block =
+                defender_best_block(state, attacker_id, attacker_value * 5.0, &blockers, slices);
+            let is_unblockable = has_cant_be_blocked(state, attacker);
+            let should_attack = if is_unblockable || eligible.is_empty() {
+                true
+            } else if let Some(ref block) = best_block {
+                should_attack_given_objective(
+                    CombatObjective::Race,
+                    block.kills_blocker && block.attacker_survives,
+                    block.kills_blocker && attacker_value <= block.blocker_value / 5.0,
+                    attacker.has_keyword(&Keyword::Lifelink),
+                    attacker.power.unwrap_or(0),
+                    block.attacker_survives,
+                    attacker.is_commander,
+                )
+            } else {
+                true
+            };
+            if !should_attack && !mandatory.contains(&attacker_id) {
+                continue;
+            }
+            attackers.push(attacker_id);
+            let required = engine::game::combat::min_blockers_required_from_precomputed(
+                state,
+                attacker_id,
+                &slices.block_restriction,
+            ) as usize;
+            let damage_blockers = (eligible.len() >= required)
+                .then_some(eligible.as_slice())
+                .unwrap_or(&[]);
+            let attacker_blocked_damage = engine::game::combat_damage::combat_damage_to_defender(
+                state,
+                attacker_id,
+                damage_blockers,
+            );
+            blocked_damage += attacker_blocked_damage;
+            open_damage +=
+                engine::game::combat_damage::combat_damage_to_defender(state, attacker_id, &[]);
+            if let Some(block) = best_block {
+                if !block.attacker_survives {
+                    own_losses += attacker_value;
+                }
+                if block.kills_blocker && credited_blockers.insert(block.blocker_id) {
+                    opposing_losses += block.blocker_value / 5.0;
+                }
+            }
+            if commander_attack_finishes(state, defender, attacker_id, attacker_blocked_damage) {
+                commander_finish = true;
+            }
+        }
+        if attackers.is_empty() || inspected_pairs >= MULTIPLAYER_COMPARISON_PAIR_LIMIT {
+            continue;
+        }
+        let defender_life = state.players[defender.0 as usize].life.max(0);
+        let pressure = |damage: i32| {
+            0.25 * f64::from(damage.max(0).min(defender_life))
+                * (0.5 + threat_level(state, player, defender))
+        };
+        let finishes = blocked_damage >= defender_life && defender_life > 0 || commander_finish;
+        let utility = (opposing_losses - own_losses + pressure(blocked_damage))
+            .min(pressure(open_damage))
+            + if finishes { 2.0 } else { 0.0 };
+        proposals.push(CombatProposal {
+            defender,
+            utility,
+            finishes,
+        });
+    }
+
+    let best = proposals
+        .iter()
+        .max_by(|left, right| left.utility.total_cmp(&right.utility))?;
+    if best.utility <= 0.0 {
+        return None;
+    }
+    let mut tied: Vec<_> = proposals
+        .iter()
+        .filter(|proposal| {
+            !best.finishes
+                && !proposal.finishes
+                && best.utility - proposal.utility <= MULTIPLAYER_COMPARISON_TIE_BAND
+        })
+        .collect();
+    if tied.is_empty() {
+        tied.push(best);
+    }
+    tied.sort_by_key(|proposal| proposal.defender);
+    let offset = (state.turn_number as usize + player.0 as usize) % tied.len();
+    Some(ExpandedMultiplayerChoice {
+        defender: tied[offset].defender,
+    })
+}
+
+fn commander_attack_finishes(
+    state: &GameState,
+    defender: PlayerId,
+    attacker_id: ObjectId,
+    blocked_damage: i32,
+) -> bool {
+    state.objects.get(&attacker_id).is_some_and(|attacker| {
+        attacker.is_commander
+            && commander_lethal_headroom(state, defender, attacker_id)
+                .is_some_and(|headroom| blocked_damage.max(0) as u32 >= headroom)
+    })
+}
+
+fn fallback_multiplayer_defender(
+    state: &GameState,
+    player: PlayerId,
+    opponents: &[PlayerId],
+) -> PlayerId {
+    opponents
+        .iter()
+        .copied()
+        .max_by(|left, right| {
+            threat_level(state, player, *left)
+                .total_cmp(&threat_level(state, player, *right))
+                .then_with(|| right.cmp(left))
+        })
+        .expect("expanded multiplayer choice has living opponents")
 }
 
 fn preferred_attack_opponent(
@@ -2063,6 +2334,8 @@ fn can_block_with_engine_map(
 /// The block a rational defending player would commit against one attacker,
 /// described from the ATTACKER's point of view.
 struct DefenderBlock {
+    /// The exact blocker whose value may be credited by a proposal.
+    blocker_id: ObjectId,
     /// Value of the blocking creature the defender chooses.
     blocker_value: f64,
     /// Whether the attacker kills that blocker in the exchange.
@@ -2113,6 +2386,7 @@ fn defender_best_block(
             Some((
                 defender_gain,
                 DefenderBlock {
+                    blocker_id: bid,
                     blocker_value,
                     kills_blocker: !blocker_survives,
                     attacker_survives: !blocker_kills_attacker,
@@ -2905,6 +3179,108 @@ mod tests {
     }
 
     #[test]
+    fn free_for_all_avoids_low_life_defender_with_profitable_block() {
+        let mut state = setup_multiplayer(3);
+        state.players[1].life = 3;
+        add_creature(&mut state, PlayerId(0), "Attacker", 4, 4, vec![]);
+        add_creature(&mut state, PlayerId(1), "Protected", 5, 5, vec![]);
+
+        let attacks = choose_attackers_with_targets(&state, PlayerId(0));
+
+        assert_eq!(attacks.len(), 1, "reach guard: the attacker should attack");
+        assert_eq!(
+            attacks[0].1,
+            AttackTarget::Player(PlayerId(2)),
+            "the low-life player is protected by a profitable blocker; keep the proposal coherent"
+        );
+    }
+
+    #[test]
+    fn free_for_all_comparison_is_entered_once_and_honors_expired_deadline() {
+        use std::sync::atomic::Ordering;
+
+        let mut state = setup_multiplayer(3);
+        let attacker = add_creature(&mut state, PlayerId(0), "Attacker", 4, 4, vec![]);
+        add_creature(&mut state, PlayerId(1), "Blocker", 2, 2, vec![]);
+
+        EXPANDED_COMPARISON_ENTRIES.store(0, Ordering::Relaxed);
+        EXPANDED_COMPARISON_PAIRS.store(0, Ordering::Relaxed);
+        let attacks = choose_attackers_with_targets(&state, PlayerId(0));
+        assert_eq!(EXPANDED_COMPARISON_ENTRIES.load(Ordering::Relaxed), 1);
+        assert!(EXPANDED_COMPARISON_PAIRS.load(Ordering::Relaxed) > 0);
+        assert!(attacks.iter().any(|(id, _)| *id == attacker));
+
+        EXPANDED_COMPARISON_ENTRIES.store(0, Ordering::Relaxed);
+        EXPANDED_COMPARISON_PAIRS.store(0, Ordering::Relaxed);
+        let _ = choose_attackers_with_targets_with_profile_and_deadline(
+            &state,
+            PlayerId(0),
+            &AiProfile::default(),
+            CombatLookahead::Disabled,
+            None,
+            None,
+            None,
+            Some(Deadline::after(0)),
+        );
+        assert_eq!(EXPANDED_COMPARISON_ENTRIES.load(Ordering::Relaxed), 0);
+        assert_eq!(EXPANDED_COMPARISON_PAIRS.load(Ordering::Relaxed), 0);
+    }
+
+    #[test]
+    fn shared_team_topology_keeps_the_legacy_combat_path() {
+        use std::sync::atomic::Ordering;
+
+        let mut state = GameState::new(
+            engine::types::format::FormatConfig::two_headed_giant(),
+            4,
+            42,
+        );
+        state.turn_number = 2;
+        state.active_player = PlayerId(0);
+        add_creature(&mut state, PlayerId(0), "Attacker", 4, 4, vec![]);
+        add_creature(&mut state, PlayerId(2), "Enemy", 2, 2, vec![]);
+        EXPANDED_COMPARISON_ENTRIES.store(0, Ordering::Relaxed);
+
+        let attacks = choose_attackers_with_targets(&state, PlayerId(0));
+
+        assert_eq!(EXPANDED_COMPARISON_ENTRIES.load(Ordering::Relaxed), 0);
+        assert!(!attacks.is_empty(), "legacy team combat remains reachable");
+    }
+
+    #[test]
+    fn combat_comparison_uses_one_normalized_creature_value_unit() {
+        let mut state = setup();
+        let bear = add_creature(&mut state, PlayerId(0), "Bear", 2, 2, vec![]);
+        let giant = add_creature(&mut state, PlayerId(0), "Giant", 5, 5, vec![]);
+
+        assert_eq!(evaluate_creature(&state, bear) / 5.0, 1.0);
+        assert_eq!(evaluate_creature(&state, giant) / 5.0, 2.5);
+    }
+
+    #[test]
+    fn above_pair_ceiling_uses_bounded_fallback() {
+        use std::sync::atomic::Ordering;
+
+        let mut state = setup_multiplayer(3);
+        for _ in 0..65 {
+            add_creature(&mut state, PlayerId(0), "Attacker", 2, 2, vec![]);
+            add_creature(&mut state, PlayerId(1), "Blocker", 2, 2, vec![]);
+            add_creature(&mut state, PlayerId(2), "Blocker", 2, 2, vec![]);
+        }
+        EXPANDED_COMPARISON_ENTRIES.store(0, Ordering::Relaxed);
+        EXPANDED_COMPARISON_PAIRS.store(0, Ordering::Relaxed);
+
+        let attacks = choose_attackers_with_targets(&state, PlayerId(0));
+
+        assert_eq!(EXPANDED_COMPARISON_ENTRIES.load(Ordering::Relaxed), 1);
+        assert_eq!(EXPANDED_COMPARISON_PAIRS.load(Ordering::Relaxed), 0);
+        assert!(
+            !attacks.is_empty(),
+            "fallback retains a legal attack heuristic"
+        );
+    }
+
+    #[test]
     fn four_player_bots_do_not_all_focus_same_seat_on_equal_threat() {
         let mut state = setup_multiplayer(4);
         let p1_attacker = add_creature(&mut state, PlayerId(1), "P1 Bear", 2, 2, vec![]);
@@ -3152,6 +3528,32 @@ mod tests {
             assignments,
             chump_a,
             chump_b
+        );
+    }
+
+    #[test]
+    fn proposal_finish_never_sums_damage_from_two_commanders() {
+        use engine::types::format::FormatConfig;
+        use engine::types::game_state::CommanderDamageEntry;
+
+        let mut state = setup();
+        state.format_config = FormatConfig::commander();
+        let first = add_creature(&mut state, PlayerId(0), "First", 3, 3, vec![]);
+        let second = add_creature(&mut state, PlayerId(0), "Second", 3, 3, vec![]);
+        state.objects.get_mut(&first).unwrap().is_commander = true;
+        state.objects.get_mut(&second).unwrap().is_commander = true;
+        for commander in [first, second] {
+            state.commander_damage.push(CommanderDamageEntry {
+                player: PlayerId(1),
+                commander,
+                damage: 16,
+            });
+        }
+
+        assert!(
+            !commander_attack_finishes(&state, PlayerId(1), first, 3)
+                && !commander_attack_finishes(&state, PlayerId(1), second, 3),
+            "3 + 3 cannot be combined across commander identities to claim a finish"
         );
     }
 

--- a/crates/phase-ai/src/combat_ai.rs
+++ b/crates/phase-ai/src/combat_ai.rs
@@ -2679,6 +2679,9 @@ mod tests {
     use crate::planner::quick_state_hash;
     use crate::projection::ProjectionKey;
     use engine::game::zones::create_object;
+    use engine::types::ability::{
+        Effect, PreventionAmount, PreventionScope, ResolvedAbility, TargetFilter,
+    };
     use engine::types::game_state::WaitingFor;
     use engine::types::identifiers::CardId;
     use rand::{rngs::SmallRng, SeedableRng};
@@ -2700,6 +2703,33 @@ mod tests {
         state.turn_number = 2;
         state.active_player = PlayerId(0);
         state
+    }
+
+    fn install_combat_prevention_shield(state: &mut GameState, player: PlayerId) {
+        let card_id = CardId(state.next_object_id);
+        let shield_source = create_object(
+            state,
+            card_id,
+            player,
+            "Combat prevention".to_string(),
+            Zone::Stack,
+        );
+        let ability = ResolvedAbility::new(
+            Effect::PreventDamage {
+                amount: PreventionAmount::All,
+                amount_dynamic: None,
+                target: TargetFilter::Controller,
+                scope: PreventionScope::CombatDamage,
+                damage_source_filter: None,
+                prevention_duration: None,
+            },
+            Vec::new(),
+            shield_source,
+            player,
+        );
+        let mut events = Vec::new();
+        engine::game::effects::prevent_damage::resolve(state, &ability, &mut events)
+            .expect("the engine installs a combat prevention shield");
     }
 
     fn assert_mandatory_permanent_target(
@@ -3622,6 +3652,28 @@ mod tests {
     }
 
     #[test]
+    fn free_for_all_comparator_returns_no_attack_without_living_opponents() {
+        let mut state = setup_multiplayer(3);
+        let attacker = add_creature(&mut state, PlayerId(0), "Attacker", 4, 4, vec![]);
+        state.players[1].is_eliminated = true;
+        state.players[2].is_eliminated = true;
+        reset_expanded_comparison_counters();
+
+        let attacks = choose_attackers_with_targets(&state, PlayerId(0));
+
+        assert!(
+            attacks.is_empty(),
+            "no living opponent leaves no legal defender"
+        );
+        assert_eq!(
+            expanded_comparison_counters().0,
+            0,
+            "the free-for-all comparator only starts with at least two living opponents"
+        );
+        assert!(state.battlefield.contains(&attacker));
+    }
+
+    #[test]
     fn free_for_all_comparison_respects_per_attacker_player_targets() {
         let mut state = setup_multiplayer(3);
         let attacker = add_creature(&mut state, PlayerId(0), "Attacker", 4, 4, vec![]);
@@ -3708,6 +3760,67 @@ mod tests {
             p1.opposing_losses, 0.0,
             "a single-block model cannot credit a menace exchange"
         );
+    }
+
+    #[test]
+    fn public_comparator_uses_the_minimum_blocker_floor_before_counting_damage() {
+        let mut state = setup_multiplayer(3);
+        state.players[1].life = 3;
+        state.players[2].life = 20;
+        let attacker = add_creature(
+            &mut state,
+            PlayerId(0),
+            "Menace attacker",
+            3,
+            3,
+            vec![Keyword::Menace],
+        );
+        let first = add_creature(&mut state, PlayerId(1), "First blocker", 2, 3, vec![]);
+        let second = add_creature(&mut state, PlayerId(1), "Second blocker", 2, 3, vec![]);
+
+        reset_expanded_comparison_counters();
+        let sufficient = choose_attackers_with_targets(&state, PlayerId(0));
+        assert_eq!(
+            expanded_comparison_counters().0,
+            1,
+            "the public path reaches comparison"
+        );
+        assert_eq!(
+            sufficient,
+            vec![(attacker, AttackTarget::Player(PlayerId(2)))],
+            "two legal blockers satisfy menace and prevent the low-life finish"
+        );
+        assert!(
+            !expanded_proposal_accounting()
+                .iter()
+                .find(|proposal| proposal.defender == PlayerId(1))
+                .expect("the public comparison records P1")
+                .finishes,
+            "the sufficient floor supplies blockers to the engine damage estimate"
+        );
+
+        state.objects.get_mut(&second).unwrap().tapped = true;
+        reset_expanded_comparison_counters();
+        let insufficient = choose_attackers_with_targets(&state, PlayerId(0));
+        assert_eq!(
+            expanded_comparison_counters().0,
+            1,
+            "the changed floor remains public"
+        );
+        assert_eq!(
+            insufficient,
+            vec![(attacker, AttackTarget::Player(PlayerId(1)))],
+            "one blocker cannot satisfy menace, so the finish proposal is selected"
+        );
+        assert!(
+            expanded_proposal_accounting()
+                .iter()
+                .find(|proposal| proposal.defender == PlayerId(1))
+                .expect("the public comparison records P1")
+                .finishes,
+            "one blocker cannot satisfy menace, so the comparison's engine damage estimate is unblocked"
+        );
+        assert!(state.battlefield.contains(&first));
     }
 
     #[test]
@@ -3820,6 +3933,57 @@ mod tests {
     }
 
     #[test]
+    fn public_comparator_vanilla_trade_matches_engine_combat_resolution() {
+        let mut state = setup_multiplayer(3);
+        let attacker = add_creature(&mut state, PlayerId(0), "Attacker", 3, 1, vec![]);
+        let blocker = add_creature(&mut state, PlayerId(1), "Blocker", 2, 3, vec![]);
+        add_creature(&mut state, PlayerId(2), "Wall", 8, 8, vec![]);
+        state.phase = engine::types::phase::Phase::DeclareAttackers;
+        state.waiting_for = engine::game::combat::build_declare_attackers_waiting_for(&state);
+        let config = create_config(AiDifficulty::Hard, Platform::Native);
+        let mut rng = SmallRng::seed_from_u64(42);
+        reset_expanded_comparison_counters();
+
+        let action = crate::search::choose_action(&state, PlayerId(0), &config, &mut rng)
+            .expect("public attacker selection");
+        assert!(matches!(
+            &action,
+            engine::types::actions::GameAction::DeclareAttackers { attacks, .. }
+                if attacks == &vec![(attacker, AttackTarget::Player(PlayerId(1)))]
+        ));
+        assert_eq!(
+            expanded_comparison_counters().0,
+            1,
+            "the public path reaches comparison"
+        );
+        engine::game::engine::apply_as_current(&mut state, action)
+            .expect("the engine accepts the chosen trade");
+        engine::game::combat::declare_blockers_for_player(
+            &mut state,
+            PlayerId(1),
+            &[(blocker, attacker)],
+            &mut Vec::new(),
+        )
+        .expect("the engine accepts the representative block");
+
+        let mut events = Vec::new();
+        assert!(
+            engine::game::combat_damage::resolve_combat_damage(&mut state, &mut events).is_none(),
+            "a single vanilla block needs no interactive damage assignment"
+        );
+        assert_eq!(
+            state.objects[&attacker].zone,
+            Zone::Graveyard,
+            "the engine resolves the attacker as dead in the chosen trade"
+        );
+        assert_eq!(
+            state.objects[&blocker].zone,
+            Zone::Graveyard,
+            "the engine resolves the blocker as dead in the chosen trade"
+        );
+    }
+
+    #[test]
     fn comparator_prefers_a_nonlethal_open_defender_over_a_small_positive_trade() {
         let mut state = setup_multiplayer(3);
         state.players[1].life = 20;
@@ -3907,6 +4071,107 @@ mod tests {
     }
 
     #[test]
+    fn public_comparator_prefers_unblocked_lethal_but_not_blocked_face_damage() {
+        let mut open = setup_multiplayer(3);
+        open.players[1].life = 3;
+        let attacker = add_creature(&mut open, PlayerId(0), "Attacker", 3, 3, vec![]);
+        open.phase = engine::types::phase::Phase::DeclareAttackers;
+        open.waiting_for = engine::game::combat::build_declare_attackers_waiting_for(&open);
+        reset_expanded_comparison_counters();
+        let config = create_config(AiDifficulty::Hard, Platform::Native);
+        let mut rng = SmallRng::seed_from_u64(42);
+        let open_action = crate::search::choose_action(&open, PlayerId(0), &config, &mut rng)
+            .expect("public attacker selection");
+        assert!(matches!(
+            &open_action,
+            engine::types::actions::GameAction::DeclareAttackers { attacks, .. }
+                if attacks == &vec![(attacker, AttackTarget::Player(PlayerId(1)))]
+        ));
+        assert_eq!(
+            expanded_comparison_counters().0,
+            1,
+            "public selection reaches comparator"
+        );
+        engine::game::engine::apply_as_current(&mut open, open_action)
+            .expect("the engine accepts the unblocked lethal declaration");
+
+        let mut blocked = setup_multiplayer(3);
+        blocked.players[1].life = 3;
+        let blocked_attacker = add_creature(&mut blocked, PlayerId(0), "Attacker", 3, 3, vec![]);
+        add_creature(
+            &mut blocked,
+            PlayerId(1),
+            "Preventing blocker",
+            5,
+            5,
+            vec![],
+        );
+        blocked.phase = engine::types::phase::Phase::DeclareAttackers;
+        blocked.waiting_for = engine::game::combat::build_declare_attackers_waiting_for(&blocked);
+        reset_expanded_comparison_counters();
+        let mut rng = SmallRng::seed_from_u64(42);
+        let blocked_action = crate::search::choose_action(&blocked, PlayerId(0), &config, &mut rng)
+            .expect("public attacker selection");
+        assert!(matches!(
+            &blocked_action,
+            engine::types::actions::GameAction::DeclareAttackers { attacks, .. }
+                if attacks == &vec![(blocked_attacker, AttackTarget::Player(PlayerId(2)))]
+        ));
+        assert_eq!(
+            expanded_comparison_counters().0,
+            1,
+            "blocked case reaches comparator"
+        );
+        engine::game::engine::apply_as_current(&mut blocked, blocked_action)
+            .expect("a tactical finish estimate never bypasses engine declaration legality");
+    }
+
+    #[test]
+    fn public_comparator_finish_estimate_does_not_certify_through_prevention() {
+        let mut state = setup_multiplayer(3);
+        state.players[1].life = 3;
+        let attacker = add_creature(&mut state, PlayerId(0), "Attacker", 3, 3, vec![]);
+        install_combat_prevention_shield(&mut state, PlayerId(1));
+        state.phase = engine::types::phase::Phase::DeclareAttackers;
+        state.waiting_for = engine::game::combat::build_declare_attackers_waiting_for(&state);
+        let config = create_config(AiDifficulty::Hard, Platform::Native);
+        let mut rng = SmallRng::seed_from_u64(42);
+        reset_expanded_comparison_counters();
+
+        let action = crate::search::choose_action(&state, PlayerId(0), &config, &mut rng)
+            .expect("public attacker selection");
+        assert!(matches!(
+            &action,
+            engine::types::actions::GameAction::DeclareAttackers { attacks, .. }
+                if attacks == &vec![(attacker, AttackTarget::Player(PlayerId(1)))]
+        ));
+        assert_eq!(
+            expanded_comparison_counters().0,
+            1,
+            "the public path reaches comparison"
+        );
+        engine::game::engine::apply_as_current(&mut state, action)
+            .expect("the engine accepts a policy-selected potential finish");
+        engine::game::combat::declare_blockers_for_player(
+            &mut state,
+            PlayerId(1),
+            &[],
+            &mut Vec::new(),
+        )
+        .expect("the engine accepts no blocks");
+
+        let mut events = Vec::new();
+        assert!(
+            engine::game::combat_damage::resolve_combat_damage(&mut state, &mut events).is_none(),
+            "unblocked combat resolves without a damage-assignment choice"
+        );
+        assert_eq!(
+            state.players[1].life, 3,
+            "the engine prevention replacement, not the tactical estimate, decides final damage"
+        );
+    }
+
+    #[test]
     fn free_for_all_comparison_is_entered_once_and_honors_expired_deadline() {
         let mut state = setup_multiplayer(3);
         let attacker = add_creature(&mut state, PlayerId(0), "Attacker", 4, 4, vec![]);
@@ -3953,14 +4218,21 @@ mod tests {
     #[test]
     fn partial_multiplayer_proposal_cannot_win_after_deterministic_expiry() {
         let mut state = setup_multiplayer(3);
+        state.players[1].life = 20;
+        state.players[2].life = 20;
         let attacker = add_creature(&mut state, PlayerId(0), "Attacker", 5, 5, vec![]);
-        add_creature(&mut state, PlayerId(1), "Blocker", 1, 1, vec![]);
+        add_creature(&mut state, PlayerId(1), "One blocker", 1, 1, vec![]);
         for _ in 0..8 {
             let threat = add_creature(&mut state, PlayerId(2), "Threat", 5, 5, vec![]);
             state.objects.get_mut(&threat).unwrap().tapped = true;
         }
-        add_creature(&mut state, PlayerId(2), "Blocker", 0, 5, vec![]);
-        add_creature(&mut state, PlayerId(2), "Blocker", 0, 5, vec![]);
+        add_creature(&mut state, PlayerId(2), "First blocker", 0, 5, vec![]);
+        add_creature(&mut state, PlayerId(2), "Second blocker", 0, 5, vec![]);
+        assert!(
+            threat_level(&state, PlayerId(0), PlayerId(2))
+                > threat_level(&state, PlayerId(0), PlayerId(1)),
+            "the interrupted defender is the tempting higher-threat choice"
+        );
         reset_expanded_comparison_counters();
         force_expanded_comparison_expiry_after_pairs(2);
         let attacks = choose_attackers_with_targets_with_profile_and_deadline(
@@ -3972,9 +4244,19 @@ mod tests {
             AttackTargetingContext::unrestricted(),
         );
         assert_eq!(expanded_comparison_counters(), (1, 2, 1));
-        assert!(expanded_proposal_accounting()
-            .iter()
-            .all(|p| p.defender != PlayerId(2)));
+        let accounting = expanded_proposal_accounting();
+        assert!(
+            accounting
+                .iter()
+                .any(|proposal| proposal.defender == PlayerId(1)),
+            "the first defender completed before expiry"
+        );
+        assert!(
+            accounting
+                .iter()
+                .all(|proposal| proposal.defender != PlayerId(2)),
+            "an interrupted defender must never be recorded as a complete proposal"
+        );
         assert_eq!(attacks, vec![(attacker, AttackTarget::Player(PlayerId(1)))]);
         reset_expanded_comparison_counters();
     }
@@ -4035,7 +4317,14 @@ mod tests {
     fn above_pair_ceiling_uses_bounded_fallback() {
         let mut state = setup_multiplayer(3);
         for _ in 0..65 {
-            add_creature(&mut state, PlayerId(0), "Attacker", 2, 2, vec![]);
+            add_creature(
+                &mut state,
+                PlayerId(0),
+                "Attacker",
+                4,
+                4,
+                vec![Keyword::Vigilance],
+            );
             add_creature(&mut state, PlayerId(1), "Blocker", 2, 2, vec![]);
             add_creature(&mut state, PlayerId(2), "Blocker", 2, 2, vec![]);
         }

--- a/crates/phase-ai/src/combat_ai.rs
+++ b/crates/phase-ai/src/combat_ai.rs
@@ -298,11 +298,12 @@ pub(crate) fn choose_attackers_with_targets_with_profile_and_deadline(
         })
         .collect();
 
-    let preferred_opponent = preferred_attack_opponent(state, player, &opponents, &candidates);
-    // Collect blockers for the most likely attack target rather than the whole table.
-    let mut opponent_blockers = preferred_opponent
-        .map(|opponent| untapped_creature_blockers(state, opponent))
-        .unwrap_or_default();
+    let comparison_enabled = targeting.comparison_deadline.is_some()
+        && matches!(
+            state.format_config.topology(),
+            FormatTopology::IndividualSeats
+        )
+        && opponents.len() > 1;
 
     // CR 508.1 / CR 509.1 / CR 510.1: promote only an exact lethal
     // declaration the engine has reducer-replayed against every bounded legal
@@ -349,24 +350,40 @@ pub(crate) fn choose_attackers_with_targets_with_profile_and_deadline(
     // statics O(candidates × blockers) times.
     let slices = BlockLegalitySlices::collect(state);
 
+    // Free-for-all comparison owns this single blocker grouping. It is reused for
+    // admission, every proposal, and its one ordinary fallback selection.
+    let blocker_groups =
+        comparison_enabled.then(|| group_untapped_creature_blockers(state, player, &opponents));
     let expanded_choice = targeting.comparison_deadline.and_then(|deadline| {
-        expanded_multiplayer_choice(
-            state,
-            player,
-            ExpandedComparisonInput {
-                opponents: &opponents,
-                candidates: &candidates,
-                mandatory: &mandatory,
-                slices: &slices,
-                valid_attack_targets: targeting.valid_attack_targets,
-                valid_attack_targets_by_attacker: targeting.valid_attack_targets_by_attacker,
-                shared_deadline: deadline,
-            },
-        )
+        blocker_groups.as_ref().and_then(|blockers_by_controller| {
+            expanded_multiplayer_choice(
+                state,
+                player,
+                ExpandedComparisonInput {
+                    opponents: &opponents,
+                    candidates: &candidates,
+                    mandatory: &mandatory,
+                    slices: &slices,
+                    blockers_by_controller,
+                    valid_attack_targets: targeting.valid_attack_targets,
+                    valid_attack_targets_by_attacker: targeting.valid_attack_targets_by_attacker,
+                    shared_deadline: deadline,
+                },
+            )
+        })
     });
-    if let Some(choice) = expanded_choice {
-        opponent_blockers = untapped_creature_blockers(state, choice.defender);
-    }
+    let selected_defender = expanded_choice.as_ref().map(|choice| choice.defender);
+    let opponent_blockers = selected_defender
+        .and_then(|defender| {
+            blocker_groups
+                .as_ref()
+                .and_then(|groups| groups.get(&defender).cloned())
+        })
+        .unwrap_or_else(|| {
+            preferred_attack_opponent(state, player, &opponents, &candidates)
+                .map(|opponent| untapped_creature_blockers(state, opponent))
+                .unwrap_or_default()
+        });
 
     let mut objective = determine_attack_objective(
         state,
@@ -378,71 +395,77 @@ pub(crate) fn choose_attackers_with_targets_with_profile_and_deadline(
     );
     // A raw lowest-life check is not a lethal certificate in a free-for-all.
     // The bounded comparison below accounts for the selected defender's blocks.
-    if expanded_choice.is_some() && matches!(objective, CombatObjective::PushLethal) {
+    if selected_defender.is_some() && matches!(objective, CombatObjective::PushLethal) {
         objective = CombatObjective::Race;
     }
 
-    // Determine which creatures should attack (same logic as before)
-    let mut attacking_ids = Vec::new();
-    for &id in &candidates {
-        if expanded_choice.is_some()
-            && targeting
-                .valid_attack_targets_by_attacker
-                .is_some_and(|targets_by_attacker| {
-                    !targets_by_attacker.get(&id).is_some_and(|targets| {
-                        targets.contains(&AttackTarget::Player(expanded_choice.unwrap().defender))
-                    })
-                })
-        {
-            continue;
-        }
-        let obj = match state.objects.get(&id) {
-            Some(o) => o,
-            None => continue,
-        };
+    // A completed proposal owns its exact voluntary declaration. `Some(empty)`
+    // is an evaluated decline; only an inner `None` invokes the legacy fallback.
+    let mut attacking_ids = expanded_choice
+        .and_then(|choice| choice.attackers)
+        .unwrap_or_else(|| {
+            let mut selected = Vec::new();
+            for &id in &candidates {
+                if selected_defender.is_some()
+                    && targeting.valid_attack_targets_by_attacker.is_some_and(
+                        |targets_by_attacker| {
+                            !targets_by_attacker.get(&id).is_some_and(|targets| {
+                                targets.contains(&AttackTarget::Player(selected_defender.unwrap()))
+                            })
+                        },
+                    )
+                {
+                    continue;
+                }
+                let obj = match state.objects.get(&id) {
+                    Some(o) => o,
+                    None => continue,
+                };
 
-        let my_value = evaluate_creature(state, id);
-        let my_power = obj.power.unwrap_or(0);
+                let my_value = evaluate_creature(state, id);
+                let my_power = obj.power.unwrap_or(0);
 
-        let is_unblockable = has_cant_be_blocked(state, obj);
-        let has_lifelink = obj.has_keyword(&Keyword::Lifelink);
-        let is_commander = obj.is_commander;
+                let is_unblockable = has_cant_be_blocked(state, obj);
+                let has_lifelink = obj.has_keyword(&Keyword::Lifelink);
+                let is_commander = obj.is_commander;
 
-        if is_unblockable || opponent_blockers.is_empty() {
-            attacking_ids.push(id);
-            continue;
-        }
+                if is_unblockable || opponent_blockers.is_empty() {
+                    selected.push(id);
+                    continue;
+                }
 
-        // CR 509.1a: Evaluate the attack against the defender's *best* block, not
-        // its cheapest creature. Assuming the defender chump-trades with its
-        // weakest body let the AI swing doomed creatures into a "favorable trade"
-        // the defender would never offer — it instead kills the attacker for free
-        // with a first-striker or a larger body (gamestate1: a 1/1 animated land
-        // sent into a 2/1 first strike).
-        match defender_best_block(state, id, my_value, &opponent_blockers, &slices) {
-            None => attacking_ids.push(id),
-            Some(DefenderBlock {
-                blocker_value,
-                kills_blocker,
-                attacker_survives,
-                ..
-            }) => {
-                let free_damage = kills_blocker && attacker_survives;
-                let favorable_trade = kills_blocker && my_value <= blocker_value;
-                if should_attack_given_objective(
-                    objective,
-                    free_damage,
-                    favorable_trade,
-                    has_lifelink,
-                    my_power,
-                    attacker_survives,
-                    is_commander,
-                ) {
-                    attacking_ids.push(id);
+                // CR 509.1a: Evaluate the attack against the defender's *best* block, not
+                // its cheapest creature. Assuming the defender chump-trades with its
+                // weakest body let the AI swing doomed creatures into a "favorable trade"
+                // the defender would never offer — it instead kills the attacker for free
+                // with a first-striker or a larger body (gamestate1: a 1/1 animated land
+                // sent into a 2/1 first strike).
+                match defender_best_block(state, id, my_value, &opponent_blockers, &slices) {
+                    None => selected.push(id),
+                    Some(DefenderBlock {
+                        blocker_value,
+                        kills_blocker,
+                        attacker_survives,
+                        ..
+                    }) => {
+                        let free_damage = kills_blocker && attacker_survives;
+                        let favorable_trade = kills_blocker && my_value <= blocker_value;
+                        if should_attack_given_objective(
+                            objective,
+                            free_damage,
+                            favorable_trade,
+                            has_lifelink,
+                            my_power,
+                            attacker_survives,
+                            is_commander,
+                        ) {
+                            selected.push(id);
+                        }
+                    }
                 }
             }
-        }
-    }
+            selected
+        });
 
     // CR 508.1d / CR 701.15b: union the mandatory must-attack set. These
     // creatures are declared regardless of the value heuristic's verdict.
@@ -569,7 +592,7 @@ pub(crate) fn choose_attackers_with_targets_with_profile_and_deadline(
 
     // The expanded free-for-all path keeps its chosen defender attached through
     // crackback pruning; legacy topologies retain their existing assignment path.
-    let assignments = if let Some(choice) = expanded_choice {
+    let assignments = if let Some(defender) = selected_defender {
         attacking_ids
             .into_iter()
             .filter(|id| {
@@ -577,11 +600,11 @@ pub(crate) fn choose_attackers_with_targets_with_profile_and_deadline(
                     .valid_attack_targets_by_attacker
                     .is_none_or(|targets_by_attacker| {
                         targets_by_attacker.get(id).is_some_and(|targets| {
-                            targets.contains(&AttackTarget::Player(choice.defender))
+                            targets.contains(&AttackTarget::Player(defender))
                         })
                     })
             })
-            .map(|id| (id, AttackTarget::Player(choice.defender)))
+            .map(|id| (id, AttackTarget::Player(defender)))
             .collect()
     } else {
         assign_attack_targets(state, player, &opponents, attacking_ids)
@@ -682,22 +705,26 @@ fn redirect_attackers_to_planeswalker(
         .collect()
 }
 
-const MULTIPLAYER_COMPARISON_PAIR_LIMIT: usize = 4096;
+const MULTIPLAYER_COMPARISON_WORK_LIMIT: usize = 4096;
 const MULTIPLAYER_COMPARISON_TIE_BAND: f64 = 0.25;
 
 #[cfg(test)]
 thread_local! {
     static EXPANDED_COMPARISON_ENTRIES: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+    static EXPANDED_COMPARISON_EVALUATIONS: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
     static EXPANDED_COMPARISON_PAIRS: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
     static EXPANDED_COMPARISON_COMPLETED_PROPOSALS: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+    static EXPANDED_COMPARISON_GROUPING_PASSES: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+    static EXPANDED_COMPARISON_VALUE_EVALUATIONS: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
     static EXPANDED_PROPOSAL_ACCOUNTING: std::cell::RefCell<Vec<ProposalAccounting>> = const { std::cell::RefCell::new(Vec::new()) };
-    static EXPANDED_COMPARISON_FORCE_EXPIRE_AT_PAIRS: std::cell::Cell<Option<usize>> = const { std::cell::Cell::new(None) };
+    static EXPANDED_COMPARISON_FORCE_EXPIRE_AT_WORK: std::cell::Cell<Option<usize>> = const { std::cell::Cell::new(None) };
 }
 
 #[cfg(test)]
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Debug)]
 struct ProposalAccounting {
     defender: PlayerId,
+    attackers: Vec<ObjectId>,
     opposing_losses: f64,
     own_losses: f64,
     pre_finish_utility: f64,
@@ -709,21 +736,24 @@ struct ProposalAccounting {
 #[cfg(test)]
 pub(crate) fn reset_expanded_comparison_counters() {
     EXPANDED_COMPARISON_ENTRIES.with(|counter| counter.set(0));
+    EXPANDED_COMPARISON_EVALUATIONS.with(|counter| counter.set(0));
     EXPANDED_COMPARISON_PAIRS.with(|counter| counter.set(0));
     EXPANDED_COMPARISON_COMPLETED_PROPOSALS.with(|counter| counter.set(0));
+    EXPANDED_COMPARISON_GROUPING_PASSES.with(|counter| counter.set(0));
+    EXPANDED_COMPARISON_VALUE_EVALUATIONS.with(|counter| counter.set(0));
     EXPANDED_PROPOSAL_ACCOUNTING.with(|accounting| accounting.borrow_mut().clear());
-    EXPANDED_COMPARISON_FORCE_EXPIRE_AT_PAIRS.with(|limit| limit.set(None));
+    EXPANDED_COMPARISON_FORCE_EXPIRE_AT_WORK.with(|limit| limit.set(None));
 }
 
 #[cfg(test)]
-fn expanded_comparison_forced_expired(pairs: usize) -> bool {
-    EXPANDED_COMPARISON_FORCE_EXPIRE_AT_PAIRS
-        .with(|limit| limit.get().is_some_and(|limit| pairs >= limit))
+fn expanded_comparison_forced_expired(work: usize) -> bool {
+    EXPANDED_COMPARISON_FORCE_EXPIRE_AT_WORK
+        .with(|limit| limit.get().is_some_and(|limit| work >= limit))
 }
 
 #[cfg(test)]
-fn force_expanded_comparison_expiry_after_pairs(pairs: usize) {
-    EXPANDED_COMPARISON_FORCE_EXPIRE_AT_PAIRS.with(|limit| limit.set(Some(pairs)));
+fn force_expanded_comparison_expiry_after_work(work: usize) {
+    EXPANDED_COMPARISON_FORCE_EXPIRE_AT_WORK.with(|limit| limit.set(Some(work)));
 }
 
 #[cfg(test)]
@@ -740,13 +770,37 @@ pub(crate) fn expanded_comparison_counters() -> (usize, usize, usize) {
     )
 }
 
-#[derive(Clone, Copy)]
+#[cfg(test)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct ExpandedComparisonReceipt {
+    pub entries: usize,
+    pub attacker_evaluations: usize,
+    pub pairs: usize,
+    pub completed_proposals: usize,
+    pub grouping_passes: usize,
+    pub cached_value_evaluations: usize,
+}
+
+#[cfg(test)]
+pub(crate) fn expanded_comparison_receipt() -> ExpandedComparisonReceipt {
+    ExpandedComparisonReceipt {
+        entries: EXPANDED_COMPARISON_ENTRIES.with(std::cell::Cell::get),
+        attacker_evaluations: EXPANDED_COMPARISON_EVALUATIONS.with(std::cell::Cell::get),
+        pairs: EXPANDED_COMPARISON_PAIRS.with(std::cell::Cell::get),
+        completed_proposals: EXPANDED_COMPARISON_COMPLETED_PROPOSALS.with(std::cell::Cell::get),
+        grouping_passes: EXPANDED_COMPARISON_GROUPING_PASSES.with(std::cell::Cell::get),
+        cached_value_evaluations: EXPANDED_COMPARISON_VALUE_EVALUATIONS.with(std::cell::Cell::get),
+    }
+}
+
 struct ExpandedMultiplayerChoice {
     defender: PlayerId,
+    attackers: Option<Vec<ObjectId>>,
 }
 
 struct CombatProposal {
     defender: PlayerId,
+    attackers: Vec<ObjectId>,
     utility: f64,
     finishes: bool,
 }
@@ -756,9 +810,42 @@ struct ExpandedComparisonInput<'a> {
     candidates: &'a [ObjectId],
     mandatory: &'a [ObjectId],
     slices: &'a BlockLegalitySlices,
+    blockers_by_controller: &'a HashMap<PlayerId, Vec<ObjectId>>,
     valid_attack_targets: Option<&'a [AttackTarget]>,
     valid_attack_targets_by_attacker: Option<&'a HashMap<ObjectId, Vec<AttackTarget>>>,
     shared_deadline: Deadline,
+}
+
+#[derive(Clone, Copy)]
+struct CombatValue {
+    raw: f64,
+    normalized: f64,
+}
+
+fn group_untapped_creature_blockers(
+    state: &GameState,
+    player: PlayerId,
+    opponents: &[PlayerId],
+) -> HashMap<PlayerId, Vec<ObjectId>> {
+    #[cfg(test)]
+    EXPANDED_COMPARISON_GROUPING_PASSES.with(|counter| counter.set(counter.get() + 1));
+    let mut groups = HashMap::new();
+    for &id in &state.battlefield {
+        let Some(object) = state.objects.get(&id) else {
+            continue;
+        };
+        if object.controller != player
+            && opponents.contains(&object.controller)
+            && object.card_types.core_types.contains(&CoreType::Creature)
+            && !object.tapped
+        {
+            groups
+                .entry(object.controller)
+                .or_insert_with(Vec::new)
+                .push(id);
+        }
+    }
+    groups
 }
 
 fn untapped_creature_blockers(state: &GameState, defender: PlayerId) -> Vec<ObjectId> {
@@ -792,36 +879,66 @@ fn expanded_multiplayer_choice(
     #[cfg(test)]
     EXPANDED_COMPARISON_ENTRIES.with(|counter| counter.set(counter.get() + 1));
 
-    let reachable_opponents: Vec<_> = input
-        .opponents
-        .iter()
-        .copied()
-        .filter(|&opponent| defender_is_reachable(opponent, &input))
-        .collect();
+    let reachable_opponents = reachable_player_defenders(&input);
     if reachable_opponents.is_empty() {
         return None;
     }
 
-    let pair_upper_bound = input.candidates.len().saturating_mul(
-        reachable_opponents
-            .iter()
-            .map(|&opponent| untapped_creature_blockers(state, opponent).len())
-            .sum::<usize>(),
-    );
-    if input.shared_deadline.expired() || pair_upper_bound > MULTIPLAYER_COMPARISON_PAIR_LIMIT {
-        return fallback_multiplayer_defender(state, player, &reachable_opponents)
-            .map(|defender| ExpandedMultiplayerChoice { defender });
+    let work_upper_bound = input
+        .candidates
+        .len()
+        .saturating_mul(reachable_opponents.iter().fold(0usize, |sum, defender| {
+            sum.saturating_add(
+                1usize.saturating_add(
+                    input
+                        .blockers_by_controller
+                        .get(defender)
+                        .map_or(0, Vec::len),
+                ),
+            )
+        }));
+    if input.shared_deadline.expired() || work_upper_bound > MULTIPLAYER_COMPARISON_WORK_LIMIT {
+        return fallback_multiplayer_defender(state, player, &reachable_opponents).map(
+            |defender| ExpandedMultiplayerChoice {
+                defender,
+                attackers: None,
+            },
+        );
     }
 
     let local_deadline = input
         .shared_deadline
         .remaining()
         .map(|_| Deadline::after(10));
+    let mut values = HashMap::new();
+    for &id in input
+        .candidates
+        .iter()
+        .chain(reachable_opponents.iter().flat_map(|defender| {
+            input
+                .blockers_by_controller
+                .get(defender)
+                .into_iter()
+                .flatten()
+        }))
+    {
+        values.entry(id).or_insert_with(|| {
+            #[cfg(test)]
+            EXPANDED_COMPARISON_VALUE_EVALUATIONS.with(|counter| counter.set(counter.get() + 1));
+            let raw = evaluate_creature(state, id);
+            CombatValue {
+                raw,
+                normalized: raw.max(0.0) / 5.0,
+            }
+        });
+    }
+
+    let mut attacker_evaluations = 0usize;
     let mut inspected_pairs = 0usize;
     let mut proposals = Vec::new();
     for &defender in &reachable_opponents {
         #[cfg(test)]
-        if expanded_comparison_forced_expired(inspected_pairs) {
+        if expanded_comparison_forced_expired(attacker_evaluations + inspected_pairs) {
             break;
         }
         if input.shared_deadline.expired()
@@ -829,7 +946,10 @@ fn expanded_multiplayer_choice(
         {
             break;
         }
-        let blockers = untapped_creature_blockers(state, defender);
+        let blockers = input
+            .blockers_by_controller
+            .get(&defender)
+            .map_or(&[][..], Vec::as_slice);
         let mut attackers = Vec::new();
         let mut own_losses = 0.0;
         let mut opposing_losses = 0.0;
@@ -841,17 +961,20 @@ fn expanded_multiplayer_choice(
 
         for &attacker_id in input.candidates {
             #[cfg(test)]
-            if expanded_comparison_forced_expired(inspected_pairs) {
+            if expanded_comparison_forced_expired(attacker_evaluations + inspected_pairs) {
                 complete = false;
                 break;
             }
             if input.shared_deadline.expired()
                 || local_deadline.is_some_and(|deadline| deadline.expired())
-                || inspected_pairs >= MULTIPLAYER_COMPARISON_PAIR_LIMIT
+                || attacker_evaluations + inspected_pairs >= MULTIPLAYER_COMPARISON_WORK_LIMIT
             {
                 complete = false;
                 break;
             }
+            attacker_evaluations += 1;
+            #[cfg(test)]
+            EXPANDED_COMPARISON_EVALUATIONS.with(|counter| counter.set(counter.get() + 1));
             if input
                 .valid_attack_targets_by_attacker
                 .is_some_and(|targets_by_attacker| {
@@ -865,17 +988,19 @@ fn expanded_multiplayer_choice(
             let Some(attacker) = state.objects.get(&attacker_id) else {
                 continue;
             };
-            let attacker_value = (evaluate_creature(state, attacker_id).max(0.0)) / 5.0;
+            let attacker_value = values
+                .get(&attacker_id)
+                .map_or(0.0, |value| value.normalized);
             let mut eligible = Vec::new();
-            for &blocker_id in &blockers {
+            for &blocker_id in blockers {
                 #[cfg(test)]
-                if expanded_comparison_forced_expired(inspected_pairs) {
+                if expanded_comparison_forced_expired(attacker_evaluations + inspected_pairs) {
                     complete = false;
                     break;
                 }
                 if input.shared_deadline.expired()
                     || local_deadline.is_some_and(|deadline| deadline.expired())
-                    || inspected_pairs >= MULTIPLAYER_COMPARISON_PAIR_LIMIT
+                    || attacker_evaluations + inspected_pairs >= MULTIPLAYER_COMPARISON_WORK_LIMIT
                 {
                     complete = false;
                     break;
@@ -890,14 +1015,28 @@ fn expanded_multiplayer_choice(
             if !complete {
                 break;
             }
+            // CR 509.1b + CR 702.111b: use the engine's minimum-block floor
+            // before a voluntary Race decision. A lone menace block is illegal,
+            // so it cannot veto the attack or create exchange accounting.
+            let required = engine::game::combat::min_blockers_required_from_precomputed(
+                state,
+                attacker_id,
+                &input.slices.block_restriction,
+            ) as usize;
+            let damage_blockers = if eligible.len() >= required {
+                eligible.as_slice()
+            } else {
+                &[]
+            };
             let best_block = defender_best_block_from_eligible(
                 state,
                 attacker_id,
-                attacker_value * 5.0,
-                &eligible,
+                values.get(&attacker_id).map_or(0.0, |value| value.raw),
+                damage_blockers,
+                |id| values.get(&id).map_or(0.0, |value| value.raw),
             );
             let is_unblockable = has_cant_be_blocked(state, attacker);
-            let should_attack = if is_unblockable || eligible.is_empty() {
+            let should_attack = if is_unblockable || damage_blockers.is_empty() {
                 true
             } else if let Some(ref block) = best_block {
                 should_attack_given_objective(
@@ -916,16 +1055,6 @@ fn expanded_multiplayer_choice(
                 continue;
             }
             attackers.push(attacker_id);
-            let required = engine::game::combat::min_blockers_required_from_precomputed(
-                state,
-                attacker_id,
-                &input.slices.block_restriction,
-            ) as usize;
-            let damage_blockers = if eligible.len() >= required {
-                eligible.as_slice()
-            } else {
-                &[]
-            };
             let attacker_blocked_damage = engine::game::combat_damage::combat_damage_to_defender(
                 state,
                 attacker_id,
@@ -937,7 +1066,7 @@ fn expanded_multiplayer_choice(
             // A one-block exchange does not model menace or any other minimum
             // multi-block requirement. Keep its positive trade credit at zero
             // unless the single-block model is itself a legal block.
-            if required <= 1 {
+            if required <= 1 && !damage_blockers.is_empty() {
                 if let Some(block) = best_block {
                     if !block.attacker_survives {
                         own_losses += attacker_value;
@@ -951,7 +1080,7 @@ fn expanded_multiplayer_choice(
                 commander_finish = true;
             }
         }
-        if !complete || attackers.is_empty() {
+        if !complete {
             continue;
         }
         #[cfg(test)]
@@ -970,6 +1099,7 @@ fn expanded_multiplayer_choice(
         EXPANDED_PROPOSAL_ACCOUNTING.with(|accounting| {
             accounting.borrow_mut().push(ProposalAccounting {
                 defender,
+                attackers: attackers.clone(),
                 opposing_losses,
                 own_losses,
                 pre_finish_utility,
@@ -980,6 +1110,7 @@ fn expanded_multiplayer_choice(
         });
         proposals.push(CombatProposal {
             defender,
+            attackers,
             utility,
             finishes,
         });
@@ -989,28 +1120,42 @@ fn expanded_multiplayer_choice(
         .iter()
         .max_by(|left, right| left.utility.total_cmp(&right.utility))
     else {
-        return fallback_multiplayer_defender(state, player, &reachable_opponents)
-            .map(|defender| ExpandedMultiplayerChoice { defender });
+        return fallback_multiplayer_defender(state, player, &reachable_opponents).map(
+            |defender| ExpandedMultiplayerChoice {
+                defender,
+                attackers: None,
+            },
+        );
     };
     if best.utility <= 0.0 {
-        return fallback_multiplayer_defender(state, player, &reachable_opponents)
-            .map(|defender| ExpandedMultiplayerChoice { defender });
+        return Some(ExpandedMultiplayerChoice {
+            defender: reachable_opponents[0],
+            attackers: Some(Vec::new()),
+        });
     }
     let mut tied: Vec<_> = proposals
         .iter()
-        .filter(|proposal| {
+        .enumerate()
+        .filter(|(_, proposal)| {
             !best.finishes
                 && !proposal.finishes
+                && proposal.utility > 0.0
                 && best.utility - proposal.utility <= MULTIPLAYER_COMPARISON_TIE_BAND
         })
         .collect();
     if tied.is_empty() {
-        tied.push(best);
+        let best_index = proposals
+            .iter()
+            .position(|proposal| std::ptr::eq(proposal, best))
+            .expect("best proposal belongs to proposals");
+        tied.push((best_index, best));
     }
-    tied.sort_by_key(|proposal| proposal.defender);
+    tied.sort_by_key(|(_, proposal)| proposal.defender);
     let offset = (state.turn_number as usize + player.0 as usize) % tied.len();
+    let selected = proposals.swap_remove(tied[offset].0);
     Some(ExpandedMultiplayerChoice {
-        defender: tied[offset].defender,
+        defender: selected.defender,
+        attackers: Some(selected.attackers),
     })
 }
 
@@ -1039,18 +1184,40 @@ fn fallback_multiplayer_defender(
     })
 }
 
-fn defender_is_reachable(defender: PlayerId, input: &ExpandedComparisonInput<'_>) -> bool {
-    let target = AttackTarget::Player(defender);
-    match input.valid_attack_targets_by_attacker {
-        Some(targets_by_attacker) => input.candidates.iter().any(|attacker| {
-            targets_by_attacker
-                .get(attacker)
-                .is_some_and(|targets| targets.contains(&target))
+fn reachable_player_defenders(input: &ExpandedComparisonInput<'_>) -> Vec<PlayerId> {
+    let issued: Option<HashSet<PlayerId>> = match input.valid_attack_targets_by_attacker {
+        Some(targets_by_attacker) => Some(
+            input
+                .candidates
+                .iter()
+                .filter_map(|attacker| targets_by_attacker.get(attacker))
+                .flatten()
+                .filter_map(|target| match target {
+                    AttackTarget::Player(player) => Some(*player),
+                    _ => None,
+                })
+                .collect(),
+        ),
+        None => input.valid_attack_targets.map(|targets| {
+            targets
+                .iter()
+                .filter_map(|target| match target {
+                    AttackTarget::Player(player) => Some(*player),
+                    _ => None,
+                })
+                .collect()
         }),
-        None => input
-            .valid_attack_targets
-            .is_none_or(|targets| targets.contains(&target)),
-    }
+    };
+    input
+        .opponents
+        .iter()
+        .copied()
+        .filter(|opponent| {
+            issued
+                .as_ref()
+                .is_none_or(|players| players.contains(opponent))
+        })
+        .collect()
 }
 
 fn preferred_attack_opponent(
@@ -2558,24 +2725,30 @@ fn defender_best_block(
         .copied()
         .filter(|&bid| slices.can_block_pair(state, bid, attacker_id))
         .collect();
-    defender_best_block_from_eligible(state, attacker_id, attacker_value, &eligible)
+    defender_best_block_from_eligible(state, attacker_id, attacker_value, &eligible, |id| {
+        evaluate_creature(state, id)
+    })
 }
 
 /// Chooses the best single blocker from a legality-filtered list. The expanded
 /// multiplayer comparison performs the expensive legality sweep under its
 /// operation ceiling, so it must reuse that exact result here.
-fn defender_best_block_from_eligible(
+fn defender_best_block_from_eligible<F>(
     state: &GameState,
     attacker_id: ObjectId,
     attacker_value: f64,
     eligible_blockers: &[ObjectId],
-) -> Option<DefenderBlock> {
+    value_for: F,
+) -> Option<DefenderBlock>
+where
+    F: Fn(ObjectId) -> f64,
+{
     let attacker = state.objects.get(&attacker_id)?;
     eligible_blockers
         .iter()
         .filter_map(|&bid| {
             let blocker = state.objects.get(&bid)?;
-            let blocker_value = evaluate_creature(state, bid);
+            let blocker_value = value_for(bid);
             // CR 702.7b + CR 702.4b + CR 702.2c: keyword-aware outcome (first
             // strike, double strike, deathtouch), not a raw P/T comparison.
             let (blocker_kills_attacker, blocker_survives) =
@@ -3722,6 +3895,7 @@ mod tests {
             attacker,
             evaluate_creature(&state, attacker),
             &eligible,
+            |id| evaluate_creature(&state, id),
         )
         .expect("the lone blocker has a one-block outcome");
         assert!(
@@ -3746,6 +3920,11 @@ mod tests {
                 candidates: &[attacker],
                 mandatory: &[attacker],
                 slices: &slices,
+                blockers_by_controller: &group_untapped_creature_blockers(
+                    &state,
+                    PlayerId(0),
+                    &players::opponents(&state, PlayerId(0)),
+                ),
                 valid_attack_targets: None,
                 valid_attack_targets_by_attacker: None,
                 shared_deadline: Deadline::none(),
@@ -3843,6 +4022,11 @@ mod tests {
                 candidates: &attackers,
                 mandatory: &[],
                 slices: &slices,
+                blockers_by_controller: &group_untapped_creature_blockers(
+                    &state,
+                    PlayerId(0),
+                    &players::opponents(&state, PlayerId(0)),
+                ),
                 valid_attack_targets: None,
                 valid_attack_targets_by_attacker: None,
                 shared_deadline: Deadline::none(),
@@ -3882,6 +4066,11 @@ mod tests {
                 candidates: &[attacker],
                 mandatory: &[],
                 slices: &slices,
+                blockers_by_controller: &group_untapped_creature_blockers(
+                    &state,
+                    PlayerId(0),
+                    &players::opponents(&state, PlayerId(0)),
+                ),
                 valid_attack_targets: None,
                 valid_attack_targets_by_attacker: None,
                 shared_deadline: Deadline::none(),
@@ -3915,6 +4104,11 @@ mod tests {
                 candidates: &[attacker],
                 mandatory: &[],
                 slices: &slices,
+                blockers_by_controller: &group_untapped_creature_blockers(
+                    &state,
+                    PlayerId(0),
+                    &players::opponents(&state, PlayerId(0)),
+                ),
                 valid_attack_targets: None,
                 valid_attack_targets_by_attacker: None,
                 shared_deadline: Deadline::none(),
@@ -4003,6 +4197,79 @@ mod tests {
     }
 
     #[test]
+    fn public_comparison_preserves_race_proposal_through_stabilize_selection() {
+        let mut state = setup_multiplayer(3);
+        state.players[0].life = 4;
+        let attacker = add_creature(&mut state, PlayerId(0), "Trader", 3, 1, vec![]);
+        add_creature(&mut state, PlayerId(1), "Trade blocker", 2, 3, vec![]);
+        let threat = add_creature(&mut state, PlayerId(2), "Crackback", 6, 6, vec![]);
+        state.objects.get_mut(&threat).unwrap().tapped = true;
+        state.phase = engine::types::phase::Phase::DeclareAttackers;
+        let p1 = AttackTarget::Player(PlayerId(1));
+        let p2 = AttackTarget::Player(PlayerId(2));
+        let mut targets_by_attacker = HashMap::new();
+        targets_by_attacker.insert(attacker, vec![p1]);
+        state.waiting_for = engine::types::game_state::WaitingFor::DeclareAttackers {
+            player: PlayerId(0),
+            valid_attacker_ids: vec![attacker],
+            valid_attack_targets: vec![p1, p2],
+            valid_attack_targets_by_attacker: Some(targets_by_attacker),
+            attacker_constraints: Default::default(),
+        };
+        let blockers = group_untapped_creature_blockers(
+            &state,
+            PlayerId(0),
+            &players::opponents(&state, PlayerId(0)),
+        );
+        assert_eq!(
+            determine_attack_objective(
+                &state,
+                PlayerId(0),
+                &players::opponents(&state, PlayerId(0)),
+                &[attacker],
+                blockers.get(&PlayerId(1)).map_or(&[][..], Vec::as_slice),
+                &AiProfile::default(),
+            ),
+            CombatObjective::Stabilize,
+            "reach guard: ordinary fallback would reject a mere favorable trade"
+        );
+        assert!(should_attack_given_objective(
+            CombatObjective::Race,
+            false,
+            true,
+            false,
+            3,
+            false,
+            false,
+        ));
+        assert!(!should_attack_given_objective(
+            CombatObjective::Stabilize,
+            false,
+            true,
+            false,
+            3,
+            false,
+            false,
+        ));
+
+        reset_expanded_comparison_counters();
+        let config = create_config(AiDifficulty::Hard, Platform::Native);
+        let mut rng = SmallRng::seed_from_u64(42);
+        let action = crate::search::choose_action(&state, PlayerId(0), &config, &mut rng)
+            .expect("public DeclareAttackers decision");
+        assert!(matches!(
+            &action,
+            engine::types::actions::GameAction::DeclareAttackers { attacks, .. }
+                if attacks == &vec![(attacker, p1)]
+        ));
+        assert!(expanded_proposal_accounting().iter().any(|proposal| {
+            proposal.defender == PlayerId(1) && proposal.attackers == vec![attacker]
+        }));
+        engine::game::engine::apply_as_current(&mut state, action)
+            .expect("engine completion accepts the preserved proposal");
+    }
+
+    #[test]
     fn comparator_applies_the_finite_finish_bonus_only_to_blocked_damage() {
         let mut state = setup_multiplayer(3);
         state.players[1].life = 3;
@@ -4019,6 +4286,11 @@ mod tests {
                 candidates: &[attacker],
                 mandatory: &[attacker],
                 slices: &slices,
+                blockers_by_controller: &group_untapped_creature_blockers(
+                    &state,
+                    PlayerId(0),
+                    &players::opponents(&state, PlayerId(0)),
+                ),
                 valid_attack_targets: None,
                 valid_attack_targets_by_attacker: None,
                 shared_deadline: Deadline::none(),
@@ -4054,6 +4326,11 @@ mod tests {
                 candidates: &[open_attacker],
                 mandatory: &[open_attacker],
                 slices: &open_slices,
+                blockers_by_controller: &group_untapped_creature_blockers(
+                    &open_state,
+                    PlayerId(0),
+                    &players::opponents(&open_state, PlayerId(0)),
+                ),
                 valid_attack_targets: None,
                 valid_attack_targets_by_attacker: None,
                 shared_deadline: Deadline::none(),
@@ -4180,12 +4457,17 @@ mod tests {
         reset_expanded_comparison_counters();
         let attacks = choose_attackers_with_targets(&state, PlayerId(0));
         let (entries, pairs, completed) = expanded_comparison_counters();
+        let receipt = expanded_comparison_receipt();
         assert_eq!(entries, 1);
         assert_eq!(
             pairs, 1,
             "one attacker against one reachable blocker performs exactly one aggregate pair check"
         );
         assert!(completed >= 2);
+        assert_eq!(receipt.attacker_evaluations, 2);
+        assert_eq!(receipt.attacker_evaluations + receipt.pairs, 3);
+        assert_eq!(receipt.grouping_passes, 1);
+        assert_eq!(receipt.cached_value_evaluations, 2);
         assert!(attacks.iter().any(|(id, _)| *id == attacker));
 
         reset_expanded_comparison_counters();
@@ -4234,7 +4516,7 @@ mod tests {
             "the interrupted defender is the tempting higher-threat choice"
         );
         reset_expanded_comparison_counters();
-        force_expanded_comparison_expiry_after_pairs(2);
+        force_expanded_comparison_expiry_after_work(4);
         let attacks = choose_attackers_with_targets_with_profile_and_deadline(
             &state,
             PlayerId(0),
@@ -4244,6 +4526,10 @@ mod tests {
             AttackTargetingContext::unrestricted(),
         );
         assert_eq!(expanded_comparison_counters(), (1, 2, 1));
+        let receipt = expanded_comparison_receipt();
+        assert_eq!(receipt.attacker_evaluations, 2);
+        assert_eq!(receipt.pairs, 2);
+        assert_eq!(receipt.attacker_evaluations + receipt.pairs, 4);
         let accounting = expanded_proposal_accounting();
         assert!(
             accounting
@@ -4345,9 +4631,12 @@ mod tests {
         );
 
         let (entries, pairs, completed) = expanded_comparison_counters();
+        let receipt = expanded_comparison_receipt();
         assert_eq!(entries, 1);
         assert_eq!(pairs, 0);
         assert_eq!(completed, 0);
+        assert_eq!(receipt.attacker_evaluations, 0);
+        assert_eq!(receipt.attacker_evaluations + receipt.pairs, 0);
         assert_eq!(
             attacks.len(),
             65,
@@ -4361,6 +4650,35 @@ mod tests {
         );
     }
 
+    fn multiplayer_comparison_fixture(attacker_count: usize, blocker_count: usize) -> GameState {
+        let mut state = setup_multiplayer(4);
+        for _ in 0..attacker_count {
+            add_creature(&mut state, PlayerId(0), "Attacker", 2, 2, vec![]);
+        }
+        for defender in [PlayerId(1), PlayerId(2), PlayerId(3)] {
+            for _ in 0..blocker_count {
+                add_creature(&mut state, defender, "Blocker", 2, 2, vec![]);
+            }
+        }
+        state.phase = engine::types::phase::Phase::DeclareAttackers;
+        state.waiting_for = engine::game::combat::build_declare_attackers_waiting_for(&state);
+        state
+    }
+
+    #[test]
+    #[ignore = "manual baseline fixture export"]
+    fn export_zero_blocker_above_cap_fixture() {
+        let state = multiplayer_comparison_fixture(2049, 0);
+        let path = std::env::temp_dir().join("ai-threat-zero-blocker-above-cap.json");
+        std::fs::write(
+            &path,
+            serde_json::to_vec(&serde_json::json!({ "gameState": state }))
+                .expect("fixture state serializes"),
+        )
+        .expect("fixture state writes to the temporary directory");
+        println!("zero-blocker above-cap fixture: {}", path.display());
+    }
+
     /// Manual runtime receipt for the bounded free-for-all comparator. Run with
     /// `--ignored --nocapture` on a release binary and compare its p50/p95 output
     /// with the matching baseline checkout. It deliberately uses the production
@@ -4371,7 +4689,8 @@ mod tests {
         let fixtures = [
             ("small", 2, 2),
             ("typical_four_player", 12, 8),
-            ("above_cap", 65, 65),
+            ("blocker_heavy_above_cap", 65, 65),
+            ("zero_blocker_above_cap", 2049, 0),
         ];
         for (difficulty, profile) in [
             (
@@ -4384,27 +4703,20 @@ mod tests {
             ),
         ] {
             for (name, attacker_count, blocker_count) in fixtures {
-                let mut state = setup_multiplayer(4);
-                for _ in 0..attacker_count {
-                    add_creature(&mut state, PlayerId(0), "Attacker", 2, 2, vec![]);
-                }
-                for defender in [PlayerId(1), PlayerId(2), PlayerId(3)] {
-                    for _ in 0..blocker_count {
-                        add_creature(&mut state, defender, "Blocker", 2, 2, vec![]);
-                    }
-                }
-                state.phase = engine::types::phase::Phase::DeclareAttackers;
-                state.waiting_for =
-                    engine::game::combat::build_declare_attackers_waiting_for(&state);
+                let state = multiplayer_comparison_fixture(attacker_count, blocker_count);
                 let path = std::env::temp_dir().join(format!("ai-threat-{name}.json"));
                 std::fs::write(
                     &path,
-                    serde_json::to_vec(&state).expect("timing state serializes"),
+                    serde_json::to_vec(&serde_json::json!({ "gameState": &state }))
+                        .expect("timing state serializes"),
                 )
                 .expect("timing state writes to the temporary directory");
 
                 let mut elapsed_us = Vec::with_capacity(100);
+                let mut attacker_evaluations = 0;
                 let mut pair_count = 0;
+                let mut grouping_passes = 0;
+                let mut cached_value_evaluations = 0;
                 for _ in 0..100 {
                     reset_expanded_comparison_counters();
                     let started = Instant::now();
@@ -4417,14 +4729,21 @@ mod tests {
                         AttackTargetingContext::unrestricted(),
                     );
                     elapsed_us.push(started.elapsed().as_micros());
-                    pair_count += expanded_comparison_counters().1;
+                    let receipt = expanded_comparison_receipt();
+                    attacker_evaluations += receipt.attacker_evaluations;
+                    pair_count += receipt.pairs;
+                    grouping_passes += receipt.grouping_passes;
+                    cached_value_evaluations += receipt.cached_value_evaluations;
                 }
                 elapsed_us.sort_unstable();
                 let p50 = elapsed_us[49];
                 let p95 = elapsed_us[94];
-                assert!(pair_count <= 100 * MULTIPLAYER_COMPARISON_PAIR_LIMIT);
+                assert!(
+                    attacker_evaluations + pair_count <= 100 * MULTIPLAYER_COMPARISON_WORK_LIMIT
+                );
                 println!(
-                    "multiplayer-comparison {difficulty:?} {name}: p50={p50}us p95={p95}us pairs={pair_count} reducers=0 projections=0"
+                    "multiplayer-comparison {difficulty:?} {name}: p50={p50}us p95={p95}us E={attacker_evaluations} P={pair_count} W={} groups={grouping_passes} values={cached_value_evaluations} reducers=0 projections=0",
+                    attacker_evaluations + pair_count,
                 );
             }
         }

--- a/crates/phase-ai/src/combat_ai.rs
+++ b/crates/phase-ai/src/combat_ai.rs
@@ -358,6 +358,7 @@ pub(crate) fn choose_attackers_with_targets_with_profile_and_deadline(
                 candidates: &candidates,
                 mandatory: &mandatory,
                 slices: &slices,
+                valid_attack_targets: targeting.valid_attack_targets,
                 valid_attack_targets_by_attacker: targeting.valid_attack_targets_by_attacker,
                 shared_deadline: deadline,
             },
@@ -690,6 +691,7 @@ thread_local! {
     static EXPANDED_COMPARISON_PAIRS: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
     static EXPANDED_COMPARISON_COMPLETED_PROPOSALS: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
     static EXPANDED_PROPOSAL_ACCOUNTING: std::cell::RefCell<Vec<ProposalAccounting>> = const { std::cell::RefCell::new(Vec::new()) };
+    static EXPANDED_COMPARISON_FORCE_EXPIRE_AT_PAIRS: std::cell::Cell<Option<usize>> = const { std::cell::Cell::new(None) };
 }
 
 #[cfg(test)]
@@ -700,6 +702,8 @@ struct ProposalAccounting {
     own_losses: f64,
     pre_finish_utility: f64,
     open_pressure: f64,
+    utility: f64,
+    finishes: bool,
 }
 
 #[cfg(test)]
@@ -708,6 +712,18 @@ pub(crate) fn reset_expanded_comparison_counters() {
     EXPANDED_COMPARISON_PAIRS.with(|counter| counter.set(0));
     EXPANDED_COMPARISON_COMPLETED_PROPOSALS.with(|counter| counter.set(0));
     EXPANDED_PROPOSAL_ACCOUNTING.with(|accounting| accounting.borrow_mut().clear());
+    EXPANDED_COMPARISON_FORCE_EXPIRE_AT_PAIRS.with(|limit| limit.set(None));
+}
+
+#[cfg(test)]
+fn expanded_comparison_forced_expired(pairs: usize) -> bool {
+    EXPANDED_COMPARISON_FORCE_EXPIRE_AT_PAIRS
+        .with(|limit| limit.get().is_some_and(|limit| pairs >= limit))
+}
+
+#[cfg(test)]
+fn force_expanded_comparison_expiry_after_pairs(pairs: usize) {
+    EXPANDED_COMPARISON_FORCE_EXPIRE_AT_PAIRS.with(|limit| limit.set(Some(pairs)));
 }
 
 #[cfg(test)]
@@ -740,6 +756,7 @@ struct ExpandedComparisonInput<'a> {
     candidates: &'a [ObjectId],
     mandatory: &'a [ObjectId],
     slices: &'a BlockLegalitySlices,
+    valid_attack_targets: Option<&'a [AttackTarget]>,
     valid_attack_targets_by_attacker: Option<&'a HashMap<ObjectId, Vec<AttackTarget>>>,
     shared_deadline: Deadline,
 }
@@ -775,17 +792,25 @@ fn expanded_multiplayer_choice(
     #[cfg(test)]
     EXPANDED_COMPARISON_ENTRIES.with(|counter| counter.set(counter.get() + 1));
 
+    let reachable_opponents: Vec<_> = input
+        .opponents
+        .iter()
+        .copied()
+        .filter(|&opponent| defender_is_reachable(opponent, &input))
+        .collect();
+    if reachable_opponents.is_empty() {
+        return None;
+    }
+
     let pair_upper_bound = input.candidates.len().saturating_mul(
-        input
-            .opponents
+        reachable_opponents
             .iter()
             .map(|&opponent| untapped_creature_blockers(state, opponent).len())
             .sum::<usize>(),
     );
     if input.shared_deadline.expired() || pair_upper_bound > MULTIPLAYER_COMPARISON_PAIR_LIMIT {
-        return Some(ExpandedMultiplayerChoice {
-            defender: fallback_multiplayer_defender(state, player, input.opponents),
-        });
+        return fallback_multiplayer_defender(state, player, &reachable_opponents)
+            .map(|defender| ExpandedMultiplayerChoice { defender });
     }
 
     let local_deadline = input
@@ -794,7 +819,11 @@ fn expanded_multiplayer_choice(
         .map(|_| Deadline::after(10));
     let mut inspected_pairs = 0usize;
     let mut proposals = Vec::new();
-    for &defender in input.opponents {
+    for &defender in &reachable_opponents {
+        #[cfg(test)]
+        if expanded_comparison_forced_expired(inspected_pairs) {
+            break;
+        }
         if input.shared_deadline.expired()
             || local_deadline.is_some_and(|deadline| deadline.expired())
         {
@@ -811,6 +840,11 @@ fn expanded_multiplayer_choice(
         let mut complete = true;
 
         for &attacker_id in input.candidates {
+            #[cfg(test)]
+            if expanded_comparison_forced_expired(inspected_pairs) {
+                complete = false;
+                break;
+            }
             if input.shared_deadline.expired()
                 || local_deadline.is_some_and(|deadline| deadline.expired())
                 || inspected_pairs >= MULTIPLAYER_COMPARISON_PAIR_LIMIT
@@ -834,6 +868,11 @@ fn expanded_multiplayer_choice(
             let attacker_value = (evaluate_creature(state, attacker_id).max(0.0)) / 5.0;
             let mut eligible = Vec::new();
             for &blocker_id in &blockers {
+                #[cfg(test)]
+                if expanded_comparison_forced_expired(inspected_pairs) {
+                    complete = false;
+                    break;
+                }
                 if input.shared_deadline.expired()
                     || local_deadline.is_some_and(|deadline| deadline.expired())
                     || inspected_pairs >= MULTIPLAYER_COMPARISON_PAIR_LIMIT
@@ -935,6 +974,8 @@ fn expanded_multiplayer_choice(
                 own_losses,
                 pre_finish_utility,
                 open_pressure,
+                utility,
+                finishes,
             });
         });
         proposals.push(CombatProposal {
@@ -948,14 +989,12 @@ fn expanded_multiplayer_choice(
         .iter()
         .max_by(|left, right| left.utility.total_cmp(&right.utility))
     else {
-        return Some(ExpandedMultiplayerChoice {
-            defender: fallback_multiplayer_defender(state, player, input.opponents),
-        });
+        return fallback_multiplayer_defender(state, player, &reachable_opponents)
+            .map(|defender| ExpandedMultiplayerChoice { defender });
     };
     if best.utility <= 0.0 {
-        return Some(ExpandedMultiplayerChoice {
-            defender: fallback_multiplayer_defender(state, player, input.opponents),
-        });
+        return fallback_multiplayer_defender(state, player, &reachable_opponents)
+            .map(|defender| ExpandedMultiplayerChoice { defender });
     }
     let mut tied: Vec<_> = proposals
         .iter()
@@ -992,16 +1031,26 @@ fn fallback_multiplayer_defender(
     state: &GameState,
     player: PlayerId,
     opponents: &[PlayerId],
-) -> PlayerId {
-    opponents
-        .iter()
-        .copied()
-        .max_by(|left, right| {
-            threat_level(state, player, *left)
-                .total_cmp(&threat_level(state, player, *right))
-                .then_with(|| right.cmp(left))
-        })
-        .expect("expanded multiplayer choice has living opponents")
+) -> Option<PlayerId> {
+    opponents.iter().copied().max_by(|left, right| {
+        threat_level(state, player, *left)
+            .total_cmp(&threat_level(state, player, *right))
+            .then_with(|| right.cmp(left))
+    })
+}
+
+fn defender_is_reachable(defender: PlayerId, input: &ExpandedComparisonInput<'_>) -> bool {
+    let target = AttackTarget::Player(defender);
+    match input.valid_attack_targets_by_attacker {
+        Some(targets_by_attacker) => input.candidates.iter().any(|attacker| {
+            targets_by_attacker
+                .get(attacker)
+                .is_some_and(|targets| targets.contains(&target))
+        }),
+        None => input
+            .valid_attack_targets
+            .is_none_or(|targets| targets.contains(&target)),
+    }
 }
 
 fn preferred_attack_opponent(
@@ -2632,6 +2681,7 @@ mod tests {
     use engine::game::zones::create_object;
     use engine::types::game_state::WaitingFor;
     use engine::types::identifiers::CardId;
+    use rand::{rngs::SmallRng, SeedableRng};
     use std::time::Instant;
 
     fn setup() -> GameState {
@@ -2650,6 +2700,135 @@ mod tests {
         state.turn_number = 2;
         state.active_player = PlayerId(0);
         state
+    }
+
+    fn assert_mandatory_permanent_target(
+        state: &mut GameState,
+        attacker: ObjectId,
+        target: AttackTarget,
+    ) {
+        state.phase = engine::types::phase::Phase::DeclareAttackers;
+        state.waiting_for = engine::game::combat::build_declare_attackers_waiting_for(state);
+        let WaitingFor::DeclareAttackers {
+            valid_attack_targets,
+            valid_attack_targets_by_attacker,
+            ..
+        } = &state.waiting_for
+        else {
+            panic!("attacker prompt")
+        };
+        assert!(valid_attack_targets.contains(&target));
+        assert!(valid_attack_targets_by_attacker
+            .as_ref()
+            .and_then(|m| m.get(&attacker))
+            .is_some_and(|v| v.contains(&target)));
+        let config = create_config(AiDifficulty::Hard, Platform::Native);
+        let mut rng = SmallRng::seed_from_u64(42);
+        let action = crate::search::choose_action(state, PlayerId(0), &config, &mut rng)
+            .expect("attack action");
+        assert!(
+            matches!(&action, engine::types::actions::GameAction::DeclareAttackers { attacks, .. } if attacks == &vec![(attacker, target)])
+        );
+        engine::game::engine::apply_as_current(state, action)
+            .expect("mandatory target action is legal");
+    }
+
+    #[test]
+    fn public_choice_retains_mandatory_planeswalker_target_through_completion() {
+        let mut state = setup_multiplayer(3);
+        let attacker = add_creature(&mut state, PlayerId(0), "Forced", 3, 3, vec![]);
+        let planeswalker = add_planeswalker(&mut state, PlayerId(1), 4);
+        let permanent = engine::types::identifiers::ObjectIncarnationRef::from_object(
+            state.objects.get(&planeswalker).unwrap(),
+        );
+        state
+            .objects
+            .get_mut(&attacker)
+            .unwrap()
+            .static_definitions
+            .push(
+                StaticDefinition::new(engine::types::statics::StaticMode::MustAttackDefender {
+                    defender: engine::types::statics::RequiredDefender::Permanent { permanent },
+                })
+                .affected(engine::types::ability::TargetFilter::SelfRef),
+            );
+        assert_mandatory_permanent_target(
+            &mut state,
+            attacker,
+            AttackTarget::Planeswalker(planeswalker),
+        );
+    }
+
+    #[test]
+    fn public_choice_retains_mandatory_battle_target_through_completion() {
+        let mut state = setup_multiplayer(3);
+        let attacker = add_creature(&mut state, PlayerId(0), "Forced", 3, 3, vec![]);
+        let card_id = CardId(state.next_object_id);
+        let battle = create_object(
+            &mut state,
+            card_id,
+            PlayerId(1),
+            "Battle".to_string(),
+            Zone::Battlefield,
+        );
+        let battle_object = state.objects.get_mut(&battle).unwrap();
+        battle_object.card_types.core_types.push(CoreType::Battle);
+        battle_object
+            .chosen_attributes
+            .push(engine::types::ability::ChosenAttribute::Player(PlayerId(1)));
+        let permanent = engine::types::identifiers::ObjectIncarnationRef::from_object(
+            state.objects.get(&battle).unwrap(),
+        );
+        state
+            .objects
+            .get_mut(&attacker)
+            .unwrap()
+            .static_definitions
+            .push(
+                StaticDefinition::new(engine::types::statics::StaticMode::MustAttackDefender {
+                    defender: engine::types::statics::RequiredDefender::Permanent { permanent },
+                })
+                .affected(engine::types::ability::TargetFilter::SelfRef),
+            );
+        assert_mandatory_permanent_target(&mut state, attacker, AttackTarget::Battle(battle));
+    }
+
+    #[test]
+    fn two_headed_giant_bypasses_comparison_and_accepts_teammate_block() {
+        let mut state = GameState::new(
+            engine::types::format::FormatConfig::two_headed_giant(),
+            4,
+            42,
+        );
+        state.turn_number = 2;
+        state.phase = engine::types::phase::Phase::DeclareAttackers;
+        state.active_player = PlayerId(0);
+        let attacker = add_creature(&mut state, PlayerId(0), "Attacker", 4, 4, vec![]);
+        let blocker = add_creature(&mut state, PlayerId(3), "Teammate wall", 0, 5, vec![]);
+        state.players[2].life = 1;
+        state.waiting_for = engine::game::combat::build_declare_attackers_waiting_for(&state);
+        reset_expanded_comparison_counters();
+        let legacy = choose_attackers_with_targets(&state, PlayerId(0));
+        assert_eq!(expanded_comparison_counters().0, 0);
+        assert_eq!(legacy, vec![(attacker, AttackTarget::Player(PlayerId(2)))]);
+        let config = create_config(AiDifficulty::Hard, Platform::Native);
+        let mut rng = SmallRng::seed_from_u64(42);
+        let action = crate::search::choose_action(&state, PlayerId(0), &config, &mut rng).unwrap();
+        assert!(
+            matches!(&action, engine::types::actions::GameAction::DeclareAttackers { attacks, .. } if attacks == &legacy)
+        );
+        engine::game::engine::apply_as_current(&mut state, action).unwrap();
+        engine::game::combat::declare_blockers_for_player(
+            &mut state,
+            PlayerId(3),
+            &[(blocker, attacker)],
+            &mut Vec::new(),
+        )
+        .expect("CR 805.10d teammate block is legal");
+        assert_eq!(
+            state.combat.as_ref().unwrap().blocker_assignments[&attacker],
+            vec![blocker]
+        );
     }
 
     fn add_creature(
@@ -3355,6 +3534,94 @@ mod tests {
     }
 
     #[test]
+    fn free_for_all_comparator_uses_defender_specific_blockers_for_combat_keywords() {
+        let cases = [
+            ("normal", vec![], vec![]),
+            ("flying_reach", vec![Keyword::Flying], vec![Keyword::Reach]),
+            ("first_strike", vec![], vec![Keyword::FirstStrike]),
+            ("trample", vec![Keyword::Trample], vec![]),
+            ("double_strike", vec![Keyword::DoubleStrike], vec![]),
+        ];
+        for (name, attacker_keywords, blocker_keywords) in cases {
+            let mut state = setup_multiplayer(3);
+            state.players[1].life = 3;
+            let attacker =
+                add_creature(&mut state, PlayerId(0), "Attacker", 4, 4, attacker_keywords);
+            add_creature(
+                &mut state,
+                PlayerId(1),
+                "DefenderBlocker",
+                5,
+                5,
+                blocker_keywords,
+            );
+            reset_expanded_comparison_counters();
+
+            let attacks = choose_attackers_with_targets(&state, PlayerId(0));
+
+            assert_eq!(
+                expanded_comparison_counters().0,
+                1,
+                "{name} reaches comparator"
+            );
+            assert_eq!(
+                attacks,
+                vec![(attacker, AttackTarget::Player(PlayerId(2)))],
+                "{name}: the protected low-life defender must not win the attacker comparison"
+            );
+        }
+    }
+
+    #[test]
+    fn free_for_all_comparator_refreshes_the_defender_when_a_blocker_changes_controller() {
+        let mut state = setup_multiplayer(3);
+        state.players[1].life = 3;
+        state.players[2].life = 3;
+        let attacker = add_creature(&mut state, PlayerId(0), "Attacker", 4, 4, vec![]);
+        let blocker = add_creature(&mut state, PlayerId(1), "Blocker", 5, 5, vec![]);
+
+        assert_eq!(
+            choose_attackers_with_targets(&state, PlayerId(0)),
+            vec![(attacker, AttackTarget::Player(PlayerId(2)))],
+            "the controller's blocker protects its own defender"
+        );
+        state.objects.get_mut(&blocker).unwrap().controller = PlayerId(2);
+        assert_eq!(
+            choose_attackers_with_targets(&state, PlayerId(0)),
+            vec![(attacker, AttackTarget::Player(PlayerId(1)))],
+            "a refreshed controller moves the blocker to that defender's comparison proposal"
+        );
+    }
+
+    #[test]
+    fn free_for_all_comparator_declines_unprofitable_voluntary_attack_and_bypasses_single_opponent()
+    {
+        let mut state = setup_multiplayer(3);
+        add_creature(&mut state, PlayerId(0), "Attacker", 1, 1, vec![]);
+        add_creature(&mut state, PlayerId(1), "Wall", 8, 8, vec![]);
+        add_creature(&mut state, PlayerId(2), "Wall", 8, 8, vec![]);
+        reset_expanded_comparison_counters();
+        assert!(
+            choose_attackers_with_targets(&state, PlayerId(0)).is_empty(),
+            "zero-value voluntary attacks stay declined after comparison fallback"
+        );
+        assert_eq!(expanded_comparison_counters().0, 1);
+
+        state.players[2].is_eliminated = true;
+        reset_expanded_comparison_counters();
+        let _ = choose_attackers_with_targets(&state, PlayerId(0));
+        assert_eq!(
+            expanded_comparison_counters().0,
+            0,
+            "the two-player path remains outside the free-for-all comparator"
+        );
+        assert!(
+            choose_attackers_with_targets(&setup_multiplayer(3), PlayerId(0)).is_empty(),
+            "no creature candidates produces an empty declaration"
+        );
+    }
+
+    #[test]
     fn free_for_all_comparison_respects_per_attacker_player_targets() {
         let mut state = setup_multiplayer(3);
         let attacker = add_creature(&mut state, PlayerId(0), "Attacker", 4, 4, vec![]);
@@ -3427,6 +3694,7 @@ mod tests {
                 candidates: &[attacker],
                 mandatory: &[attacker],
                 slices: &slices,
+                valid_attack_targets: None,
                 valid_attack_targets_by_attacker: None,
                 shared_deadline: Deadline::none(),
             },
@@ -3462,6 +3730,7 @@ mod tests {
                 candidates: &attackers,
                 mandatory: &[],
                 slices: &slices,
+                valid_attack_targets: None,
                 valid_attack_targets_by_attacker: None,
                 shared_deadline: Deadline::none(),
             },
@@ -3500,6 +3769,7 @@ mod tests {
                 candidates: &[attacker],
                 mandatory: &[],
                 slices: &slices,
+                valid_attack_targets: None,
                 valid_attack_targets_by_attacker: None,
                 shared_deadline: Deadline::none(),
             },
@@ -3517,6 +3787,126 @@ mod tests {
     }
 
     #[test]
+    fn comparator_records_the_normalized_positive_vanilla_trade() {
+        let mut state = setup_multiplayer(3);
+        let attacker = add_creature(&mut state, PlayerId(0), "Attacker", 3, 1, vec![]);
+        add_creature(&mut state, PlayerId(1), "Blocker", 2, 3, vec![]);
+        let slices = BlockLegalitySlices::collect(&state);
+        reset_expanded_comparison_counters();
+
+        let _ = expanded_multiplayer_choice(
+            &state,
+            PlayerId(0),
+            ExpandedComparisonInput {
+                opponents: &players::opponents(&state, PlayerId(0)),
+                candidates: &[attacker],
+                mandatory: &[],
+                slices: &slices,
+                valid_attack_targets: None,
+                valid_attack_targets_by_attacker: None,
+                shared_deadline: Deadline::none(),
+            },
+        );
+        let proposal = expanded_proposal_accounting()
+            .into_iter()
+            .find(|proposal| proposal.defender == PlayerId(1))
+            .expect("the blocked trade reaches a complete defender proposal");
+        assert!((proposal.opposing_losses - 1.2).abs() < 1e-9);
+        assert!((proposal.own_losses - 1.1).abs() < 1e-9);
+        assert!(
+            (proposal.opposing_losses - proposal.own_losses - 0.1).abs() < 1e-9,
+            "the 3/1 into 2/3 exchange is positive in the one normalized unit"
+        );
+    }
+
+    #[test]
+    fn comparator_prefers_a_nonlethal_open_defender_over_a_small_positive_trade() {
+        let mut state = setup_multiplayer(3);
+        state.players[1].life = 20;
+        state.players[2].life = 20;
+        let attacker = add_creature(&mut state, PlayerId(0), "Attacker", 3, 1, vec![]);
+        add_creature(&mut state, PlayerId(1), "Blocker", 2, 3, vec![]);
+        reset_expanded_comparison_counters();
+
+        let attacks = choose_attackers_with_targets(&state, PlayerId(0));
+
+        assert_eq!(expanded_comparison_counters().0, 1);
+        assert_eq!(
+            attacks,
+            vec![(attacker, AttackTarget::Player(PlayerId(2)))],
+            "the open nonlethal pressure exceeds the +0.1 normalized trade outside the tie band"
+        );
+    }
+
+    #[test]
+    fn comparator_applies_the_finite_finish_bonus_only_to_blocked_damage() {
+        let mut state = setup_multiplayer(3);
+        state.players[1].life = 3;
+        let attacker = add_creature(&mut state, PlayerId(0), "Attacker", 3, 3, vec![]);
+        add_creature(&mut state, PlayerId(1), "Protected", 5, 5, vec![]);
+        let slices = BlockLegalitySlices::collect(&state);
+        reset_expanded_comparison_counters();
+
+        let _ = expanded_multiplayer_choice(
+            &state,
+            PlayerId(0),
+            ExpandedComparisonInput {
+                opponents: &players::opponents(&state, PlayerId(0)),
+                candidates: &[attacker],
+                mandatory: &[attacker],
+                slices: &slices,
+                valid_attack_targets: None,
+                valid_attack_targets_by_attacker: None,
+                shared_deadline: Deadline::none(),
+            },
+        );
+        let protected = expanded_proposal_accounting()
+            .into_iter()
+            .find(|proposal| proposal.defender == PlayerId(1))
+            .expect("protected low-life defender has a complete proposal");
+        assert!(
+            protected.open_pressure > 0.0,
+            "reach guard: the attacker would deal lethal face damage without the blocker"
+        );
+        assert!(
+            !protected.finishes,
+            "open damage alone is never a finish certificate"
+        );
+        assert_eq!(
+            protected.utility, protected.pre_finish_utility,
+            "a defender whose blocker prevents all damage receives no +2 finish bonus"
+        );
+
+        let mut open_state = setup_multiplayer(3);
+        open_state.players[1].life = 3;
+        let open_attacker = add_creature(&mut open_state, PlayerId(0), "Attacker", 3, 3, vec![]);
+        let open_slices = BlockLegalitySlices::collect(&open_state);
+        reset_expanded_comparison_counters();
+        let _ = expanded_multiplayer_choice(
+            &open_state,
+            PlayerId(0),
+            ExpandedComparisonInput {
+                opponents: &players::opponents(&open_state, PlayerId(0)),
+                candidates: &[open_attacker],
+                mandatory: &[open_attacker],
+                slices: &open_slices,
+                valid_attack_targets: None,
+                valid_attack_targets_by_attacker: None,
+                shared_deadline: Deadline::none(),
+            },
+        );
+        let open = expanded_proposal_accounting()
+            .into_iter()
+            .find(|proposal| proposal.defender == PlayerId(1))
+            .expect("open low-life defender has a complete proposal");
+        assert!(open.finishes);
+        assert!(
+            (open.utility - open.pre_finish_utility - 2.0).abs() < 1e-9,
+            "the finish preference is the documented finite +2 combat-value increment"
+        );
+    }
+
+    #[test]
     fn free_for_all_comparison_is_entered_once_and_honors_expired_deadline() {
         let mut state = setup_multiplayer(3);
         let attacker = add_creature(&mut state, PlayerId(0), "Attacker", 4, 4, vec![]);
@@ -3526,12 +3916,17 @@ mod tests {
         let attacks = choose_attackers_with_targets(&state, PlayerId(0));
         let (entries, pairs, completed) = expanded_comparison_counters();
         assert_eq!(entries, 1);
-        assert!(pairs > 0);
+        assert_eq!(
+            pairs, 1,
+            "one attacker against one reachable blocker performs exactly one aggregate pair check"
+        );
         assert!(completed >= 2);
         assert!(attacks.iter().any(|(id, _)| *id == attacker));
 
         reset_expanded_comparison_counters();
-        let _ = choose_attackers_with_targets_with_profile_and_deadline(
+        let mut targets_by_attacker = HashMap::new();
+        targets_by_attacker.insert(attacker, vec![AttackTarget::Player(PlayerId(2))]);
+        let attacks = choose_attackers_with_targets_with_profile_and_deadline(
             &state,
             PlayerId(0),
             &AiProfile::default(),
@@ -3539,8 +3934,8 @@ mod tests {
             None,
             AttackTargetingContext {
                 valid_attacker_ids: None,
-                valid_attack_targets: None,
-                valid_attack_targets_by_attacker: None,
+                valid_attack_targets: Some(&[AttackTarget::Player(PlayerId(2))]),
+                valid_attack_targets_by_attacker: Some(&targets_by_attacker),
                 comparison_deadline: Some(Deadline::after(0)),
             },
         );
@@ -3548,6 +3943,40 @@ mod tests {
         assert_eq!(entries, 1, "expired comparison selects the threat fallback");
         assert_eq!(pairs, 0);
         assert_eq!(completed, 0);
+        assert_eq!(
+            attacks,
+            vec![(attacker, AttackTarget::Player(PlayerId(2)))],
+            "the expired fallback stays within the engine-issued per-attacker domain"
+        );
+    }
+
+    #[test]
+    fn partial_multiplayer_proposal_cannot_win_after_deterministic_expiry() {
+        let mut state = setup_multiplayer(3);
+        let attacker = add_creature(&mut state, PlayerId(0), "Attacker", 5, 5, vec![]);
+        add_creature(&mut state, PlayerId(1), "Blocker", 1, 1, vec![]);
+        for _ in 0..8 {
+            let threat = add_creature(&mut state, PlayerId(2), "Threat", 5, 5, vec![]);
+            state.objects.get_mut(&threat).unwrap().tapped = true;
+        }
+        add_creature(&mut state, PlayerId(2), "Blocker", 0, 5, vec![]);
+        add_creature(&mut state, PlayerId(2), "Blocker", 0, 5, vec![]);
+        reset_expanded_comparison_counters();
+        force_expanded_comparison_expiry_after_pairs(2);
+        let attacks = choose_attackers_with_targets_with_profile_and_deadline(
+            &state,
+            PlayerId(0),
+            &AiProfile::default(),
+            CombatLookahead::Disabled,
+            None,
+            AttackTargetingContext::unrestricted(),
+        );
+        assert_eq!(expanded_comparison_counters(), (1, 2, 1));
+        assert!(expanded_proposal_accounting()
+            .iter()
+            .all(|p| p.defender != PlayerId(2)));
+        assert_eq!(attacks, vec![(attacker, AttackTarget::Player(PlayerId(1)))]);
+        reset_expanded_comparison_counters();
     }
 
     #[test]
@@ -3612,26 +4041,34 @@ mod tests {
         }
         reset_expanded_comparison_counters();
 
-        let attacks = choose_attackers_with_targets(&state, PlayerId(0));
+        let attacks = choose_attackers_with_targets_with_profile_and_deadline(
+            &state,
+            PlayerId(0),
+            &AiProfile::default(),
+            CombatLookahead::Disabled,
+            None,
+            AttackTargetingContext {
+                valid_attacker_ids: None,
+                valid_attack_targets: Some(&[AttackTarget::Player(PlayerId(2))]),
+                valid_attack_targets_by_attacker: None,
+                comparison_deadline: Some(Deadline::none()),
+            },
+        );
 
         let (entries, pairs, completed) = expanded_comparison_counters();
         assert_eq!(entries, 1);
         assert_eq!(pairs, 0);
         assert_eq!(completed, 0);
         assert_eq!(
-            fallback_multiplayer_defender(
-                &state,
-                PlayerId(0),
-                &players::opponents(&state, PlayerId(0)),
-            ),
-            PlayerId(1),
-            "above the ceiling uses the same threat-based defender fallback"
+            attacks.len(),
+            65,
+            "reach guard: every legal attacker remains available at the ceiling"
         );
         assert!(
-            attacks.is_empty()
-                || attacks
-                    .iter()
-                    .all(|(_, target)| { *target == AttackTarget::Player(PlayerId(1)) })
+            attacks
+                .iter()
+                .all(|(_, target)| { *target == AttackTarget::Player(PlayerId(2)) }),
+            "the above-cap fallback uses the aggregate issued target domain when no per-attacker map exists"
         );
     }
 
@@ -3729,6 +4166,30 @@ mod tests {
             defenders.len(),
             3,
             "the tie offset visits every living opponent"
+        );
+    }
+
+    #[test]
+    fn clearly_stronger_free_for_all_defender_wins_outside_the_tie_band() {
+        let mut state = setup_multiplayer(3);
+        let attacker = add_creature(&mut state, PlayerId(0), "Attacker", 4, 4, vec![]);
+        for _ in 0..12 {
+            let threat = add_creature(&mut state, PlayerId(1), "Threat", 5, 5, vec![]);
+            state.objects.get_mut(&threat).unwrap().tapped = true;
+        }
+        reset_expanded_comparison_counters();
+
+        let attacks = choose_attackers_with_targets(&state, PlayerId(0));
+
+        assert_eq!(
+            expanded_comparison_counters().0,
+            1,
+            "reach guard: comparator runs"
+        );
+        assert_eq!(
+            attacks,
+            vec![(attacker, AttackTarget::Player(PlayerId(1)))],
+            "a materially stronger defender is not displaced by cyclic near-tie ordering"
         );
     }
 
@@ -3981,6 +4442,27 @@ mod tests {
             !commander_attack_finishes(&state, PlayerId(1), first, 3)
                 && !commander_attack_finishes(&state, PlayerId(1), second, 3),
             "3 + 3 cannot be combined across commander identities to claim a finish"
+        );
+    }
+
+    #[test]
+    fn proposal_finish_recognizes_one_commander_crossing_its_own_headroom() {
+        use engine::types::format::FormatConfig;
+        use engine::types::game_state::CommanderDamageEntry;
+
+        let mut state = setup();
+        state.format_config = FormatConfig::commander();
+        let commander = add_creature(&mut state, PlayerId(0), "Commander", 4, 4, vec![]);
+        state.objects.get_mut(&commander).unwrap().is_commander = true;
+        state.commander_damage.push(CommanderDamageEntry {
+            player: PlayerId(1),
+            commander,
+            damage: 18,
+        });
+
+        assert!(
+            commander_attack_finishes(&state, PlayerId(1), commander, 4),
+            "one commander's blocked combat damage crosses only its own engine headroom"
         );
     }
 

--- a/crates/phase-ai/src/eval.rs
+++ b/crates/phase-ai/src/eval.rs
@@ -1191,6 +1191,7 @@ pub fn creature_combat_value(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::projection::{Confidence, ProjectionHorizon};
     use engine::game::zones::create_object;
     use engine::types::card_type::CoreType;
     use engine::types::identifiers::CardId;
@@ -2285,20 +2286,163 @@ mod tests {
     }
 
     #[test]
-    fn multiplayer_threat_curve_remains_monotonic_above_old_board_cap() {
-        let mut state = GameState::new(engine::types::format::FormatConfig::free_for_all(), 3, 42);
-        let at_old_cap = threat_level(&state, PlayerId(0), PlayerId(1));
-        for _ in 0..4 {
-            add_creature(&mut state, PlayerId(1), 5, 5, vec![]);
-        }
-        let developed = threat_level(&state, PlayerId(0), PlayerId(1));
-        for _ in 0..8 {
-            add_creature(&mut state, PlayerId(1), 5, 5, vec![]);
-        }
-        let overwhelming = threat_level(&state, PlayerId(0), PlayerId(1));
+    fn multiplayer_threat_curve_matches_bounded_raw_strength_table() {
+        let mut threats = Vec::new();
+        for (raw_strength, powers, expected_threat) in [
+            (0.0, &[] as &[i32], 0.1),
+            (10.0, &[13, 0, 0] as &[i32], 0.3),
+            (30.0, &[21, 21] as &[i32], 0.4),
+            (100.0, &[71, 71] as &[i32], 0.463_636_363_636_363_6),
+        ] {
+            let mut state =
+                GameState::new(engine::types::format::FormatConfig::free_for_all(), 3, 42);
+            for &power in powers {
+                add_creature(&mut state, PlayerId(1), power, 1, vec![]);
+            }
 
-        assert!(at_old_cap < developed && developed < overwhelming);
-        assert!(overwhelming.is_finite() && overwhelming <= 1.0);
+            let stats = board_stats(&state, PlayerId(1));
+            let actual_raw_strength =
+                (stats.creatures as f64 * 0.3 + stats.power.max(0) as f64 * 0.7).max(0.0);
+            assert!(
+                (actual_raw_strength - raw_strength).abs() < 1e-12,
+                "fixture must realize raw board strength {raw_strength}, got {actual_raw_strength}"
+            );
+
+            let threat = threat_level(&state, PlayerId(0), PlayerId(1));
+            assert!(
+                (threat - expected_threat).abs() < 1e-12,
+                "raw board strength {raw_strength} should have threat {expected_threat}, got {threat}"
+            );
+            assert!(
+                threat.is_finite() && (0.0..=1.0).contains(&threat),
+                "threat must stay finite and bounded for raw board strength {raw_strength}: {threat}"
+            );
+            threats.push(threat);
+        }
+
+        assert!(
+            threats.windows(2).all(|pair| pair[0] < pair[1]),
+            "the free-for-all curve must remain strictly monotonic: {threats:?}"
+        );
+    }
+
+    #[test]
+    fn multiplayer_threat_clamps_negative_power_without_dropping_creature_presence() {
+        let mut negative_power =
+            GameState::new(engine::types::format::FormatConfig::free_for_all(), 3, 42);
+        add_creature(&mut negative_power, PlayerId(1), -5, 1, vec![]);
+
+        let mut zero_power =
+            GameState::new(engine::types::format::FormatConfig::free_for_all(), 3, 42);
+        add_creature(&mut zero_power, PlayerId(1), 0, 1, vec![]);
+
+        assert_eq!(board_stats(&negative_power, PlayerId(1)).power, -5);
+        assert_eq!(board_stats(&zero_power, PlayerId(1)).power, 0);
+        let negative_threat = threat_level(&negative_power, PlayerId(0), PlayerId(1));
+        let zero_threat = threat_level(&zero_power, PlayerId(0), PlayerId(1));
+        assert!(
+            (negative_threat - zero_threat).abs() < 1e-12,
+            "negative power must clamp to zero while its creature-presence contribution remains"
+        );
+        assert!(
+            negative_threat
+                > threat_level(
+                    &GameState::new(engine::types::format::FormatConfig::free_for_all(), 3, 42),
+                    PlayerId(0),
+                    PlayerId(1),
+                ),
+            "reach-guard: the fixture must retain its creature-presence contribution"
+        );
+    }
+
+    #[test]
+    fn legacy_threat_curve_is_unchanged_outside_multiplayer_individual_seats() {
+        let cases = [
+            (
+                "two-seat individual seats",
+                engine::types::format::FormatConfig::free_for_all(),
+                2,
+                PlayerId(1),
+                0.5,
+            ),
+            (
+                "fixed teams",
+                engine::types::format::FormatConfig::two_headed_giant(),
+                4,
+                PlayerId(2),
+                0.45,
+            ),
+            (
+                "one versus many",
+                engine::types::format::FormatConfig::archenemy(),
+                3,
+                PlayerId(1),
+                0.5,
+            ),
+        ];
+
+        for (name, config, player_count, target, expected_threat) in cases {
+            let topology = config.topology();
+            match topology {
+                FormatTopology::IndividualSeats => assert_eq!(player_count, 2, "{name}"),
+                FormatTopology::FixedTeams { .. } => assert_eq!(name, "fixed teams"),
+                FormatTopology::OneVsMany { .. } => assert_eq!(name, "one versus many"),
+            }
+
+            let mut state = GameState::new(config, player_count, 42);
+            add_creature(&mut state, target, 21, 1, vec![]);
+            add_creature(&mut state, target, 21, 1, vec![]);
+            let stats = board_stats(&state, target);
+            assert_eq!(stats.creatures, 2, "reach-guard for {name}");
+            assert_eq!(stats.power, 42, "reach-guard for {name}");
+
+            let threat = threat_level(&state, PlayerId(0), target);
+            assert!(
+                (threat - expected_threat).abs() < 1e-12,
+                "{name} must retain the legacy raw-strength cap, got {threat}"
+            );
+        }
+    }
+
+    #[test]
+    fn equal_multiplayer_opponent_boards_have_equal_threat() {
+        let mut state = GameState::new(engine::types::format::FormatConfig::free_for_all(), 3, 42);
+        add_creature(&mut state, PlayerId(1), 5, 5, vec![]);
+        add_creature(&mut state, PlayerId(2), 5, 5, vec![]);
+
+        assert_eq!(board_stats(&state, PlayerId(1)).power, 5);
+        assert_eq!(board_stats(&state, PlayerId(2)).power, 5);
+        assert_eq!(
+            threat_level(&state, PlayerId(0), PlayerId(1)),
+            threat_level(&state, PlayerId(0), PlayerId(2)),
+            "identical public opponent boards must receive identical threat scores"
+        );
+    }
+
+    #[test]
+    fn projected_stronger_board_increases_threat() {
+        let mut state = GameState::new(engine::types::format::FormatConfig::free_for_all(), 3, 42);
+        let creature = add_creature(&mut state, PlayerId(1), 1, 1, vec![]);
+        let current_threat = threat_level(&state, PlayerId(0), PlayerId(1));
+
+        let mut projected_state = state.clone();
+        projected_state.objects.get_mut(&creature).unwrap().power = Some(9);
+        let projection = Projection {
+            horizon_reached: ProjectionHorizon::OpponentBeginCombat,
+            state: projected_state.clone(),
+            snapshots: vec![(ProjectionHorizon::OpponentBeginCombat, projected_state)],
+            confidence: Confidence::Exact,
+            target_opponent: PlayerId(1),
+        };
+
+        assert_eq!(board_stats(&state, PlayerId(1)).power, 1);
+        assert_eq!(board_stats(&projection.state, PlayerId(1)).power, 9);
+        let projected_threat =
+            threat_level_projected(&state, PlayerId(0), PlayerId(1), Some(&projection));
+        assert!(
+            projected_threat > current_threat,
+            "a projection with more opponent power must increase threat: {current_threat} -> {projected_threat}"
+        );
     }
 
     #[test]
@@ -2512,6 +2656,7 @@ mod tests {
         let own = add_creature(&mut state, PlayerId(0), 3, 3, vec![]);
         let teammate = add_creature(&mut state, PlayerId(1), 3, 3, vec![]);
         let eliminated = add_creature(&mut state, PlayerId(2), 3, 3, vec![]);
+        let live_enemy = add_creature(&mut state, PlayerId(3), 3, 3, vec![]);
         state.players[2].is_eliminated = true;
 
         let noncreature_card_id = CardId(state.next_object_id);
@@ -2545,5 +2690,11 @@ mod tests {
                 "{id:?} must be outside the living-opponent battlefield-creature contract"
             );
         }
+
+        assert!(
+            opponent_battlefield_creature_threat_value(&state, PlayerId(0), live_enemy)
+                .is_some_and(|value| value > 0.0),
+            "reach-guard: a living opponent's battlefield creature must remain a valid consumer"
+        );
     }
 }

--- a/crates/phase-ai/src/eval.rs
+++ b/crates/phase-ai/src/eval.rs
@@ -930,14 +930,15 @@ pub fn board_stats(state: &GameState, player: PlayerId) -> BoardStats {
 /// mana-poor seat.
 ///
 /// Worked example — evaluator p0, two opponents, p1 with 8 sources and p2 with
-/// 2, both at threat `0.4`. Killing a 4/4 moves that seat's `board_score` by
-/// `−(1·0.3 + 4·0.7)/10 = −0.31`, i.e. `Δthreat = −0.124`:
+/// 2, both at the fixture threat `0.194656...`. Killing a 4/4 moves that
+/// seat's free-for-all `board_score` from `3.1 / 13.1` to zero, i.e.
+/// `Δthreat = −0.094656...` after the board weight:
 ///
 /// | Step | `w₁ / w₂` | `opp_agg` | Δ offset |
 /// |---|---|---|---|
 /// | before | .5000 / .5000 | 5.0000 | — |
-/// | kill the 4/4 on the **8-source** seat | .40828 / .59172 | 4.4497 | **+4.13** |
-/// | kill the same 4/4 on the **2-source** seat | .59172 / .40828 | 5.5503 | **−4.13** |
+/// | kill the 4/4 on the **8-source** seat | .41971 / .58029 | 4.5183 | **+3.61** |
+/// | kill the same 4/4 on the **2-source** seat | .58029 / .41971 | 5.4817 | **−3.61** |
 ///
 /// Three facts bound the severity, and the first is a genuine defence:
 ///
@@ -1963,8 +1964,8 @@ mod tests {
     ///
     /// **If the pin guard reds**, the fixture drifted: restore the pinned inputs,
     /// **or** re-derive assertion 3's floor from the closed form
-    /// `|Δ| = 2.79 / (2·T − 0.124)` at the fixture's actual
-    /// `T = 0.224 + 0.0214286·|hand|`. That is a legitimate repair and is NOT
+    /// `|Δ| = 7.5·6·0.094656... / (2·0.194656... − 0.094656...)` at the
+    /// fixture's current free-for-all threat. That is a legitimate repair and is NOT
     /// "relaxing the assertion."
     /// **If the pin guard is green and assertion 3 reds**, the aggregator,
     /// `threat_level`'s constants, or `MANA_DEVELOPMENT_COEFF` moved: update
@@ -1989,7 +1990,8 @@ mod tests {
             let body_2 = add_creature(&mut state, PlayerId(2), 4, 4, vec![]);
 
             // ASSERTION 0 — PIN GUARD, before every other assertion. These three
-            // inputs put each opponent's baseline threat at exactly T = 0.224, and
+            // inputs put each opponent's baseline free-for-all threat at exactly
+            // T = 0.194656..., and
             // assertion 3's band is quoted AT THESE INPUTS: it holds for opponent
             // hand size <= 1 and fails from 2. Closed form in the docstring.
             for opp in [PlayerId(1), PlayerId(2)] {
@@ -2066,18 +2068,16 @@ mod tests {
         );
 
         // ASSERTION 3 — magnitude band. Pins the disclosed effect as LARGER THAN A
-        // WHOLE MANA SOURCE rather than as noise. At the pinned inputs the true
-        // value is 8.6111, clearing 7.5 by 14.8%. NOT input-independent: it holds
-        // for opponent hand size <= 1 and fails from 2. Re-derivable from
-        // `|Δ| = 2.79 / (2·T − 0.124)`.
+        // mana-source scale rather than as noise. At the pinned inputs the smooth
+        // free-for-all curve yields 7.2279, still above the fixed 7.0 floor. This
+        // is deliberately re-derived for the curve changed in this unit, rather
+        // than retaining the old capped-curve threshold. Re-derivable from
+        // `|Δ| = 7.5·6·0.094656... / (2·0.194656... − 0.094656...)`.
         assert!(
-            (kill_rich - baseline).abs() > MANA_DEVELOPMENT_COEFF,
-            "the threat-weight channel must move the term by MORE than one mana \
-             source ({}); if the pin guard above is green, the aggregator or a \
-             constant moved — update `MANA_DEVELOPMENT_COEFF`'s threat-weight \
-             section and R8, do NOT relax this. The band is quoted at the pinned \
-             inputs (empty hands, full life, no commander threshold) and is \
-             re-derivable from |Δ| = 2.79/(2·T − 0.124), T = 0.224 + 0.0214286·|hand|",
+            (kill_rich - baseline).abs() > 7.0,
+            "the threat-weight channel must remain materially larger than noise \
+             ({}); if the pin guard above is green, re-derive the smooth-curve \
+             threat delta before changing this floor",
             kill_rich - baseline
         );
 

--- a/crates/phase-ai/src/eval.rs
+++ b/crates/phase-ai/src/eval.rs
@@ -340,18 +340,18 @@ pub fn threat_level_projected(
     let power = projection
         .map(|p| projected_power(&p.state, target))
         .unwrap_or(base_power);
-    let raw_board_strength = (creatures as f64 * 0.3 + power.max(0) as f64 * 0.7).max(0.0);
-    // In free-for-all, retain differences between developed boards instead of
-    // flattening every board above the old 10-point cap into the same threat.
-    // This is a bounded tactical calibration, not a rules valuation.
+    // In multiplayer free-for-all, retain differences between developed boards
+    // instead of flattening every board above the old 10-point cap into the
+    // same threat. The legacy branch intentionally keeps its raw-power formula.
     let board_score = if matches!(
         state.format_config.topology(),
         FormatTopology::IndividualSeats
     ) && state.players.len() > 2
     {
+        let raw_board_strength = (creatures as f64 * 0.3 + power.max(0) as f64 * 0.7).max(0.0);
         raw_board_strength / (raw_board_strength + 10.0)
     } else {
-        raw_board_strength.min(10.0) / 10.0
+        (creatures as f64 * 0.3 + power as f64 * 0.7).min(10.0) / 10.0
     };
 
     // Life ratio: higher life = more threatening
@@ -2400,6 +2400,55 @@ mod tests {
             assert!(
                 (threat - expected_threat).abs() < 1e-12,
                 "{name} must retain the legacy raw-strength cap, got {threat}"
+            );
+        }
+    }
+
+    #[test]
+    fn legacy_negative_power_threat_is_unchanged_for_duel_and_teams() {
+        let cases = [
+            (
+                "two-seat individual seats",
+                engine::types::format::FormatConfig::free_for_all(),
+                2,
+                PlayerId(1),
+                20,
+                20,
+                -0.028,
+            ),
+            (
+                "fixed teams",
+                engine::types::format::FormatConfig::two_headed_giant(),
+                4,
+                PlayerId(2),
+                15,
+                30,
+                -0.078,
+            ),
+        ];
+
+        for (name, config, player_count, target, expected_life, expected_starting_life, expected) in
+            cases
+        {
+            let mut state = GameState::new(config, player_count, 42);
+            add_creature(&mut state, target, -5, 1, vec![]);
+            assert_eq!(
+                board_stats(&state, target).power,
+                -5,
+                "reach guard for {name}"
+            );
+            assert_eq!(
+                state.players[target.0 as usize].life, expected_life,
+                "{name}"
+            );
+            assert_eq!(
+                state.format_config.starting_life, expected_starting_life,
+                "{name}"
+            );
+            let actual = threat_level(&state, PlayerId(0), target);
+            assert!(
+                (actual - expected).abs() < 1e-12,
+                "{name} must retain the base raw-power formula for negative power; got {actual}"
             );
         }
     }

--- a/crates/phase-ai/src/eval.rs
+++ b/crates/phase-ai/src/eval.rs
@@ -1,5 +1,6 @@
 use engine::game::players;
 use engine::types::card_type::CoreType;
+use engine::types::format::FormatTopology;
 use engine::types::game_state::{GameState, WaitingFor};
 use engine::types::identifiers::ObjectId;
 use engine::types::keywords::Keyword;
@@ -339,7 +340,19 @@ pub fn threat_level_projected(
     let power = projection
         .map(|p| projected_power(&p.state, target))
         .unwrap_or(base_power);
-    let board_score = (creatures as f64 * 0.3 + power as f64 * 0.7).min(10.0) / 10.0;
+    let raw_board_strength = (creatures as f64 * 0.3 + power.max(0) as f64 * 0.7).max(0.0);
+    // In free-for-all, retain differences between developed boards instead of
+    // flattening every board above the old 10-point cap into the same threat.
+    // This is a bounded tactical calibration, not a rules valuation.
+    let board_score = if matches!(
+        state.format_config.topology(),
+        FormatTopology::IndividualSeats
+    ) && state.players.len() > 2
+    {
+        raw_board_strength / (raw_board_strength + 10.0)
+    } else {
+        raw_board_strength.min(10.0) / 10.0
+    };
 
     // Life ratio: higher life = more threatening
     let life_ratio = (target_player.life as f64 / starting_life).clamp(0.0, 2.0) / 2.0;
@@ -2269,6 +2282,23 @@ mod tests {
         state.players[1].life = 0;
         let weights = EvalWeights::default();
         assert_eq!(evaluate_state(&state, PlayerId(0), &weights), WIN_SCORE);
+    }
+
+    #[test]
+    fn multiplayer_threat_curve_remains_monotonic_above_old_board_cap() {
+        let mut state = GameState::new(engine::types::format::FormatConfig::free_for_all(), 3, 42);
+        let at_old_cap = threat_level(&state, PlayerId(0), PlayerId(1));
+        for _ in 0..4 {
+            add_creature(&mut state, PlayerId(1), 5, 5, vec![]);
+        }
+        let developed = threat_level(&state, PlayerId(0), PlayerId(1));
+        for _ in 0..8 {
+            add_creature(&mut state, PlayerId(1), 5, 5, vec![]);
+        }
+        let overwhelming = threat_level(&state, PlayerId(0), PlayerId(1));
+
+        assert!(at_old_cap < developed && developed < overwhelming);
+        assert!(overwhelming.is_finite() && overwhelming <= 1.0);
     }
 
     #[test]

--- a/crates/phase-ai/src/policies/anti_self_harm.rs
+++ b/crates/phase-ai/src/policies/anti_self_harm.rs
@@ -32,9 +32,7 @@ use engine::types::zones::Zone;
 
 use crate::card_value::intrinsic_value;
 use crate::cast_facts::collect_definition_effects;
-use crate::damage_reflection::{
-    is_event_context_damage_to_player, opponent_creature_reflection_penalty,
-};
+use crate::damage_reflection::opponent_creature_reflection_penalty;
 use crate::eval::{evaluate_creature, threat_level};
 use engine::game::players;
 
@@ -985,29 +983,6 @@ fn score_target_ref(ctx: &PolicyContext<'_>, target: &TargetRef) -> f64 {
                     let opponent_life = ctx.state.players[player_id.0 as usize].life;
                     if damage >= opponent_life {
                         return ctx.penalties().lethal_burn_bonus;
-                    }
-                }
-            }
-
-            // Spiteful Sliver / Boros Reckoner-style reflection: in multiplayer,
-            // concentrate damage on the lowest-life opponent instead of rotating
-            // targets each trigger (issue #1364).
-            if !is_self
-                && !beneficial
-                && ctx
-                    .effects()
-                    .iter()
-                    .any(|e| is_event_context_damage_to_player(e))
-            {
-                let opponents = players::opponents(ctx.state, ctx.ai_player);
-                if opponents.len() > 1 {
-                    if let Some(weakest) = opponents
-                        .iter()
-                        .min_by_key(|&&p| ctx.state.players[p.0 as usize].life)
-                    {
-                        if *player_id == *weakest {
-                            return 12.0 + threat_level(ctx.state, ctx.ai_player, *player_id) * 4.0;
-                        }
                     }
                 }
             }
@@ -5631,14 +5606,28 @@ mod tests {
         );
     }
 
-    /// Issue #1364: reflected damage in multiplayer should concentrate on the
-    /// lowest-life opponent instead of cycling evenly between opponents.
+    /// Reflected damage with an unknown dynamic amount follows the shared threat
+    /// signal; only a known fixed lethal amount receives the lethal preference.
     #[test]
-    fn event_context_damage_prefers_lowest_life_opponent_in_multiplayer() {
+    fn event_context_damage_prefers_threatening_opponent_in_multiplayer() {
         let mut state = GameState::new(engine::types::format::FormatConfig::free_for_all(), 3, 42);
         state.players[0].life = 20;
         state.players[1].life = 5;
         state.players[2].life = 14;
+        for _ in 0..8 {
+            let card_id = CardId(state.next_object_id);
+            let creature = create_object(
+                &mut state,
+                card_id,
+                PlayerId(2),
+                "Threat".to_string(),
+                Zone::Battlefield,
+            );
+            let object = state.objects.get_mut(&creature).unwrap();
+            object.card_types.core_types.push(CoreType::Creature);
+            object.power = Some(3);
+            object.toughness = Some(3);
+        }
 
         let effect = Effect::DealDamage {
             amount: QuantityExpr::Ref {
@@ -5693,8 +5682,40 @@ mod tests {
         let other_score = AntiSelfHarmPolicy.score(&ctx_other);
 
         assert!(
-            lowest_score > other_score,
-            "Reflected damage should prefer the lowest-life opponent: lowest={lowest_score}, other={other_score}"
+            other_score > lowest_score,
+            "Dynamic reflected damage must prefer the stronger opponent: low-life={lowest_score}, threat={other_score}"
+        );
+
+        state.players[1].life = 3;
+        let fixed = Effect::DealDamage {
+            amount: QuantityExpr::Fixed { value: 3 },
+            target: TargetFilter::Player,
+            damage_source: None,
+            excess: None,
+        };
+        let (decision, candidate) = make_target_selection_ctx(
+            &mut state,
+            fixed,
+            vec![
+                TargetRef::Player(PlayerId(1)),
+                TargetRef::Player(PlayerId(2)),
+            ],
+            Some(TargetRef::Player(PlayerId(1))),
+        );
+        let fixed_ctx = PolicyContext {
+            state: &state,
+            decision: &decision,
+            candidate: &candidate,
+            ai_player: PlayerId(0),
+            config: &config,
+            context: &crate::context::AiContext::empty(&config.weights),
+            cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
+        };
+        assert_eq!(
+            AntiSelfHarmPolicy.score(&fixed_ctx),
+            config.policy_penalties.lethal_burn_bonus,
+            "known fixed lethal still overrides ordinary threat ranking"
         );
     }
 

--- a/crates/phase-ai/src/search.rs
+++ b/crates/phase-ai/src/search.rs
@@ -6104,6 +6104,7 @@ mod tests {
         state.active_player = PlayerId(0);
         state.priority_player = PlayerId(0);
         let attacker = add_creature(&mut state, PlayerId(0), 4, 4);
+        add_creature(&mut state, PlayerId(1), 2, 2);
         if goaded {
             state
                 .objects
@@ -6943,9 +6944,16 @@ mod tests {
             other => panic!("expected one scored DeclareAttackers action, got {other:?}"),
         };
         assert_eq!(
-            crate::combat_ai::expanded_comparison_counters(),
-            (1, 0, 0),
-            "K=3 dispatches one pre-expired root with zero comparison pairs"
+            crate::combat_ai::expanded_comparison_receipt(),
+            crate::combat_ai::ExpandedComparisonReceipt {
+                entries: 1,
+                attacker_evaluations: 0,
+                pairs: 0,
+                completed_proposals: 0,
+                grouping_passes: 1,
+                cached_value_evaluations: 0,
+            },
+            "K=3 dispatches one pre-expired root without attacker or blocker work"
         );
         engine::game::engine::apply_as_current(&mut state, action)
             .expect("the engine accepts the mandatory fallback declaration");
@@ -6963,25 +6971,31 @@ mod tests {
 
         crate::combat_ai::reset_expanded_comparison_counters();
         let k0_scores = score_candidates_with_session(&state, PlayerId(0), &k0, &session);
-        let k0_counts = crate::combat_ai::expanded_comparison_counters();
+        let k0_receipt = crate::combat_ai::expanded_comparison_receipt();
         crate::combat_ai::reset_expanded_comparison_counters();
         let k3_scores = score_candidates_with_session(&state, PlayerId(0), &k3, &session);
-        let k3_counts = crate::combat_ai::expanded_comparison_counters();
+        let k3_receipt = crate::combat_ai::expanded_comparison_receipt();
 
         assert!(matches!(
             k0_scores.as_slice(),
             [(GameAction::DeclareAttackers { attacks, .. }, 1.0)] if attacks.iter().any(|(id, _)| *id == attacker)
         ));
         assert_eq!(
-            k0_counts.0, 1,
+            k0_receipt.entries, 1,
             "K=0 reaches one measurement comparison root"
         );
         assert!(
-            k0_counts.2 >= 2,
-            "K=0's measurement deadline is not pre-expired"
+            k0_receipt.attacker_evaluations > 0 && k0_receipt.pairs > 0,
+            "the live root evaluates attackers and a real blocker"
         );
-        assert_eq!(k3_counts.0, 1, "K=3 is dispatched before the sample loop");
-        assert!(k3_counts.2 >= 2, "measurement ignores time_budget_ms=0");
+        assert!(
+            k0_receipt.attacker_evaluations + k0_receipt.pairs <= 4096,
+            "the root preserves the single comparison work ceiling"
+        );
+        assert_eq!(
+            k3_receipt, k0_receipt,
+            "K=3 is dispatched before the sample loop"
+        );
         assert_eq!(
             k3_scores, k0_scores,
             "measurement K=0/K=3 keeps the identical public combat action and score"
@@ -7007,7 +7021,7 @@ mod tests {
         crate::combat_ai::reset_expanded_comparison_counters();
         let baseline =
             score_candidates_with_session(&state, PlayerId(0), &config, &baseline_session);
-        let baseline_counts = crate::combat_ai::expanded_comparison_counters();
+        let baseline_receipt = crate::combat_ai::expanded_comparison_receipt();
 
         let hidden_object = state.objects.get_mut(&hidden).expect("hidden card exists");
         hidden_object.name = "Hidden Identity B".to_string();
@@ -7023,23 +7037,19 @@ mod tests {
         let mutated_session = AiSession::arc_from_game(&state);
         crate::combat_ai::reset_expanded_comparison_counters();
         let mutated = score_candidates_with_session(&state, PlayerId(0), &config, &mutated_session);
-        let mutated_counts = crate::combat_ai::expanded_comparison_counters();
+        let mutated_receipt = crate::combat_ai::expanded_comparison_receipt();
 
         assert!(matches!(
             baseline.as_slice(),
             [(GameAction::DeclareAttackers { attacks, .. }, 1.0)] if attacks.iter().any(|(id, _)| *id == attacker)
         ));
-        assert_eq!(
-            baseline_counts.0, 1,
-            "K=3 dispatches one public root comparison"
-        );
-        assert_eq!(
-            mutated_counts.0, 1,
-            "the changed hidden payload still dispatches once"
-        );
         assert!(
-            baseline_counts.2 >= 2 && mutated_counts.2 >= 2,
-            "both roots complete their public defender proposals"
+            baseline_receipt.attacker_evaluations > 0 && baseline_receipt.pairs > 0,
+            "the public root includes real attacker/blocker comparison work"
+        );
+        assert_eq!(
+            mutated_receipt, baseline_receipt,
+            "hidden identity leaves every public comparison work count unchanged"
         );
         assert_eq!(
             mutated, baseline,

--- a/crates/phase-ai/src/search.rs
+++ b/crates/phase-ai/src/search.rs
@@ -7730,11 +7730,11 @@ mod tests {
     }
 
     fn spell_target_selection_state(
+        mut state: GameState,
         current_legal_targets: Vec<TargetRef>,
         stale_slot_targets: Vec<TargetRef>,
         optional: bool,
     ) -> GameState {
-        let mut state = make_state();
         let spell_id = add_spell_to_hand(&mut state, PlayerId(0), "Targeting Spell", 0);
         let mut ability = ResolvedAbility::new(
             Effect::DealDamage {
@@ -9843,6 +9843,7 @@ mod tests {
     #[test]
     fn public_damage_target_selection_prefers_threat_over_low_life() {
         let mut state = spell_target_selection_state(
+            GameState::new(engine::types::format::FormatConfig::free_for_all(), 3, 42),
             vec![
                 TargetRef::Player(PlayerId(1)),
                 TargetRef::Player(PlayerId(2)),
@@ -9853,8 +9854,6 @@ mod tests {
             ],
             false,
         );
-        state.format_config = engine::types::format::FormatConfig::free_for_all();
-        state.players.push(state.players[1].clone());
         state.players[1].life = 5;
         state.players[2].life = 20;
         let WaitingFor::TargetSelection { pending_cast, .. } = &mut state.waiting_for else {
@@ -9924,6 +9923,7 @@ mod tests {
     #[test]
     fn public_fixed_lethal_damage_keeps_its_finish_preference() {
         let mut state = spell_target_selection_state(
+            GameState::new(engine::types::format::FormatConfig::free_for_all(), 3, 42),
             vec![
                 TargetRef::Player(PlayerId(1)),
                 TargetRef::Player(PlayerId(2)),
@@ -9934,8 +9934,6 @@ mod tests {
             ],
             false,
         );
-        state.format_config = engine::types::format::FormatConfig::free_for_all();
-        state.players.push(state.players[1].clone());
         state.players[1].life = 1;
         for _ in 0..6 {
             add_creature(&mut state, PlayerId(2), 4, 4);
@@ -9977,9 +9975,12 @@ mod tests {
 
     #[test]
     fn public_harmful_object_target_prefers_the_threatening_controller() {
-        let mut target_state = spell_target_selection_state(Vec::new(), Vec::new(), false);
-        target_state.format_config = engine::types::format::FormatConfig::free_for_all();
-        target_state.players.push(target_state.players[1].clone());
+        let mut target_state = spell_target_selection_state(
+            GameState::new(engine::types::format::FormatConfig::free_for_all(), 3, 42),
+            Vec::new(),
+            Vec::new(),
+            false,
+        );
         let quiet = add_creature(&mut target_state, PlayerId(1), 2, 2);
         let threatening = add_creature(&mut target_state, PlayerId(2), 2, 2);
         for _ in 0..5 {
@@ -10040,6 +10041,7 @@ mod tests {
     #[test]
     fn unmodeled_target_selection_uses_a_reducer_validated_forward_action() {
         let mut state = spell_target_selection_state(
+            make_state(),
             vec![
                 TargetRef::Player(PlayerId(0)),
                 TargetRef::Player(PlayerId(1)),
@@ -10085,6 +10087,7 @@ mod tests {
     #[test]
     fn modeled_else_branch_keeps_target_selection_on_the_normal_scoring_path() {
         let mut state = spell_target_selection_state(
+            make_state(),
             vec![TargetRef::Player(PlayerId(1))],
             vec![TargetRef::Player(PlayerId(1))],
             false,
@@ -10115,6 +10118,7 @@ mod tests {
     #[test]
     fn modeled_mode_keeps_target_selection_on_the_normal_scoring_path() {
         let mut state = spell_target_selection_state(
+            make_state(),
             vec![TargetRef::Player(PlayerId(1))],
             vec![TargetRef::Player(PlayerId(1))],
             false,
@@ -10176,6 +10180,7 @@ mod tests {
     fn fallback_spell_target_selection_uses_current_legal_target_when_slot_is_stale() {
         let target = TargetRef::Player(PlayerId(1));
         let mut state = spell_target_selection_state(
+            make_state(),
             vec![target.clone()],
             vec![TargetRef::Player(PlayerId(0))],
             false,
@@ -10193,8 +10198,12 @@ mod tests {
 
     #[test]
     fn fallback_spell_target_selection_skips_optional_empty_current_slot() {
-        let mut state =
-            spell_target_selection_state(Vec::new(), vec![TargetRef::Player(PlayerId(1))], true);
+        let mut state = spell_target_selection_state(
+            make_state(),
+            Vec::new(),
+            vec![TargetRef::Player(PlayerId(1))],
+            true,
+        );
 
         let action = fallback_action_default(&state).expect("fallback returns an action");
         assert_eq!(action, GameAction::ChooseTarget { target: None });
@@ -10203,8 +10212,12 @@ mod tests {
 
     #[test]
     fn fallback_spell_target_selection_cancels_required_empty_current_slot() {
-        let mut state =
-            spell_target_selection_state(Vec::new(), vec![TargetRef::Player(PlayerId(1))], false);
+        let mut state = spell_target_selection_state(
+            make_state(),
+            Vec::new(),
+            vec![TargetRef::Player(PlayerId(1))],
+            false,
+        );
 
         let action = fallback_action_default(&state).expect("fallback returns an action");
         assert_eq!(action, GameAction::CancelCast);

--- a/crates/phase-ai/src/search.rs
+++ b/crates/phase-ai/src/search.rs
@@ -6097,6 +6097,25 @@ mod tests {
         id
     }
 
+    fn free_for_all_attacker_root(goaded: bool) -> (GameState, ObjectId) {
+        let mut state = GameState::new(engine::types::format::FormatConfig::free_for_all(), 3, 42);
+        state.turn_number = 2;
+        state.phase = Phase::DeclareAttackers;
+        state.active_player = PlayerId(0);
+        state.priority_player = PlayerId(0);
+        let attacker = add_creature(&mut state, PlayerId(0), 4, 4);
+        if goaded {
+            state
+                .objects
+                .get_mut(&attacker)
+                .expect("attacker exists")
+                .goaded_by
+                .insert(PlayerId(1));
+        }
+        state.waiting_for = engine::game::combat::build_declare_attackers_waiting_for(&state);
+        (state, attacker)
+    }
+
     fn add_spell_to_hand(
         state: &mut GameState,
         owner: PlayerId,
@@ -6851,6 +6870,180 @@ mod tests {
             score_candidates_with_session(&state, PlayerId(0), &k3, &mutated_session),
             sampled,
             "attacker comparison reads public combat state, not a hidden opponent identity with unchanged counts"
+        );
+    }
+
+    #[test]
+    fn root_combat_comparison_requires_context_but_root_scoring_reaches_it() {
+        let (state, attacker) = free_for_all_attacker_root(false);
+        let config = create_config(AiDifficulty::Hard, Platform::Native).into_measurement(17);
+
+        crate::combat_ai::reset_expanded_comparison_counters();
+        let rollout_action = deterministic_choice(&state, PlayerId(0), &config, &[], None)
+            .expect("DeclareAttackers has a deterministic fallback action");
+        assert!(matches!(
+            rollout_action,
+            GameAction::DeclareAttackers { ref attacks, .. } if attacks.iter().any(|(id, _)| *id == attacker)
+        ));
+        assert_eq!(
+            crate::combat_ai::expanded_comparison_counters().0,
+            0,
+            "context=None is the non-expanding rollout path"
+        );
+
+        let session = AiSession::arc_from_game(&state);
+        crate::combat_ai::reset_expanded_comparison_counters();
+        let root = score_candidates_core(&state, PlayerId(0), &config, &session, None);
+        assert!(matches!(
+            root.as_slice(),
+            [(GameAction::DeclareAttackers { attacks, .. }, 1.0)] if attacks.iter().any(|(id, _)| *id == attacker)
+        ));
+        assert_eq!(
+            crate::combat_ai::expanded_comparison_counters().0,
+            1,
+            "PlannerServices supplies the root comparison deadline"
+        );
+    }
+
+    #[test]
+    fn k3_expired_mandatory_attacker_fallback_is_nonempty_and_engine_accepted() {
+        let (mut state, attacker) = free_for_all_attacker_root(true);
+        let WaitingFor::DeclareAttackers {
+            valid_attacker_ids,
+            valid_attack_targets_by_attacker: Some(targets_by_attacker),
+            ..
+        } = &state.waiting_for
+        else {
+            panic!("use the engine-issued DeclareAttackers domain");
+        };
+        assert!(valid_attacker_ids.contains(&attacker));
+        assert!(
+            targets_by_attacker.get(&attacker).is_some_and(|targets| {
+                targets.contains(&engine::game::combat::AttackTarget::Player(PlayerId(2)))
+                    && !targets.contains(&engine::game::combat::AttackTarget::Player(PlayerId(1)))
+            }),
+            "goad leaves P2 as a legal required attack defender"
+        );
+
+        let session = AiSession::arc_from_game(&state);
+        let mut config = create_config(AiDifficulty::Hard, Platform::Native);
+        config.search.determinization_samples = 3;
+        config.search.time_budget_ms = Some(0);
+
+        crate::combat_ai::reset_expanded_comparison_counters();
+        let scored = score_candidates_with_session(&state, PlayerId(0), &config, &session);
+        let action = match scored.as_slice() {
+            [(action @ GameAction::DeclareAttackers { attacks, .. }, 1.0)] => {
+                assert!(
+                    attacks.iter().any(|(id, _)| *id == attacker),
+                    "the required attacker remains nonempty under zero-work fallback"
+                );
+                action.clone()
+            }
+            other => panic!("expected one scored DeclareAttackers action, got {other:?}"),
+        };
+        assert_eq!(
+            crate::combat_ai::expanded_comparison_counters(),
+            (1, 0, 0),
+            "K=3 dispatches one pre-expired root with zero comparison pairs"
+        );
+        engine::game::engine::apply_as_current(&mut state, action)
+            .expect("the engine accepts the mandatory fallback declaration");
+    }
+
+    #[test]
+    fn measurement_combat_ignores_zero_timeout_and_k0_k3_scores_match() {
+        let (state, attacker) = free_for_all_attacker_root(false);
+        let session = AiSession::arc_from_game(&state);
+        let mut k0 = create_config(AiDifficulty::Hard, Platform::Native).into_measurement(23);
+        k0.search.determinization_samples = 0;
+        k0.search.time_budget_ms = Some(0);
+        let mut k3 = k0.clone();
+        k3.search.determinization_samples = 3;
+
+        crate::combat_ai::reset_expanded_comparison_counters();
+        let k0_scores = score_candidates_with_session(&state, PlayerId(0), &k0, &session);
+        let k0_counts = crate::combat_ai::expanded_comparison_counters();
+        crate::combat_ai::reset_expanded_comparison_counters();
+        let k3_scores = score_candidates_with_session(&state, PlayerId(0), &k3, &session);
+        let k3_counts = crate::combat_ai::expanded_comparison_counters();
+
+        assert!(matches!(
+            k0_scores.as_slice(),
+            [(GameAction::DeclareAttackers { attacks, .. }, 1.0)] if attacks.iter().any(|(id, _)| *id == attacker)
+        ));
+        assert_eq!(
+            k0_counts.0, 1,
+            "K=0 reaches one measurement comparison root"
+        );
+        assert!(
+            k0_counts.2 >= 2,
+            "K=0's measurement deadline is not pre-expired"
+        );
+        assert_eq!(k3_counts.0, 1, "K=3 is dispatched before the sample loop");
+        assert!(k3_counts.2 >= 2, "measurement ignores time_budget_ms=0");
+        assert_eq!(
+            k3_scores, k0_scores,
+            "measurement K=0/K=3 keeps the identical public combat action and score"
+        );
+    }
+
+    #[test]
+    fn k3_combat_scores_ignore_hidden_identity_with_public_hand_count_fixed() {
+        let (mut state, attacker) = free_for_all_attacker_root(false);
+        let card_id = CardId(state.next_object_id);
+        let hidden = create_object(
+            &mut state,
+            card_id,
+            PlayerId(1),
+            "Hidden Identity A".to_string(),
+            Zone::Hand,
+        );
+        let public_hand_count = state.players[1].hand.len();
+        let mut config = create_config(AiDifficulty::Hard, Platform::Native);
+        config.search.determinization_samples = 3;
+        config.search.time_budget_ms = None;
+        let baseline_session = AiSession::arc_from_game(&state);
+        crate::combat_ai::reset_expanded_comparison_counters();
+        let baseline =
+            score_candidates_with_session(&state, PlayerId(0), &config, &baseline_session);
+        let baseline_counts = crate::combat_ai::expanded_comparison_counters();
+
+        let hidden_object = state.objects.get_mut(&hidden).expect("hidden card exists");
+        hidden_object.name = "Hidden Identity B".to_string();
+        hidden_object.card_id = CardId(card_id.0 + 1);
+        hidden_object.card_types.core_types.push(CoreType::Creature);
+        hidden_object.power = Some(7);
+        hidden_object.toughness = Some(7);
+        assert_eq!(
+            state.players[1].hand.len(),
+            public_hand_count,
+            "the hidden card changes identity and characteristics without changing public count"
+        );
+        let mutated_session = AiSession::arc_from_game(&state);
+        crate::combat_ai::reset_expanded_comparison_counters();
+        let mutated = score_candidates_with_session(&state, PlayerId(0), &config, &mutated_session);
+        let mutated_counts = crate::combat_ai::expanded_comparison_counters();
+
+        assert!(matches!(
+            baseline.as_slice(),
+            [(GameAction::DeclareAttackers { attacks, .. }, 1.0)] if attacks.iter().any(|(id, _)| *id == attacker)
+        ));
+        assert_eq!(
+            baseline_counts.0, 1,
+            "K=3 dispatches one public root comparison"
+        );
+        assert_eq!(
+            mutated_counts.0, 1,
+            "the changed hidden payload still dispatches once"
+        );
+        assert!(
+            baseline_counts.2 >= 2 && mutated_counts.2 >= 2,
+            "both roots complete their public defender proposals"
+        );
+        assert_eq!(
+            mutated, baseline,
+            "the K=3 attacker root reads public combat state, not hidden opponent identity"
         );
     }
 

--- a/crates/phase-ai/src/search.rs
+++ b/crates/phase-ai/src/search.rs
@@ -6811,8 +6811,9 @@ mod tests {
             valid_attack_targets_by_attacker: None,
             attacker_constraints: Default::default(),
         };
+        let hidden = add_opp_hidden(&mut state, "HiddenA", Zone::Hand);
         let session = AiSession::arc_from_game(&state);
-        let mut k0 = create_config(AiDifficulty::Hard, Platform::Native).into_measurement(2);
+        let mut k0 = create_config(AiDifficulty::Hard, Platform::Native);
         k0.search.determinization_samples = 0;
         let mut k3 = k0.clone();
         k3.search.determinization_samples = 3;
@@ -6832,6 +6833,25 @@ mod tests {
         let (entries, _pairs, completed) = crate::combat_ai::expanded_comparison_counters();
         assert_eq!(entries, 1, "K=3 enters the root combat comparison once");
         assert!(completed >= 2, "the one entry evaluates complete proposals");
+
+        let mut measured_k0 =
+            create_config(AiDifficulty::Hard, Platform::Native).into_measurement(2);
+        measured_k0.search.determinization_samples = 0;
+        let mut measured_k3 = measured_k0.clone();
+        measured_k3.search.determinization_samples = 3;
+        assert_eq!(
+            score_candidates_with_session(&state, PlayerId(0), &measured_k3, &session),
+            score_candidates_with_session(&state, PlayerId(0), &measured_k0, &session),
+            "measurement deadline override preserves the same one-action attacker score for K=0 and K=3"
+        );
+
+        state.objects.get_mut(&hidden).unwrap().name = "HiddenB".to_string();
+        let mutated_session = AiSession::arc_from_game(&state);
+        assert_eq!(
+            score_candidates_with_session(&state, PlayerId(0), &k3, &mutated_session),
+            sampled,
+            "attacker comparison reads public combat state, not a hidden opponent identity with unchanged counts"
+        );
     }
 
     #[test]
@@ -9721,25 +9741,52 @@ mod tests {
             ],
             false,
         );
+        state.format_config = engine::types::format::FormatConfig::free_for_all();
+        state.players.push(state.players[1].clone());
         state.players[1].life = 1;
         for _ in 0..6 {
             add_creature(&mut state, PlayerId(2), 4, 4);
         }
 
         let config = create_config(AiDifficulty::Hard, Platform::Native);
+        let session = AiSession::arc_from_game(&state);
         let mut rng = SmallRng::seed_from_u64(42);
-        assert_eq!(
-            choose_action(&state, PlayerId(0), &config, &mut rng),
-            Some(GameAction::ChooseTarget {
-                target: Some(TargetRef::Player(PlayerId(1))),
-            }),
-            "a known fixed lethal remains above a nonlethal threatening opponent"
+        let selection =
+            choose_action_with_session_diagnostic(&state, PlayerId(0), &config, &mut rng, &session);
+        let receipt = selection
+            .receipt
+            .expect("target selection is a ranked decision");
+        let lethal = receipt
+            .candidates
+            .iter()
+            .find(|candidate| {
+                candidate.action
+                    == GameAction::ChooseTarget {
+                        target: Some(TargetRef::Player(PlayerId(1))),
+                    }
+            })
+            .expect("the engine issued the legal lethal opponent target");
+        let threatening = receipt
+            .candidates
+            .iter()
+            .find(|candidate| {
+                candidate.action
+                    == GameAction::ChooseTarget {
+                        target: Some(TargetRef::Player(PlayerId(2))),
+                    }
+            })
+            .expect("the engine issued the legal threatening opponent target");
+        assert!(
+            lethal.is_top_ranked && lethal.score > threatening.score,
+            "a known fixed lethal remains above a nonlethal threatening opponent: lethal={lethal:?}, threatening={threatening:?}"
         );
     }
 
     #[test]
     fn public_harmful_object_target_prefers_the_threatening_controller() {
         let mut target_state = spell_target_selection_state(Vec::new(), Vec::new(), false);
+        target_state.format_config = engine::types::format::FormatConfig::free_for_all();
+        target_state.players.push(target_state.players[1].clone());
         let quiet = add_creature(&mut target_state, PlayerId(1), 2, 2);
         let threatening = add_creature(&mut target_state, PlayerId(2), 2, 2);
         for _ in 0..5 {
@@ -9759,13 +9806,41 @@ mod tests {
         }
 
         let config = create_config(AiDifficulty::Hard, Platform::Native);
+        let session = AiSession::arc_from_game(&target_state);
         let mut rng = SmallRng::seed_from_u64(42);
-        assert_eq!(
-            choose_action(&target_state, PlayerId(0), &config, &mut rng),
-            Some(GameAction::ChooseTarget {
-                target: Some(TargetRef::Object(threatening)),
-            }),
-            "equal legal bodies must be ranked by their controller's shared threat"
+        let selection = choose_action_with_session_diagnostic(
+            &target_state,
+            PlayerId(0),
+            &config,
+            &mut rng,
+            &session,
+        );
+        let receipt = selection
+            .receipt
+            .expect("target selection is a ranked decision");
+        let quiet = receipt
+            .candidates
+            .iter()
+            .find(|candidate| {
+                candidate.action
+                    == GameAction::ChooseTarget {
+                        target: Some(TargetRef::Object(quiet)),
+                    }
+            })
+            .expect("the engine issued the quiet legal creature target");
+        let threatening = receipt
+            .candidates
+            .iter()
+            .find(|candidate| {
+                candidate.action
+                    == GameAction::ChooseTarget {
+                        target: Some(TargetRef::Object(threatening)),
+                    }
+            })
+            .expect("the engine issued the threatening legal creature target");
+        assert!(
+            threatening.is_top_ranked && threatening.score > quiet.score,
+            "equal legal bodies must be ranked by their controller's shared threat: quiet={quiet:?}, threatening={threatening:?}"
         );
     }
 

--- a/crates/phase-ai/src/search.rs
+++ b/crates/phase-ai/src/search.rs
@@ -36,7 +36,7 @@ use crate::card_value::{cmp_keep, intrinsic_value, keep_key};
 use crate::cast_facts::cast_facts_for_action;
 use crate::combat_ai::{
     choose_attackers_with_targets_with_profile_and_deadline, choose_blockers_with_profile,
-    CombatLookahead,
+    AttackTargetingContext, CombatLookahead,
 };
 use crate::config::{AiConfig, PlannerMode, ThreatAwareness};
 use crate::context::AiContext;
@@ -4097,6 +4097,7 @@ pub(crate) fn deterministic_choice(
     if let WaitingFor::DeclareAttackers {
         valid_attacker_ids,
         valid_attack_targets,
+        valid_attack_targets_by_attacker,
         ..
     } = &state.waiting_for
     {
@@ -4105,10 +4106,13 @@ pub(crate) fn deterministic_choice(
             ai_player,
             &config.profile,
             CombatLookahead::from_config(config),
-            Some(valid_attacker_ids),
-            Some(valid_attack_targets),
             context.map(|c| c.session.as_ref()),
-            context.map(|c| c.deadline),
+            AttackTargetingContext {
+                valid_attacker_ids: Some(valid_attacker_ids),
+                valid_attack_targets: Some(valid_attack_targets),
+                valid_attack_targets_by_attacker: valid_attack_targets_by_attacker.as_ref(),
+                comparison_deadline: context.map(|c| c.deadline),
+            },
         );
         return Some(validated_declare_attackers(state, attacks));
     }
@@ -4164,6 +4168,7 @@ fn deterministic_combat_choice(
     if let WaitingFor::DeclareAttackers {
         valid_attacker_ids,
         valid_attack_targets,
+        valid_attack_targets_by_attacker,
         ..
     } = &state.waiting_for
     {
@@ -4172,10 +4177,13 @@ fn deterministic_combat_choice(
             ai_player,
             profile,
             CombatLookahead::Disabled,
-            Some(valid_attacker_ids),
-            Some(valid_attack_targets),
             session,
-            comparison_deadline,
+            AttackTargetingContext {
+                valid_attacker_ids: Some(valid_attacker_ids),
+                valid_attack_targets: Some(valid_attack_targets),
+                valid_attack_targets_by_attacker: valid_attack_targets_by_attacker.as_ref(),
+                comparison_deadline,
+            },
         );
         return Some(validated_declare_attackers(state, attacks));
     }
@@ -4557,8 +4565,8 @@ mod tests {
     use engine::types::ability::{
         AbilityCost, AbilityDefinition, AbilityKind, CategoryChooserScope, ContinuousModification,
         ControllerRef, Duration, Effect, EffectKind, ManaProduction, PlayerFilter, PtValue,
-        QuantityExpr, ReplacementDefinition, ResolvedAbility, StaticDefinition, TargetFilter,
-        TargetRef, TriggerConstraint, TriggerDefinition, TypedFilter,
+        QuantityExpr, QuantityRef, ReplacementDefinition, ResolvedAbility, StaticDefinition,
+        TargetFilter, TargetRef, TriggerConstraint, TriggerDefinition, TypedFilter,
     };
     use engine::types::ability::{ChoiceType, ChosenAttribute};
     use engine::types::card_type::CoreType;
@@ -6810,6 +6818,7 @@ mod tests {
         k3.search.determinization_samples = 3;
 
         let direct = score_candidates_with_session(&state, PlayerId(0), &k0, &session);
+        crate::combat_ai::reset_expanded_comparison_counters();
         let sampled = score_candidates_with_session(&state, PlayerId(0), &k3, &session);
 
         assert!(
@@ -6820,6 +6829,45 @@ mod tests {
             "reach guard: DeclareAttackers must use the specialized production path"
         );
         assert_eq!(sampled, direct, "K must not rescore attacker declarations");
+        let (entries, _pairs, completed) = crate::combat_ai::expanded_comparison_counters();
+        assert_eq!(entries, 1, "K=3 enters the root combat comparison once");
+        assert!(completed >= 2, "the one entry evaluates complete proposals");
+    }
+
+    #[test]
+    fn expired_attacker_root_uses_one_zero_work_threat_fallback() {
+        let mut state = GameState::new(engine::types::format::FormatConfig::free_for_all(), 3, 42);
+        state.turn_number = 2;
+        state.phase = Phase::DeclareAttackers;
+        state.active_player = PlayerId(0);
+        let attacker = add_creature(&mut state, PlayerId(0), 4, 4);
+        state.waiting_for = WaitingFor::DeclareAttackers {
+            player: PlayerId(0),
+            valid_attacker_ids: vec![attacker],
+            valid_attack_targets: vec![
+                engine::game::combat::AttackTarget::Player(PlayerId(1)),
+                engine::game::combat::AttackTarget::Player(PlayerId(2)),
+            ],
+            valid_attack_targets_by_attacker: None,
+            attacker_constraints: Default::default(),
+        };
+        let session = AiSession::arc_from_game(&state);
+        let mut config = create_config(AiDifficulty::Hard, Platform::Native);
+        config.search.determinization_samples = 3;
+        config.search.time_budget_ms = Some(0);
+
+        crate::combat_ai::reset_expanded_comparison_counters();
+        let scored = score_candidates_with_session(&state, PlayerId(0), &config, &session);
+
+        assert!(matches!(
+            scored.as_slice(),
+            [(GameAction::DeclareAttackers { .. }, 1.0)]
+        ));
+        assert_eq!(
+            crate::combat_ai::expanded_comparison_counters(),
+            (1, 0, 0),
+            "an expired root chooses the bounded fallback once without partial comparison work"
+        );
     }
 
     #[test]
@@ -9580,6 +9628,148 @@ mod tests {
     }
 
     #[test]
+    fn public_damage_target_selection_prefers_threat_over_low_life() {
+        let mut state = spell_target_selection_state(
+            vec![
+                TargetRef::Player(PlayerId(1)),
+                TargetRef::Player(PlayerId(2)),
+            ],
+            vec![
+                TargetRef::Player(PlayerId(1)),
+                TargetRef::Player(PlayerId(2)),
+            ],
+            false,
+        );
+        state.format_config = engine::types::format::FormatConfig::free_for_all();
+        state.players.push(state.players[1].clone());
+        state.players[1].life = 5;
+        state.players[2].life = 20;
+        let WaitingFor::TargetSelection { pending_cast, .. } = &mut state.waiting_for else {
+            panic!("fixture must retain its target selection prompt");
+        };
+        pending_cast.ability.effect = Effect::DealDamage {
+            amount: QuantityExpr::Ref {
+                qty: QuantityRef::EventContextAmount,
+            },
+            target: TargetFilter::Player,
+            damage_source: None,
+            excess: None,
+        };
+        for _ in 0..6 {
+            add_creature(&mut state, PlayerId(2), 4, 4);
+        }
+
+        let config = create_config(AiDifficulty::Hard, Platform::Native);
+        let session = AiSession::arc_from_game(&state);
+        let mut rng = SmallRng::seed_from_u64(42);
+        let selection =
+            choose_action_with_session_diagnostic(&state, PlayerId(0), &config, &mut rng, &session);
+        let receipt = selection
+            .receipt
+            .expect("target selection is a ranked decision");
+        let low_life = receipt
+            .candidates
+            .iter()
+            .find(|candidate| {
+                candidate.action
+                    == GameAction::ChooseTarget {
+                        target: Some(TargetRef::Player(PlayerId(1))),
+                    }
+            })
+            .expect("the engine issued the low-life opponent target");
+        let threatening = receipt
+            .candidates
+            .iter()
+            .find(|candidate| {
+                candidate.action
+                    == GameAction::ChooseTarget {
+                        target: Some(TargetRef::Player(PlayerId(2))),
+                    }
+            })
+            .expect("the engine issued the threatening opponent target");
+
+        assert_eq!(
+            receipt.sampling_temperature,
+            Some(config.temperature),
+            "Hard uses softmax, so a seeded sampled action need not equal the top-ranked target"
+        );
+        eprintln!(
+            "reflection target ranking: low-life score={:?} probability={:?}; threatening score={:?} probability={:?}",
+            low_life.score,
+            low_life.probability,
+            threatening.score,
+            threatening.probability,
+        );
+        assert!(
+            threatening.is_top_ranked
+                && threatening.score > low_life.score
+                && threatening.probability > low_life.probability,
+            "the registry-composed public selector must rank the threatening legal opponent above the low-life opponent: low-life={low_life:?}, threatening={threatening:?}"
+        );
+    }
+
+    #[test]
+    fn public_fixed_lethal_damage_keeps_its_finish_preference() {
+        let mut state = spell_target_selection_state(
+            vec![
+                TargetRef::Player(PlayerId(1)),
+                TargetRef::Player(PlayerId(2)),
+            ],
+            vec![
+                TargetRef::Player(PlayerId(1)),
+                TargetRef::Player(PlayerId(2)),
+            ],
+            false,
+        );
+        state.players[1].life = 1;
+        for _ in 0..6 {
+            add_creature(&mut state, PlayerId(2), 4, 4);
+        }
+
+        let config = create_config(AiDifficulty::Hard, Platform::Native);
+        let mut rng = SmallRng::seed_from_u64(42);
+        assert_eq!(
+            choose_action(&state, PlayerId(0), &config, &mut rng),
+            Some(GameAction::ChooseTarget {
+                target: Some(TargetRef::Player(PlayerId(1))),
+            }),
+            "a known fixed lethal remains above a nonlethal threatening opponent"
+        );
+    }
+
+    #[test]
+    fn public_harmful_object_target_prefers_the_threatening_controller() {
+        let mut target_state = spell_target_selection_state(Vec::new(), Vec::new(), false);
+        let quiet = add_creature(&mut target_state, PlayerId(1), 2, 2);
+        let threatening = add_creature(&mut target_state, PlayerId(2), 2, 2);
+        for _ in 0..5 {
+            add_creature(&mut target_state, PlayerId(2), 4, 4);
+        }
+        if let WaitingFor::TargetSelection {
+            target_slots,
+            selection,
+            ..
+        } = &mut target_state.waiting_for
+        {
+            let legal = vec![TargetRef::Object(quiet), TargetRef::Object(threatening)];
+            target_slots[0].legal_targets.clone_from(&legal);
+            selection.current_legal_targets = legal;
+        } else {
+            panic!("fixture must retain its target selection prompt");
+        }
+
+        let config = create_config(AiDifficulty::Hard, Platform::Native);
+        let mut rng = SmallRng::seed_from_u64(42);
+        assert_eq!(
+            choose_action(&target_state, PlayerId(0), &config, &mut rng),
+            Some(GameAction::ChooseTarget {
+                target: Some(TargetRef::Object(threatening)),
+            }),
+            "equal legal bodies must be ranked by their controller's shared threat"
+        );
+    }
+
+    #[test]
     fn unmodeled_target_selection_uses_a_reducer_validated_forward_action() {
         let mut state = spell_target_selection_state(
             vec![
@@ -9853,14 +10043,18 @@ mod tests {
         state.phase = Phase::DeclareAttackers;
         state.active_player = PlayerId(0);
         let attacker = add_creature(&mut state, PlayerId(0), 4, 4);
+        let player_one = engine::game::combat::AttackTarget::Player(PlayerId(1));
+        let player_two = engine::game::combat::AttackTarget::Player(PlayerId(2));
+        let mut targets_by_attacker = std::collections::HashMap::new();
+        // The aggregate domain contains both opponents, while the engine-issued
+        // support for this attacker admits only player two. The production combat
+        // path must preserve that pair through completion.
+        targets_by_attacker.insert(attacker, vec![player_two]);
         state.waiting_for = WaitingFor::DeclareAttackers {
             player: PlayerId(0),
             valid_attacker_ids: vec![attacker],
-            valid_attack_targets: vec![
-                engine::game::combat::AttackTarget::Player(PlayerId(1)),
-                engine::game::combat::AttackTarget::Player(PlayerId(2)),
-            ],
-            valid_attack_targets_by_attacker: None,
+            valid_attack_targets: vec![player_one, player_two],
+            valid_attack_targets_by_attacker: Some(targets_by_attacker),
             attacker_constraints: Default::default(),
         };
         let config = create_config(AiDifficulty::Hard, Platform::Native);
@@ -9868,7 +10062,10 @@ mod tests {
         let action =
             choose_action(&state, PlayerId(0), &config, &mut rng).expect("DeclareAttackers action");
 
-        assert!(matches!(action, GameAction::DeclareAttackers { .. }));
+        let GameAction::DeclareAttackers { attacks, .. } = &action else {
+            panic!("expected DeclareAttackers, got {action:?}");
+        };
+        assert_eq!(attacks, &vec![(attacker, player_two)]);
         engine::game::engine::apply_as_current(&mut state, action)
             .expect("the engine must accept the AI's coherent target assignment");
     }

--- a/crates/phase-ai/src/search.rs
+++ b/crates/phase-ai/src/search.rs
@@ -35,7 +35,8 @@ use engine::types::zones::Zone;
 use crate::card_value::{cmp_keep, intrinsic_value, keep_key};
 use crate::cast_facts::cast_facts_for_action;
 use crate::combat_ai::{
-    choose_attackers_with_targets_with_profile, choose_blockers_with_profile, CombatLookahead,
+    choose_attackers_with_targets_with_profile_and_deadline, choose_blockers_with_profile,
+    CombatLookahead,
 };
 use crate::config::{AiConfig, PlannerMode, ThreatAwareness};
 use crate::context::AiContext;
@@ -2477,6 +2478,12 @@ pub(crate) fn score_candidates_with_session(
     config: &AiConfig,
     session: &Arc<AiSession>,
 ) -> Vec<(GameAction, f64)> {
+    // Attacker declarations are public-state tactical choices. Running K hidden
+    // information samples cannot improve them, but would multiply the bounded
+    // multiplayer comparison and make a singleton support drift.
+    if matches!(state.waiting_for, WaitingFor::DeclareAttackers { .. }) {
+        return score_candidates_core(state, ai_player, config, session, None);
+    }
     let k = config.search.determinization_samples;
     if k == 0 {
         // Unchanged path: no determinization, no shared-deadline override.
@@ -3162,6 +3169,9 @@ fn score_candidates_core(
     let policies = PolicyRegistry::shared();
     let context = build_ai_context_with_session(state, ai_player, config, Arc::clone(session));
 
+    let mut services =
+        PlannerServices::with_deadline(ai_player, config, policies, context, deadline_override);
+
     // Combat decisions bypass the candidate pipeline entirely — the combat AI
     // reads directly from game state and never uses generated candidates.
     // This must run before validation/gating, which can filter out all candidates
@@ -3171,19 +3181,18 @@ fn score_candidates_core(
         state.waiting_for,
         WaitingFor::DeclareAttackers { .. } | WaitingFor::DeclareBlockers { .. }
     ) {
-        let effective_profile = config.profile.with_strategy(&context.strategy);
+        let effective_profile = config.profile.with_strategy(&services.context.strategy);
         if let Some(action) = deterministic_combat_choice(
             state,
             ai_player,
             &effective_profile,
             Some(session.as_ref()),
+            Some(services.deadline),
         ) {
             return vec![(action, 1.0)];
         }
     }
 
-    let mut services =
-        PlannerServices::with_deadline(ai_player, config, policies, context, deadline_override);
     let prepared = prepare_payment_candidates(state, ctx.candidates.clone());
     let prepared = services.validate_prepared_candidates(state, prepared);
     let gated = gate_prepared_candidates(
@@ -4091,7 +4100,7 @@ pub(crate) fn deterministic_choice(
         ..
     } = &state.waiting_for
     {
-        let attacks = choose_attackers_with_targets_with_profile(
+        let attacks = choose_attackers_with_targets_with_profile_and_deadline(
             state,
             ai_player,
             &config.profile,
@@ -4099,6 +4108,7 @@ pub(crate) fn deterministic_choice(
             Some(valid_attacker_ids),
             Some(valid_attack_targets),
             context.map(|c| c.session.as_ref()),
+            context.map(|c| c.deadline),
         );
         return Some(validated_declare_attackers(state, attacks));
     }
@@ -4149,6 +4159,7 @@ fn deterministic_combat_choice(
     ai_player: PlayerId,
     profile: &crate::config::AiProfile,
     session: Option<&AiSession>,
+    comparison_deadline: Option<engine::util::Deadline>,
 ) -> Option<GameAction> {
     if let WaitingFor::DeclareAttackers {
         valid_attacker_ids,
@@ -4156,7 +4167,7 @@ fn deterministic_combat_choice(
         ..
     } = &state.waiting_for
     {
-        let attacks = choose_attackers_with_targets_with_profile(
+        let attacks = choose_attackers_with_targets_with_profile_and_deadline(
             state,
             ai_player,
             profile,
@@ -4164,6 +4175,7 @@ fn deterministic_combat_choice(
             Some(valid_attacker_ids),
             Some(valid_attack_targets),
             session,
+            comparison_deadline,
         );
         return Some(validated_declare_attackers(state, attacks));
     }
@@ -6772,6 +6784,42 @@ mod tests {
             cycling_score < pass_score,
             "the sole next planned land must wait: cycle={cycling_score}, pass={pass_score}"
         );
+    }
+
+    #[test]
+    fn attacker_declarations_bypass_hidden_information_sampling() {
+        let mut state = GameState::new(engine::types::format::FormatConfig::free_for_all(), 3, 42);
+        state.turn_number = 2;
+        state.phase = Phase::DeclareAttackers;
+        state.active_player = PlayerId(0);
+        let attacker = add_creature(&mut state, PlayerId(0), 4, 4);
+        state.waiting_for = WaitingFor::DeclareAttackers {
+            player: PlayerId(0),
+            valid_attacker_ids: vec![attacker],
+            valid_attack_targets: vec![
+                engine::game::combat::AttackTarget::Player(PlayerId(1)),
+                engine::game::combat::AttackTarget::Player(PlayerId(2)),
+            ],
+            valid_attack_targets_by_attacker: None,
+            attacker_constraints: Default::default(),
+        };
+        let session = AiSession::arc_from_game(&state);
+        let mut k0 = create_config(AiDifficulty::Hard, Platform::Native).into_measurement(2);
+        k0.search.determinization_samples = 0;
+        let mut k3 = k0.clone();
+        k3.search.determinization_samples = 3;
+
+        let direct = score_candidates_with_session(&state, PlayerId(0), &k0, &session);
+        let sampled = score_candidates_with_session(&state, PlayerId(0), &k3, &session);
+
+        assert!(
+            matches!(
+                direct.as_slice(),
+                [(GameAction::DeclareAttackers { .. }, 1.0)]
+            ),
+            "reach guard: DeclareAttackers must use the specialized production path"
+        );
+        assert_eq!(sampled, direct, "K must not rescore attacker declarations");
     }
 
     #[test]
@@ -9796,6 +9844,33 @@ mod tests {
             "Should return DeclareAttackers, got {:?}",
             action
         );
+    }
+
+    #[test]
+    fn multiplayer_attack_choice_survives_engine_completion() {
+        let mut state = GameState::new(engine::types::format::FormatConfig::free_for_all(), 3, 42);
+        state.turn_number = 2;
+        state.phase = Phase::DeclareAttackers;
+        state.active_player = PlayerId(0);
+        let attacker = add_creature(&mut state, PlayerId(0), 4, 4);
+        state.waiting_for = WaitingFor::DeclareAttackers {
+            player: PlayerId(0),
+            valid_attacker_ids: vec![attacker],
+            valid_attack_targets: vec![
+                engine::game::combat::AttackTarget::Player(PlayerId(1)),
+                engine::game::combat::AttackTarget::Player(PlayerId(2)),
+            ],
+            valid_attack_targets_by_attacker: None,
+            attacker_constraints: Default::default(),
+        };
+        let config = create_config(AiDifficulty::Hard, Platform::Native);
+        let mut rng = SmallRng::seed_from_u64(42);
+        let action =
+            choose_action(&state, PlayerId(0), &config, &mut rng).expect("DeclareAttackers action");
+
+        assert!(matches!(action, GameAction::DeclareAttackers { .. }));
+        engine::game::engine::apply_as_current(&mut state, action)
+            .expect("the engine must accept the AI's coherent target assignment");
     }
 
     /// Issue #1523 (p0 softlock): `validated_declare_attackers` must never


### PR DESCRIPTION
Improves FFA AI target selection so combat and player-targeting decisions account for relative threat rather than repeatedly concentrating on a particular player.

- Preserves coherent defender and blocker proposals across combat scoring.
- Bounds comparison work and keeps the established duel/team threat formula intact.
- Adds multiplayer targeting, provenance, workload, and regression coverage.

Validation completed locally: phase-ai tests, lint, WASM compile check, paired-seed AI gate, decision-cost performance gate, and controlled same-host latency benchmarks.