### PR TITLE
Recognize subject actions, emblem references, and additional poison counters

### DIFF
--- a/crates/engine/src/parser/oracle_effect/imperative.rs
+++ b/crates/engine/src/parser/oracle_effect/imperative.rs
@@ -12322,6 +12322,14 @@ pub(super) fn try_parse_player_counter(lower: &str) -> Option<ImperativeFamilyAs
             return None;
         };
 
+    // "additional" is a printed adjective after the quantity, not part of the
+    // player-counter kind. Keep the parsed quantity unchanged and consume it
+    // with nom before the counter-kind authority validates the remainder.
+    let (counter_kind, _) = opt(tag::<_, _, OracleError<'_>>("additional "))
+        .parse(counter_kind)
+        .ok()?;
+    let counter_kind = counter_kind.trim();
+
     // Validate: counter kind should be a single word (no spaces) to avoid false positives
     // like "gets +1/+1 counter" which is an object counter, not a player counter.
     if counter_kind.is_empty() || counter_kind.contains('+') || counter_kind.contains('-') {
@@ -18525,6 +18533,48 @@ mod tests {
             }
             other => panic!("Expected GivePlayerCounter, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn parse_player_counter_additional_preserves_each_quantity_form() {
+        for (text, expected_kind, expected_count) in [
+            (
+                "get an additional poison counter",
+                PlayerCounterKind::Poison,
+                QuantityExpr::Fixed { value: 1 },
+            ),
+            (
+                "gets two additional experience counters",
+                PlayerCounterKind::Experience,
+                QuantityExpr::Fixed { value: 2 },
+            ),
+            (
+                "get that many additional rad counters",
+                PlayerCounterKind::Rad,
+                QuantityExpr::Ref {
+                    qty: QuantityRef::EventContextAmount,
+                },
+            ),
+        ] {
+            match try_parse_player_counter(text) {
+                Some(ImperativeFamilyAst::GivePlayerCounter {
+                    counter_kind,
+                    count,
+                }) => {
+                    assert_eq!(counter_kind, expected_kind, "wrong kind for {text:?}");
+                    assert_eq!(count, expected_count, "wrong quantity for {text:?}");
+                }
+                other => panic!("Expected GivePlayerCounter for {text:?}, got {other:?}"),
+            }
+        }
+        assert!(
+            try_parse_player_counter("get an additional charge counter").is_none(),
+            "an unknown counter kind must still fail closed"
+        );
+        assert!(
+            try_parse_player_counter("get an additional +1/+1 counter").is_none(),
+            "an object counter must not become a player counter"
+        );
     }
 
     #[test]

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -23358,20 +23358,23 @@ fn lower_subject_predicate_ast(
             if let Some(wrapped) = wrap_target_subject_damage(clause.clone(), &subject) {
                 return wrapped;
             }
-            // CR 608.2c + CR 109.4 + CR 701.16a: `Effect::Investigate` is a
-            // fieldless unit variant with no player slot for `inject_subject_target`
-            // to stamp the subject onto, so an explicit non-caster subject ("That
-            // player investigates" — Declaration in Stone, where "that player" is
-            // the controller of the exiled target) would be silently dropped and
-            // the Clue handed to the caster. Record the subject as a pending
-            // `player_scope` (consumed by the effect-chain loop) so resolution fans
-            // the Investigate out to the anchored player instead. Only lifts an
-            // explicit parent-target player anaphor; a bare "investigate" leaves
-            // `affected == SelfRef`/`Controller` and is untouched (caster default).
-            if matches!(clause.effect, Effect::Investigate) {
+            // CR 608.2c + CR 109.4 + CR 701.16a + CR 701.53a: Investigate and
+            // Incubate have no player slot for `inject_subject_target` to stamp
+            // the subject onto. An explicit non-caster subject ("That player
+            // investigates" / "Its controller incubates") must therefore become
+            // a pending `player_scope`, so the effect-chain loop resolves the
+            // fieldless effect as the anchored player. A bare predicate retains
+            // `affected == SelfRef`/`Controller` and the caster default.
+            if matches!(clause.effect, Effect::Investigate | Effect::Incubate { .. }) {
                 if let Some(scope) = player_scope_from_parent_target_subject(&affected) {
                     ctx.pending_player_scope = Some(scope);
                 }
+            }
+
+            // CR 701.16a + CR 608.2c + CR 400.7: only Investigate supports the
+            // "for each ... this way" repetition grammar below. Incubate carries
+            // its own count expression and must not inherit this repeat-for path.
+            if matches!(clause.effect, Effect::Investigate) {
                 // CR 701.16a + CR 608.2c + CR 400.7: "investigate FOR EACH nontoken
                 // creature exiled this way" — the fieldless Investigate carries no
                 // count slot, so lift the "for each <filter> … this way" suffix to a

--- a/crates/engine/src/parser/oracle_effect/subject.rs
+++ b/crates/engine/src/parser/oracle_effect/subject.rs
@@ -8501,11 +8501,53 @@ mod tests {
             assert_eq!(stripped, predicate, "wrong predicate for {text:?}");
             let ability =
                 crate::parser::oracle_effect::parse_effect_chain(text, AbilityKind::Spell);
-            assert!(
-                !matches!(*ability.effect, Effect::Unimplemented { .. }),
-                "{text:?} must reach its existing imperative lowering, got {:?}",
-                ability.effect
-            );
+            if predicate == "incubate 2" {
+                assert!(matches!(
+                    ability.effect.as_ref(),
+                    Effect::Incubate {
+                        count: QuantityExpr::Fixed { value: 2 }
+                    }
+                ));
+            } else {
+                assert!(matches!(
+                    ability.effect.as_ref(),
+                    Effect::Draw {
+                        count: QuantityExpr::Fixed { value: 1 },
+                        ..
+                    }
+                ));
+                let discard = ability
+                    .sub_ability
+                    .as_deref()
+                    .expect("Recruit must discard");
+                assert!(matches!(
+                    discard.effect.as_ref(),
+                    Effect::Discard {
+                        count: QuantityExpr::Fixed { value: 1 },
+                        ..
+                    }
+                ));
+                let token = discard
+                    .sub_ability
+                    .as_deref()
+                    .expect("Recruit must create a token");
+                assert!(matches!(
+                    token.effect.as_ref(),
+                    Effect::Token {
+                        power: PtValue::Fixed(1),
+                        toughness: PtValue::Fixed(1),
+                        ..
+                    }
+                ));
+                assert!(matches!(
+                    token.condition.as_ref(),
+                    Some(
+                        crate::types::ability::AbilityCondition::DiscardedCardMatchesFilter {
+                            filter: TargetFilter::Not { .. }
+                        }
+                    )
+                ));
+            }
         }
     }
 

--- a/crates/engine/src/parser/oracle_effect/subject.rs
+++ b/crates/engine/src/parser/oracle_effect/subject.rs
@@ -7104,6 +7104,10 @@ pub(crate) const PREDICATE_VERBS: &[&str] = &[
     "look",
     "lose",
     "investigate",
+    // CR 701.53a: "if they do, you incubate N" (Assimilate Essence). The
+    // subject prefix is stripped so the existing imperative lowerer owns the
+    // keyword action and retains the resolving ability's controller.
+    "incubate",
     "learn",
     // CR 701.40a: Manifest — "its controller manifests the top card of their
     // library" (Reality Shift). Subject-shifted manifest clauses route through
@@ -7116,6 +7120,9 @@ pub(crate) const PREDICATE_VERBS: &[&str] = &[
     "put",
     "proliferate",
     "regenerate",
+    // CR 701.70a: "you recruit" (Queen of Dale) re-dispatches to the
+    // existing Recruit lowering after the controller subject is stripped.
+    "recruit",
     "reveal",
     "return",
     "sacrifice",
@@ -8484,6 +8491,22 @@ mod tests {
             "expected TakeTheInitiative, got {:?}",
             ability.effect
         );
+    }
+
+    #[test]
+    fn subject_prefixed_recruit_and_incubate_reach_existing_imperatives() {
+        for (text, predicate) in [("you recruit", "recruit"), ("you incubate 2", "incubate 2")] {
+            let stripped = strip_subject_clause(text)
+                .unwrap_or_else(|| panic!("{text:?} must reach subject stripping"));
+            assert_eq!(stripped, predicate, "wrong predicate for {text:?}");
+            let ability =
+                crate::parser::oracle_effect::parse_effect_chain(text, AbilityKind::Spell);
+            assert!(
+                !matches!(*ability.effect, Effect::Unimplemented { .. }),
+                "{text:?} must reach its existing imperative lowering, got {:?}",
+                ability.effect
+            );
+        }
     }
 
     #[test]

--- a/crates/engine/src/parser/oracle_util.rs
+++ b/crates/engine/src/parser/oracle_util.rs
@@ -924,6 +924,7 @@ pub const SELF_REF_TYPE_PHRASES: &[&str] = &[
     "this aura",
     "this vehicle",
     "this planeswalker",
+    "this emblem",
     "this battle",
     "this token",
     "this spacecraft",
@@ -3434,6 +3435,19 @@ mod tests {
         assert_eq!(
             normalize_card_name_refs("This creature enters tapped", "Some Card"),
             "~ enters tapped"
+        );
+    }
+
+    #[test]
+    fn normalize_this_emblem_without_matching_longer_words() {
+        assert_eq!(
+            normalize_card_name_refs("this emblem deals 1 damage to you", "Chandra"),
+            "~ deals 1 damage to you"
+        );
+        assert_eq!(
+            normalize_card_name_refs("this emblematic creature attacks", "Chandra"),
+            "this emblematic creature attacks",
+            "self-reference normalization must respect word boundaries"
         );
     }
 

--- a/crates/engine/src/parser/oracle_util.rs
+++ b/crates/engine/src/parser/oracle_util.rs
@@ -924,6 +924,7 @@ pub const SELF_REF_TYPE_PHRASES: &[&str] = &[
     "this aura",
     "this vehicle",
     "this planeswalker",
+    // CR 114.1 + CR 114.3: An emblem is an object, usually nameless; this phrase refers to that source.
     "this emblem",
     "this battle",
     "this token",

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -1052,6 +1052,7 @@ mod purged_source_attachment_count_lki;
 mod purged_source_attacked_this_turn_lki;
 mod purged_source_intervening_if_lki;
 mod purged_source_matches_filter_lki;
+mod queen_parser_near_misses;
 mod quirion_ranger_activation;
 mod rage_reflection_double_strike_grant;
 mod random_discard_cost_replacement_resume;

--- a/crates/engine/tests/integration/queen_parser_near_misses.rs
+++ b/crates/engine/tests/integration/queen_parser_near_misses.rs
@@ -3,13 +3,18 @@
 use engine::game::scenario::{GameRunner, GameScenario, P0, P1};
 use engine::game::zones::create_object;
 use engine::parser::oracle::parse_oracle_text;
-use engine::types::ability::{AbilityCost, Effect, TargetFilter};
+use engine::types::ability::{
+    AbilityCost, CastManaObjectScope, CastManaSpentMetric, Effect, QuantityExpr, QuantityRef,
+    TargetFilter,
+};
 use engine::types::actions::GameAction;
 use engine::types::card_type::CoreType;
 use engine::types::counter::CounterType;
 use engine::types::game_state::{StackEntry, StackEntryKind, WaitingFor};
 use engine::types::identifiers::{CardId, ObjectId};
+use engine::types::mana::{ManaType, ManaUnit};
 use engine::types::phase::Phase;
+use engine::types::triggers::TriggerMode;
 use engine::types::zones::Zone;
 
 use super::rules::run_combat;
@@ -18,14 +23,36 @@ const QUEEN_OF_DALE: &str = "Whenever an opponent casts their first noncreature 
 const ASSIMILATE_ESSENCE: &str = "Counter target creature or battle spell unless its controller pays {4}. If they do, you incubate 2. (Create an Incubator token with two +1/+1 counters on it and \"{2}: Transform this token.\" It transforms into a 0/0 Phyrexian artifact creature.)";
 const NECROGEN_ROTPRIEST: &str = "Toxic 2 (Players dealt combat damage by this creature also get two poison counters.)\nWhenever a creature you control with toxic deals combat damage to a player, that player gets an additional poison counter.\n{1}{B}{G}: Target creature you control with toxic gains deathtouch until end of turn.";
 const AWAKENED_INFERNO: &str = "This spell can't be countered.\n[+2]: Each opponent gets an emblem with \"At the beginning of your upkeep, this emblem deals 1 damage to you.\"\n[−3]: Chandra deals 3 damage to each non-Elemental creature.\n[−X]: Chandra deals X damage to target creature or planeswalker. If a permanent dealt damage this way would die this turn, exile it instead.";
+const DRESSED_TO_KILL: &str = "[+1]: Add {R}. Chandra deals 1 damage to up to one target player or planeswalker.\n[+1]: Exile the top card of your library. If it's red, you may cast it this turn.\n[−7]: Exile the top five cards of your library. You may cast red spells from among them this turn. You get an emblem with \"Whenever you cast a red spell, this emblem deals X damage to any target, where X is the amount of mana spent to cast that spell.\"";
+const SPARK_HUNTER: &str = "At the beginning of combat on your turn, choose up to one target Vehicle you control. Until end of turn, it becomes an artifact creature and gains haste.\n[+2]: You may sacrifice an artifact or discard a card. If you do, draw a card.\n[0]: Create a 3/2 colorless Vehicle artifact token with crew 1.\n[−7]: You get an emblem with \"Whenever an artifact you control enters, this emblem deals 3 damage to any target.\"";
+const TORCH_OF_DEFIANCE: &str = "[+1]: Exile the top card of your library. You may cast that card. If you don't, Chandra deals 2 damage to each opponent.\n[+1]: Add {R}{R}.\n[−3]: Chandra deals 4 damage to target creature.\n[−7]: You get an emblem with \"Whenever you cast a spell, this emblem deals 5 damage to any target.\"";
+const KOTH_FIRE_OF_RESISTANCE: &str = "[+2]: Search your library for a basic Mountain card, reveal it, put it into your hand, then shuffle.\n[−3]: Koth deals damage to target creature equal to the number of Mountains you control.\n[−7]: You get an emblem with \"Whenever a Mountain you control enters, this emblem deals 4 damage to any target.\"";
 const NARSET: &str = "[+1]: You gain 2 life. Add {U}, {R}, or {W}. Spend this mana only to cast a noncreature spell.\n[−2]: Draw a card, then you may discard a card. When you discard a nonland card this way, Narset deals damage equal to that card's mana value to target creature or planeswalker.\n[−6]: You get an emblem with \"Whenever you cast a noncreature spell, this emblem deals 2 damage to any target.\"";
 
 fn ability_has_unimplemented(ability: &engine::types::ability::AbilityDefinition) -> bool {
     matches!(*ability.effect, Effect::Unimplemented { .. })
+        || matches!(ability.effect.as_ref(), Effect::CreateEmblem { triggers, .. } if triggers.iter().any(|trigger| trigger.execute.as_deref().is_some_and(ability_has_unimplemented)))
         || ability
             .sub_ability
             .as_deref()
             .is_some_and(ability_has_unimplemented)
+}
+
+fn emblem_trigger_damage(
+    ability: &engine::types::ability::AbilityDefinition,
+) -> Option<(&engine::types::ability::TriggerDefinition, &Effect)> {
+    match ability.effect.as_ref() {
+        Effect::CreateEmblem { triggers, .. } => triggers.iter().find_map(|trigger| {
+            trigger
+                .execute
+                .as_deref()
+                .map(|execute| (trigger, execute.effect.as_ref()))
+        }),
+        _ => ability
+            .sub_ability
+            .as_deref()
+            .and_then(emblem_trigger_damage),
+    }
 }
 
 fn put_creature_spell_on_stack(
@@ -69,15 +96,60 @@ fn activate_emblem(runner: &mut GameRunner, source: ObjectId, amount: i32) -> Ob
 #[test]
 fn shape_all_nine_cards_reach_their_targeted_semantic_family() {
     let cards = [
-        ("The Queen of Dale", QUEEN_OF_DALE, vec!["Creature"], vec!["Human", "Noble"]),
-        ("Assimilate Essence", ASSIMILATE_ESSENCE, vec!["Instant"], vec![]),
-        ("Necrogen Rotpriest", NECROGEN_ROTPRIEST, vec!["Creature"], vec!["Phyrexian", "Zombie", "Cleric"]),
-        ("Chandra, Awakened Inferno", AWAKENED_INFERNO, vec!["Planeswalker"], vec!["Chandra"]),
-        ("Chandra, Dressed to Kill", "[+1]: Add {R}. Chandra deals 1 damage to up to one target player or planeswalker.\n[+1]: Exile the top card of your library. If it's red, you may cast it this turn.\n[−7]: Exile the top five cards of your library. You may cast red spells from among them this turn. You get an emblem with \"Whenever you cast a red spell, this emblem deals X damage to any target, where X is the amount of mana spent to cast that spell.\"", vec!["Planeswalker"], vec!["Chandra"]),
-        ("Chandra, Spark Hunter", "At the beginning of combat on your turn, choose up to one target Vehicle you control. Until end of turn, it becomes an artifact creature and gains haste.\n[+2]: You may sacrifice an artifact or discard a card. If you do, draw a card.\n[0]: Create a 3/2 colorless Vehicle artifact token with crew 1.\n[−7]: You get an emblem with \"Whenever an artifact you control enters, this emblem deals 3 damage to any target.\"", vec!["Planeswalker"], vec!["Chandra"]),
-        ("Chandra, Torch of Defiance", "[+1]: Exile the top card of your library. You may cast that card. If you don't, Chandra deals 2 damage to each opponent.\n[+1]: Add {R}{R}.\n[−3]: Chandra deals 4 damage to target creature.\n[−7]: You get an emblem with \"Whenever you cast a spell, this emblem deals 5 damage to any target.\"", vec!["Planeswalker"], vec!["Chandra"]),
-        ("Koth, Fire of Resistance", "[+2]: Search your library for a basic Mountain card, reveal it, put it into your hand, then shuffle.\n[−3]: Koth deals damage to target creature equal to the number of Mountains you control.\n[−7]: You get an emblem with \"Whenever a Mountain you control enters, this emblem deals 4 damage to any target.\"", vec!["Planeswalker"], vec!["Koth"]),
-        ("Narset of the Ancient Way", NARSET, vec!["Planeswalker"], vec!["Narset"]),
+        (
+            "The Queen of Dale",
+            QUEEN_OF_DALE,
+            vec!["Creature"],
+            vec!["Human", "Noble"],
+        ),
+        (
+            "Assimilate Essence",
+            ASSIMILATE_ESSENCE,
+            vec!["Instant"],
+            vec![],
+        ),
+        (
+            "Necrogen Rotpriest",
+            NECROGEN_ROTPRIEST,
+            vec!["Creature"],
+            vec!["Phyrexian", "Zombie", "Cleric"],
+        ),
+        (
+            "Chandra, Awakened Inferno",
+            AWAKENED_INFERNO,
+            vec!["Planeswalker"],
+            vec!["Chandra"],
+        ),
+        (
+            "Chandra, Dressed to Kill",
+            DRESSED_TO_KILL,
+            vec!["Planeswalker"],
+            vec!["Chandra"],
+        ),
+        (
+            "Chandra, Spark Hunter",
+            SPARK_HUNTER,
+            vec!["Planeswalker"],
+            vec!["Chandra"],
+        ),
+        (
+            "Chandra, Torch of Defiance",
+            TORCH_OF_DEFIANCE,
+            vec!["Planeswalker"],
+            vec!["Chandra"],
+        ),
+        (
+            "Koth, Fire of Resistance",
+            KOTH_FIRE_OF_RESISTANCE,
+            vec!["Planeswalker"],
+            vec!["Koth"],
+        ),
+        (
+            "Narset of the Ancient Way",
+            NARSET,
+            vec!["Planeswalker"],
+            vec!["Narset"],
+        ),
     ];
     for (name, oracle, types, subtypes) in cards {
         let types = types.into_iter().map(str::to_owned).collect::<Vec<_>>();
@@ -96,32 +168,109 @@ fn shape_all_nine_cards_reach_their_targeted_semantic_family() {
             parsed.abilities
         );
     }
-    let parsed = parse_oracle_text(
-        AWAKENED_INFERNO,
-        "Chandra, Awakened Inferno",
-        &[],
-        &["Planeswalker".to_string()],
-        &["Chandra".to_string()],
-    );
-    let trigger = parsed
-        .abilities
-        .iter()
-        .find_map(|ability| match ability.effect.as_ref() {
-            Effect::CreateEmblem { triggers, .. } => triggers.first(),
-            _ => None,
-        })
-        .expect("Awakened Inferno must create an emblem trigger");
-    assert!(matches!(
-        trigger
-            .execute
-            .as_deref()
-            .map(|ability| ability.effect.as_ref()),
-        Some(Effect::DealDamage {
-            target: TargetFilter::Controller,
-            damage_source: None,
+    for (name, oracle, subtype, expected_mode, expected_phase, expected_target, expected_amount) in [
+        (
+            "Chandra, Awakened Inferno",
+            AWAKENED_INFERNO,
+            "Chandra",
+            TriggerMode::Phase,
+            Some(Phase::Upkeep),
+            TargetFilter::Controller,
+            QuantityExpr::Fixed { value: 1 },
+        ),
+        (
+            "Chandra, Dressed to Kill",
+            DRESSED_TO_KILL,
+            "Chandra",
+            TriggerMode::SpellCast,
+            None,
+            TargetFilter::Any,
+            QuantityExpr::Ref {
+                qty: QuantityRef::ManaSpentToCast {
+                    scope: CastManaObjectScope::TriggeringSpell,
+                    metric: CastManaSpentMetric::Total,
+                },
+            },
+        ),
+        (
+            "Chandra, Spark Hunter",
+            SPARK_HUNTER,
+            "Chandra",
+            TriggerMode::ChangesZone,
+            None,
+            TargetFilter::Any,
+            QuantityExpr::Fixed { value: 3 },
+        ),
+        (
+            "Chandra, Torch of Defiance",
+            TORCH_OF_DEFIANCE,
+            "Chandra",
+            TriggerMode::SpellCast,
+            None,
+            TargetFilter::Any,
+            QuantityExpr::Fixed { value: 5 },
+        ),
+        (
+            "Koth, Fire of Resistance",
+            KOTH_FIRE_OF_RESISTANCE,
+            "Koth",
+            TriggerMode::ChangesZone,
+            None,
+            TargetFilter::Any,
+            QuantityExpr::Fixed { value: 4 },
+        ),
+        (
+            "Narset of the Ancient Way",
+            NARSET,
+            "Narset",
+            TriggerMode::SpellCast,
+            None,
+            TargetFilter::Any,
+            QuantityExpr::Fixed { value: 2 },
+        ),
+    ] {
+        let parsed = parse_oracle_text(
+            oracle,
+            name,
+            &[],
+            &["Planeswalker".to_string()],
+            &[subtype.to_string()],
+        );
+        let (trigger, damage) = parsed
+            .abilities
+            .iter()
+            .find_map(emblem_trigger_damage)
+            .unwrap_or_else(|| panic!("{name} must create an emblem damage trigger"));
+        assert_eq!(
+            &trigger.mode, &expected_mode,
+            "{name} emblem must retain its printed trigger mode"
+        );
+        assert_eq!(
+            &trigger.phase, &expected_phase,
+            "{name} emblem must retain its printed phase constraint"
+        );
+        let Effect::DealDamage {
+            amount,
+            target,
+            damage_source,
             ..
-        })
-    ));
+        } = damage
+        else {
+            panic!("{name} emblem trigger must deal damage, got {damage:?}");
+        };
+        assert_eq!(
+            target, &expected_target,
+            "{name} emblem damage must retain its printed target"
+        );
+        assert!(
+            damage_source.is_none(),
+            "{name} emblem damage must use the resolving emblem as its source"
+        );
+        assert_eq!(
+            amount, &expected_amount,
+            "{name} emblem damage must retain its printed amount"
+        );
+    }
 }
 
 #[test]
@@ -173,6 +322,12 @@ fn queen_of_dale_recruit_draws_discards_and_mints_token_for_its_controller() {
 fn assimilate_essence_paid_unless_creates_controller_incubator_with_two_counters() {
     let mut scenario = GameScenario::new();
     scenario.at_phase(Phase::PreCombatMain);
+    scenario.with_mana_pool(
+        P1,
+        (0..4)
+            .map(|_| ManaUnit::new(ManaType::Colorless, ObjectId(0), false, vec![]))
+            .collect(),
+    );
     let assimilate = scenario
         .add_spell_to_hand_from_oracle(P0, "Assimilate Essence", true, ASSIMILATE_ESSENCE)
         .id();
@@ -190,11 +345,11 @@ fn assimilate_essence_paid_unless_creates_controller_incubator_with_two_counters
     runner
         .act(GameAction::PayUnlessCost { pay: true })
         .expect("P1 pays the unless cost");
-    assert!(
-        runner.state().stack.iter().any(|entry| entry.id == target),
+    assert_eq!(
+        runner.state().objects[&target].zone,
+        Zone::Stack,
         "paid unless must leave target spell on stack"
     );
-    runner.advance_until_stack_empty();
     let incubators = runner
         .state()
         .objects
@@ -226,14 +381,13 @@ fn narset_emblem_is_command_zone_source_of_trigger_damage() {
         .add_planeswalker_from_oracle(P0, "Narset of the Ancient Way", "Narset", 6, NARSET)
         .as_planeswalker_with_loyalty("Narset", 6)
         .id();
-    let victim = scenario.add_creature(P1, "Damage target", 3, 3).id();
     let spell = scenario
         .add_spell_to_hand(P0, "Noncreature trigger", true)
         .id();
     let mut runner = scenario.build();
     let emblem = activate_emblem(&mut runner, narset, -6);
     let p1_before = runner.life(P1);
-    let commit = runner.cast(spell).target_object(victim).commit();
+    let commit = runner.cast(spell).target_player(P1).commit();
     assert!(
         commit.state().stack.iter().any(|entry| matches!(
             &entry.kind,
@@ -245,7 +399,7 @@ fn narset_emblem_is_command_zone_source_of_trigger_damage() {
     assert_eq!(
         outcome.state().players[P1.0 as usize].life,
         p1_before - 2,
-        "the emblem trigger must deal two damage to the selected target's controller"
+        "the emblem trigger must deal two damage to the selected player"
     );
 }
 

--- a/crates/engine/tests/integration/queen_parser_near_misses.rs
+++ b/crates/engine/tests/integration/queen_parser_near_misses.rs
@@ -28,7 +28,7 @@ fn ability_has_unimplemented(ability: &engine::types::ability::AbilityDefinition
             .is_some_and(ability_has_unimplemented)
 }
 
-fn put_instant_on_stack(
+fn put_creature_spell_on_stack(
     runner: &mut GameRunner,
     controller: engine::types::player::PlayerId,
 ) -> ObjectId {
@@ -39,13 +39,9 @@ fn put_instant_on_stack(
         "Target spell".to_string(),
         Zone::Stack,
     );
-    runner
-        .state_mut()
-        .objects
-        .get_mut(&spell)
-        .unwrap()
-        .card_types
-        .core_types = vec![CoreType::Instant];
+    let target = runner.state_mut().objects.get_mut(&spell).unwrap();
+    target.card_types.core_types = vec![CoreType::Creature];
+    target.base_card_types = target.card_types.clone();
     runner.state_mut().stack.push_back(StackEntry {
         id: spell,
         source_id: spell,
@@ -139,6 +135,9 @@ fn queen_of_dale_recruit_draws_discards_and_mints_token_for_its_controller() {
         .add_spell_to_hand(P1, "Opponent noncreature", true)
         .id();
     let mut runner = scenario.build();
+    runner.state_mut().active_player = P1;
+    runner.state_mut().priority_player = P1;
+    runner.state_mut().waiting_for = WaitingFor::Priority { player: P1 };
     runner.cast(trigger).commit();
     runner.resolve_top();
     assert!(
@@ -178,7 +177,7 @@ fn assimilate_essence_paid_unless_creates_controller_incubator_with_two_counters
         .add_spell_to_hand_from_oracle(P0, "Assimilate Essence", true, ASSIMILATE_ESSENCE)
         .id();
     let mut runner = scenario.build();
-    let target = put_instant_on_stack(&mut runner, P1);
+    let target = put_creature_spell_on_stack(&mut runner, P1);
     runner.cast(assimilate).target_object(target).commit();
     runner.resolve_top();
     assert!(
@@ -225,6 +224,7 @@ fn narset_emblem_is_command_zone_source_of_trigger_damage() {
     scenario.at_phase(Phase::PreCombatMain);
     let narset = scenario
         .add_planeswalker_from_oracle(P0, "Narset of the Ancient Way", "Narset", 6, NARSET)
+        .as_planeswalker_with_loyalty("Narset", 6)
         .id();
     let victim = scenario.add_creature(P1, "Damage target", 3, 3).id();
     let spell = scenario
@@ -252,7 +252,7 @@ fn narset_emblem_is_command_zone_source_of_trigger_damage() {
 #[test]
 fn awakened_inferno_opponent_emblem_damages_its_controller() {
     let mut scenario = GameScenario::new();
-    scenario.at_phase(Phase::Untap);
+    scenario.at_phase(Phase::PreCombatMain);
     let chandra = scenario
         .add_planeswalker_from_oracle(
             P0,
@@ -261,6 +261,7 @@ fn awakened_inferno_opponent_emblem_damages_its_controller() {
             8,
             AWAKENED_INFERNO,
         )
+        .as_planeswalker_with_loyalty("Chandra", 8)
         .id();
     for player in [P0, P1] {
         scenario.with_library_top(player, &["A", "B", "C"]);
@@ -274,6 +275,7 @@ fn awakened_inferno_opponent_emblem_damages_its_controller() {
     );
     runner.state_mut().active_player = P1;
     runner.state_mut().priority_player = P1;
+    runner.state_mut().phase = Phase::Untap;
     runner.state_mut().waiting_for = WaitingFor::Priority { player: P1 };
     let p0_before = runner.life(P0);
     let p1_before = runner.life(P1);

--- a/crates/engine/tests/integration/queen_parser_near_misses.rs
+++ b/crates/engine/tests/integration/queen_parser_near_misses.rs
@@ -12,7 +12,7 @@ use engine::types::card_type::CoreType;
 use engine::types::counter::CounterType;
 use engine::types::game_state::{StackEntry, StackEntryKind, WaitingFor};
 use engine::types::identifiers::{CardId, ObjectId};
-use engine::types::mana::{ManaType, ManaUnit};
+use engine::types::mana::{ManaCost, ManaType, ManaUnit};
 use engine::types::phase::Phase;
 use engine::types::triggers::TriggerMode;
 use engine::types::zones::Zone;
@@ -21,6 +21,7 @@ use super::rules::run_combat;
 
 const QUEEN_OF_DALE: &str = "Whenever an opponent casts their first noncreature spell each turn, you recruit. (Draw a card, then discard a card. If you discarded a nonland card, create a 1/1 white Human Soldier creature token.)";
 const ASSIMILATE_ESSENCE: &str = "Counter target creature or battle spell unless its controller pays {4}. If they do, you incubate 2. (Create an Incubator token with two +1/+1 counters on it and \"{2}: Transform this token.\" It transforms into a 0/0 Phyrexian artifact creature.)";
+const EXCISE_THE_IMPERFECT: &str = "Exile target nonland permanent. Its controller incubates X, where X is its mana value. (They create an Incubator token with X +1/+1 counters on it and \"{2}: Transform this token.\" It transforms into a 0/0 Phyrexian artifact creature.)";
 const NECROGEN_ROTPRIEST: &str = "Toxic 2 (Players dealt combat damage by this creature also get two poison counters.)\nWhenever a creature you control with toxic deals combat damage to a player, that player gets an additional poison counter.\n{1}{B}{G}: Target creature you control with toxic gains deathtouch until end of turn.";
 const AWAKENED_INFERNO: &str = "This spell can't be countered.\n[+2]: Each opponent gets an emblem with \"At the beginning of your upkeep, this emblem deals 1 damage to you.\"\n[−3]: Chandra deals 3 damage to each non-Elemental creature.\n[−X]: Chandra deals X damage to target creature or planeswalker. If a permanent dealt damage this way would die this turn, exile it instead.";
 const DRESSED_TO_KILL: &str = "[+1]: Add {R}. Chandra deals 1 damage to up to one target player or planeswalker.\n[+1]: Exile the top card of your library. If it's red, you may cast it this turn.\n[−7]: Exile the top five cards of your library. You may cast red spells from among them this turn. You get an emblem with \"Whenever you cast a red spell, this emblem deals X damage to any target, where X is the amount of mana spent to cast that spell.\"";
@@ -370,6 +371,59 @@ fn assimilate_essence_paid_unless_creates_controller_incubator_with_two_counters
             .get(&CounterType::Plus1Plus1)
             .copied(),
         Some(2)
+    );
+}
+
+/// Pinned AtomicCards Oracle: Excise's second instruction belongs to the
+/// controller of the permanent exiled by the first. CR 608.2c applies the
+/// instructions in order; CR 701.53a makes that controller's Incubator with
+/// the exiled permanent's mana value in +1/+1 counters.
+#[test]
+fn excise_the_imperfect_exiled_permanents_controller_incubates_its_mana_value() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let target = scenario
+        .add_creature(P1, "P1's Four-Mana Permanent", 2, 2)
+        .with_mana_cost(ManaCost::generic(4))
+        .id();
+    let excise = scenario
+        .add_spell_to_hand_from_oracle(P0, "Excise the Imperfect", true, EXCISE_THE_IMPERFECT)
+        .id();
+    let mut runner = scenario.build();
+
+    runner.cast(excise).target_object(target).resolve();
+    assert_eq!(
+        runner.state().objects[&target].zone,
+        Zone::Exile,
+        "Excise must exile the chosen nonland permanent before incubating"
+    );
+
+    let incubators = runner
+        .state()
+        .objects
+        .values()
+        .filter(|object| {
+            object.is_token && object.zone == Zone::Battlefield && object.name == "Incubator"
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(incubators.len(), 1, "exactly one Incubator must be created");
+    assert_eq!(
+        incubators[0].controller, P1,
+        "the exiled permanent's controller, not Excise's caster, incubates"
+    );
+    assert_eq!(
+        incubators[0]
+            .counters
+            .get(&CounterType::Plus1Plus1)
+            .copied(),
+        Some(4),
+        "Incubator counters equal the exiled permanent's known mana value"
+    );
+    assert!(
+        incubators
+            .iter()
+            .all(|incubator| incubator.controller != P0),
+        "P0 must not receive an Incubator from P1's permanent"
     );
 }
 

--- a/crates/engine/tests/integration/queen_parser_near_misses.rs
+++ b/crates/engine/tests/integration/queen_parser_near_misses.rs
@@ -1,0 +1,314 @@
+//! Production regressions for shared parser grammar surfaced by Queen-set cards.
+
+use engine::game::scenario::{GameRunner, GameScenario, P0, P1};
+use engine::game::zones::create_object;
+use engine::parser::oracle::parse_oracle_text;
+use engine::types::ability::{AbilityCost, Effect, TargetFilter};
+use engine::types::actions::GameAction;
+use engine::types::card_type::CoreType;
+use engine::types::counter::CounterType;
+use engine::types::game_state::{StackEntry, StackEntryKind, WaitingFor};
+use engine::types::identifiers::{CardId, ObjectId};
+use engine::types::phase::Phase;
+use engine::types::zones::Zone;
+
+use super::rules::run_combat;
+
+const QUEEN_OF_DALE: &str = "Whenever an opponent casts their first noncreature spell each turn, you recruit. (Draw a card, then discard a card. If you discarded a nonland card, create a 1/1 white Human Soldier creature token.)";
+const ASSIMILATE_ESSENCE: &str = "Counter target creature or battle spell unless its controller pays {4}. If they do, you incubate 2. (Create an Incubator token with two +1/+1 counters on it and \"{2}: Transform this token.\" It transforms into a 0/0 Phyrexian artifact creature.)";
+const NECROGEN_ROTPRIEST: &str = "Toxic 2 (Players dealt combat damage by this creature also get two poison counters.)\nWhenever a creature you control with toxic deals combat damage to a player, that player gets an additional poison counter.\n{1}{B}{G}: Target creature you control with toxic gains deathtouch until end of turn.";
+const AWAKENED_INFERNO: &str = "This spell can't be countered.\n[+2]: Each opponent gets an emblem with \"At the beginning of your upkeep, this emblem deals 1 damage to you.\"\n[−3]: Chandra deals 3 damage to each non-Elemental creature.\n[−X]: Chandra deals X damage to target creature or planeswalker. If a permanent dealt damage this way would die this turn, exile it instead.";
+const NARSET: &str = "[+1]: You gain 2 life. Add {U}, {R}, or {W}. Spend this mana only to cast a noncreature spell.\n[−2]: Draw a card, then you may discard a card. When you discard a nonland card this way, Narset deals damage equal to that card's mana value to target creature or planeswalker.\n[−6]: You get an emblem with \"Whenever you cast a noncreature spell, this emblem deals 2 damage to any target.\"";
+
+fn ability_has_unimplemented(ability: &engine::types::ability::AbilityDefinition) -> bool {
+    matches!(*ability.effect, Effect::Unimplemented { .. })
+        || ability
+            .sub_ability
+            .as_deref()
+            .is_some_and(ability_has_unimplemented)
+}
+
+fn put_instant_on_stack(
+    runner: &mut GameRunner,
+    controller: engine::types::player::PlayerId,
+) -> ObjectId {
+    let spell = create_object(
+        runner.state_mut(),
+        CardId(9_101),
+        controller,
+        "Target spell".to_string(),
+        Zone::Stack,
+    );
+    runner
+        .state_mut()
+        .objects
+        .get_mut(&spell)
+        .unwrap()
+        .card_types
+        .core_types = vec![CoreType::Instant];
+    runner.state_mut().stack.push_back(StackEntry {
+        id: spell,
+        source_id: spell,
+        controller,
+        kind: StackEntryKind::Spell {
+            card_id: CardId(9_101),
+            ability: None,
+            casting_variant: engine::types::game_state::CastingVariant::Normal,
+            actual_mana_spent: 0,
+        },
+    });
+    spell
+}
+
+fn activate_emblem(runner: &mut GameRunner, source: ObjectId, amount: i32) -> ObjectId {
+    let index = runner.state().objects[&source]
+        .abilities
+        .iter()
+        .position(|ability| matches!(ability.cost, Some(AbilityCost::Loyalty { amount: actual }) if actual == amount))
+        .expect("emblem loyalty ability");
+    runner.activate(source, index).resolve();
+    *runner.state().command_zone.last().expect("created emblem")
+}
+
+#[test]
+fn shape_all_nine_cards_reach_their_targeted_semantic_family() {
+    let cards = [
+        ("The Queen of Dale", QUEEN_OF_DALE, vec!["Creature"], vec!["Human", "Noble"]),
+        ("Assimilate Essence", ASSIMILATE_ESSENCE, vec!["Instant"], vec![]),
+        ("Necrogen Rotpriest", NECROGEN_ROTPRIEST, vec!["Creature"], vec!["Phyrexian", "Zombie", "Cleric"]),
+        ("Chandra, Awakened Inferno", AWAKENED_INFERNO, vec!["Planeswalker"], vec!["Chandra"]),
+        ("Chandra, Dressed to Kill", "[+1]: Add {R}. Chandra deals 1 damage to up to one target player or planeswalker.\n[+1]: Exile the top card of your library. If it's red, you may cast it this turn.\n[−7]: Exile the top five cards of your library. You may cast red spells from among them this turn. You get an emblem with \"Whenever you cast a red spell, this emblem deals X damage to any target, where X is the amount of mana spent to cast that spell.\"", vec!["Planeswalker"], vec!["Chandra"]),
+        ("Chandra, Spark Hunter", "At the beginning of combat on your turn, choose up to one target Vehicle you control. Until end of turn, it becomes an artifact creature and gains haste.\n[+2]: You may sacrifice an artifact or discard a card. If you do, draw a card.\n[0]: Create a 3/2 colorless Vehicle artifact token with crew 1.\n[−7]: You get an emblem with \"Whenever an artifact you control enters, this emblem deals 3 damage to any target.\"", vec!["Planeswalker"], vec!["Chandra"]),
+        ("Chandra, Torch of Defiance", "[+1]: Exile the top card of your library. You may cast that card. If you don't, Chandra deals 2 damage to each opponent.\n[+1]: Add {R}{R}.\n[−3]: Chandra deals 4 damage to target creature.\n[−7]: You get an emblem with \"Whenever you cast a spell, this emblem deals 5 damage to any target.\"", vec!["Planeswalker"], vec!["Chandra"]),
+        ("Koth, Fire of Resistance", "[+2]: Search your library for a basic Mountain card, reveal it, put it into your hand, then shuffle.\n[−3]: Koth deals damage to target creature equal to the number of Mountains you control.\n[−7]: You get an emblem with \"Whenever a Mountain you control enters, this emblem deals 4 damage to any target.\"", vec!["Planeswalker"], vec!["Koth"]),
+        ("Narset of the Ancient Way", NARSET, vec!["Planeswalker"], vec!["Narset"]),
+    ];
+    for (name, oracle, types, subtypes) in cards {
+        let types = types.into_iter().map(str::to_owned).collect::<Vec<_>>();
+        let subtypes = subtypes.into_iter().map(str::to_owned).collect::<Vec<_>>();
+        let parsed = parse_oracle_text(oracle, name, &[], &types, &subtypes);
+        assert!(
+            parsed
+                .abilities
+                .iter()
+                .all(|ability| !ability_has_unimplemented(ability))
+                && parsed.triggers.iter().all(|trigger| trigger
+                    .execute
+                    .as_deref()
+                    .is_none_or(|ability| !ability_has_unimplemented(ability))),
+            "{name} must not hide an unsupported printed ability: {:#?}",
+            parsed.abilities
+        );
+    }
+    let parsed = parse_oracle_text(
+        AWAKENED_INFERNO,
+        "Chandra, Awakened Inferno",
+        &[],
+        &["Planeswalker".to_string()],
+        &["Chandra".to_string()],
+    );
+    let trigger = parsed
+        .abilities
+        .iter()
+        .find_map(|ability| match ability.effect.as_ref() {
+            Effect::CreateEmblem { triggers, .. } => triggers.first(),
+            _ => None,
+        })
+        .expect("Awakened Inferno must create an emblem trigger");
+    assert!(matches!(
+        trigger
+            .execute
+            .as_deref()
+            .map(|ability| ability.effect.as_ref()),
+        Some(Effect::DealDamage {
+            target: TargetFilter::Controller,
+            damage_source: None,
+            ..
+        })
+    ));
+}
+
+#[test]
+fn queen_of_dale_recruit_draws_discards_and_mints_token_for_its_controller() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.add_creature_from_oracle(P0, "The Queen of Dale", 3, 3, QUEEN_OF_DALE);
+    let discarded = scenario.add_spell_to_hand(P0, "Nonland discard", true).id();
+    scenario.with_library_top(P0, &["Recruit draw"]);
+    let trigger = scenario
+        .add_spell_to_hand(P1, "Opponent noncreature", true)
+        .id();
+    let mut runner = scenario.build();
+    runner.cast(trigger).commit();
+    runner.resolve_top();
+    assert!(
+        matches!(runner.state().waiting_for, WaitingFor::DiscardChoice { .. }),
+        "Recruit must reach its discard choice"
+    );
+    runner
+        .act(GameAction::SelectCards {
+            cards: vec![discarded],
+        })
+        .expect("P0 selects Recruit discard");
+    assert_eq!(
+        runner.state().objects[&discarded].zone,
+        Zone::Graveyard,
+        "P0 must discard the selected nonland"
+    );
+    let tokens = runner
+        .state()
+        .objects
+        .values()
+        .filter(|object| {
+            object.is_token && object.zone == Zone::Battlefield && object.name == "Human Soldier"
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(tokens.len(), 1, "Recruit must make exactly one token");
+    assert_eq!(
+        tokens[0].controller, P0,
+        "the triggering opponent must not receive Recruit's token"
+    );
+}
+
+#[test]
+fn assimilate_essence_paid_unless_creates_controller_incubator_with_two_counters() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let assimilate = scenario
+        .add_spell_to_hand_from_oracle(P0, "Assimilate Essence", true, ASSIMILATE_ESSENCE)
+        .id();
+    let mut runner = scenario.build();
+    let target = put_instant_on_stack(&mut runner, P1);
+    runner.cast(assimilate).target_object(target).commit();
+    runner.resolve_top();
+    assert!(
+        matches!(
+            runner.state().waiting_for,
+            WaitingFor::UnlessPayment { player: P1, .. }
+        ),
+        "P1 must receive the unless-payment choice"
+    );
+    runner
+        .act(GameAction::PayUnlessCost { pay: true })
+        .expect("P1 pays the unless cost");
+    assert!(
+        runner.state().stack.iter().any(|entry| entry.id == target),
+        "paid unless must leave target spell on stack"
+    );
+    runner.advance_until_stack_empty();
+    let incubators = runner
+        .state()
+        .objects
+        .values()
+        .filter(|object| {
+            object.is_token && object.zone == Zone::Battlefield && object.name == "Incubator"
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(
+        incubators.len(),
+        1,
+        "the spell controller must create one Incubator"
+    );
+    assert_eq!(incubators[0].controller, P0);
+    assert_eq!(
+        incubators[0]
+            .counters
+            .get(&CounterType::Plus1Plus1)
+            .copied(),
+        Some(2)
+    );
+}
+
+#[test]
+fn narset_emblem_is_command_zone_source_of_trigger_damage() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let narset = scenario
+        .add_planeswalker_from_oracle(P0, "Narset of the Ancient Way", "Narset", 6, NARSET)
+        .id();
+    let victim = scenario.add_creature(P1, "Damage target", 3, 3).id();
+    let spell = scenario
+        .add_spell_to_hand(P0, "Noncreature trigger", true)
+        .id();
+    let mut runner = scenario.build();
+    let emblem = activate_emblem(&mut runner, narset, -6);
+    let p1_before = runner.life(P1);
+    let commit = runner.cast(spell).target_object(victim).commit();
+    assert!(
+        commit.state().stack.iter().any(|entry| matches!(
+            &entry.kind,
+            StackEntryKind::TriggeredAbility { .. }
+        ) && entry.source_id == emblem),
+        "the command-zone emblem must source its trigger"
+    );
+    let outcome = commit.resolve();
+    assert_eq!(
+        outcome.state().players[P1.0 as usize].life,
+        p1_before - 2,
+        "the emblem trigger must deal two damage to the selected target's controller"
+    );
+}
+
+#[test]
+fn awakened_inferno_opponent_emblem_damages_its_controller() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::Untap);
+    let chandra = scenario
+        .add_planeswalker_from_oracle(
+            P0,
+            "Chandra, Awakened Inferno",
+            "Chandra",
+            8,
+            AWAKENED_INFERNO,
+        )
+        .id();
+    for player in [P0, P1] {
+        scenario.with_library_top(player, &["A", "B", "C"]);
+    }
+    let mut runner = scenario.build();
+    let emblem = activate_emblem(&mut runner, chandra, 2);
+    assert_eq!(
+        runner.state().objects[&emblem].controller,
+        P1,
+        "Each opponent gets an emblem controlled by that opponent"
+    );
+    runner.state_mut().active_player = P1;
+    runner.state_mut().priority_player = P1;
+    runner.state_mut().waiting_for = WaitingFor::Priority { player: P1 };
+    let p0_before = runner.life(P0);
+    let p1_before = runner.life(P1);
+    runner.advance_to_upkeep();
+    assert!(
+        runner.state().stack.iter().any(|entry| matches!(
+            &entry.kind,
+            StackEntryKind::TriggeredAbility { .. }
+        ) && entry.source_id == emblem
+            && entry.controller == P1),
+        "P1's upkeep trigger must be sourced by P1's emblem"
+    );
+    runner.advance_until_stack_empty();
+    assert_eq!(
+        runner.life(P1),
+        p1_before - 1,
+        "the opponent-owned emblem damages its controller"
+    );
+    assert_eq!(runner.life(P0), p0_before, "the creator takes no damage");
+}
+
+#[test]
+fn necrogen_rotpriest_combat_damage_adds_one_extra_poison_to_recipient() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let necrogen = scenario
+        .add_creature_from_oracle(P0, "Necrogen Rotpriest", 1, 3, NECROGEN_ROTPRIEST)
+        .id();
+    let mut runner = scenario.build();
+    run_combat(&mut runner, vec![necrogen], vec![]);
+    runner.advance_until_stack_empty();
+    assert_eq!(
+        runner.state().players[P1.0 as usize].poison_counters,
+        3,
+        "Toxic 2 plus one additional poison counter must equal three"
+    );
+    assert_eq!(runner.state().players[P0.0 as usize].poison_counters, 0);
+}


### PR DESCRIPTION
Recognize subject-prefixed recruit/incubate actions, emblem self-references, and additional player counters through existing parser helpers. Preserve the recipient for subject-prefixed incubation: when Excise the Imperfect exiles an opponent’s permanent, that opponent incubates rather than the caster. No runtime types or resolvers are added.

A pinned 35,804-row comparison of source candidate 25918b701d found 10 newly supported cards, including The Queen of Dale and Excise the Imperfect. Other emblem changes only normalize source text. That candidate passed formatting, parser gate, clippy, and six focused regressions; its full suite passed 27,472 tests with one stack-budget SIGABRT reproduced on the untouched base (11 skipped).

The rebased PR includes an additional recipient-scoping correction and stronger semantic assertions. All three review findings are resolved. Current-head CI has passed formatting/clippy/parser gate, card-data generation and validation, frontend, WASM, and the Rust test build; test shards remain pending. The supplementary local targeted run timed out while compiling, so it supplies no current-head runtime result. CI remains authoritative for this head.
