### PR TITLE
Fix target context in generic instead effects

### DIFF
--- a/crates/engine/src/parser/oracle_effect/conditions.rs
+++ b/crates/engine/src/parser/oracle_effect/conditions.rs
@@ -22,8 +22,10 @@ use super::super::oracle_nom::quantity as nom_quantity;
 use super::super::oracle_quantity::{canonicalize_quantity_ref, parse_cda_quantity};
 use super::super::oracle_target::{parse_target, parse_type_phrase_folding, parse_zone_word};
 use super::super::oracle_util::{parse_comparison_suffix, parse_subtype, TextPair};
+#[cfg(test)]
+use super::parse_effect_chain;
 use super::sequence::parse_dig_from_among;
-use super::{parse_effect_chain, scan_contains_phrase, ParseContext};
+use super::{scan_contains_phrase, ParseContext};
 use crate::parser::oracle_ir::ast::{parsed_clause, ContinuationAst};
 use crate::parser::oracle_ir::diagnostic::OracleDiagnostic;
 use crate::parser::oracle_ir::effect_chain::{
@@ -4073,11 +4075,19 @@ pub(super) fn try_parse_generic_instead_clause(
     text: &str,
     kind: AbilityKind,
     ctx: &mut ParseContext,
+    parent_target_available: bool,
 ) -> InsteadLowering {
     // Forward form: "If <cond>, [body] instead." — split on the leading "If, "
     // and strip a trailing/leading "instead" from the body.
     if let Some((cond_text, effect_text, order)) = split_forward_instead_clause(text) {
-        return build_instead_def(cond_text, effect_text, kind, ctx, order);
+        return build_instead_def(
+            cond_text,
+            effect_text,
+            kind,
+            ctx,
+            parent_target_available,
+            order,
+        );
     }
 
     // CR 614.1a + CR 608.2c: Inverted form — "[body] instead if <cond>." (e.g.
@@ -4091,6 +4101,7 @@ pub(super) fn try_parse_generic_instead_clause(
             effect_text,
             kind,
             ctx,
+            parent_target_available,
             InsteadClauseOrder::Inverted,
         );
     }
@@ -4218,6 +4229,7 @@ fn build_instead_def(
     effect_text: String,
     kind: AbilityKind,
     ctx: &mut ParseContext,
+    parent_target_available: bool,
     order: InsteadClauseOrder,
 ) -> InsteadLowering {
     // CR 608.2c: An additional-cost-paid "instead" fold ("if it/this spell was
@@ -4258,7 +4270,8 @@ fn build_instead_def(
         };
     };
 
-    let instead_def = parse_effect_chain(&effect_text, kind);
+    let instead_def =
+        super::parse_child_ability_with_parent_target(&effect_text, kind, parent_target_available);
     let mut result = instead_def;
     result.condition = Some(AbilityCondition::ConditionInstead {
         inner: Box::new(condition),
@@ -10657,6 +10670,7 @@ mod tests {
             "If it entered from your library or was cast from your library, draw two cards instead.",
             AbilityKind::Spell,
             &mut ParseContext::default(),
+            false,
         ) else {
             panic!("instead clause must lower to a conditional branch");
         };

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -32835,7 +32835,10 @@ pub(crate) fn parse_ability_ir(
     // chain path after a decline.
     let conditional_protection = match mode {
         ChainLoweringMode::Standalone => {
-            let mut bypass_ctx = ParseContext::default();
+            let mut bypass_ctx = ParseContext {
+                parent_target_available: ctx.parent_target_available,
+                ..ParseContext::default()
+            };
             parse_conditional_protection_grant_ir(text, kind, &mut bypass_ctx)
         }
         ChainLoweringMode::WithContext => parse_conditional_protection_grant_ir(text, kind, ctx),
@@ -32942,6 +32945,29 @@ pub(crate) fn parse_ability_ir_with_context(
     ctx: &mut ParseContext,
 ) -> AbilityIr {
     parse_ability_ir(text, kind, ChainLoweringMode::WithContext, ctx)
+}
+
+/// Parse a nested effect body with only its parent-target binding preserved.
+///
+/// Nested replacement bodies are independent ability parses: parser-local state
+/// from their enclosing clause must not leak into them. `ParentTarget` is the
+/// sole inherited binding because it names the earlier selected object that the
+/// nested body's pronouns may continue to reference.
+pub(super) fn parse_child_ability_with_parent_target(
+    text: &str,
+    kind: AbilityKind,
+    parent_target_available: bool,
+) -> AbilityDefinition {
+    let mut child_ctx = ParseContext {
+        parent_target_available,
+        ..ParseContext::default()
+    };
+    lower_ability_ir(&parse_ability_ir(
+        text,
+        kind,
+        ChainLoweringMode::Standalone,
+        &mut child_ctx,
+    ))
 }
 
 /// The algebraic identity T8 rests on, written literally:
@@ -35201,28 +35227,32 @@ pub(crate) fn parse_effect_chain_ir(
         // destroy working branches. So we only remember the verdict, and enforce it
         // at the LAST resort — immediately before the generic emission at the tail
         // of this loop, where every other owner has already had its chance.
-        let instead_condition_unlowerable =
-            match try_parse_generic_instead_clause(normalized_text, kind, ctx) {
-                conditions::InsteadLowering::Branch(instead_def) if !builder.is_empty() => {
-                    builder
-                        .clause(
-                            normalized_text,
-                            placeholder_parsed_clause("instead_clause_placeholder"),
-                            chunk.boundary_after,
-                            ClauseDisposition::ReplaceMeaning {
-                                kind: ReplaceMeaningKind::Instead(instead_def),
-                            },
-                        )
-                        .push();
-                    continue;
-                }
-                // A branch with no antecedent in this chain (empty builder) keeps its
-                // historical fall-through, as does anything this grammar does not own.
-                conditions::InsteadLowering::Branch(_) | conditions::InsteadLowering::NotOwned => {
-                    false
-                }
-                conditions::InsteadLowering::ConditionUnlowerable => true,
-            };
+        let instead_parent_target_available =
+            ctx.parent_target_available || chain_has_prior_typed_referent(builder.clauses(), false);
+        let instead_condition_unlowerable = match try_parse_generic_instead_clause(
+            normalized_text,
+            kind,
+            ctx,
+            instead_parent_target_available,
+        ) {
+            conditions::InsteadLowering::Branch(instead_def) if !builder.is_empty() => {
+                builder
+                    .clause(
+                        normalized_text,
+                        placeholder_parsed_clause("instead_clause_placeholder"),
+                        chunk.boundary_after,
+                        ClauseDisposition::ReplaceMeaning {
+                            kind: ReplaceMeaningKind::Instead(instead_def),
+                        },
+                    )
+                    .push();
+                continue;
+            }
+            // A branch with no antecedent in this chain (empty builder) keeps its
+            // historical fall-through, as does anything this grammar does not own.
+            conditions::InsteadLowering::Branch(_) | conditions::InsteadLowering::NotOwned => false,
+            conditions::InsteadLowering::ConditionUnlowerable => true,
+        };
 
         let has_card_predicate_guess = chain_has_card_predicate_guess(builder.clauses());
         let (predicate_guess_cond, predicate_guess_text) = if has_card_predicate_guess {

--- a/crates/engine/src/parser/oracle_effect/tests.rs
+++ b/crates/engine/src/parser/oracle_effect/tests.rs
@@ -17509,6 +17509,157 @@ fn conditional_protection_grant_routes_through_ability_ir() {
     assert!(def.sub_ability.is_none());
 }
 
+const FIVE_COLOR_PROTECTION_BODY: &str = "It gains protection from white if you control a Plains, from blue if you control an Island, from black if you control a Swamp, from red if you control a Mountain, and from green if you control a Forest.";
+
+fn assert_five_color_protection_on(def: &AbilityDefinition, affected: TargetFilter) {
+    use crate::types::keywords::{Keyword, ProtectionTarget};
+    use crate::types::mana::ManaColor;
+
+    let Effect::GenericEffect {
+        static_abilities, ..
+    } = def.effect.as_ref()
+    else {
+        panic!("expected protection GenericEffect, got {:?}", def.effect);
+    };
+    assert_eq!(static_abilities.len(), 5);
+    let granted: Vec<_> = static_abilities
+        .iter()
+        .map(|ability| {
+            assert_eq!(ability.affected, Some(affected.clone()));
+            let [ContinuousModification::AddKeyword {
+                keyword: Keyword::Protection(color),
+            }] = ability.modifications.as_slice()
+            else {
+                panic!(
+                    "expected one protection grant, got {:?}",
+                    ability.modifications
+                );
+            };
+            color.clone()
+        })
+        .collect();
+    assert_eq!(
+        granted,
+        vec![
+            ProtectionTarget::Color(ManaColor::White),
+            ProtectionTarget::Color(ManaColor::Blue),
+            ProtectionTarget::Color(ManaColor::Black),
+            ProtectionTarget::Color(ManaColor::Red),
+            ProtectionTarget::Color(ManaColor::Green),
+        ]
+    );
+}
+
+#[test]
+fn flare_of_faith_binds_its_instead_body_to_the_selected_creature() {
+    let def = parse_effect_chain(
+        "Target creature gets +2/+2 until end of turn. If it's a Human, instead it gets +3/+3 and gains indestructible until end of turn.",
+        AbilityKind::Spell,
+    );
+    let Effect::Pump {
+        power,
+        toughness,
+        target: TargetFilter::Typed(target),
+    } = def.effect.as_ref()
+    else {
+        panic!("expected targeted root pump, got {:?}", def.effect);
+    };
+    assert!(target.type_filters.contains(&TypeFilter::Creature));
+    assert_eq!(*power, PtValue::Fixed(2));
+    assert_eq!(*toughness, PtValue::Fixed(2));
+
+    let instead = def
+        .sub_ability
+        .as_ref()
+        .unwrap_or_else(|| panic!("expected Human instead branch, got {def:?}"));
+    let Some(AbilityCondition::ConditionInstead { inner }) = instead.condition.as_ref() else {
+        panic!(
+            "expected ConditionInstead Human gate, got {:?}",
+            instead.condition
+        );
+    };
+    let AbilityCondition::TargetMatchesFilter {
+        filter: TargetFilter::Typed(filter),
+        ..
+    } = inner.as_ref()
+    else {
+        panic!("expected Human target filter, got {inner:?}");
+    };
+    assert!(filter
+        .type_filters
+        .contains(&TypeFilter::Subtype("Human".to_string())));
+    let Effect::GenericEffect {
+        static_abilities, ..
+    } = instead.effect.as_ref()
+    else {
+        panic!(
+            "expected ParentTarget Human override, got {:?}",
+            instead.effect
+        );
+    };
+    assert!(static_abilities.iter().any(|ability| {
+        ability.affected == Some(TargetFilter::ParentTarget)
+            && ability
+                .modifications
+                .contains(&ContinuousModification::AddPower { value: 3 })
+            && ability
+                .modifications
+                .contains(&ContinuousModification::AddToughness { value: 3 })
+            && ability
+                .modifications
+                .contains(&ContinuousModification::AddKeyword {
+                    keyword: Keyword::Indestructible,
+                })
+    }));
+}
+
+#[test]
+fn generic_instead_child_uses_the_standalone_protection_recognizer_with_parent_target() {
+    let def = parse_effect_chain(
+        &format!(
+            "Target creature gets +2/+2. If it's a Human, instead {FIVE_COLOR_PROTECTION_BODY}"
+        ),
+        AbilityKind::Spell,
+    );
+    let instead = def
+        .sub_ability
+        .as_ref()
+        .expect("expected generic instead branch");
+    assert_five_color_protection_on(instead, TargetFilter::ParentTarget);
+}
+
+#[test]
+fn standalone_protection_body_keeps_self_reference_without_a_parent_target() {
+    let def = parse_effect_chain(FIVE_COLOR_PROTECTION_BODY, AbilityKind::Spell);
+    assert_five_color_protection_on(&def, TargetFilter::SelfRef);
+}
+
+#[test]
+fn standalone_protection_bypass_isolates_outer_context_except_parent_target() {
+    let mut outer_ctx = ParseContext {
+        subject: Some(TargetFilter::SelfRef),
+        actor: Some(ControllerRef::Opponent),
+        current_trigger_index: Some(3),
+        in_trigger: true,
+        parent_target_available: true,
+        ..ParseContext::default()
+    };
+    let original_ctx = outer_ctx.clone();
+
+    let def = lower_ability_ir(&parse_ability_ir(
+        FIVE_COLOR_PROTECTION_BODY,
+        AbilityKind::Spell,
+        ChainLoweringMode::Standalone,
+        &mut outer_ctx,
+    ));
+
+    assert_five_color_protection_on(&def, TargetFilter::ParentTarget);
+    assert_eq!(
+        outer_ctx, original_ctx,
+        "standalone bypass must not mutate its caller"
+    );
+}
+
 /// The extracted keyword-word → kind combinator (deduplicated with the static
 /// `each … has <kw>` clause) recognizes every graveyard-cast keyword.
 #[test]

--- a/crates/engine/tests/integration/flare_of_faith_parent_target.rs
+++ b/crates/engine/tests/integration/flare_of_faith_parent_target.rs
@@ -1,0 +1,96 @@
+//! Regression for Flare of Faith's conditional `instead` override.
+
+use engine::game::keywords::has_keyword;
+use engine::game::scenario::{GameScenario, P0};
+use engine::types::keywords::Keyword;
+use engine::types::mana::ManaCost;
+use engine::types::phase::Phase;
+
+const FLARE_OF_FAITH_ORACLE: &str = "Target creature gets +2/+2 until end of turn. If it's a Human, instead it gets +3/+3 and gains indestructible until end of turn.";
+
+#[test]
+fn flare_of_faith_human_target_gets_the_override_and_leaves_decoy_unchanged() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let flare = scenario
+        .add_spell_to_hand_from_oracle(P0, "Flare of Faith", true, FLARE_OF_FAITH_ORACLE)
+        .with_mana_cost(ManaCost::zero())
+        .id();
+    let human = scenario
+        .add_creature(P0, "Human Target", 7, 5)
+        .with_subtypes(vec!["Human"])
+        .id();
+    let non_human_decoy = scenario
+        .add_creature(P0, "Non-Human Decoy", 11, 13)
+        .with_subtypes(vec!["Bear"])
+        .id();
+    let mut runner = scenario.build();
+
+    let outcome = runner.cast(flare).target_object(human).resolve();
+    let state = outcome.state();
+    let human_after = &state.objects[&human];
+    let decoy_after = &state.objects[&non_human_decoy];
+
+    assert_eq!(human_after.power.expect("Human remains a creature") - 7, 3);
+    assert_eq!(
+        human_after.toughness.expect("Human remains a creature") - 5,
+        3
+    );
+    assert!(has_keyword(human_after, &Keyword::Indestructible));
+    assert_eq!(
+        decoy_after.power.expect("decoy remains a creature") - 11,
+        0,
+        "only the selected target receives the override"
+    );
+    assert_eq!(
+        decoy_after.toughness.expect("decoy remains a creature") - 13,
+        0,
+        "only the selected target receives the override"
+    );
+    assert!(!has_keyword(decoy_after, &Keyword::Indestructible));
+}
+
+#[test]
+fn flare_of_faith_nonhuman_target_gets_base_pump_without_indestructible() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let flare = scenario
+        .add_spell_to_hand_from_oracle(P0, "Flare of Faith", true, FLARE_OF_FAITH_ORACLE)
+        .with_mana_cost(ManaCost::zero())
+        .id();
+    let non_human = scenario
+        .add_creature(P0, "Non-Human Target", 9, 4)
+        .with_subtypes(vec!["Bear"])
+        .id();
+    let human_decoy = scenario
+        .add_creature(P0, "Human Decoy", 3, 12)
+        .with_subtypes(vec!["Human"])
+        .id();
+    let mut runner = scenario.build();
+
+    let outcome = runner.cast(flare).target_object(non_human).resolve();
+    let state = outcome.state();
+    let target_after = &state.objects[&non_human];
+    let decoy_after = &state.objects[&human_decoy];
+
+    assert_eq!(
+        target_after.power.expect("target remains a creature") - 9,
+        2
+    );
+    assert_eq!(
+        target_after.toughness.expect("target remains a creature") - 4,
+        2
+    );
+    assert!(!has_keyword(target_after, &Keyword::Indestructible));
+    assert_eq!(
+        decoy_after.power.expect("decoy remains a creature") - 3,
+        0,
+        "the Human condition checks the selected target, not another creature"
+    );
+    assert_eq!(
+        decoy_after.toughness.expect("decoy remains a creature") - 12,
+        0,
+        "the Human condition checks the selected target, not another creature"
+    );
+    assert!(!has_keyword(decoy_after, &Keyword::Indestructible));
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -294,6 +294,7 @@ mod finality_counter_death_to_exile;
 mod fire_lord_ozai_each_opponent_library_top;
 mod fireball_x_cost_surcharge_timing;
 mod first_family_union_color_count;
+mod flare_of_faith_parent_target;
 mod flashback_nonmana_payability;
 mod flickerwisp_delayed_return;
 mod floodpits_drowner;


### PR DESCRIPTION
## Summary

Adds parser support for Flare of Faith’s targeted Human `instead` override, preserving only parent-target availability in a fresh child parse context. The standalone conditional-protection bypass follows the same isolation boundary; no runtime, types, frontend, or AI changes.

<!-- What this PR changes and why. One or two sentences. -->

## Files changed

- `crates/engine/src/parser/oracle_effect/conditions.rs`
- `crates/engine/src/parser/oracle_effect/mod.rs`
- `crates/engine/src/parser/oracle_effect/tests.rs`
- `crates/engine/tests/integration/flare_of_faith_parent_target.rs`
- `crates/engine/tests/integration/main.rs`

<!-- Every changed path, as a short bullet list. -->

## Track

Developer

## LLM

Model: gpt-5.6-terra
Tier: Frontier
Thinking: high

<!-- Keep Model and Tier as exact, standalone canonical lines. AI-assisted PRs
must report their actual Frontier model, Tier: Frontier, and thinking level.
If your harness does not expose an exact model identifier, report the name it
does give you — e.g. "Model: gpt-5.6-sol (via GitHub Copilot; canonical id not
exposed)" — rather than guessing an identifier. See AI-CONTRIBUTOR.md
§0.1.1. -->

## Implementation method (required)

Method: /engine-implementer
<!-- Or: Method: not-applicable — <specific non-engine reason> -->

## CR references

None.

<!-- `CR XXX.Y` annotations added or touched, or "None" for non-rules changes. -->

## Verification

- [x] Required checks ran clean, or the exact CI-owned alternative is stated below.
- [x] Gate A output below is for the current committed head.
- [x] Final review-impl below is clean for the current committed head.
- [x] Both anchors cite existing analogous code at the same seam.

- `cargo fmt --all` — exit 0.
- `cargo clippy-strict` — exit 0 (5m34s).
- Flare of Faith exact AST assertion — 1 passing assertion.
- Three conditional-protection reach guards — 1 passing assertion each.
- Flare of Faith cast-pipeline harness, Human target — 1 passing test.
- Flare of Faith cast-pipeline harness, non-Human target — 1 passing test.
- `cargo semantic-audit` — exit 0; 32,805 cards; 258 global findings; Flare of Faith absent.
- `cargo coverage` — exit 0; 31,882/35,804 (89.0%); Flare of Faith `supported: true`, `gap_count: 0`.
- `./scripts/gen-card-data.sh` — normal run succeeded after one initial sandbox DNS-restricted attempt; export confirmed `ParentTarget`, `+3/+3`, and `Indestructible`, with no warnings or residual unsupported output.
- Original normal commit hooks — passed parser Gates G/A, PreLowered ratchet, and CR-anchor self-check/tree walk.

<!-- Commands run and exact results. Every required box must be checked. -->

## Gate A

Gate G PASS (router/grant architecture: strict router vs permissive grant boundary intact)
Gate A: scanned 2 file(s) under crates/engine/src/parser (working tree vs 9b175e42f9b7e339cf503ad035fbe1d26b9049b1).
Gate A PASS head=61698d7bac971194841ee70d12d3caab2d6c658a base=9b175e42f9b7e339cf503ad035fbe1d26b9049b1

## Anchored on

- `crates/engine/src/parser/oracle_effect/conditions.rs:10669` — Fblthp, the Lost’s full generic `instead`-branch assembly.
- `crates/engine/src/parser/oracle_effect/mod.rs:32171` — Dominaria’s Judgment standalone conditional-protection IR owner.
- `crates/engine/src/parser/oracle_effect/conditions.rs:4196` — Anax’s generic `instead` replacement-condition lowering authority.

## Final review-impl

Final review-impl PASS head=61698d7bac971194841ee70d12d3caab2d6c658a

## Claimed parse impact

Flare of Faith.

<!-- List exact card names only when the parse-diff changes cards. -->

## Scope Expansion

None.

<!-- Describe any change that crosses the issue/card's stated scope. -->

## Validation Failures

None.

<!-- Replace with the unresolved validation failure and its evidence. -->

## CI Failures

None.

<!-- Replace with the unresolved CI failure and its evidence. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed conditional “instead” effects so they correctly apply to the selected target.
  - Corrected target handling for nested effects, including protection abilities and conditional bonuses.
  - Ensured standalone effects retain the appropriate target reference without affecting surrounding effect context.

- **Tests**
  - Added coverage for conditional target selection, Human-target bonuses, indestructibility, and five-color protection effects.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->