### PR TITLE
Parse plural turn skips and any-upkeep activations

### DIFF
--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -4,7 +4,7 @@ use crate::parser::oracle_nom::error::{OracleError, OracleResult};
 use nom::branch::alt;
 use nom::bytes::complete::{tag, take_until, take_while};
 use nom::character::complete::multispace0;
-use nom::combinator::{all_consuming, opt, value};
+use nom::combinator::{all_consuming, map, opt, value};
 use nom::sequence::{preceded, terminated};
 use nom::Parser;
 use serde::{Deserialize, Serialize};
@@ -9686,12 +9686,17 @@ fn parse_activation_turn_window(i: &str) -> OracleResult<'_, ActivationTurnWindo
 /// CR 602.5b: the composed `during <role> <window>` activation gate — the
 /// shared prefix is consumed once, then each axis by its own sub-combinator.
 fn parse_activation_during_gate(i: &str) -> OracleResult<'_, ActivationRestriction> {
-    let (rest, (role, window)) = preceded(
+    preceded(
         tag::<_, _, OracleError<'_>>("during "),
-        (parse_activation_turn_role, parse_activation_turn_window),
+        alt((
+            value(any_upkeep_activation_restriction(), tag("any upkeep step")),
+            map(
+                (parse_activation_turn_role, parse_activation_turn_window),
+                |(role, window)| activation_turn_gate(role, window),
+            ),
+        )),
     )
-    .parse(i)?;
-    Ok((rest, activation_turn_gate(role, window)))
+    .parse(i)
 }
 
 /// CR 602.5b: map a (role, window) pair onto an EXISTING enforced
@@ -9745,6 +9750,14 @@ fn opponents_upkeep_activation_restriction() -> ActivationRestriction {
                 ParsedCondition::IsDuringUpkeep,
             ],
         }),
+    }
+}
+
+/// "Any upkeep" has no player-scope predicate: it permits activation during
+/// the upkeep step of either player's turn.
+fn any_upkeep_activation_restriction() -> ActivationRestriction {
+    ActivationRestriction::RequiresCondition {
+        condition: Some(ParsedCondition::IsDuringUpkeep),
     }
 }
 

--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -9683,7 +9683,7 @@ fn parse_activation_turn_window(i: &str) -> OracleResult<'_, ActivationTurnWindo
     .parse(i)
 }
 
-/// CR 602.5b: the composed `during <role> <window>` activation gate — the
+/// CR 602.1b: the composed `during <role> <window>` activation gate — the
 /// shared prefix is consumed once, then each axis by its own sub-combinator.
 fn parse_activation_during_gate(i: &str) -> OracleResult<'_, ActivationRestriction> {
     preceded(
@@ -9753,8 +9753,8 @@ fn opponents_upkeep_activation_restriction() -> ActivationRestriction {
     }
 }
 
-/// "Any upkeep" has no player-scope predicate: it permits activation during
-/// the upkeep step of either player's turn.
+/// CR 602.1b + CR 503.1: activation instructions can restrict activation to
+/// the upkeep step. "Any upkeep" imposes no active-player restriction.
 fn any_upkeep_activation_restriction() -> ActivationRestriction {
     ActivationRestriction::RequiresCondition {
         condition: Some(ParsedCondition::IsDuringUpkeep),

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -12473,7 +12473,7 @@ fn parse_skip_step_name(input: &str) -> OracleResult<'_, StepSkipTarget> {
 
 /// CR 614.10: Parse "[subject] skip[s] [their|your] next [N] turn[s]" — temporal
 /// penalty effect. Handles:
-///   - "you skip your next turn" / "skip your next turn" → Controller, 1
+///   - "you skip your next [N] turn[s]" / "skip your next [N] turn[s]" → Controller, N
 ///   - "target opponent skips their next turn" → Opponent-target, 1
 ///   - "target player skips their next turn" → Player-target, 1
 ///   - "target opponent skips their next N turns" → Opponent-target, N
@@ -12482,54 +12482,56 @@ fn parse_skip_step_name(input: &str) -> OracleResult<'_, StepSkipTarget> {
 ///     multiplier is supplied by the outer `Effect::FlipCoins` loop, which
 ///     invokes this handler once per heads).
 fn try_parse_skip_next_turn(tp: TextPair) -> Option<ParsedEffectClause> {
-    // Bare subjectless form (controller skips).
-    if nom_on_lower(tp.original, tp.lower, |input| {
-        alt((
-            value((), tag::<_, _, OracleError<'_>>("you skip your next turn")),
-            value((), tag("skip your next turn")),
-        ))
-        .parse(input)
-    })
-    .is_some()
-    {
-        return Some(parsed_clause(Effect::SkipNextTurn {
-            target: TargetFilter::Controller,
-            count: QuantityExpr::Fixed { value: 1 },
-        }));
-    }
-
-    // Targeted form: "target {opponent|player} skips their next [N|X] turn[s]".
-    // Guard on the lowercase prefix before delegating to `parse_target`.
-    nom::combinator::peek(alt((
-        tag::<_, _, OracleError<'_>>("target opponent "),
-        tag("target player "),
-    )))
-    .parse(tp.lower)
-    .ok()?;
-
-    // Delegate the target extraction to the canonical parser so any future
-    // target shape ("target opponent of your choice", etc.) picks it up.
-    let (target, after_target_orig) = super::oracle_target::parse_target(tp.original);
-    let after_target_lower = &tp.lower[tp.lower.len() - after_target_orig.len()..];
-
-    // Verb: " skips " / " skip " (surrounding spaces keep word boundary safe).
-    let (after_verb_lower, _) = alt((tag::<_, _, OracleError<'_>>(" skips "), tag(" skip ")))
-        .parse(after_target_lower)
+    // Both subject forms share the count and `turn[s]` grammar below. Keep the
+    // controller prefix in nom so plural counts use the same `parse_count_expr`
+    // authority as targeted effects.
+    let (target, after_next_orig) = if let Some((_, after_next_orig)) =
+        nom_on_lower(tp.original, tp.lower, |input| {
+            value(
+                (),
+                alt((
+                    tag::<_, _, OracleError<'_>>("you skip your next "),
+                    tag("skip your next "),
+                )),
+            )
+            .parse(input)
+        }) {
+        (TargetFilter::Controller, after_next_orig)
+    } else {
+        // Targeted form: "target {opponent|player} skips their next [N|X] turn[s]".
+        // Guard on the lowercase prefix before delegating to `parse_target`.
+        nom::combinator::peek(alt((
+            tag::<_, _, OracleError<'_>>("target opponent "),
+            tag("target player "),
+        )))
+        .parse(tp.lower)
         .ok()?;
 
-    // Possessive: "their next " / "your next ".
-    let (after_next_lower, _) = alt((
-        tag::<_, _, OracleError<'_>>("their next "),
-        tag("your next "),
-    ))
-    .parse(after_verb_lower)
-    .ok()?;
+        // Delegate the target extraction to the canonical parser so any future
+        // target shape ("target opponent of your choice", etc.) picks it up.
+        let (target, after_target_orig) = super::oracle_target::parse_target(tp.original);
+        let after_target_lower = &tp.lower[tp.lower.len() - after_target_orig.len()..];
+
+        // Verb: " skips " / " skip " (surrounding spaces keep word boundary safe).
+        let (after_verb_lower, _) = alt((tag::<_, _, OracleError<'_>>(" skips "), tag(" skip ")))
+            .parse(after_target_lower)
+            .ok()?;
+
+        // Possessive: "their next " / "your next ".
+        let (after_next_lower, _) = alt((
+            tag::<_, _, OracleError<'_>>("their next "),
+            tag("your next "),
+        ))
+        .parse(after_verb_lower)
+        .ok()?;
+        let after_next_orig = &tp.original[tp.lower.len() - after_next_lower.len()..];
+        (target, after_next_orig)
+    };
 
     // Optional count between "next " and "turn[s]". Default to 1 if the very
     // next token is "turn"/"turns" (e.g. "skips their next turn"). When
     // `parse_count_expr` succeeds it trims leading whitespace on the remainder,
     // so match "turn[s]" without a leading-space prefix below.
-    let after_next_orig = &tp.original[tp.lower.len() - after_next_lower.len()..];
     let (count, after_count_orig) = if let Some((expr, after_num_orig)) =
         super::oracle_util::parse_count_expr(after_next_orig)
     {

--- a/crates/engine/src/parser/oracle_effect/tests.rs
+++ b/crates/engine/src/parser/oracle_effect/tests.rs
@@ -43215,7 +43215,8 @@ fn flip_n_coins_emits_flip_coins_variant() {
     );
 }
 
-/// CR 614.10: controller and targeted forms share the same optional count grammar.
+/// CR 614.10: skipping a future turn replaces that turn with nothing.
+/// Controller and targeted phrases share the parser's optional count grammar.
 #[test]
 fn skip_next_turn_parses_controller_and_targeted_singular_plural_forms() {
     for (text, expected_count) in [

--- a/crates/engine/src/parser/oracle_effect/tests.rs
+++ b/crates/engine/src/parser/oracle_effect/tests.rs
@@ -43215,23 +43215,45 @@ fn flip_n_coins_emits_flip_coins_variant() {
     );
 }
 
-/// CR 614.10: "Target opponent skips their next turn." (no X, no flip)
-/// parses as a standalone SkipNextTurn with count=1 and opponent target.
+/// CR 614.10: controller and targeted forms share the same optional count grammar.
 #[test]
-fn target_opponent_skips_next_turn_parses() {
-    let def = parse_effect_chain("Target opponent skips their next turn.", AbilityKind::Spell);
-    let Effect::SkipNextTurn { target, count } = &*def.effect else {
-        panic!("expected SkipNextTurn, got {:?}", def.effect);
-    };
-    assert_eq!(
-        count,
-        &crate::types::ability::QuantityExpr::Fixed { value: 1 }
-    );
-    assert!(matches!(
-        target,
-        TargetFilter::Typed(tf)
-            if tf.controller == Some(ControllerRef::Opponent)
-    ));
+fn skip_next_turn_parses_controller_and_targeted_singular_plural_forms() {
+    for (text, expected_count) in [
+        ("You skip your next turn.", 1),
+        ("You skip your next two turns.", 2),
+        ("Skip your next turn.", 1),
+    ] {
+        let def = parse_effect_chain(text, AbilityKind::Spell);
+        assert!(
+            matches!(
+                &*def.effect,
+                Effect::SkipNextTurn {
+                    target: TargetFilter::Controller,
+                    count: crate::types::ability::QuantityExpr::Fixed { value },
+                } if *value == expected_count
+            ),
+            "expected controller to skip {expected_count} turn(s), got {:?}",
+            def.effect
+        );
+    }
+
+    for (text, expected_count) in [
+        ("Target opponent skips their next turn.", 1),
+        ("Target opponent skips their next two turns.", 2),
+    ] {
+        let def = parse_effect_chain(text, AbilityKind::Spell);
+        assert!(
+            matches!(
+                &*def.effect,
+                Effect::SkipNextTurn {
+                    target: TargetFilter::Typed(tf),
+                    count: crate::types::ability::QuantityExpr::Fixed { value },
+                } if tf.controller == Some(ControllerRef::Opponent) && *value == expected_count
+            ),
+            "expected opponent to skip {expected_count} turn(s), got {:?}",
+            def.effect
+        );
+    }
 }
 
 /// CR 614.10a: "You skip your next untap step" is a one-shot step skip,

--- a/crates/engine/src/parser/oracle_tests.rs
+++ b/crates/engine/src/parser/oracle_tests.rs
@@ -946,6 +946,49 @@ fn activation_during_gate_composes_turn_role_and_window_axes() {
     }
 }
 
+#[test]
+fn activated_ability_any_upkeep_restriction_uses_unscoped_upkeep_condition() {
+    const DWARVEN_ARMORY: &str =
+        "{2}, Sacrifice a land: Put a +2/+2 counter on target creature. Activate only during any upkeep step.";
+    const TOLARIA: &str = "{T}: Add {U}.\n{T}: Target creature loses banding and all \"bands with other\" abilities until end of turn. Activate only during any upkeep step.";
+    let expected = ActivationRestriction::RequiresCondition {
+        condition: Some(ParsedCondition::IsDuringUpkeep),
+    };
+    fn has_unimplemented(definition: &AbilityDefinition) -> bool {
+        matches!(definition.effect.as_ref(), Effect::Unimplemented { .. })
+            || definition
+                .sub_ability
+                .as_deref()
+                .is_some_and(has_unimplemented)
+    }
+
+    let armory = parse(DWARVEN_ARMORY, "Dwarven Armory", &[], &["Enchantment"], &[]);
+    assert_eq!(armory.abilities.len(), 1, "got {:#?}", armory.abilities);
+    assert!(
+        armory.abilities[0]
+            .activation_restrictions
+            .contains(&expected),
+        "Dwarven Armory must retain its any-upkeep restriction: {:#?}",
+        armory.abilities[0]
+    );
+    assert!(
+        !has_unimplemented(&armory.abilities[0]),
+        "Dwarven Armory's parsed ability must not retain an unimplemented timing tail: {:#?}",
+        armory.abilities[0]
+    );
+
+    let tolaria = parse(TOLARIA, "Tolaria", &[], &["Land"], &[]);
+    assert_eq!(tolaria.abilities.len(), 2, "got {:#?}", tolaria.abilities);
+    assert!(
+        tolaria
+            .abilities
+            .iter()
+            .any(|ability| ability.activation_restrictions.contains(&expected)),
+        "Tolaria's second ability must retain its any-upkeep restriction: {:#?}",
+        tolaria.abilities
+    );
+}
+
 /// CR 508.1: a STANDALONE combat-window activation gate — "Activate only before
 /// attackers are declared" / "Activate only before combat" (Arcum's Whistle,
 /// Arcum's Sleigh) with no "during <role>" first half — must map to the enforced

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -1054,6 +1054,8 @@ mod purged_source_attacked_this_turn_lki;
 mod purged_source_intervening_if_lki;
 mod purged_source_matches_filter_lki;
 mod queen_parser_near_misses;
+mod queen_velocity_skip_turns;
+mod queen_velocity_upkeep;
 mod quirion_ranger_activation;
 mod rage_reflection_double_strike_grant;
 mod random_discard_cost_replacement_resume;

--- a/crates/engine/tests/integration/queen_velocity_skip_turns.rs
+++ b/crates/engine/tests/integration/queen_velocity_skip_turns.rs
@@ -1,0 +1,57 @@
+//! Regression coverage for Eater of Days' plural controller turn skip.
+
+use engine::game::scenario::{GameScenario, P0, P1};
+use engine::game::turns::start_next_turn;
+use engine::types::events::GameEvent;
+use engine::types::mana::ManaCost;
+use engine::types::phase::Phase;
+
+const EATER_OF_DAYS: &str =
+    "Flying, trample\nWhen this creature enters, you skip your next two turns.";
+
+/// CR 614.10 + CR 614.10a: Eater of Days' ETB creates two independently
+/// satisfied next-turn skip replacements for its controller.
+#[test]
+fn eater_of_days_etb_skips_controllers_next_two_turns() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let eater = scenario
+        .add_creature_to_hand_from_oracle(P0, "Eater of Days", 9, 8, EATER_OF_DAYS)
+        .with_mana_cost(ManaCost::zero())
+        .id();
+    let mut runner = scenario.build();
+
+    runner.cast(eater).resolve();
+    assert_eq!(
+        runner.state().turns_to_skip[P0.0 as usize],
+        2,
+        "ETB must arm both of Eater of Days' skipped turns"
+    );
+
+    let mut events = Vec::<GameEvent>::new();
+    start_next_turn(runner.state_mut(), &mut events);
+    assert_eq!(
+        runner.state().active_player,
+        P1,
+        "P1 takes the intervening turn"
+    );
+    assert_eq!(runner.state().turns_to_skip[P0.0 as usize], 2);
+    runner.state_mut().phase = Phase::Cleanup;
+
+    start_next_turn(runner.state_mut(), &mut events);
+    assert_eq!(
+        runner.state().active_player,
+        P1,
+        "P0's first scheduled turn is skipped"
+    );
+    assert_eq!(runner.state().turns_to_skip[P0.0 as usize], 1);
+    runner.state_mut().phase = Phase::Cleanup;
+
+    start_next_turn(runner.state_mut(), &mut events);
+    assert_eq!(
+        runner.state().active_player,
+        P1,
+        "P0's second scheduled turn is skipped"
+    );
+    assert_eq!(runner.state().turns_to_skip[P0.0 as usize], 0);
+}

--- a/crates/engine/tests/integration/queen_velocity_upkeep.rs
+++ b/crates/engine/tests/integration/queen_velocity_upkeep.rs
@@ -80,8 +80,9 @@ fn any_upkeep_activation_timing_allows_either_players_upkeep_only() {
     );
 }
 
-// CR 602.2 + CR 602.5b: an explicit any-player permission and the timing
-// restriction both apply when a noncontroller activates the ability.
+// CR 602.1b + CR 602.2 + CR 602.5: an explicit any-player permission allows
+// noncontroller activation, but the timing instruction still restricts it.
+// CR 503.1: the upkeep step gives players a priority window for activation.
 #[test]
 fn opponent_can_activate_any_player_abilities_only_during_either_upkeep() {
     let cards = [

--- a/crates/engine/tests/integration/queen_velocity_upkeep.rs
+++ b/crates/engine/tests/integration/queen_velocity_upkeep.rs
@@ -1,0 +1,144 @@
+//! Real Oracle activation timing and actor permissions for `any upkeep step`.
+
+use engine::game::restrictions::check_activation_restrictions;
+use engine::game::scenario::{GameRunner, GameScenario, P0, P1};
+use engine::types::ability::{AbilityKind, ActivationRestriction};
+use engine::types::actions::GameAction;
+use engine::types::counter::CounterType;
+use engine::types::game_state::WaitingFor;
+use engine::types::identifiers::ObjectId;
+use engine::types::mana::{ManaType, ManaUnit};
+use engine::types::phase::Phase;
+
+const DWARVEN_ARMORY: &str =
+    "{2}, Sacrifice a land: Put a +2/+2 counter on target creature. Activate only during any upkeep step.";
+const TOLARIA: &str = "{T}: Add {U}.\n{T}: Target creature loses banding and all \"bands with other\" abilities until end of turn. Activate only during any upkeep step.";
+
+fn assert_any_upkeep_gate(
+    runner: &mut GameRunner,
+    source: ObjectId,
+    ability_index: usize,
+    restrictions: &[ActivationRestriction],
+    card_name: &str,
+) {
+    for active_player in [P0, P1] {
+        let state = runner.state_mut();
+        state.active_player = active_player;
+        state.phase = Phase::Upkeep;
+        assert!(
+            check_activation_restrictions(state, P0, source, ability_index, restrictions).is_ok(),
+            "{card_name} must be legal during {active_player:?}'s upkeep"
+        );
+    }
+
+    for phase in [Phase::PreCombatMain, Phase::End] {
+        let state = runner.state_mut();
+        state.phase = phase;
+        assert!(
+            check_activation_restrictions(state, P0, source, ability_index, restrictions).is_err(),
+            "{card_name} must be illegal during {phase:?}"
+        );
+    }
+}
+
+#[test]
+fn any_upkeep_activation_timing_allows_either_players_upkeep_only() {
+    let mut armory_scenario = GameScenario::new();
+    let armory = armory_scenario
+        .add_enchantment_from_oracle(P0, "Dwarven Armory", DWARVEN_ARMORY)
+        .id();
+    let mut armory_runner = armory_scenario.build();
+    let armory_restrictions = armory_runner.state().objects[&armory].abilities[0]
+        .activation_restrictions
+        .clone();
+    assert_any_upkeep_gate(
+        &mut armory_runner,
+        armory,
+        0,
+        &armory_restrictions,
+        "Dwarven Armory",
+    );
+
+    let mut tolaria_scenario = GameScenario::new();
+    let tolaria = tolaria_scenario
+        .add_land_from_oracle(P0, "Tolaria", TOLARIA)
+        .id();
+    let mut tolaria_runner = tolaria_scenario.build();
+    let (tolaria_index, tolaria_restrictions) = tolaria_runner.state().objects[&tolaria]
+        .abilities
+        .iter()
+        .enumerate()
+        .find(|(_, ability)| !ability.activation_restrictions.is_empty())
+        .map(|(index, ability)| (index, ability.activation_restrictions.clone()))
+        .expect("Tolaria's restricted ability must survive Oracle parsing");
+    assert_any_upkeep_gate(
+        &mut tolaria_runner,
+        tolaria,
+        tolaria_index,
+        &tolaria_restrictions,
+        "Tolaria",
+    );
+}
+
+// CR 602.2 + CR 602.5b: an explicit any-player permission and the timing
+// restriction both apply when a noncontroller activates the ability.
+#[test]
+fn opponent_can_activate_any_player_abilities_only_during_either_upkeep() {
+    let cards = [
+        (
+            "Armageddon Clock",
+            "At the beginning of your upkeep, put a doom counter on this artifact.\nAt the beginning of your draw step, this artifact deals damage equal to the number of doom counters on it to each player.\n{4}: Remove a doom counter from this artifact. Any player may activate this ability but only during any upkeep step.",
+            CounterType::Generic("doom".into()),
+            4,
+        ),
+        (
+            "Infinite Hourglass",
+            "At the beginning of your upkeep, put a time counter on this artifact.\nAll creatures get +1/+0 for each time counter on this artifact.\n{3}: Remove a time counter from this artifact. Any player may activate this ability but only during any upkeep step.",
+            CounterType::Time,
+            3,
+        ),
+    ];
+    for (name, oracle, counter, mana) in cards {
+        for active_player in [P0, P1] {
+            for phase in [Phase::Upkeep, Phase::PreCombatMain, Phase::End] {
+                let mut scenario = GameScenario::new();
+                scenario.at_phase(phase);
+                let source = scenario.add_artifact_from_oracle(P0, name, oracle).id();
+                scenario.with_counter(source, counter.clone(), 2);
+                scenario.with_mana_pool(
+                    P1,
+                    (0..mana)
+                        .map(|_| ManaUnit::new(ManaType::Colorless, ObjectId(0), false, vec![]))
+                        .collect(),
+                );
+                let mut runner = scenario.build();
+                runner.state_mut().active_player = active_player;
+                runner.state_mut().priority_player = P1;
+                runner.state_mut().waiting_for = WaitingFor::Priority { player: P1 };
+                let index = runner.state().objects[&source]
+                    .abilities
+                    .iter()
+                    .position(|ability| ability.kind == AbilityKind::Activated)
+                    .expect("the parsed card must have an activated ability");
+                if phase == Phase::Upkeep {
+                    runner.activate(source, index).resolve();
+                    assert_eq!(
+                        runner.state().objects[&source].counters.get(&counter),
+                        Some(&1),
+                        "P1 must remove a counter from {name} during {active_player:?}'s upkeep"
+                    );
+                } else {
+                    assert!(
+                        runner
+                            .act(GameAction::ActivateAbility {
+                                source_id: source,
+                                ability_index: index,
+                            })
+                            .is_err(),
+                        "{name} must reject P1's activation during {phase:?}"
+                    );
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Parse plural controller turn skips and “during any upkeep step” through the existing quantity and activation-restriction helpers. Eater of Days now skips two turns; upkeep-only abilities remain restricted on every player’s turn, including abilities opponents may activate.

A pinned 35,804-row comparison found five affected cards and four newly supported cards: Eater of Days, Dwarven Armory, Armageddon Clock, and Infinite Hourglass. Tolaria loses its timing gap but retains an unrelated unsupported ability. No engine types or resolvers change.

Validation on the source tree: all 11 focused tests passed, including production casting/turn skipping and P1 activation of both any-player artifacts during either upkeep with rejection in main/end steps. Formatting, parser gates, clippy, and Terra high implementation review passed. Fresh base/head semantic audits have identical findings. The full source-tree engine suite ran 27,555 tests: 27,554 passed, one stack-budget SIGABRT failed, and 11 were skipped. The same `game_state_stack_budget::four_player_commander_action_fits_a_bounded_stack` failure was reproduced on the untouched baseline during the earlier batch. Current-PR CI validates the rebased tree; the review follow-up changes CR comments only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Abilities can now be activated during either player’s upkeep when specified by card text.
  * Skip-next-turn effects now support controller and targeted forms with singular or plural turn counts.

* **Bug Fixes**
  * Corrected upkeep activation legality outside of upkeep steps.
  * Improved handling of effects that skip multiple turns.

* **Tests**
  * Added coverage for upkeep restrictions and multi-turn skip effects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->