### PR TITLE
Expose the engine's deck compatibility protocol to native harnesses

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -5,6 +5,7 @@ wasm-release = "build --package engine-wasm --target wasm32-unknown-unknown --re
 test-all = "nextest run --workspace --features engine/proptest"
 clippy-strict = "clippy --all-targets -- -D warnings"
 export-cards = "run --profile tool --features cli --bin oracle-gen --"
+deck-check = "run --profile tool -p phase-engine --features cli --bin deck-check --"
 serve = "run --release --bin phase-server"
 coverage = "run --profile tool --bin coverage-report -- data/"
 parser-gaps = "run --profile tool --bin parser-gap-analyzer -- data/"

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -86,6 +86,11 @@ path = "src/bin/card_data_validate.rs"
 test = false
 
 [[bin]]
+name = "deck-check"
+path = "src/bin/deck_check.rs"
+# Test-enabled: inline tests exercise ordered DTO output and input/output failures.
+
+[[bin]]
 name = "interaction-bindings"
 path = "src/bin/interaction_bindings.rs"
 required-features = ["interaction-bindings"]

--- a/crates/engine/src/bin/deck_check.rs
+++ b/crates/engine/src/bin/deck_check.rs
@@ -1,0 +1,214 @@
+//! Evaluate a JSON array of `DeckCompatibilityRequest` values.
+//!
+//! Usage: `deck-check <card-data.json> <requests.json>`
+//! Stdout is an ordered JSON array of unchanged `DeckCompatibilityResult` values.
+//! Exit 0 means evaluation/output succeeded, including incompatible decks; input
+//! or output errors are reported on stderr with exit 2. The caller supplies a
+//! complete card-data export and chooses the format and `summary_only` flag.
+//! Existing request defaults and null selected-format verdicts are preserved.
+//! Empty batches produce `[]`. See `docs/native-deck-validation.md` for examples.
+//!
+//! `set-check --deck` owns parser coverage and AST regression inspection. This
+//! separate transport exposes the existing format-legality DTO, including distinct
+//! commander/companion/planar/signature-spell zones and player-count context, for
+//! native harnesses such as POD-Lab. Extending set-check would mix its parser-audit
+//! options/output with a different, unchanged engine request/response protocol.
+
+use std::ffi::OsString;
+use std::io::{self, Write};
+use std::path::PathBuf;
+use std::process::ExitCode;
+
+use engine::database::CardDatabase;
+use engine::game::deck_validation::{
+    evaluate_deck_compatibility, DeckCompatibilityRequest, DeckCompatibilityResult,
+};
+
+fn main() -> ExitCode {
+    match run(std::env::args_os().skip(1), io::stdout().lock()) {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(error) => {
+            eprintln!("deck-check: {error}");
+            ExitCode::from(2)
+        }
+    }
+}
+
+fn run(mut args: impl Iterator<Item = OsString>, mut output: impl Write) -> Result<(), String> {
+    let (Some(card_data_path), Some(requests_path), None) = (args.next(), args.next(), args.next())
+    else {
+        return Err("Usage: deck-check <card-data.json> <requests.json>".to_string());
+    };
+    let card_data_path = PathBuf::from(card_data_path);
+    let requests_path = PathBuf::from(requests_path);
+    let input = std::fs::read(&requests_path)
+        .map_err(|error| format!("could not read {}: {error}", requests_path.display()))?;
+    let requests: Vec<DeckCompatibilityRequest> = serde_json::from_slice(&input)
+        .map_err(|error| format!("invalid requests in {}: {error}", requests_path.display()))?;
+    let db = CardDatabase::from_export(&card_data_path)
+        .map_err(|error| format!("could not load {}: {error}", card_data_path.display()))?;
+    let results: Vec<DeckCompatibilityResult> = requests
+        .iter()
+        .map(|request| evaluate_deck_compatibility(&db, request))
+        .collect();
+    let mut json = serde_json::to_vec(&results)
+        .map_err(|error| format!("could not serialize results: {error}"))?;
+    json.push(b'\n');
+    output
+        .write_all(&json)
+        .and_then(|()| output.flush())
+        .map_err(|error| format!("could not write results: {error}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::{json, Value};
+    use tempfile::TempDir;
+
+    const CARD_DATA: &str = include_str!("../../tests/fixtures/runtime_card_export_fixture.json");
+
+    fn input_files(card_data: &str, requests: &str) -> (TempDir, [OsString; 2]) {
+        let dir = tempfile::tempdir().unwrap();
+        let card_data_path = dir.path().join("card data.json");
+        let requests_path = dir.path().join("requests é.json");
+        std::fs::write(&card_data_path, card_data).unwrap();
+        std::fs::write(&requests_path, requests).unwrap();
+        (
+            dir,
+            [
+                card_data_path.into_os_string(),
+                requests_path.into_os_string(),
+            ],
+        )
+    }
+
+    #[test]
+    fn preserves_order_and_complete_engine_results() {
+        let input = json!([
+            {
+                "main_deck": vec!["Forest"; 60],
+                "selected_format": "Standard",
+                "summary_only": false
+            },
+            {
+                "main_deck": ["Forest", "Unknown transport fixture"],
+                "selected_format": "Commander",
+                "player_count": 4,
+                "summary_only": false
+            },
+            {
+                "main_deck": vec!["Forest"; 60],
+                "selected_format": "Standard",
+                "summary_only": true
+            },
+            {
+                "selected_format": "Commander",
+                "player_count": 4,
+                "summary_only": true
+            },
+            {}
+        ]);
+        let (_dir, paths) = input_files(CARD_DATA, &input.to_string());
+        let mut output = Vec::new();
+        run(paths.into_iter(), &mut output).unwrap();
+        assert_eq!(output.last(), Some(&b'\n'));
+        let actual: Vec<DeckCompatibilityResult> = serde_json::from_slice(&output).unwrap();
+        assert_eq!(actual.len(), 5);
+        assert_eq!(actual[0].selected_format_compatible, Some(true));
+        assert!(actual[0].coverage.is_some());
+        assert_eq!(actual[1].selected_format_compatible, Some(false));
+        assert!(!actual[1].selected_format_reasons.is_empty());
+        assert_eq!(actual[1].unknown_cards, ["Unknown transport fixture"]);
+        assert!(actual[1].coverage.is_some());
+        assert_eq!(actual[2].selected_format_compatible, Some(true));
+        assert!(actual[2].coverage.is_none());
+        assert_eq!(actual[3].selected_format_compatible, Some(false));
+        assert!(!actual[3].selected_format_reasons.is_empty());
+        assert!(actual[3].coverage.is_none());
+        assert_eq!(actual[4].selected_format_compatible, None);
+
+        let db = CardDatabase::from_json_str(CARD_DATA).unwrap();
+        let requests: Vec<DeckCompatibilityRequest> = serde_json::from_value(input).unwrap();
+        let expected: Vec<_> = requests
+            .iter()
+            .map(|request| evaluate_deck_compatibility(&db, request))
+            .collect();
+        assert_eq!(
+            serde_json::from_slice::<Value>(&output).unwrap(),
+            serde_json::to_value(expected).unwrap()
+        );
+    }
+
+    #[test]
+    fn rejects_malformed_request_batches_without_output() {
+        for input in [
+            "",
+            "[",
+            "{}",
+            "null",
+            "[null]",
+            r#"[{"main_deck": "Forest"}]"#,
+            r#"[{"selected_format": "not-a-format"}]"#,
+            r#"[{"summary_only": "true"}]"#,
+            r#"[{}, {"commander": [42]}]"#,
+            "[{}] trailing",
+        ] {
+            let (_dir, paths) = input_files(CARD_DATA, input);
+            let mut output = Vec::new();
+            let error = run(paths.into_iter(), &mut output).unwrap_err();
+            assert!(error.contains("invalid requests"), "{input:?}: {error}");
+            assert!(output.is_empty(), "{input:?}");
+        }
+    }
+
+    #[test]
+    fn empty_request_batch_produces_empty_results() {
+        let (_dir, paths) = input_files(CARD_DATA, "[]");
+        let mut output = Vec::new();
+        run(paths.into_iter(), &mut output).unwrap();
+        assert_eq!(output, b"[]\n");
+    }
+
+    #[test]
+    fn requires_exactly_two_paths() {
+        for args in [vec![], vec!["cards.json"], vec!["a", "b", "extra"]] {
+            let mut output = Vec::new();
+            let error = run(args.into_iter().map(OsString::from), &mut output).unwrap_err();
+            assert!(error.contains("Usage: deck-check"));
+            assert!(output.is_empty());
+        }
+    }
+
+    #[test]
+    fn reports_missing_input_path_without_output() {
+        for index in [0, 1] {
+            let (dir, mut paths) = input_files(CARD_DATA, "[{}]");
+            let missing = dir.path().join("missing.json");
+            paths[index] = missing.clone().into_os_string();
+            let mut output = Vec::new();
+            let error = run(paths.into_iter(), &mut output).unwrap_err();
+            assert!(error.contains(&missing.display().to_string()));
+            assert!(output.is_empty());
+        }
+    }
+
+    #[test]
+    fn rejects_malformed_card_data_without_output() {
+        for card_data in ["[", "[]", r#"{"broken": {}}"#] {
+            let (_dir, paths) = input_files(card_data, "[{}]");
+            let mut output = Vec::new();
+            let error = run(paths.into_iter(), &mut output).unwrap_err();
+            assert!(error.contains("could not load"));
+            assert!(output.is_empty());
+        }
+    }
+
+    #[test]
+    fn reports_output_failure() {
+        let (_dir, paths) = input_files(CARD_DATA, "[{}]");
+        let mut no_space = [0_u8; 0];
+        let error = run(paths.into_iter(), no_space.as_mut_slice()).unwrap_err();
+        assert!(error.contains("could not write results"));
+    }
+}

--- a/docs/native-deck-validation.md
+++ b/docs/native-deck-validation.md
@@ -1,0 +1,42 @@
+# Native deck compatibility
+
+`cargo deck-check CARD-DATA.JSON REQUESTS.JSON` exposes the engine's existing
+`DeckCompatibilityRequest` / `DeckCompatibilityResult` protocol. After building,
+the `deck-check` executable takes the same two paths. Supply a matching generated
+card-data export. Stdout is an ordered JSON result array; stderr carries input or
+output failures. Exit 0 means evaluation succeeded, including incompatible decks;
+exit 2 means the operation failed. An empty request array produces `[]`.
+
+For example, save this as `requests.json`:
+
+```json
+[
+  {
+    "main_deck": ["Forest"],
+    "commander": ["Lathril, Blade of the Elves"],
+    "selected_format": "Commander",
+    "player_count": 4,
+    "summary_only": false
+  }
+]
+```
+
+This deliberately incomplete deck receives the engine's invalid-deck verdict,
+not a CLI failure. Card copies are repeated names. Format values use the existing
+DTO's case-sensitive spelling. All supported request fields and result semantics
+remain owned by `crates/engine/src/game/deck_validation.rs`; the executable does
+not add legality or coverage rules.
+
+POD-Lab's `pod_lab.fields.validate` is the external consumer: it validates complete
+candidate/opponent decks against the exact gameplay dataset before freezing a run.
+The Cargo alias supplies an in-repository entry point. `set-check --deck` already
+provides coverage for parser development; use it for per-deck coverage, AST hashes
+and snapshot differences. This adapter exists for the additional format-legality
+and zoned-deck request protocol, rather than introducing that protocol into the
+parser-audit CLI. It does not claim that parser support certifies correct gameplay.
+
+Reproducible checks live inline in `deck_check.rs`. They cover DTO/result parity,
+ordered mixed requests, empty batches, malformed input, missing/non-ASCII paths,
+and output failure. With Tilt unavailable, run the `deck-check` binary tests in
+the `phase-engine` package with the `cli` feature. Follow normal Tilt instructions
+when it is running; do not launch competing builds.


### PR DESCRIPTION
Native harnesses need the engine's format-legality verdicts for complete zoned
decks. `set-check --deck` already exposes parser coverage, but does not expose
the DeckCompatibilityRequest/Result protocol. This thin adapter delegates every
request to that existing engine authority and returns ordered JSON results.
It adds no legality or coverage rules.

The separate tool keeps format-legality DTO transport apart from set-check's AST
snapshot/diff and parser-audit options. POD-Lab consumes the protocol before
freezing candidate/opponent inputs. A Cargo alias, module rationale and usage
guide make the entry point discoverable in this repository. Empty batches return
an empty array; incompatible decks remain successful evaluations.

Seven in-tree binary tests passed in native server-release, covering full/summary
DTO parity, ordering, empty and malformed requests, path failures and output
failure. The test-enabled Cargo entry documents why these tests remain enabled.
Formatting and local parser/CR checks passed; the known Windows ratchet separator
bug required the separately proposed corrected checker with unchanged thresholds.
Maintainer acceptance of a separate native executable remains the design decision.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the `cargo deck-check` command for evaluating deck compatibility requests from JSON input.
  - Outputs ordered JSON results, including support for empty request batches and incompatible deck results.
  - Reports input and output failures clearly and returns an appropriate failure status when processing cannot complete.

- **Documentation**
  - Added documentation covering command usage, input/output behavior, result ordering, error handling, and validation examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->