### PR TITLE
Add deterministic Oracle semantic discovery reports

### DIFF
--- a/crates/engine/src/bin/coverage_parse_diff.rs
+++ b/crates/engine/src/bin/coverage_parse_diff.rs
@@ -963,6 +963,7 @@ mod tests {
     /// the fixture matches.
     fn card(name: &str, oracle: &str, parse_details: &[ParsedItem]) -> CardCoverageResult {
         CardCoverageResult {
+            card_face_key: None,
             card_name: name.to_string(),
             set_code: String::new(),
             supported: true,

--- a/crates/engine/src/bin/oracle_contrastive_audit.rs
+++ b/crates/engine/src/bin/oracle_contrastive_audit.rs
@@ -1,0 +1,1129 @@
+//! Deterministic semantic-collision audit for controlled Oracle mutations.
+
+use std::collections::BTreeMap;
+use std::env;
+use std::error::Error;
+use std::fs;
+use std::io::Write;
+use std::ops::ControlFlow;
+use std::path::{Path, PathBuf};
+use std::process;
+
+use engine::database::mtgjson::AtomicCardsFile;
+use engine::database::synthesis::build_oracle_face;
+use engine::game::coverage::card_face_gaps;
+use engine::parser::oracle_ir::diagnostic::OracleDiagnostic;
+use engine::types::ability::{ControllerRef, Effect, FilterProp, QuantityExpr, TargetFilter};
+use engine::types::ability_visit::visit_ability_def;
+use engine::types::card::CardFace;
+use nom::branch::alt;
+use nom::bytes::complete::{tag, take_until, take_while};
+use nom::character::complete::digit1;
+use nom::combinator::{all_consuming, map_res, recognize as nom_recognize};
+use nom::sequence::delimited;
+use nom::Parser;
+use serde::Serialize;
+use sha2::{Digest, Sha256};
+
+const TOOL: &str = "oracle_contrastive_audit";
+const FAMILIES: [&str; 3] = [
+    "life_recipient_v1",
+    "token_count_article_two_v1",
+    "destroy_nontoken_v1",
+];
+
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum Status {
+    BothUnsupported,
+    BaseUnsupported,
+    MutantUnsupported,
+    BothDiagnostic,
+    BaseDiagnostic,
+    MutantDiagnostic,
+    UncheckableCarrierCount,
+    SemanticCollision,
+    ProjectionChangedElsewhere,
+    ChangedAsRequired,
+}
+
+impl Status {
+    fn reason_code(self) -> &'static str {
+        match self {
+            Self::BothUnsupported => "both_unsupported",
+            Self::BaseUnsupported => "base_unsupported",
+            Self::MutantUnsupported => "mutant_unsupported",
+            Self::BothDiagnostic => "both_diagnostic",
+            Self::BaseDiagnostic => "base_diagnostic",
+            Self::MutantDiagnostic => "mutant_diagnostic",
+            Self::UncheckableCarrierCount => "uncheckable_carrier_count",
+            Self::SemanticCollision => "semantic_collision",
+            Self::ProjectionChangedElsewhere => "projection_changed_elsewhere",
+            Self::ChangedAsRequired => "changed_as_required",
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+struct Mutation {
+    family: &'static str,
+    direction: &'static str,
+    text: String,
+}
+
+#[derive(Default, Serialize)]
+struct FamilyCensus {
+    faces_scanned: usize,
+    grammar_matches: usize,
+    attempted: usize,
+    rejected_before_synthesis: BTreeMap<String, usize>,
+}
+
+#[derive(Serialize)]
+struct ProjectionPair {
+    base_carrier_count: usize,
+    mutant_carrier_count: usize,
+    base: Option<Effect>,
+    mutant: Option<Effect>,
+}
+
+#[derive(Serialize)]
+struct AuditResult {
+    atomic_key: String,
+    face_name: String,
+    oracle_id: Option<String>,
+    family: &'static str,
+    direction: &'static str,
+    original_text: String,
+    mutated_text: String,
+    byte_span: ByteSpan,
+    base_handler_gaps: Vec<String>,
+    mutant_handler_gaps: Vec<String>,
+    base_warnings: Vec<OracleDiagnostic>,
+    mutant_warnings: Vec<OracleDiagnostic>,
+    projections: ProjectionPair,
+    status: Status,
+    reason_code: &'static str,
+}
+
+#[derive(Serialize)]
+struct ByteSpan {
+    start: usize,
+    end: usize,
+}
+
+#[derive(Serialize)]
+struct Report {
+    schema_version: u32,
+    tool: &'static str,
+    support_authority: &'static str,
+    input_label: String,
+    input_sha256: String,
+    families: [&'static str; 3],
+    census: BTreeMap<&'static str, FamilyCensus>,
+    status_counts: BTreeMap<Status, usize>,
+    results: Vec<AuditResult>,
+}
+
+fn decimal(input: &str) -> nom::IResult<&str, i32> {
+    map_res(digit1, str::parse::<i32>).parse(input)
+}
+
+fn recognize_life(text: &str) -> Option<Mutation> {
+    if let Ok((_, amount)) =
+        all_consuming(delimited(tag("You gain "), decimal, tag(" life."))).parse(text)
+    {
+        return Some(Mutation {
+            family: FAMILIES[0],
+            direction: "you_to_target_opponent",
+            text: format!("Target opponent gains {amount} life."),
+        });
+    }
+    let (_, amount) = all_consuming(delimited(
+        tag("Target opponent gains "),
+        decimal,
+        tag(" life."),
+    ))
+    .parse(text)
+    .ok()?;
+    Some(Mutation {
+        family: FAMILIES[0],
+        direction: "target_opponent_to_you",
+        text: format!("You gain {amount} life."),
+    })
+}
+
+fn description_is_single_token(description: &str) -> bool {
+    let structurally_valid = all_consuming(nom_recognize((
+        digit1::<&str, nom::error::Error<&str>>,
+        tag("/"),
+        digit1,
+        take_while(|c: char| !matches!(c, '\n' | '\r' | '"' | '.' | '—' | '(' | ')' | ';' | ':')),
+    )))
+    .parse(description)
+    .is_ok();
+    if !structurally_valid {
+        return false;
+    }
+    let mut forbidden = alt((tag::<_, _, nom::error::Error<_>>(" token"), tag(" and a ")));
+    let mut remaining = description;
+    while !remaining.is_empty() {
+        if forbidden.parse(remaining).is_ok() {
+            return false;
+        }
+        let Some((offset, ch)) = remaining.char_indices().next() else {
+            break;
+        };
+        remaining = &remaining[offset + ch.len_utf8()..];
+    }
+    true
+}
+
+fn recognize_token(text: &str) -> Option<Mutation> {
+    fn singular(input: &str) -> nom::IResult<&str, &str> {
+        all_consuming(delimited(
+            tag("Create a "),
+            nom_recognize((digit1, tag("/"), digit1, take_until(" token."))),
+            tag(" token."),
+        ))
+        .parse(input)
+    }
+
+    fn plural(input: &str) -> nom::IResult<&str, &str> {
+        all_consuming(delimited(
+            tag("Create two "),
+            nom_recognize((digit1, tag("/"), digit1, take_until(" tokens."))),
+            tag(" tokens."),
+        ))
+        .parse(input)
+    }
+
+    if let Ok((_, description)) = singular(text) {
+        if description_is_single_token(description) {
+            return Some(Mutation {
+                family: FAMILIES[1],
+                direction: "one_to_two",
+                text: format!("Create two {description} tokens."),
+            });
+        }
+        return None;
+    }
+    let (_, description) = plural(text).ok()?;
+    description_is_single_token(description).then(|| Mutation {
+        family: FAMILIES[1],
+        direction: "two_to_one",
+        text: format!("Create a {description} token."),
+    })
+}
+
+fn recognize_destroy(text: &str) -> Option<Mutation> {
+    fn sentence(input: &str) -> nom::IResult<&str, &str> {
+        alt((
+            tag("Destroy target creature."),
+            tag("Destroy target nontoken creature."),
+        ))
+        .parse(input)
+    }
+
+    let (_, qualified) = all_consuming(sentence).parse(text).ok()?;
+    if qualified == "Destroy target creature." {
+        Some(Mutation {
+            family: FAMILIES[2],
+            direction: "creature_to_nontoken",
+            text: "Destroy target nontoken creature.".to_string(),
+        })
+    } else {
+        Some(Mutation {
+            family: FAMILIES[2],
+            direction: "nontoken_to_creature",
+            text: "Destroy target creature.".to_string(),
+        })
+    }
+}
+
+fn recognize_mutation(text: &str) -> Option<Mutation> {
+    recognize_life(text)
+        .or_else(|| recognize_token(text))
+        .or_else(|| recognize_destroy(text))
+}
+
+fn carriers(face: &CardFace, family: &str) -> Vec<Effect> {
+    let mut found = Vec::new();
+    for ability in &face.abilities {
+        let _ = visit_ability_def(ability, &mut |effect| {
+            let relevant = matches!(
+                (family, effect),
+                ("life_recipient_v1", Effect::GainLife { .. })
+                    | ("token_count_article_two_v1", Effect::Token { .. })
+                    | ("destroy_nontoken_v1", Effect::Destroy { .. })
+            );
+            if relevant {
+                found.push(effect.clone());
+            }
+            ControlFlow::Continue(())
+        });
+    }
+    found
+}
+
+fn compare_life(base: &Effect, mutant: &Effect, direction: &str) -> Status {
+    let (
+        Effect::GainLife {
+            amount: base_amount,
+            player: base_player,
+        },
+        Effect::GainLife {
+            amount: mutant_amount,
+            player: mutant_player,
+        },
+    ) = (base, mutant)
+    else {
+        return Status::UncheckableCarrierCount;
+    };
+
+    fn recipient(filter: &TargetFilter) -> Option<bool> {
+        match filter {
+            TargetFilter::Controller => Some(false),
+            TargetFilter::Typed(typed)
+                if typed.type_filters.is_empty()
+                    && typed.controller == Some(ControllerRef::Opponent)
+                    && typed.properties.is_empty() =>
+            {
+                Some(true)
+            }
+            _ => None,
+        }
+    }
+
+    if base_player == mutant_player {
+        return Status::SemanticCollision;
+    }
+    if !matches!(base_amount, QuantityExpr::Fixed { .. })
+        || !matches!(mutant_amount, QuantityExpr::Fixed { .. })
+    {
+        return Status::UncheckableCarrierCount;
+    }
+    let (Some(base_is_opponent), Some(mutant_is_opponent)) =
+        (recipient(base_player), recipient(mutant_player))
+    else {
+        return Status::UncheckableCarrierCount;
+    };
+    let expected = match direction {
+        "you_to_target_opponent" => !base_is_opponent && mutant_is_opponent,
+        "target_opponent_to_you" => base_is_opponent && !mutant_is_opponent,
+        _ => return Status::UncheckableCarrierCount,
+    };
+    if !expected {
+        return Status::ProjectionChangedElsewhere;
+    }
+    let mut normalized_base = base.clone();
+    let mut normalized_mutant = mutant.clone();
+    if let Effect::GainLife { player, .. } = &mut normalized_base {
+        *player = TargetFilter::Controller;
+    }
+    if let Effect::GainLife { player, .. } = &mut normalized_mutant {
+        *player = TargetFilter::Controller;
+    }
+    if normalized_base == normalized_mutant {
+        Status::ChangedAsRequired
+    } else {
+        Status::ProjectionChangedElsewhere
+    }
+}
+
+fn compare_token(base: &Effect, mutant: &Effect, direction: &str) -> Status {
+    let (
+        Effect::Token {
+            count: base_count, ..
+        },
+        Effect::Token {
+            count: mutant_count,
+            ..
+        },
+    ) = (base, mutant)
+    else {
+        return Status::SemanticCollision;
+    };
+    if base_count == mutant_count {
+        return Status::SemanticCollision;
+    }
+    let (
+        QuantityExpr::Fixed { value: base_value },
+        QuantityExpr::Fixed {
+            value: mutant_value,
+        },
+    ) = (base_count, mutant_count)
+    else {
+        return Status::UncheckableCarrierCount;
+    };
+    let (base_expected, mutant_expected) = match direction {
+        "one_to_two" => (1, 2),
+        "two_to_one" => (2, 1),
+        _ => return Status::UncheckableCarrierCount,
+    };
+    if *base_value != base_expected || *mutant_value != mutant_expected {
+        return Status::ProjectionChangedElsewhere;
+    }
+    let mut normalized_base = base.clone();
+    let mut normalized_mutant = mutant.clone();
+    if let Effect::Token { count, .. } = &mut normalized_base {
+        *count = QuantityExpr::Fixed { value: 1 };
+    }
+    if let Effect::Token { count, .. } = &mut normalized_mutant {
+        *count = QuantityExpr::Fixed { value: 1 };
+    }
+    if normalized_base == normalized_mutant {
+        Status::ChangedAsRequired
+    } else {
+        Status::ProjectionChangedElsewhere
+    }
+}
+
+fn compare_destroy(base: &Effect, mutant: &Effect, direction: &str) -> Status {
+    let (
+        Effect::Destroy {
+            target: base_target,
+            ..
+        },
+        Effect::Destroy {
+            target: mutant_target,
+            ..
+        },
+    ) = (base, mutant)
+    else {
+        return Status::SemanticCollision;
+    };
+    let (TargetFilter::Typed(base_filter), TargetFilter::Typed(mutant_filter)) =
+        (base_target, mutant_target)
+    else {
+        return Status::UncheckableCarrierCount;
+    };
+    let base_non_tokens = base_filter
+        .properties
+        .iter()
+        .filter(|property| matches!(property, FilterProp::NonToken))
+        .count();
+    let mutant_non_tokens = mutant_filter
+        .properties
+        .iter()
+        .filter(|property| matches!(property, FilterProp::NonToken))
+        .count();
+    if base_non_tokens > 1 || mutant_non_tokens > 1 {
+        return Status::UncheckableCarrierCount;
+    }
+    if base_target == mutant_target {
+        return Status::SemanticCollision;
+    }
+    let expected = match direction {
+        "creature_to_nontoken" => base_non_tokens == 0 && mutant_non_tokens == 1,
+        "nontoken_to_creature" => base_non_tokens == 1 && mutant_non_tokens == 0,
+        _ => false,
+    };
+    if !expected {
+        return Status::ProjectionChangedElsewhere;
+    }
+    let mut normalized_base = base.clone();
+    let mut normalized_mutant = mutant.clone();
+    for effect in [&mut normalized_base, &mut normalized_mutant] {
+        if let Effect::Destroy {
+            target: TargetFilter::Typed(filter),
+            ..
+        } = effect
+        {
+            filter
+                .properties
+                .retain(|property| !matches!(property, FilterProp::NonToken));
+        }
+    }
+    if normalized_base == normalized_mutant {
+        Status::ChangedAsRequired
+    } else {
+        Status::ProjectionChangedElsewhere
+    }
+}
+
+fn classify(
+    base_face: &CardFace,
+    mutant_face: &CardFace,
+    family: &str,
+    direction: &str,
+) -> (Status, Vec<String>, Vec<String>, ProjectionPair) {
+    let base_gaps = card_face_gaps(base_face);
+    let mutant_gaps = card_face_gaps(mutant_face);
+    let status = match (base_gaps.is_empty(), mutant_gaps.is_empty()) {
+        (false, false) => Some(Status::BothUnsupported),
+        (false, true) => Some(Status::BaseUnsupported),
+        (true, false) => Some(Status::MutantUnsupported),
+        (true, true) => None,
+    };
+    let status = status.or(
+        match (
+            base_face.parse_warnings.is_empty(),
+            mutant_face.parse_warnings.is_empty(),
+        ) {
+            (false, false) => Some(Status::BothDiagnostic),
+            (false, true) => Some(Status::BaseDiagnostic),
+            (true, false) => Some(Status::MutantDiagnostic),
+            (true, true) => None,
+        },
+    );
+    let base = carriers(base_face, family);
+    let mutant = carriers(mutant_face, family);
+    let projections = ProjectionPair {
+        base_carrier_count: base.len(),
+        mutant_carrier_count: mutant.len(),
+        base: base.first().cloned(),
+        mutant: mutant.first().cloned(),
+    };
+    let status = status.unwrap_or_else(|| {
+        if base.len() != 1 || mutant.len() != 1 {
+            return Status::UncheckableCarrierCount;
+        }
+        match family {
+            "life_recipient_v1" => compare_life(&base[0], &mutant[0], direction),
+            "token_count_article_two_v1" => compare_token(&base[0], &mutant[0], direction),
+            "destroy_nontoken_v1" => compare_destroy(&base[0], &mutant[0], direction),
+            _ => unreachable!("closed family list"),
+        }
+    });
+    (status, base_gaps, mutant_gaps, projections)
+}
+
+fn audit(input: &Path, input_label: String) -> Result<Report, Box<dyn Error>> {
+    let bytes = fs::read(input)?;
+    // Digest and deserialize the same read so a concurrent corpus refresh
+    // cannot make the provenance describe different bytes than the results.
+    let cards: AtomicCardsFile = serde_json::from_slice(&bytes)?;
+    let mut census: BTreeMap<_, _> = FAMILIES
+        .into_iter()
+        .map(|family| (family, FamilyCensus::default()))
+        .collect();
+    let mut results = Vec::new();
+    let mut keys: Vec<_> = cards.data.into_iter().collect();
+    keys.sort_by(|left, right| left.0.cmp(&right.0));
+    for (atomic_key, mut faces) in keys {
+        faces.sort_by(|left, right| {
+            let left_identity = (
+                left.face_name.as_deref().unwrap_or(&left.name),
+                left.identifiers.scryfall_oracle_id.as_deref(),
+            );
+            let right_identity = (
+                right.face_name.as_deref().unwrap_or(&right.name),
+                right.identifiers.scryfall_oracle_id.as_deref(),
+            );
+            left_identity.cmp(&right_identity)
+        });
+        for face in faces {
+            for family in FAMILIES {
+                census.get_mut(family).unwrap().faces_scanned += 1;
+            }
+            let Some(text) = face.text.as_deref() else {
+                for family in FAMILIES {
+                    *census
+                        .get_mut(family)
+                        .unwrap()
+                        .rejected_before_synthesis
+                        .entry("missing_text".to_string())
+                        .or_default() += 1;
+                }
+                continue;
+            };
+            let Some(mutation) = recognize_mutation(text) else {
+                for family in FAMILIES {
+                    *census
+                        .get_mut(family)
+                        .unwrap()
+                        .rejected_before_synthesis
+                        .entry("grammar_mismatch".to_string())
+                        .or_default() += 1;
+                }
+                continue;
+            };
+            for family in FAMILIES {
+                if family != mutation.family {
+                    *census
+                        .get_mut(family)
+                        .unwrap()
+                        .rejected_before_synthesis
+                        .entry("grammar_mismatch".to_string())
+                        .or_default() += 1;
+                }
+            }
+            let family_census = census.get_mut(mutation.family).unwrap();
+            family_census.grammar_matches += 1;
+            let oracle_id = face.identifiers.scryfall_oracle_id.clone();
+            let base_face = build_oracle_face(&face, oracle_id.clone());
+            let mut mutated_card = face.clone();
+            mutated_card.text = Some(mutation.text.clone());
+            let mutant_face = build_oracle_face(&mutated_card, oracle_id.clone());
+            family_census.attempted += 1;
+            let (status, base_gaps, mutant_gaps, projections) = classify(
+                &base_face,
+                &mutant_face,
+                mutation.family,
+                mutation.direction,
+            );
+            results.push(AuditResult {
+                atomic_key: atomic_key.clone(),
+                face_name: face.face_name.clone().unwrap_or_else(|| face.name.clone()),
+                oracle_id,
+                family: mutation.family,
+                direction: mutation.direction,
+                original_text: text.to_string(),
+                mutated_text: mutation.text,
+                byte_span: ByteSpan {
+                    start: 0,
+                    end: text.len(),
+                },
+                base_handler_gaps: base_gaps,
+                mutant_handler_gaps: mutant_gaps,
+                base_warnings: base_face.parse_warnings,
+                mutant_warnings: mutant_face.parse_warnings,
+                projections,
+                status,
+                reason_code: status.reason_code(),
+            });
+        }
+    }
+    results.sort_by(|left, right| {
+        (
+            &left.atomic_key,
+            &left.face_name,
+            &left.oracle_id,
+            left.family,
+            left.direction,
+            &left.mutated_text,
+        )
+            .cmp(&(
+                &right.atomic_key,
+                &right.face_name,
+                &right.oracle_id,
+                right.family,
+                right.direction,
+                &right.mutated_text,
+            ))
+    });
+    let mut status_counts = BTreeMap::new();
+    for result in &results {
+        *status_counts.entry(result.status).or_default() += 1;
+    }
+    Ok(Report {
+        schema_version: 1,
+        tool: TOOL,
+        support_authority: "card_face_gaps_per_face_handler_coverage",
+        input_label,
+        input_sha256: format!("{:x}", Sha256::digest(bytes)),
+        families: FAMILIES,
+        census,
+        status_counts,
+        results,
+    })
+}
+
+fn arguments_from(
+    args: impl IntoIterator<Item = String>,
+) -> Result<(PathBuf, String, Option<PathBuf>), String> {
+    let mut positional = None;
+    let mut output = None;
+    let mut args = args.into_iter();
+    while let Some(arg) = args.next() {
+        if arg == "--output" {
+            output = Some(PathBuf::from(
+                args.next().ok_or("--output requires a path")?,
+            ));
+        } else if positional.replace(arg).is_some() {
+            return Err("usage: oracle_contrastive_audit [data-dir] [--output path]".to_string());
+        }
+    }
+    let spelling = positional.unwrap_or_else(|| "data".to_string());
+    let (input, input_label) = resolve_input(&spelling);
+    Ok((input, input_label, output))
+}
+
+fn resolve_input(spelling: &str) -> (PathBuf, String) {
+    let supplied = PathBuf::from(&spelling);
+    let input = if supplied.file_name().and_then(|name| name.to_str()) == Some("AtomicCards.json") {
+        supplied.clone()
+    } else {
+        supplied.join("mtgjson/AtomicCards.json")
+    };
+    let input_label = if spelling == "data" || supplied.is_absolute() {
+        "mtgjson/AtomicCards.json".to_string()
+    } else {
+        spelling.to_string()
+    };
+    (input, input_label)
+}
+
+fn run() -> Result<(), Box<dyn Error>> {
+    let mut stdout = std::io::stdout();
+    run_with_args(env::args().skip(1), &mut stdout)
+}
+
+fn run_with_args(
+    args: impl IntoIterator<Item = String>,
+    stdout: &mut dyn Write,
+) -> Result<(), Box<dyn Error>> {
+    let (input, input_label, output) = arguments_from(args).map_err(std::io::Error::other)?;
+    let rendered = render_report(&audit(&input, input_label)?)?;
+    if let Some(path) = output {
+        fs::write(path, rendered)?;
+    } else {
+        stdout.write_all(&rendered)?;
+    }
+    Ok(())
+}
+
+fn render_report(report: &Report) -> Result<Vec<u8>, serde_json::Error> {
+    let mut rendered = serde_json::to_vec_pretty(report)?;
+    rendered.push(b'\n');
+    Ok(rendered)
+}
+
+fn main() {
+    if let Err(error) = run() {
+        eprintln!("{TOOL}: {error}");
+        process::exit(1);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use engine::database::mtgjson::AtomicCard;
+    use engine::types::ability::{AbilityDefinition, AbilityKind, TypedFilter};
+
+    fn raw_card(text: &str) -> AtomicCard {
+        serde_json::from_value(serde_json::json!({
+            "name": "Fixture",
+            "colors": ["W"],
+            "colorIdentity": ["W"],
+            "layout": "normal",
+            "type": "Instant",
+            "types": ["Instant"],
+            "subtypes": [],
+            "supertypes": [],
+            "text": text,
+            "manaValue": 1.0,
+            "legalities": {},
+            "identifiers": { "scryfallOracleId": "fixture-oracle-id" }
+        }))
+        .unwrap()
+    }
+
+    #[test]
+    fn life_grammar_is_reciprocal_and_all_consuming() {
+        let mutation = recognize_life("You gain 12 life.").unwrap();
+        assert_eq!(mutation.text, "Target opponent gains 12 life.");
+        assert_eq!(
+            recognize_life(&mutation.text).unwrap().text,
+            "You gain 12 life."
+        );
+        assert!(recognize_life("When You gain 12 life.").is_none());
+        assert!(recognize_life("You gain 12 life. Draw a card.").is_none());
+        assert!(recognize_life("You gain 12 life.\n").is_none());
+    }
+
+    #[test]
+    fn token_grammar_is_reciprocal_and_rejects_ambiguous_descriptions() {
+        let mutation = recognize_token("Create two 1/1 white Soldier creature tokens.").unwrap();
+        assert_eq!(mutation.text, "Create a 1/1 white Soldier creature token.");
+        assert_eq!(
+            recognize_token(&mutation.text).unwrap().text,
+            "Create two 1/1 white Soldier creature tokens."
+        );
+        assert!(recognize_token("Create an 1/1 white Spirit creature token.").is_none());
+        assert!(recognize_token("Create a Food token.").is_none());
+        assert!(recognize_token("Create a 1/1 token and a Food token.").is_none());
+        assert!(recognize_token("Create a 1/1 white \"Soldier\" creature token.").is_none());
+        assert!(recognize_token("Create a 1/1 white Soldier\ncreature token.").is_none());
+        assert!(recognize_token("Create a 1/1 white Soldier (armed) creature token.").is_none());
+        assert!(
+            recognize_token("Create a 1/1 white Soldier creature token. Draw a card.").is_none()
+        );
+    }
+
+    #[test]
+    fn destroy_grammar_is_reciprocal_and_all_consuming() {
+        assert_eq!(
+            recognize_destroy("Destroy target creature.").unwrap().text,
+            "Destroy target nontoken creature."
+        );
+        assert_eq!(
+            recognize_destroy("Destroy target nontoken creature.")
+                .unwrap()
+                .text,
+            "Destroy target creature."
+        );
+        assert!(recognize_destroy("Destroy target creature. Draw a card.").is_none());
+    }
+
+    #[test]
+    fn production_angels_mercy_reaches_an_exact_life_projection() {
+        let mut base = raw_card("You gain 7 life.");
+        base.name = "Angel's Mercy".to_string();
+        let mut mutant = base.clone();
+        mutant.text = Some("Target opponent gains 7 life.".to_string());
+        assert_eq!(base.name, mutant.name);
+        assert_eq!(base.types, mutant.types);
+        assert_eq!(base.mana_value, mutant.mana_value);
+        assert_eq!(
+            base.identifiers.scryfall_oracle_id,
+            mutant.identifiers.scryfall_oracle_id
+        );
+        let base_face = build_oracle_face(&base, Some("fixture-oracle-id".to_string()));
+        let mutant_face = build_oracle_face(&mutant, Some("fixture-oracle-id".to_string()));
+        let (status, _, _, projections) = classify(
+            &base_face,
+            &mutant_face,
+            "life_recipient_v1",
+            "you_to_target_opponent",
+        );
+        assert_eq!(status, Status::ChangedAsRequired);
+        assert!(projections.base.is_some());
+        assert!(projections.mutant.is_some());
+    }
+
+    fn production_status(text: &str) -> Status {
+        let base = raw_card(text);
+        let mutation = recognize_mutation(text).expect("fixture must reach a controlled family");
+        let mut mutant = base.clone();
+        mutant.text = Some(mutation.text);
+        let base_face = build_oracle_face(&base, Some("fixture-oracle-id".to_string()));
+        let mutant_face = build_oracle_face(&mutant, Some("fixture-oracle-id".to_string()));
+        classify(
+            &base_face,
+            &mutant_face,
+            mutation.family,
+            mutation.direction,
+        )
+        .0
+    }
+
+    #[test]
+    fn production_synthesis_reaches_exact_token_and_destroy_projections() {
+        assert_eq!(
+            production_status("Create two 1/1 white Soldier creature tokens."),
+            Status::ChangedAsRequired
+        );
+        assert_eq!(
+            production_status("Destroy target creature."),
+            Status::ChangedAsRequired
+        );
+    }
+
+    #[test]
+    fn support_and_diagnostics_precede_carrier_projection() {
+        let clean = build_oracle_face(
+            &raw_card("You gain 7 life."),
+            Some("fixture-oracle-id".to_string()),
+        );
+        let mut unsupported = clean.clone();
+        unsupported.abilities = vec![AbilityDefinition::new(
+            AbilityKind::Spell,
+            Effect::unimplemented("fixture", "unsupported"),
+        )];
+        assert_eq!(
+            classify(
+                &unsupported,
+                &unsupported,
+                "life_recipient_v1",
+                "you_to_target_opponent"
+            )
+            .0,
+            Status::BothUnsupported
+        );
+        assert_eq!(
+            classify(
+                &unsupported,
+                &clean,
+                "life_recipient_v1",
+                "you_to_target_opponent"
+            )
+            .0,
+            Status::BaseUnsupported
+        );
+        assert_eq!(
+            classify(
+                &clean,
+                &unsupported,
+                "life_recipient_v1",
+                "you_to_target_opponent"
+            )
+            .0,
+            Status::MutantUnsupported
+        );
+
+        let warning = OracleDiagnostic::TargetFallback {
+            context: "fixture".to_string(),
+            text: "fixture".to_string(),
+            line_index: 0,
+        };
+        let mut diagnostic = clean.clone();
+        diagnostic.parse_warnings.push(warning);
+        assert_eq!(
+            classify(
+                &diagnostic,
+                &diagnostic,
+                "life_recipient_v1",
+                "you_to_target_opponent"
+            )
+            .0,
+            Status::BothDiagnostic
+        );
+        assert_eq!(
+            classify(
+                &diagnostic,
+                &clean,
+                "life_recipient_v1",
+                "you_to_target_opponent"
+            )
+            .0,
+            Status::BaseDiagnostic
+        );
+        assert_eq!(
+            classify(
+                &clean,
+                &diagnostic,
+                "life_recipient_v1",
+                "you_to_target_opponent"
+            )
+            .0,
+            Status::MutantDiagnostic
+        );
+    }
+
+    #[test]
+    fn comparison_statuses_distinguish_collision_extra_delta_and_exact_delta() {
+        let controller = Effect::GainLife {
+            amount: QuantityExpr::Fixed { value: 3 },
+            player: TargetFilter::Controller,
+        };
+        let opponent = Effect::GainLife {
+            amount: QuantityExpr::Fixed { value: 3 },
+            player: TargetFilter::Typed(TypedFilter::default().controller(ControllerRef::Opponent)),
+        };
+        let opponent_wrong_amount = Effect::GainLife {
+            amount: QuantityExpr::Fixed { value: 4 },
+            player: TargetFilter::Typed(TypedFilter::default().controller(ControllerRef::Opponent)),
+        };
+        assert_eq!(
+            compare_life(&controller, &controller, "you_to_target_opponent"),
+            Status::SemanticCollision
+        );
+        assert_eq!(
+            compare_life(&controller, &opponent, "you_to_target_opponent"),
+            Status::ChangedAsRequired
+        );
+
+        assert_eq!(
+            compare_life(
+                &controller,
+                &opponent_wrong_amount,
+                "you_to_target_opponent"
+            ),
+            Status::ProjectionChangedElsewhere
+        );
+        let unsupported_opponent_shape = Effect::GainLife {
+            amount: QuantityExpr::Fixed { value: 3 },
+            player: TargetFilter::Opponent,
+        };
+        assert_eq!(
+            compare_life(
+                &controller,
+                &unsupported_opponent_shape,
+                "you_to_target_opponent"
+            ),
+            Status::UncheckableCarrierCount
+        );
+    }
+
+    #[test]
+    fn zero_and_multiple_carriers_are_uncheckable_after_clean_gates() {
+        let empty = CardFace::default();
+        assert_eq!(
+            classify(
+                &empty,
+                &empty,
+                "life_recipient_v1",
+                "you_to_target_opponent"
+            )
+            .0,
+            Status::UncheckableCarrierCount
+        );
+        let mut multiple = empty.clone();
+        multiple.abilities = vec![
+            AbilityDefinition::new(
+                AbilityKind::Spell,
+                Effect::GainLife {
+                    amount: QuantityExpr::Fixed { value: 1 },
+                    player: TargetFilter::Controller,
+                },
+            ),
+            AbilityDefinition::new(
+                AbilityKind::Spell,
+                Effect::GainLife {
+                    amount: QuantityExpr::Fixed { value: 1 },
+                    player: TargetFilter::Controller,
+                },
+            ),
+        ];
+        assert_eq!(
+            classify(
+                &multiple,
+                &multiple,
+                "life_recipient_v1",
+                "you_to_target_opponent"
+            )
+            .0,
+            Status::UncheckableCarrierCount
+        );
+    }
+
+    #[test]
+    fn duplicate_nontoken_properties_are_uncheckable() {
+        let destroy = |properties| Effect::Destroy {
+            target: TargetFilter::Typed(TypedFilter {
+                properties,
+                ..TypedFilter::creature()
+            }),
+            cant_regenerate: false,
+        };
+        let unqualified = destroy(vec![]);
+        let duplicate = destroy(vec![FilterProp::NonToken, FilterProp::NonToken]);
+        assert_eq!(
+            compare_destroy(&unqualified, &duplicate, "creature_to_nontoken"),
+            Status::UncheckableCarrierCount
+        );
+    }
+
+    #[test]
+    fn carrier_count_includes_siblings_and_nested_sub_abilities() {
+        let gain = || Effect::GainLife {
+            amount: QuantityExpr::Fixed { value: 1 },
+            player: TargetFilter::Controller,
+        };
+        let face = CardFace {
+            abilities: vec![
+                AbilityDefinition::new(AbilityKind::Spell, gain())
+                    .sub_ability(AbilityDefinition::new(AbilityKind::Spell, gain())),
+                AbilityDefinition::new(AbilityKind::Spell, gain()),
+            ],
+            ..CardFace::default()
+        };
+        assert_eq!(carriers(&face, "life_recipient_v1").len(), 3);
+    }
+
+    #[test]
+    fn report_order_and_rendering_are_deterministic() {
+        fn raw_value(name: &str, text: &str) -> serde_json::Value {
+            serde_json::json!({
+                "name": name,
+                "colors": ["W"],
+                "colorIdentity": ["W"],
+                "layout": "normal",
+                "type": "Instant",
+                "types": ["Instant"],
+                "subtypes": [],
+                "supertypes": [],
+                "text": text,
+                "manaValue": 1.0,
+                "legalities": {},
+                "identifiers": { "scryfallOracleId": name }
+            })
+        }
+
+        let first = serde_json::json!({
+            "data": {
+                "Zulu": [raw_value("Zulu", "Destroy target creature.")],
+                "Alpha": [raw_value("Alpha", "You gain 3 life.")]
+            }
+        });
+        let second = serde_json::json!({
+            "data": {
+                "Alpha": [raw_value("Alpha", "You gain 3 life.")],
+                "Zulu": [raw_value("Zulu", "Destroy target creature.")]
+            }
+        });
+        let directory = env::temp_dir();
+        let first_path = directory.join(format!("oracle-contrastive-{}-a.json", process::id()));
+        let second_path = directory.join(format!("oracle-contrastive-{}-b.json", process::id()));
+        fs::write(&first_path, serde_json::to_vec(&first).unwrap()).unwrap();
+        fs::write(&second_path, serde_json::to_vec(&second).unwrap()).unwrap();
+        let mut first_report = audit(&first_path, "fixture".to_string()).unwrap();
+        let mut second_report = audit(&second_path, "fixture".to_string()).unwrap();
+        fs::remove_file(first_path).unwrap();
+        fs::remove_file(second_path).unwrap();
+
+        // Input hashes truthfully differ when JSON member order differs. Once
+        // that provenance field is held constant, result bytes must not depend
+        // on the source map's insertion order.
+        second_report.input_sha256 = first_report.input_sha256.clone();
+        let first_bytes = render_report(&first_report).unwrap();
+        let second_bytes = render_report(&second_report).unwrap();
+        assert_eq!(first_bytes, second_bytes);
+        assert_eq!(first_bytes.last(), Some(&b'\n'));
+        let rendered = String::from_utf8(first_bytes).unwrap();
+        assert!(!rendered.contains(directory.to_string_lossy().as_ref()));
+        assert!(!rendered.contains("timestamp"));
+        first_report.results.reverse();
+        assert_ne!(render_report(&first_report).unwrap(), second_bytes);
+    }
+
+    #[test]
+    fn absolute_input_and_output_locations_do_not_enter_report_labels() {
+        let directory = env::temp_dir().join(format!("oracle-contrastive-cli-{}", process::id()));
+        let corpus_directory = directory.join("mtgjson");
+        let corpus = corpus_directory.join("AtomicCards.json");
+        fs::create_dir_all(&corpus_directory).unwrap();
+        let fixture = serde_json::json!({
+            "data": {
+                "Fixture": [{
+                    "name": "Fixture",
+                    "colors": ["W"],
+                    "colorIdentity": ["W"],
+                    "layout": "normal",
+                    "type": "Instant",
+                    "types": ["Instant"],
+                    "subtypes": [],
+                    "supertypes": [],
+                    "text": "You gain 3 life.",
+                    "manaValue": 1.0,
+                    "legalities": {},
+                    "identifiers": { "scryfallOracleId": "fixture" }
+                }]
+            }
+        });
+        fs::write(&corpus, serde_json::to_vec(&fixture).unwrap()).unwrap();
+        let spelling = corpus.to_string_lossy();
+        let (resolved, label) = resolve_input(&spelling);
+        assert_eq!(resolved, corpus);
+        assert_eq!(label, "mtgjson/AtomicCards.json");
+
+        let output = directory.join("report.json");
+        fs::write(&output, b"must be overwritten").unwrap();
+        let mut unused_stdout = Vec::new();
+        run_with_args(
+            vec![
+                spelling.to_string(),
+                "--output".to_string(),
+                output.to_string_lossy().into_owned(),
+            ],
+            &mut unused_stdout,
+        )
+        .unwrap();
+        assert!(unused_stdout.is_empty());
+        let file_bytes = fs::read(&output).unwrap();
+        let mut stdout_bytes = Vec::new();
+        run_with_args(vec![spelling.to_string()], &mut stdout_bytes).unwrap();
+        assert_eq!(file_bytes, stdout_bytes);
+        let rendered = String::from_utf8(file_bytes).unwrap();
+        assert!(!rendered.contains(directory.to_string_lossy().as_ref()));
+        assert!(rendered.contains("\"input_label\": \"mtgjson/AtomicCards.json\""));
+        assert!(rendered.contains("\"family\": \"life_recipient_v1\""));
+        fs::remove_file(output).unwrap();
+        fs::remove_file(corpus).unwrap();
+        fs::remove_dir(corpus_directory).unwrap();
+        fs::remove_dir(directory).unwrap();
+    }
+}

--- a/crates/engine/src/bin/oracle_gen.rs
+++ b/crates/engine/src/bin/oracle_gen.rs
@@ -1,4 +1,6 @@
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
+use std::fs::OpenOptions;
+use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 use std::process;
 use std::thread;
@@ -12,12 +14,19 @@ use engine::database::mtgjson::{
 use engine::database::removed_cards::is_removed_offensive_card;
 use engine::database::set_catalog::load_set_catalog;
 use engine::database::synthesis::{
-    build_oracle_face, build_oracle_face_multi, layout_faces, map_layout, LayoutKind,
+    build_oracle_face, build_oracle_face_multi, layout_faces, map_layout,
+    prepare_oracle_parser_input, LayoutKind,
 };
 use engine::database::{set_gating, BracketLists, BracketSignals, CardDatabase};
 use engine::game::coverage::{
     audit_semantic, card_face_has_unimplemented_parts, format_semantic_audit_markdown,
 };
+use engine::parser::oracle_ir::trace::{
+    canonicalize_events, classify_collapse, sha256_bytes, sha256_json, sha256_string, CensusFace,
+    FaceCounts, FaceRef, OuterRoute, OuterRouteCensusRow, PairManifest, PairOmittedEvidence,
+    PairReport, ParserTrace, ParserTraceReport, StageComparison, TraceStage,
+};
+use engine::parser::parse_oracle_text_traced;
 use engine::types::card::{CardFace, CardLayout, Rarity};
 
 #[derive(Debug, Clone, Serialize)]
@@ -54,6 +63,312 @@ struct CardExportEntry {
     /// flags are false to keep card-data.json compact.
     #[serde(default, skip_serializing_if = "is_clean_signals")]
     bracket_signals: BracketSignals,
+    #[serde(skip)]
+    trace_input: Option<OracleTraceInput>,
+}
+
+#[derive(Debug, Clone)]
+struct OracleTraceInput {
+    oracle_text: String,
+    card_name: String,
+    mtgjson_keyword_names: Vec<String>,
+    types: Vec<String>,
+    subtypes: Vec<String>,
+    has_cleave_variant: bool,
+}
+
+impl OracleTraceInput {
+    fn from_atomic(source: &AtomicCard, skip_mtgjson_keywords: bool) -> Self {
+        let input = prepare_oracle_parser_input(source, skip_mtgjson_keywords);
+        Self {
+            oracle_text: input.oracle_text,
+            card_name: input.card_name,
+            mtgjson_keyword_names: input.keyword_names,
+            types: input.types,
+            subtypes: input.subtypes,
+            has_cleave_variant: input.has_cleave_variant,
+        }
+    }
+
+    fn trace(&self) -> ParserTrace {
+        parse_oracle_text_traced(
+            &self.oracle_text,
+            &self.card_name,
+            &self.mtgjson_keyword_names,
+            &self.types,
+            &self.subtypes,
+        )
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ParserTraceArgs {
+    pairs: PathBuf,
+    output: PathBuf,
+}
+
+fn parse_trace_args(args: &[String]) -> Result<(Option<ParserTraceArgs>, Vec<String>), String> {
+    let mut pairs = None;
+    let mut output = None;
+    let mut remaining = Vec::with_capacity(args.len());
+    let mut index = 0;
+    while index < args.len() {
+        let slot = match args[index].as_str() {
+            "--parser-trace-pairs" => Some(&mut pairs),
+            "--parser-trace-out" => Some(&mut output),
+            _ => None,
+        };
+        if let Some(slot) = slot {
+            if slot.is_some() {
+                return Err(format!("duplicate trace flag: {}", args[index]));
+            }
+            index += 1;
+            let value = args
+                .get(index)
+                .filter(|value| !value.starts_with('-'))
+                .ok_or_else(|| format!("{} requires a path argument", args[index - 1]))?;
+            *slot = Some(PathBuf::from(value));
+        } else {
+            remaining.push(args[index].clone());
+        }
+        index += 1;
+    }
+    match (pairs, output) {
+        (None, None) => Ok((None, remaining)),
+        (Some(pairs), Some(output)) => Ok((Some(ParserTraceArgs { pairs, output }), remaining)),
+        _ => Err("--parser-trace-pairs and --parser-trace-out must be supplied together".into()),
+    }
+}
+
+fn load_pair_manifest(path: &Path) -> Result<PairManifest, String> {
+    let bytes = std::fs::read(path).map_err(|error| format!("{}: {error}", path.display()))?;
+    let mut manifest: PairManifest =
+        serde_json::from_slice(&bytes).map_err(|error| format!("{}: {error}", path.display()))?;
+    if manifest.schema_version != 1 {
+        return Err(format!(
+            "unsupported pair manifest schema_version {}",
+            manifest.schema_version
+        ));
+    }
+    manifest.pairs.sort();
+    let mut seen = BTreeSet::new();
+    for pair in &manifest.pairs {
+        if pair.left_card_face_key == pair.right_card_face_key {
+            return Err(format!(
+                "pair uses the same key twice: {}",
+                pair.left_card_face_key
+            ));
+        }
+        let canonical = if pair.left_card_face_key <= pair.right_card_face_key {
+            (&pair.left_card_face_key, &pair.right_card_face_key)
+        } else {
+            (&pair.right_card_face_key, &pair.left_card_face_key)
+        };
+        if !seen.insert(canonical) {
+            return Err(format!(
+                "duplicate pair: {} / {}",
+                pair.left_card_face_key, pair.right_card_face_key
+            ));
+        }
+    }
+    Ok(manifest)
+}
+
+fn stage_comparison(stage: TraceStage, left_hash: String, right_hash: String) -> StageComparison {
+    StageComparison {
+        stage,
+        candidate_equal: left_hash == right_hash,
+        left_sha256: left_hash,
+        right_sha256: right_hash,
+    }
+}
+
+fn build_trace_report(
+    face_index: &BTreeMap<String, CardExportEntry>,
+    manifest: PairManifest,
+    card_data_bytes: &[u8],
+) -> Result<ParserTraceReport, String> {
+    for pair in &manifest.pairs {
+        for key in [&pair.left_card_face_key, &pair.right_card_face_key] {
+            if !face_index.contains_key(key) {
+                return Err(format!("unknown card_face_key: {key}"));
+            }
+        }
+    }
+    let mut traces: BTreeMap<String, Option<ParserTrace>> = BTreeMap::new();
+    let mut census: BTreeMap<OuterRoute, (usize, BTreeMap<String, String>)> = BTreeMap::new();
+    let mut unavailable = 0;
+    for (key, entry) in face_index {
+        let trace = entry.trace_input.as_ref().map(OracleTraceInput::trace);
+        if let Some(trace) = &trace {
+            for event in &trace.events {
+                let row = census.entry(event.route).or_default();
+                row.0 += 1;
+                row.1.insert(key.clone(), entry.face.name.clone());
+            }
+        } else {
+            unavailable += 1;
+        }
+        traces.insert(key.clone(), trace);
+    }
+    let mut pairs = Vec::with_capacity(manifest.pairs.len());
+    for pair in manifest.pairs {
+        let left_entry = &face_index[&pair.left_card_face_key];
+        let right_entry = &face_index[&pair.right_card_face_key];
+        let left = traces[&pair.left_card_face_key]
+            .as_ref()
+            .ok_or_else(|| format!("trace input unavailable: {}", pair.left_card_face_key))?;
+        let right = traces[&pair.right_card_face_key]
+            .as_ref()
+            .ok_or_else(|| format!("trace input unavailable: {}", pair.right_card_face_key))?;
+        let stages = vec![
+            stage_comparison(
+                TraceStage::OriginalSource,
+                sha256_string(&left.original_source),
+                sha256_string(&right.original_source),
+            ),
+            stage_comparison(
+                TraceStage::NormalizedSource,
+                sha256_string(&left.normalized_source),
+                sha256_string(&right.normalized_source),
+            ),
+            stage_comparison(
+                TraceStage::DocumentIr,
+                sha256_json(&left.document_ir_candidate),
+                sha256_json(&right.document_ir_candidate),
+            ),
+            stage_comparison(
+                TraceStage::RawLoweredIr,
+                sha256_json(&left.raw_lowered_candidate),
+                sha256_json(&right.raw_lowered_candidate),
+            ),
+            stage_comparison(
+                TraceStage::ProductionParsedOutput,
+                sha256_json(&left.production_candidate),
+                sha256_json(&right.production_candidate),
+            ),
+        ];
+        let mut collapse = classify_collapse(&stages);
+        if collapse.from == Some(TraceStage::DocumentIr) {
+            collapse.kind = "earliest_loss_unresolved".to_string();
+            collapse.from = None;
+        }
+        let mut left_events = left.events.clone();
+        let mut right_events = right.events.clone();
+        canonicalize_events("left", &mut left_events);
+        canonicalize_events("right", &mut right_events);
+        let left_routes = left_events
+            .iter()
+            .map(|event| event.route)
+            .collect::<BTreeSet<_>>();
+        let right_routes = right_events
+            .iter()
+            .map(|event| event.route)
+            .collect::<BTreeSet<_>>();
+        let mut shared_outer_routes = left_routes
+            .intersection(&right_routes)
+            .copied()
+            .collect::<Vec<_>>();
+        shared_outer_routes.sort_by_key(|route| route.stable_id());
+        let mut limitations = BTreeSet::from(["no_inner_recognizer_trace".to_string()]);
+        limitations.insert("earlier_stage_comparison_incomplete".to_string());
+        if left_entry
+            .trace_input
+            .as_ref()
+            .is_some_and(|input| input.has_cleave_variant)
+            || right_entry
+                .trace_input
+                .as_ref()
+                .is_some_and(|input| input.has_cleave_variant)
+        {
+            limitations.insert("cleave_variant_secondary_parse_out_of_scope".to_string());
+        }
+        if left_events.iter().chain(&right_events).any(|event| {
+            event.payload_visibility
+                != engine::parser::oracle_ir::trace::PayloadVisibility::NativeIr
+        }) {
+            limitations.insert("opaque_outer_payload".into());
+        }
+        pairs.push(PairReport {
+            left: FaceRef {
+                card_face_key: pair.left_card_face_key,
+                name: left_entry.face.name.clone(),
+            },
+            right: FaceRef {
+                card_face_key: pair.right_card_face_key,
+                name: right_entry.face.name.clone(),
+            },
+            collapse,
+            stages,
+            left_outer_route_events: left_events,
+            right_outer_route_events: right_events,
+            shared_outer_routes,
+            location_precision: "outer_document_route",
+            limitation_codes: limitations,
+            omitted_evidence: PairOmittedEvidence {
+                left: left.omitted_evidence.clone(),
+                right: right.omitted_evidence.clone(),
+            },
+        });
+    }
+    let mut outer_route_census = census
+        .into_iter()
+        .map(|(route, (event_count, faces))| {
+            let card_faces = faces
+                .into_iter()
+                .map(|(card_face_key, name)| CensusFace {
+                    card_face_key,
+                    name,
+                })
+                .collect::<Vec<_>>();
+            OuterRouteCensusRow {
+                route,
+                event_count,
+                face_count: card_faces.len(),
+                card_faces,
+            }
+        })
+        .collect::<Vec<_>>();
+    outer_route_census.sort_by_key(|row| row.route.stable_id());
+    Ok(ParserTraceReport {
+        schema_version: 1,
+        algorithm_version: "parser-stage-trace-v1",
+        card_data_sha256: sha256_bytes(card_data_bytes),
+        faces: FaceCounts {
+            winning_faces: face_index.len(),
+            traced_faces: face_index.len() - unavailable,
+            unavailable_events: unavailable,
+            faces_with_unavailable_events: unavailable,
+        },
+        pairs,
+        outer_route_census,
+    })
+}
+
+fn write_trace_report_atomic(path: &Path, report: &ParserTraceReport) -> io::Result<()> {
+    let parent = path.parent().unwrap_or_else(|| Path::new("."));
+    let file_name = path.file_name().ok_or_else(|| {
+        io::Error::new(io::ErrorKind::InvalidInput, "trace output has no file name")
+    })?;
+    let temp = parent.join(format!(
+        ".{}.{}.tmp",
+        file_name.to_string_lossy(),
+        process::id()
+    ));
+    let result = (|| {
+        let mut file = OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&temp)?;
+        serde_json::to_writer_pretty(&mut file, report).map_err(io::Error::other)?;
+        file.write_all(b"\n")?;
+        file.sync_all()?;
+        std::fs::rename(&temp, path)
+    })();
+    if result.is_err() {
+        let _ = std::fs::remove_file(&temp);
+    }
+    result
 }
 
 fn is_clean_signals(sig: &BracketSignals) -> bool {
@@ -356,6 +671,7 @@ struct CardWorkCtx<'a> {
     token_source_metadata: &'a HashMap<TokenSourceMetadataKey, TokenSourceMetadata>,
     rarity_map: &'a HashMap<String, BTreeSet<Rarity>>,
     bracket_lists: &'a BracketLists,
+    trace_enabled: bool,
     #[cfg(feature = "forge")]
     forge_index: Option<&'a engine::database::forge::ForgeIndex>,
 }
@@ -452,6 +768,9 @@ fn build_card_work<'a>(
                     rulings: source.rulings.clone(),
                     rarities,
                     bracket_signals,
+                    trace_input: ctx
+                        .trace_enabled
+                        .then(|| OracleTraceInput::from_atomic(source, false)),
                 },
                 FacePriority::Homonym,
             ));
@@ -518,6 +837,9 @@ fn build_card_work<'a>(
                     rulings,
                     rarities,
                     bracket_signals,
+                    trace_input: ctx
+                        .trace_enabled
+                        .then(|| OracleTraceInput::from_atomic(source, true)),
                 },
                 FacePriority::SameClass,
             ));
@@ -555,6 +877,9 @@ fn build_card_work<'a>(
                 rulings: faces[0].rulings.clone(),
                 rarities,
                 bracket_signals,
+                trace_input: ctx
+                    .trace_enabled
+                    .then(|| OracleTraceInput::from_atomic(&faces[0], false)),
             },
             FacePriority::SameClass,
         ));
@@ -870,28 +1195,39 @@ fn stamp_token_source_metadata(
 }
 
 fn main() {
-    let args: Vec<String> = std::env::args().collect();
+    let initial_args: Vec<String> = std::env::args().collect();
 
     // Check for semantic-audit subcommand before normal parsing
-    if args.get(1).map(|s| s.as_str()) == Some("semantic-audit") {
-        run_semantic_audit(&args[2..]);
+    if initial_args.get(1).map(|s| s.as_str()) == Some("semantic-audit") {
+        run_semantic_audit(&initial_args[2..]);
         return;
     }
 
-    if args.get(1).map(|s| s.as_str()) == Some("rulings") {
-        run_rulings(&args[2..]);
+    if initial_args.get(1).map(|s| s.as_str()) == Some("rulings") {
+        run_rulings(&initial_args[2..]);
         return;
     }
 
-    if args.get(1).map(|s| s.as_str()) == Some("set-list") {
-        run_set_list(&args[2..]);
+    if initial_args.get(1).map(|s| s.as_str()) == Some("set-list") {
+        run_set_list(&initial_args[2..]);
         return;
     }
 
-    if args.get(1).map(|s| s.as_str()) == Some("decks") {
-        run_decks(&args[2..]);
+    if initial_args.get(1).map(|s| s.as_str()) == Some("decks") {
+        run_decks(&initial_args[2..]);
         return;
     }
+
+    let (trace_args, args) = parse_trace_args(&initial_args).unwrap_or_else(|error| {
+        eprintln!("Error: {error}");
+        process::exit(2);
+    });
+    let trace_manifest = trace_args.as_ref().map(|trace| {
+        load_pair_manifest(&trace.pairs).unwrap_or_else(|error| {
+            eprintln!("Error loading parser trace pairs: {error}");
+            process::exit(2);
+        })
+    });
 
     let mut data_dir: Option<PathBuf> = None;
     let mut mtgjson_override: Option<PathBuf> = None;
@@ -1135,6 +1471,7 @@ fn main() {
         token_source_metadata: &token_source_metadata,
         rarity_map: &rarity_map,
         bracket_lists: &bracket_lists,
+        trace_enabled: trace_args.is_some(),
         #[cfg(feature = "forge")]
         forge_index: forge_index.as_ref(),
     };
@@ -1236,6 +1573,21 @@ fn main() {
     }
 
     let json = serde_json::to_string(&face_index).expect("Failed to serialize card data");
+    if let (Some(trace), Some(manifest)) = (&trace_args, trace_manifest) {
+        if output.as_ref() == Some(&trace.output) {
+            eprintln!("Error: --output and --parser-trace-out must be different paths");
+            process::exit(2);
+        }
+        let report =
+            build_trace_report(&face_index, manifest, json.as_bytes()).unwrap_or_else(|error| {
+                eprintln!("Error building parser trace report: {error}");
+                process::exit(2);
+            });
+        write_trace_report_atomic(&trace.output, &report).unwrap_or_else(|error| {
+            eprintln!("Error writing {}: {error}", trace.output.display());
+            process::exit(2);
+        });
+    }
     if let Some(ref out_path) = output {
         std::fs::write(out_path, &json)
             .unwrap_or_else(|e| panic!("Failed to write {}: {e}", out_path.display()));
@@ -1820,6 +2172,65 @@ mod tests {
 
     use super::*;
 
+    #[test]
+    fn parser_trace_args_require_a_complete_unique_pair() {
+        let args = vec![
+            "oracle-gen".to_string(),
+            "/data".to_string(),
+            "--parser-trace-pairs".to_string(),
+            "pairs.json".to_string(),
+            "--stats".to_string(),
+            "--parser-trace-out".to_string(),
+            "report.json".to_string(),
+        ];
+        let (trace, remaining) = parse_trace_args(&args).expect("paired flags are valid");
+        assert_eq!(
+            trace.expect("trace mode").output,
+            PathBuf::from("report.json")
+        );
+        assert_eq!(remaining, vec!["oracle-gen", "/data", "--stats"]);
+        assert!(
+            parse_trace_args(&["oracle-gen".into(), "--parser-trace-out".into(), "x".into()])
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn parser_trace_manifest_rejects_duplicate_and_same_key_pairs() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("pairs.json");
+        std::fs::write(&path, r#"{"schema_version":1,"pairs":[{"left_card_face_key":"a","right_card_face_key":"a"}]}"#).expect("write fixture");
+        assert!(load_pair_manifest(&path).is_err());
+        std::fs::write(&path, r#"{"schema_version":1,"unknown":true,"pairs":[]}"#)
+            .expect("write fixture");
+        assert!(load_pair_manifest(&path).is_err());
+        std::fs::write(&path, r#"{"schema_version":1,"pairs":[{"left_card_face_key":"a","right_card_face_key":"b"},{"left_card_face_key":"a","right_card_face_key":"b"}]}"#).expect("write fixture");
+        assert!(load_pair_manifest(&path).is_err());
+    }
+
+    #[test]
+    fn parser_trace_atomic_writer_uses_one_trailing_newline() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("report.json");
+        let report = ParserTraceReport {
+            schema_version: 1,
+            algorithm_version: "parser-stage-trace-v1",
+            card_data_sha256: "00".into(),
+            faces: FaceCounts {
+                winning_faces: 0,
+                traced_faces: 0,
+                unavailable_events: 0,
+                faces_with_unavailable_events: 0,
+            },
+            pairs: Vec::new(),
+            outer_route_census: Vec::new(),
+        };
+        write_trace_report_atomic(&path, &report).expect("atomic report write");
+        let bytes = std::fs::read(path).expect("read report");
+        assert!(bytes.ends_with(b"\n"));
+        assert!(!bytes.ends_with(b"\n\n"));
+    }
+
     fn make_entry(oracle_id: &str, printings: &[&str], layout: Option<&str>) -> CardExportEntry {
         make_entry_with_legalities(oracle_id, printings, layout, &[])
     }
@@ -1845,6 +2256,7 @@ mod tests {
             rulings: Vec::new(),
             rarities: BTreeSet::new(),
             bracket_signals: BracketSignals::default(),
+            trace_input: None,
         }
     }
 

--- a/crates/engine/src/bin/set_check.rs
+++ b/crates/engine/src/bin/set_check.rs
@@ -34,7 +34,9 @@
 //! hash changes **iff** the parsed representation or the source `oracle_text`
 //! changes — and is stable otherwise.
 
-use std::collections::BTreeMap;
+use std::cmp::Ordering;
+use std::collections::{BTreeMap, BTreeSet};
+use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::process;
 
@@ -50,6 +52,8 @@ use engine::types::format::DeckCopyLimit;
 use engine::types::keywords::Keyword;
 use engine::types::mana::ManaCost;
 use serde::Serialize;
+use serde_json::Value;
+use sha2::{Digest, Sha256};
 
 /// Canonical, parse-only projection of a [`CardFace`] used as the `ast_hash`
 /// input. See the module docs for the exact field contract. Fields borrow
@@ -123,6 +127,499 @@ struct SnapshotEntry {
     ast_hash: String,
     supported: bool,
     gap_count: usize,
+}
+
+const MARKERS: &[&str] = &[
+    "all",
+    "another",
+    "each",
+    "five",
+    "four",
+    "if",
+    "its",
+    "may",
+    "nine",
+    "noncreature",
+    "nonland",
+    "nontoken",
+    "not",
+    "one",
+    "only",
+    "opponent",
+    "opponents",
+    "other",
+    "seven",
+    "six",
+    "ten",
+    "their",
+    "three",
+    "two",
+    "unless",
+    "until",
+    "you",
+    "your",
+];
+
+type OmittedString = engine::parser::audit_projection::OmittedDefinitionDescription;
+
+fn omit_definition_descriptions(
+    value: &mut Value,
+    pointer: &str,
+    omitted: &mut Vec<OmittedString>,
+) {
+    omitted
+        .extend(engine::parser::audit_projection::omit_definition_descriptions_at(value, pointer));
+}
+
+fn structural_projection(face: &CardFace) -> (Value, Vec<OmittedString>) {
+    let mut value = serde_json::to_value(CanonicalFace::from_face(face))
+        .expect("CanonicalFace is composed of serializable parser types");
+    value
+        .as_object_mut()
+        .expect("CanonicalFace serializes as an object")
+        .remove("oracle_text");
+    let mut omitted = Vec::new();
+    omit_definition_descriptions(&mut value, "", &mut omitted);
+    omitted.sort();
+    (value, omitted)
+}
+
+fn is_rules_bearing(projection: &Value) -> bool {
+    projection.as_object().is_some_and(|map| {
+        map.values().any(|value| match value {
+            Value::Null => false,
+            Value::Array(values) => !values.is_empty(),
+            Value::Object(values) => !values.is_empty(),
+            _ => true,
+        })
+    })
+}
+
+fn is_name_boundary(byte: Option<u8>) -> bool {
+    byte.is_none_or(|b| !b.is_ascii_alphanumeric() && b != b'\'')
+}
+
+fn normalize_self_name(text: &str, name: &str) -> String {
+    if name.is_empty() {
+        return text.to_ascii_lowercase();
+    }
+    let lower = text.to_ascii_lowercase();
+    let needle = name.to_ascii_lowercase();
+    let mut result = String::with_capacity(lower.len());
+    let mut offset = 0;
+    while let Some(relative) = lower[offset..].find(&needle) {
+        let start = offset + relative;
+        let end = start + needle.len();
+        if is_name_boundary(start.checked_sub(1).map(|i| lower.as_bytes()[i]))
+            && is_name_boundary(lower.as_bytes().get(end).copied())
+        {
+            result.push_str(&lower[offset..start]);
+            result.push('~');
+            offset = end;
+        } else {
+            let next = start
+                + lower[start..]
+                    .chars()
+                    .next()
+                    .expect("find returned a character boundary")
+                    .len_utf8();
+            result.push_str(&lower[offset..next]);
+            offset = next;
+        }
+    }
+    result.push_str(&lower[offset..]);
+    result
+}
+
+fn strip_balanced_reminder_text(text: &str) -> String {
+    let mut result = String::with_capacity(text.len());
+    let mut chars = text.char_indices().peekable();
+    while let Some((start, character)) = chars.next() {
+        if character == '(' {
+            let mut depth = 1;
+            let mut nested = false;
+            let mut end = None;
+            for (index, inner) in chars.by_ref() {
+                match inner {
+                    '(' => {
+                        depth += 1;
+                        nested = true;
+                    }
+                    ')' => {
+                        depth -= 1;
+                        if depth == 0 {
+                            end = Some(index + inner.len_utf8());
+                            break;
+                        }
+                    }
+                    _ => {}
+                }
+            }
+            match end {
+                Some(end) if nested => result.push_str(&text[start..end]),
+                Some(_) => {}
+                None => {
+                    result.push_str(&text[start..]);
+                    break;
+                }
+            }
+        } else {
+            result.push(character);
+        }
+    }
+    result
+}
+
+fn oracle_tokens(text: &str, name: &str) -> Vec<String> {
+    let normalized = strip_balanced_reminder_text(&normalize_self_name(text, name));
+    let bytes = normalized.as_bytes();
+    let mut tokens = Vec::new();
+    let mut index = 0;
+    while index < bytes.len() {
+        if bytes[index] == b'~' {
+            tokens.push("~".to_string());
+            index += 1;
+        } else if bytes[index].is_ascii_alphabetic() {
+            let start = index;
+            index += 1;
+            while index < bytes.len()
+                && (bytes[index].is_ascii_alphabetic()
+                    || (bytes[index] == b'\''
+                        && index + 1 < bytes.len()
+                        && bytes[index + 1].is_ascii_alphabetic()))
+            {
+                index += 1;
+            }
+            tokens.push(normalized[start..index].to_string());
+        } else if bytes[index].is_ascii_digit() {
+            let start = index;
+            index += 1;
+            while index < bytes.len() && bytes[index].is_ascii_digit() {
+                index += 1;
+            }
+            tokens.push(normalized[start..index].to_string());
+        } else {
+            index += 1;
+        }
+    }
+    tokens
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+struct ChangedSpan {
+    a_start: usize,
+    a_end: usize,
+    a_tokens: Vec<String>,
+    b_start: usize,
+    b_end: usize,
+    b_tokens: Vec<String>,
+}
+
+fn lcs_spans(a: &[String], b: &[String]) -> (usize, Vec<ChangedSpan>) {
+    let width = b.len() + 1;
+    let mut lengths = vec![0usize; (a.len() + 1) * width];
+    for ai in (0..a.len()).rev() {
+        for bi in (0..b.len()).rev() {
+            lengths[ai * width + bi] = if a[ai] == b[bi] {
+                1 + lengths[(ai + 1) * width + bi + 1]
+            } else {
+                lengths[(ai + 1) * width + bi].max(lengths[ai * width + bi + 1])
+            };
+        }
+    }
+    let lcs = lengths[0];
+    let (mut ai, mut bi) = (0, 0);
+    let mut spans = Vec::new();
+    while ai < a.len() || bi < b.len() {
+        if ai < a.len() && bi < b.len() && a[ai] == b[bi] {
+            ai += 1;
+            bi += 1;
+            continue;
+        }
+        let (a_start, b_start) = (ai, bi);
+        while ai < a.len() || bi < b.len() {
+            if ai < a.len() && bi < b.len() && a[ai] == b[bi] {
+                break;
+            }
+            if ai == a.len() {
+                bi += 1;
+            } else if bi == b.len()
+                || lengths[(ai + 1) * width + bi] >= lengths[ai * width + bi + 1]
+            {
+                ai += 1;
+            } else {
+                bi += 1;
+            }
+        }
+        spans.push(ChangedSpan {
+            a_start,
+            a_end: ai,
+            a_tokens: a[a_start..ai].to_vec(),
+            b_start,
+            b_end: bi,
+            b_tokens: b[b_start..bi].to_vec(),
+        });
+    }
+    (lcs, spans)
+}
+
+#[derive(Debug, Clone)]
+struct CollisionMember {
+    key: String,
+    name: String,
+    oracle_text: String,
+    tokens: Vec<String>,
+    omitted_strings: Vec<OmittedString>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct CandidateFace {
+    key: String,
+    name: String,
+    oracle_text: String,
+    omitted_strings: Vec<OmittedString>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize)]
+struct Ratio {
+    numerator: usize,
+    denominator: usize,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct CollisionCandidate {
+    status: &'static str,
+    a: CandidateFace,
+    b: CandidateFace,
+    identity_sensitive_omission: bool,
+    similarity: Ratio,
+    markers: Vec<String>,
+    changed_spans: Vec<ChangedSpan>,
+    natural_rebalance_pair: bool,
+    #[serde(skip)]
+    changed_token_count: usize,
+}
+
+#[derive(Serialize)]
+struct ReportInput {
+    path: &'static str,
+    sha256: String,
+}
+
+#[derive(Serialize)]
+struct ReportParameters {
+    minimum_similarity: Ratio,
+    markers_version: u8,
+    projection_omits: [&'static str; 2],
+    filter: String,
+}
+
+#[derive(Serialize)]
+struct CollisionReport {
+    schema_version: u8,
+    algorithm_version: &'static str,
+    result_kind: &'static str,
+    input: ReportInput,
+    parameters: ReportParameters,
+    supported_cards: usize,
+    rules_bearing_supported_cards: usize,
+    identical_projected_groups: usize,
+    largest_group_size: usize,
+    pairs_examined: usize,
+    pairs_rejected_by_length_bound: usize,
+    candidate_pairs: usize,
+    candidates: Vec<CollisionCandidate>,
+}
+
+fn natural_rebalance_pair(a: &str, b: &str) -> bool {
+    fn without_prefix(name: &str) -> Option<&str> {
+        name.get(..2)
+            .filter(|prefix| prefix.eq_ignore_ascii_case("a-"))
+            .map(|_| &name[2..])
+    }
+    without_prefix(a).is_some_and(|stripped| stripped.eq_ignore_ascii_case(b))
+        || without_prefix(b).is_some_and(|stripped| stripped.eq_ignore_ascii_case(a))
+}
+
+fn candidate_face(member: &CollisionMember) -> CandidateFace {
+    CandidateFace {
+        key: member.key.clone(),
+        name: member.name.clone(),
+        oracle_text: member.oracle_text.clone(),
+        omitted_strings: member.omitted_strings.clone(),
+    }
+}
+
+fn compare_candidates(a: &CollisionCandidate, b: &CollisionCandidate) -> Ordering {
+    let a_scaled = a.similarity.numerator * b.similarity.denominator;
+    let b_scaled = b.similarity.numerator * a.similarity.denominator;
+    b_scaled
+        .cmp(&a_scaled)
+        .then_with(|| a.changed_token_count.cmp(&b.changed_token_count))
+        .then_with(|| a.a.key.cmp(&b.a.key))
+        .then_with(|| a.b.key.cmp(&b.b.key))
+        .then_with(|| a.a.name.cmp(&b.a.name))
+        .then_with(|| a.b.name.cmp(&b.b.name))
+}
+
+fn build_collision_report(
+    db: &CardDatabase,
+    coverage: &[CardCoverageResult],
+    selected_coverage: &[&CardCoverageResult],
+    filter: String,
+    input_digest: String,
+) -> Result<CollisionReport, String> {
+    let mut coverage_by_key = BTreeMap::new();
+    for result in coverage {
+        let key = result
+            .card_face_key
+            .as_deref()
+            .ok_or_else(|| format!("coverage result has no face key: {}", result.card_name))?;
+        if coverage_by_key.insert(key, result).is_some() {
+            return Err(format!("duplicate coverage face key: {key}"));
+        }
+    }
+    let selected: BTreeSet<String> = selected_coverage
+        .iter()
+        .map(|result| {
+            result.card_face_key.clone().ok_or_else(|| {
+                format!(
+                    "selected coverage result has no face key: {}",
+                    result.card_name
+                )
+            })
+        })
+        .collect::<Result<_, _>>()?;
+    let mut supported_cards = 0;
+    let mut rules_bearing_supported_cards = 0;
+    let mut groups: BTreeMap<String, Vec<CollisionMember>> = BTreeMap::new();
+    for (key, face) in db.face_iter() {
+        if !selected.contains(key) {
+            continue;
+        }
+        let coverage = coverage_by_key
+            .get(key)
+            .ok_or_else(|| format!("missing coverage result for face {key} ({})", face.name))?;
+        if !coverage.supported {
+            continue;
+        }
+        supported_cards += 1;
+        let Some(oracle_text) = face
+            .oracle_text
+            .as_deref()
+            .filter(|text| !text.trim().is_empty())
+        else {
+            continue;
+        };
+        let (projection, omitted_strings) = structural_projection(face);
+        if !is_rules_bearing(&projection) {
+            continue;
+        }
+        rules_bearing_supported_cards += 1;
+        let projection_json = serde_json::to_string(&projection)
+            .map_err(|error| format!("failed to serialize collision projection: {error}"))?;
+        groups
+            .entry(projection_json)
+            .or_default()
+            .push(CollisionMember {
+                key: key.to_string(),
+                name: face.name.clone(),
+                oracle_text: oracle_text.to_string(),
+                tokens: oracle_tokens(oracle_text, &face.name),
+                omitted_strings,
+            });
+    }
+
+    let mut identical_projected_groups = 0;
+    let mut largest_group_size = 0;
+    let mut pairs_examined = 0;
+    let mut pairs_rejected_by_length_bound = 0;
+    let marker_set: BTreeSet<&str> = MARKERS.iter().copied().collect();
+    let mut candidates = Vec::new();
+    for members in groups.values_mut().filter(|members| members.len() > 1) {
+        identical_projected_groups += 1;
+        largest_group_size = largest_group_size.max(members.len());
+        members.sort_by(|a, b| a.key.cmp(&b.key).then_with(|| a.name.cmp(&b.name)));
+        for ai in 0..members.len() {
+            for bi in ai + 1..members.len() {
+                pairs_examined += 1;
+                let (a, b) = (&members[ai], &members[bi]);
+                if a.tokens == b.tokens {
+                    continue;
+                }
+                let total_len = a.tokens.len() + b.tokens.len();
+                if 8 * a.tokens.len().min(b.tokens.len()) < 3 * total_len {
+                    pairs_rejected_by_length_bound += 1;
+                    continue;
+                }
+                let (lcs, changed_spans) = lcs_spans(&a.tokens, &b.tokens);
+                if 8 * lcs < 3 * total_len {
+                    continue;
+                }
+                let markers: Vec<String> = changed_spans
+                    .iter()
+                    .flat_map(|span| span.a_tokens.iter().chain(&span.b_tokens))
+                    .filter(|token| marker_set.contains(token.as_str()))
+                    .cloned()
+                    .collect::<BTreeSet<_>>()
+                    .into_iter()
+                    .collect();
+                if markers.is_empty() {
+                    continue;
+                }
+                let identity_sensitive_omission = a
+                    .omitted_strings
+                    .iter()
+                    .chain(&b.omitted_strings)
+                    .any(|omission| omission.carrier == "TriggerDefinition");
+                let changed_token_count = changed_spans
+                    .iter()
+                    .map(|span| span.a_tokens.len() + span.b_tokens.len())
+                    .sum();
+                candidates.push(CollisionCandidate {
+                    status: "unverified_structural_collision_candidate",
+                    a: candidate_face(a),
+                    b: candidate_face(b),
+                    identity_sensitive_omission,
+                    similarity: Ratio {
+                        numerator: 2 * lcs,
+                        denominator: total_len,
+                    },
+                    markers,
+                    changed_spans,
+                    natural_rebalance_pair: natural_rebalance_pair(&a.name, &b.name),
+                    changed_token_count,
+                });
+            }
+        }
+    }
+    candidates.sort_by(compare_candidates);
+    Ok(CollisionReport {
+        schema_version: 1,
+        algorithm_version: "structural-collision-v1",
+        result_kind: "structural_collision_candidates",
+        input: ReportInput {
+            path: "card-data.json",
+            sha256: input_digest,
+        },
+        parameters: ReportParameters {
+            minimum_similarity: Ratio {
+                numerator: 3,
+                denominator: 4,
+            },
+            markers_version: 1,
+            projection_omits: ["top_level_oracle_text", "definition_description"],
+            filter,
+        },
+        supported_cards,
+        rules_bearing_supported_cards,
+        identical_projected_groups,
+        largest_group_size,
+        pairs_examined,
+        pairs_rejected_by_length_bound,
+        candidate_pairs: candidates.len(),
+        candidates,
+    })
 }
 
 /// CR 205.4c: Any land with the supertype "basic" is a basic land.
@@ -226,32 +723,34 @@ impl<'a> Summary<'a> {
         }
     }
 
-    fn print(&self) {
+    fn write(&self, out: &mut dyn Write) -> std::io::Result<()> {
         let unsupported = self.total - self.supported;
         let pct = if self.total > 0 {
             (self.supported as f64 / self.total as f64) * 100.0
         } else {
             0.0
         };
-        println!("{}", self.label);
-        println!(
+        writeln!(out, "{}", self.label)?;
+        writeln!(
+            out,
             "  total: {}  supported: {}  unsupported: {}  ({pct:.1}%)",
             self.total, self.supported, unsupported
-        );
+        )?;
         if !self.gap_freq.is_empty() {
-            println!("  gap breakdown:");
+            writeln!(out, "  gap breakdown:")?;
             let mut gaps: Vec<(&String, &usize)> = self.gap_freq.iter().collect();
             gaps.sort_by(|a, b| b.1.cmp(a.1).then_with(|| a.0.cmp(b.0)));
             for (handler, count) in gaps {
-                println!("    {count:>4}  {handler}");
+                writeln!(out, "    {count:>4}  {handler}")?;
             }
         }
         if !self.unsupported.is_empty() {
-            println!("  unsupported cards:");
+            writeln!(out, "  unsupported cards:")?;
             for card in &self.unsupported {
-                println!("    {} (gaps: {})", card.card_name, card.gap_count);
+                writeln!(out, "    {} (gaps: {})", card.card_name, card.gap_count)?;
             }
         }
+        Ok(())
     }
 }
 
@@ -273,14 +772,37 @@ fn resolve_data_root(explicit: Option<&str>) -> Option<PathBuf> {
     None
 }
 
-#[derive(Default)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum Mode {
+    Summary,
+    Snapshot(String),
+    Diff(String),
+    StructuralCollisions,
+}
+
+enum ParseOutcome {
+    Run(Options),
+    Help,
+}
+
 struct Options {
     data_root: Option<String>,
     set: Option<String>,
     deck: Option<String>,
-    snapshot: Option<String>,
-    diff: Option<String>,
+    mode: Mode,
     quiet: bool,
+}
+
+impl Default for Options {
+    fn default() -> Self {
+        Self {
+            data_root: None,
+            set: None,
+            deck: None,
+            mode: Mode::Summary,
+            quiet: false,
+        }
+    }
 }
 
 fn print_usage() {
@@ -300,23 +822,46 @@ fn print_usage() {
     eprintln!(
         "  --diff <FILE>       Compare current ast_hashes to a baseline; exit 1 if any moved."
     );
+    eprintln!("  --structural-collisions  Report deterministic structural collision candidates.");
     eprintln!("  --quiet             In --diff mode, print only the changed/regression counts.");
 }
 
-fn parse_args() -> Result<Options, String> {
+fn parse_args_from(args: impl IntoIterator<Item = String>) -> Result<ParseOutcome, String> {
     let mut opts = Options::default();
-    let mut args = std::env::args().skip(1).peekable();
+    let mut args = args.into_iter().peekable();
     while let Some(arg) = args.next() {
         match arg.as_str() {
             "--set" => opts.set = Some(args.next().ok_or("--set requires a value")?),
             "--deck" => opts.deck = Some(args.next().ok_or("--deck requires a value")?),
-            "--snapshot" => opts.snapshot = Some(args.next().ok_or("--snapshot requires a value")?),
-            "--diff" => opts.diff = Some(args.next().ok_or("--diff requires a value")?),
-            "--quiet" => opts.quiet = true,
-            "-h" | "--help" => {
-                print_usage();
-                process::exit(0);
+            "--snapshot" => {
+                if opts.mode != Mode::Summary {
+                    return Err(
+                        "--snapshot, --diff, and --structural-collisions are mutually exclusive"
+                            .to_string(),
+                    );
+                }
+                opts.mode = Mode::Snapshot(args.next().ok_or("--snapshot requires a value")?);
             }
+            "--diff" => {
+                if opts.mode != Mode::Summary {
+                    return Err(
+                        "--snapshot, --diff, and --structural-collisions are mutually exclusive"
+                            .to_string(),
+                    );
+                }
+                opts.mode = Mode::Diff(args.next().ok_or("--diff requires a value")?);
+            }
+            "--structural-collisions" => {
+                if opts.mode != Mode::Summary {
+                    return Err(
+                        "--snapshot, --diff, and --structural-collisions are mutually exclusive"
+                            .to_string(),
+                    );
+                }
+                opts.mode = Mode::StructuralCollisions;
+            }
+            "--quiet" => opts.quiet = true,
+            "-h" | "--help" => return Ok(ParseOutcome::Help),
             other if other.starts_with("--") => {
                 return Err(format!("unknown flag: {other}"));
             }
@@ -328,7 +873,7 @@ fn parse_args() -> Result<Options, String> {
             }
         }
     }
-    Ok(opts)
+    Ok(ParseOutcome::Run(opts))
 }
 
 /// Build the (lowercase-keyed) face lookup used to compute `ast_hash`.
@@ -366,7 +911,12 @@ fn filter_cards<'a>(
                 wanted.contains(&key)
                     && db
                         .face_iter()
-                        .find(|(_, f)| f.name.eq_ignore_ascii_case(&c.card_name))
+                        .find(|(face_key, face)| {
+                            c.card_face_key.as_deref().map_or_else(
+                                || face.name.eq_ignore_ascii_case(&c.card_name),
+                                |coverage_key| *face_key == coverage_key,
+                            )
+                        })
                         .map(|(_, f)| !is_basic_land(f))
                         .unwrap_or(true)
             })
@@ -402,22 +952,45 @@ fn build_snapshot(
         .collect()
 }
 
-fn run() -> Result<i32, String> {
-    let opts = parse_args()?;
-
+fn run_with_io(opts: Options, out: &mut dyn Write, err: &mut dyn Write) -> Result<i32, String> {
     let data_root = resolve_data_root(opts.data_root.as_deref())
         .ok_or("could not locate card-data.json (pass DATA_ROOT or set PHASE_CARDS_PATH)")?;
     let export_path = data_root.join("card-data.json");
-    let db = CardDatabase::from_export(&export_path)
+    let input_bytes = std::fs::read(&export_path)
+        .map_err(|e| format!("failed to read {}: {e}", export_path.display()))?;
+    let input_digest = (opts.mode == Mode::StructuralCollisions)
+        .then(|| format!("{:x}", Sha256::digest(&input_bytes)));
+    let db = CardDatabase::from_export_reader(input_bytes.as_slice())
         .map_err(|e| format!("failed to load {}: {e}", export_path.display()))?;
+    drop(input_bytes);
 
     let summary = analyze_coverage(&db);
     let faces = face_by_key(&db);
 
     let (label, retained) = filter_cards(&db, &summary.cards, &opts)?;
 
+    if opts.mode == Mode::StructuralCollisions {
+        let report = build_collision_report(
+            &db,
+            &summary.cards,
+            &retained,
+            label,
+            input_digest.expect("collision mode computes an input digest"),
+        )?;
+        serde_json::to_writer_pretty(&mut *out, &report)
+            .map_err(|e| format!("failed to serialize structural collision report: {e}"))?;
+        writeln!(out).map_err(|e| format!("failed to write report: {e}"))?;
+        writeln!(
+            err,
+            "structural-collision-v1: {} candidates from {} supported rules-bearing cards",
+            report.candidate_pairs, report.rules_bearing_supported_cards
+        )
+        .map_err(|e| format!("failed to write report summary: {e}"))?;
+        return Ok(0);
+    }
+
     // --diff: regression mode. Recompute hashes and compare to baseline.
-    if let Some(baseline_path) = &opts.diff {
+    if let Mode::Diff(baseline_path) = &opts.mode {
         let baseline: BTreeMap<String, SnapshotEntry> = {
             let text = std::fs::read_to_string(baseline_path)
                 .map_err(|e| format!("failed to read baseline {baseline_path}: {e}"))?;
@@ -425,27 +998,32 @@ fn run() -> Result<i32, String> {
                 .map_err(|e| format!("failed to parse baseline {baseline_path}: {e}"))?
         };
         let current = build_snapshot(&faces, &retained);
-        return Ok(run_diff(&baseline, &current, opts.quiet));
+        return run_diff(&baseline, &current, opts.quiet, out)
+            .map_err(|e| format!("failed to write diff: {e}"));
     }
 
     // --snapshot: write baseline.
-    if let Some(snapshot_path) = &opts.snapshot {
+    if let Mode::Snapshot(snapshot_path) = &opts.mode {
         let snapshot = build_snapshot(&faces, &retained);
         let json = serde_json::to_string_pretty(&snapshot)
             .map_err(|e| format!("failed to serialize snapshot: {e}"))?;
         std::fs::write(snapshot_path, json)
             .map_err(|e| format!("failed to write snapshot {snapshot_path}: {e}"))?;
-        eprintln!(
+        writeln!(
+            err,
             "Wrote snapshot of {} cards ({}) to {}",
             snapshot.len(),
             label,
             snapshot_path
-        );
+        )
+        .map_err(|e| format!("failed to write snapshot summary: {e}"))?;
         return Ok(0);
     }
 
     // Default: print the filtered coverage summary.
-    Summary::build(label, &retained).print();
+    Summary::build(label, &retained)
+        .write(out)
+        .map_err(|e| format!("failed to write summary: {e}"))?;
     Ok(0)
 }
 
@@ -456,7 +1034,8 @@ fn run_diff(
     baseline: &BTreeMap<String, SnapshotEntry>,
     current: &BTreeMap<String, SnapshotEntry>,
     quiet: bool,
-) -> i32 {
+    out: &mut dyn Write,
+) -> std::io::Result<i32> {
     let mut changed: Vec<(&String, &SnapshotEntry, &SnapshotEntry)> = Vec::new();
     let mut added: Vec<&String> = Vec::new();
     let mut removed: Vec<&String> = Vec::new();
@@ -482,24 +1061,27 @@ fn run_diff(
         changed.iter().filter(|(_, old, _)| old.supported).collect();
 
     if quiet {
-        println!(
+        writeln!(
+            out,
             "changed: {}  regression-suspects: {}  added: {}  removed: {}",
             changed.len(),
             regressions.len(),
             added.len(),
             removed.len()
-        );
+        )?;
     } else {
         if changed.is_empty() && added.is_empty() && removed.is_empty() {
-            println!(
+            writeln!(
+                out,
                 "No AST changes: {} cards match the baseline.",
                 current.len()
-            );
+            )?;
         }
         if !changed.is_empty() {
-            println!("Changed AST ({}):", changed.len());
+            writeln!(out, "Changed AST ({}):", changed.len())?;
             for (key, old, cur) in &changed {
-                println!(
+                writeln!(
+                    out,
                     "  {key}: hash {} -> {}  supported {} -> {}  gaps {} -> {}",
                     old.ast_hash,
                     cur.ast_hash,
@@ -507,42 +1089,59 @@ fn run_diff(
                     cur.supported,
                     old.gap_count,
                     cur.gap_count
-                );
+                )?;
             }
         }
         if !regressions.is_empty() {
-            println!(
+            writeln!(
+                out,
                 "Regression suspects (baseline supported, AST moved) ({}):",
                 regressions.len()
-            );
+            )?;
             for (key, old, cur) in &regressions {
-                println!(
+                writeln!(
+                    out,
                     "  {key}: supported {} -> {}  gaps {} -> {}",
                     old.supported, cur.supported, old.gap_count, cur.gap_count
-                );
+                )?;
             }
         }
         if !added.is_empty() {
-            println!("New cards not in baseline ({}):", added.len());
+            writeln!(out, "New cards not in baseline ({}):", added.len())?;
             for key in &added {
-                println!("  {key}");
+                writeln!(out, "  {key}")?;
             }
         }
         if !removed.is_empty() {
-            println!("Baseline cards missing now ({}):", removed.len());
+            writeln!(out, "Baseline cards missing now ({}):", removed.len())?;
             for key in &removed {
-                println!("  {key}");
+                writeln!(out, "  {key}")?;
             }
         }
     }
 
     // Exit non-zero if anything moved so scripts/CI can gate on a clean diff.
-    i32::from(!changed.is_empty() || !added.is_empty() || !removed.is_empty())
+    Ok(i32::from(
+        !changed.is_empty() || !added.is_empty() || !removed.is_empty(),
+    ))
 }
 
 fn main() {
-    match run() {
-        Ok(code) => process::exit(code),
+    match parse_args_from(std::env::args().skip(1)) {
+        Ok(ParseOutcome::Help) => {
+            print_usage();
+            process::exit(0);
+        }
+        Ok(ParseOutcome::Run(opts)) => {
+            match run_with_io(opts, &mut std::io::stdout(), &mut std::io::stderr()) {
+                Ok(code) => process::exit(code),
+                Err(msg) => {
+                    eprintln!("set-check: {msg}");
+                    print_usage();
+                    process::exit(2);
+                }
+            }
+        }
         Err(msg) => {
             eprintln!("set-check: {msg}");
             print_usage();
@@ -555,12 +1154,33 @@ fn main() {
 mod tests {
     use super::*;
     use engine::types::ability::{AbilityKind, Effect};
+    use engine::types::replacements::ReplacementEvent;
+    use engine::types::statics::StaticMode;
+    use engine::types::triggers::TriggerMode;
 
     fn face_with_oracle(oracle: &str) -> CardFace {
         CardFace {
             oracle_text: Some(oracle.to_string()),
             ..CardFace::default()
         }
+    }
+
+    fn coverage_row(key: &str, name: &str, supported: bool, set: &str) -> CardCoverageResult {
+        CardCoverageResult {
+            card_face_key: Some(key.to_string()),
+            card_name: name.to_string(),
+            set_code: String::new(),
+            supported,
+            gap_details: Vec::new(),
+            gap_count: usize::from(!supported),
+            oracle_text: None,
+            parse_details: Vec::new(),
+            printings: vec![set.to_string()],
+        }
+    }
+
+    fn database_from_faces(faces: BTreeMap<String, CardFace>) -> CardDatabase {
+        CardDatabase::from_json_str(&serde_json::to_string(&faces).unwrap()).unwrap()
     }
 
     #[test]
@@ -616,6 +1236,15 @@ mod tests {
     }
 
     #[test]
+    fn sha256_digest_uses_exact_input_bytes() {
+        assert_eq!(
+            format!("{:x}", Sha256::digest(b"abc")),
+            "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+        );
+        assert_ne!(Sha256::digest(b"abc"), Sha256::digest(b"abc\n"));
+    }
+
+    #[test]
     fn ast_hash_changes_when_oracle_text_changes() {
         let a = face_with_oracle("Flying");
         let b = face_with_oracle("Trample");
@@ -637,6 +1266,345 @@ mod tests {
             Effect::unimplemented("b", "draw two cards"),
         )];
         assert_ne!(ast_hash(&a), ast_hash(&b));
+    }
+
+    #[test]
+    fn projection_omits_only_recognized_definition_descriptions() {
+        let mut ability = AbilityDefinition::new(
+            AbilityKind::Spell,
+            Effect::unimplemented("fixture", "raw effect description"),
+        );
+        ability.description = Some("ability description".to_string());
+        let mut trigger = TriggerDefinition::new(TriggerMode::YouAttack);
+        trigger.description = Some("trigger description".to_string());
+        let mut static_definition = StaticDefinition::new(StaticMode::Continuous);
+        static_definition.description = Some("static description".to_string());
+        let mut replacement = ReplacementDefinition::new(ReplacementEvent::GainLife);
+        replacement.description = Some("replacement description".to_string());
+        let face = CardFace {
+            oracle_text: Some("fixture".to_string()),
+            abilities: vec![ability],
+            triggers: vec![trigger],
+            static_abilities: vec![static_definition],
+            replacements: vec![replacement],
+            ..CardFace::default()
+        };
+
+        let (projection, omitted) = structural_projection(&face);
+        assert!(projection.get("oracle_text").is_none());
+        assert_eq!(
+            omitted
+                .iter()
+                .map(|item| (
+                    item.json_pointer.as_str(),
+                    item.value.as_str(),
+                    item.carrier
+                ))
+                .collect::<Vec<_>>(),
+            vec![
+                (
+                    "/abilities/0/description",
+                    "ability description",
+                    "AbilityDefinition"
+                ),
+                (
+                    "/replacements/0/description",
+                    "replacement description",
+                    "ReplacementDefinition"
+                ),
+                (
+                    "/static_abilities/0/description",
+                    "static description",
+                    "StaticDefinition"
+                ),
+                (
+                    "/triggers/0/description",
+                    "trigger description",
+                    "TriggerDefinition"
+                ),
+            ]
+        );
+        let json = serde_json::to_string(&projection).unwrap();
+        assert!(json.contains("raw effect description"));
+    }
+
+    #[test]
+    fn projection_retains_raw_description_on_near_miss_and_unknown_key() {
+        let mut near_miss = serde_json::json!({
+            "kind": "Spell",
+            "effect": {},
+            "sub_ability": null,
+            "duration": null,
+            "description": "retain me",
+        });
+        near_miss["future_field"] = Value::Bool(true);
+        let mut omitted = Vec::new();
+        omit_definition_descriptions(&mut near_miss, "/fixture", &mut omitted);
+        assert!(omitted.is_empty());
+        assert_eq!(near_miss["description"], "retain me");
+
+        let mut unrecognized = serde_json::json!({"description": "also retain me"});
+        omit_definition_descriptions(&mut unrecognized, "/other", &mut omitted);
+        assert_eq!(unrecognized["description"], "also retain me");
+    }
+
+    #[test]
+    fn projection_keeps_every_rules_root_and_array_order() {
+        let face = CardFace::default();
+        let (projection, _) = structural_projection(&face);
+        assert_eq!(
+            projection
+                .as_object()
+                .unwrap()
+                .keys()
+                .map(String::as_str)
+                .collect::<BTreeSet<_>>(),
+            BTreeSet::from([
+                "additional_cost",
+                "abilities",
+                "casting_options",
+                "casting_restrictions",
+                "cleave_variant",
+                "deck_copy_limit",
+                "keywords",
+                "modal",
+                "replacements",
+                "solve_condition",
+                "static_abilities",
+                "strive_cost",
+                "triggers",
+            ])
+        );
+
+        let first = AbilityDefinition::new(
+            AbilityKind::Spell,
+            Effect::unimplemented("first", "first raw payload"),
+        );
+        let second = AbilityDefinition::new(
+            AbilityKind::Spell,
+            Effect::unimplemented("second", "second raw payload"),
+        );
+        let forward = CardFace {
+            abilities: vec![first.clone(), second.clone()],
+            ..CardFace::default()
+        };
+        let reverse = CardFace {
+            abilities: vec![second, first],
+            ..CardFace::default()
+        };
+        assert_ne!(
+            structural_projection(&forward).0,
+            structural_projection(&reverse).0
+        );
+    }
+
+    #[test]
+    fn collision_join_and_filter_use_exact_face_keys_for_same_name_rows() {
+        let mut first = face_with_oracle("Flying.");
+        first.name = "Same Name".to_string();
+        first.keywords.push(Keyword::Flying);
+        let mut second = first.clone();
+        second.oracle_text = Some("Flying if able.".to_string());
+        let db = database_from_faces(BTreeMap::from([
+            ("same name".to_string(), first),
+            ("same name [other]".to_string(), second),
+        ]));
+        let coverage = vec![
+            coverage_row("same name", "Same Name", true, "ONE"),
+            coverage_row("same name [other]", "Same Name", false, "TWO"),
+        ];
+        let opts = Options {
+            set: Some("two".to_string()),
+            ..Options::default()
+        };
+        let (_, selected) = filter_cards(&db, &coverage, &opts).unwrap();
+        assert_eq!(selected.len(), 1);
+        assert_eq!(
+            selected[0].card_face_key.as_deref(),
+            Some("same name [other]")
+        );
+
+        let all = coverage.iter().collect::<Vec<_>>();
+        let report = build_collision_report(
+            &db,
+            &coverage,
+            &all,
+            "all cards".to_string(),
+            "digest".to_string(),
+        )
+        .unwrap();
+        assert_eq!(report.supported_cards, 1);
+        assert_eq!(report.rules_bearing_supported_cards, 1);
+    }
+
+    #[test]
+    fn report_builds_ranked_marker_candidate_and_is_deterministic() {
+        let make_face = |name: &str, oracle: &str| {
+            let mut face = face_with_oracle(oracle);
+            face.name = name.to_string();
+            face.keywords.push(Keyword::Flying);
+            face
+        };
+        let db = database_from_faces(BTreeMap::from([
+            (
+                "alpha".to_string(),
+                make_face("Alpha", "Flying flying flying."),
+            ),
+            (
+                "beta".to_string(),
+                make_face("Beta", "Flying flying if flying."),
+            ),
+        ]));
+        let coverage = vec![
+            coverage_row("beta", "Beta", true, "SET"),
+            coverage_row("alpha", "Alpha", true, "SET"),
+        ];
+        let selected = coverage.iter().collect::<Vec<_>>();
+        let first = build_collision_report(
+            &db,
+            &coverage,
+            &selected,
+            "all cards".to_string(),
+            "digest".to_string(),
+        )
+        .unwrap();
+        let second = build_collision_report(
+            &db,
+            &coverage,
+            &selected,
+            "all cards".to_string(),
+            "digest".to_string(),
+        )
+        .unwrap();
+        assert_eq!(first.candidate_pairs, 1);
+        assert_eq!(first.candidates[0].a.key, "alpha");
+        assert_eq!(first.candidates[0].markers, vec!["if"]);
+        assert_eq!(
+            serde_json::to_vec_pretty(&first).unwrap(),
+            serde_json::to_vec_pretty(&second).unwrap()
+        );
+    }
+
+    #[test]
+    fn run_with_io_emits_reproducible_collision_json() {
+        let mut face = face_with_oracle("Flying.");
+        face.name = "Fixture".to_string();
+        face.keywords.push(Keyword::Flying);
+        let directory = tempfile::tempdir().unwrap();
+        std::fs::write(
+            directory.path().join("card-data.json"),
+            serde_json::to_vec(&BTreeMap::from([("fixture".to_string(), face)])).unwrap(),
+        )
+        .unwrap();
+        let options = || Options {
+            data_root: Some(directory.path().display().to_string()),
+            mode: Mode::StructuralCollisions,
+            ..Options::default()
+        };
+        let (mut first_out, mut first_err) = (Vec::new(), Vec::new());
+        assert_eq!(
+            run_with_io(options(), &mut first_out, &mut first_err).unwrap(),
+            0
+        );
+        let (mut second_out, mut second_err) = (Vec::new(), Vec::new());
+        assert_eq!(
+            run_with_io(options(), &mut second_out, &mut second_err).unwrap(),
+            0
+        );
+        assert_eq!(first_out, second_out);
+        assert_eq!(first_err, second_err);
+        let report: Value = serde_json::from_slice(&first_out).unwrap();
+        assert_eq!(report["algorithm_version"], "structural-collision-v1");
+        assert_eq!(report["input"]["path"], "card-data.json");
+        assert_eq!(report["candidate_pairs"], 0);
+    }
+
+    #[test]
+    fn tokenizer_handles_names_reminders_and_hostile_larger_words() {
+        assert_eq!(
+            oracle_tokens(
+                "Clone clones Clone's text. Clone attacks. (Reminder only.)",
+                "Clone"
+            ),
+            vec!["~", "clones", "clone's", "text", "~", "attacks"]
+        );
+        assert_eq!(
+            oracle_tokens("Test (nested (text) stays) one.", "Test"),
+            vec!["~", "nested", "text", "stays", "one"]
+        );
+    }
+
+    #[test]
+    fn lcs_uses_a_first_ties_and_reports_half_open_spans() {
+        let a = vec!["one", "x", "one"]
+            .into_iter()
+            .map(String::from)
+            .collect::<Vec<_>>();
+        let b = vec!["one", "one", "x"]
+            .into_iter()
+            .map(String::from)
+            .collect::<Vec<_>>();
+        let (length, spans) = lcs_spans(&a, &b);
+        assert_eq!(length, 2);
+        assert_eq!(
+            spans,
+            vec![
+                ChangedSpan {
+                    a_start: 1,
+                    a_end: 2,
+                    a_tokens: vec!["x".to_string()],
+                    b_start: 1,
+                    b_end: 1,
+                    b_tokens: vec![],
+                },
+                ChangedSpan {
+                    a_start: 3,
+                    a_end: 3,
+                    a_tokens: vec![],
+                    b_start: 2,
+                    b_end: 3,
+                    b_tokens: vec!["x".to_string()],
+                }
+            ]
+        );
+    }
+
+    #[test]
+    fn argument_modes_are_mutually_exclusive() {
+        let ParseOutcome::Run(opts) =
+            parse_args_from(["--structural-collisions".to_string()]).unwrap()
+        else {
+            panic!("expected runnable options");
+        };
+        assert_eq!(opts.mode, Mode::StructuralCollisions);
+        assert!(parse_args_from([
+            "--structural-collisions".to_string(),
+            "--snapshot".to_string(),
+            "out.json".to_string(),
+        ])
+        .is_err());
+        assert!(matches!(
+            parse_args_from(["--help".to_string()]),
+            Ok(ParseOutcome::Help)
+        ));
+        assert!(parse_args_from(["--unknown".to_string(), "--help".to_string()]).is_err());
+        assert!(parse_args_from([
+            "--snapshot".to_string(),
+            "out.json".to_string(),
+            "--diff".to_string(),
+            "base.json".to_string(),
+        ])
+        .is_err());
+    }
+
+    #[test]
+    fn rebalance_pair_requires_one_leading_prefix() {
+        assert!(natural_rebalance_pair(
+            "A-Sizzling Soloist",
+            "Sizzling Soloist"
+        ));
+        assert!(!natural_rebalance_pair("A-A-Card", "Card"));
+        assert!(!natural_rebalance_pair("Card", "Other Card"));
     }
 
     #[test]
@@ -665,11 +1633,15 @@ mod tests {
         current.get_mut("moved card").unwrap().supported = false;
         current.get_mut("moved card").unwrap().gap_count = 1;
 
-        let code = run_diff(&baseline, &current, true);
+        let mut output = Vec::new();
+        let code = run_diff(&baseline, &current, true, &mut output).unwrap();
         assert_eq!(code, 1, "a changed hash must yield a non-zero exit code");
 
         // Identical snapshots produce a clean (zero) exit.
-        assert_eq!(run_diff(&baseline, &baseline.clone(), true), 0);
+        assert_eq!(
+            run_diff(&baseline, &baseline.clone(), true, &mut Vec::new()).unwrap(),
+            0
+        );
     }
 
     #[test]

--- a/crates/engine/src/database/synthesis.rs
+++ b/crates/engine/src/database/synthesis.rs
@@ -41,6 +41,70 @@ use crate::types::zones::Zone;
 // Shared helpers for building card faces from MTGJSON data
 // ---------------------------------------------------------------------------
 
+/// Exact primary Oracle-parser input prepared by the production face builder.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OracleParserInput {
+    pub oracle_text: String,
+    pub card_name: String,
+    pub keyword_names: Vec<String>,
+    pub types: Vec<String>,
+    pub subtypes: Vec<String>,
+    pub has_cleave_variant: bool,
+    cleave_oracle_text: Option<String>,
+}
+
+/// Prepare the single primary parse performed by `build_oracle_face_inner`.
+pub fn prepare_oracle_parser_input(
+    mtgjson: &AtomicCard,
+    skip_mtgjson_keywords: bool,
+) -> OracleParserInput {
+    let mtgjson_keyword_names = mtgjson
+        .keywords
+        .as_ref()
+        .map(|keywords| {
+            keywords
+                .iter()
+                .map(|keyword| keyword.to_ascii_lowercase())
+                .collect()
+        })
+        .unwrap_or_default();
+    let keyword_names = if skip_mtgjson_keywords {
+        vec!["__force_keyword_extract__".to_string()]
+    } else {
+        mtgjson_keyword_names
+    };
+    let raw_oracle_text = mtgjson.text.as_deref().unwrap_or("");
+    let (oracle_text, cleave_text) = prepare_cleave_oracle_text(raw_oracle_text, &keyword_names);
+    OracleParserInput {
+        oracle_text,
+        card_name: mtgjson
+            .face_name
+            .as_deref()
+            .unwrap_or(&mtgjson.name)
+            .to_string(),
+        keyword_names,
+        types: mtgjson.types.clone(),
+        subtypes: mtgjson.subtypes.clone(),
+        has_cleave_variant: cleave_text.is_some(),
+        cleave_oracle_text: cleave_text,
+    }
+}
+
+/// CR 702.148a-b + CR 612: Cleave removes bracketed rules text as a text-changing effect.
+fn prepare_cleave_oracle_text(
+    raw_oracle_text: &str,
+    keyword_names: &[String],
+) -> (String, Option<String>) {
+    if keyword_names.iter().any(|name| name == "cleave") {
+        (
+            apply_bracket_mode(raw_oracle_text, BracketMode::KeepContent),
+            Some(apply_bracket_mode(raw_oracle_text, BracketMode::RemoveSpan)),
+        )
+    } else {
+        (raw_oracle_text.to_string(), None)
+    }
+}
+
 /// CR 702.148a-b + CR 612: Parse a face's Oracle text under Cleave's
 /// text-changing semantics, returning the printed-cost parse and (when the face
 /// has Cleave) the bracket-removed cleave variant.
@@ -69,19 +133,34 @@ pub(crate) fn parse_oracle_with_cleave_brackets(
     crate::parser::oracle::ParsedAbilities,
     Option<CleaveVariant>,
 ) {
-    let has_cleave = keyword_names.iter().any(|n| n == "cleave");
+    let (base_oracle_text, cleave_text) =
+        prepare_cleave_oracle_text(raw_oracle_text, keyword_names);
+    parse_prepared_oracle_text(
+        &base_oracle_text,
+        cleave_text.as_deref(),
+        card_name,
+        keyword_names,
+        types,
+        subtypes,
+    )
+}
 
-    let base_oracle_text = if has_cleave {
-        apply_bracket_mode(raw_oracle_text, BracketMode::KeepContent)
-    } else {
-        raw_oracle_text.to_string()
-    };
-    let parsed = parse_oracle_text(&base_oracle_text, card_name, keyword_names, types, subtypes);
+fn parse_prepared_oracle_text(
+    base_oracle_text: &str,
+    cleave_text: Option<&str>,
+    card_name: &str,
+    keyword_names: &[String],
+    types: &[String],
+    subtypes: &[String],
+) -> (
+    crate::parser::oracle::ParsedAbilities,
+    Option<CleaveVariant>,
+) {
+    let parsed = parse_oracle_text(base_oracle_text, card_name, keyword_names, types, subtypes);
 
-    let cleave_variant = if has_cleave {
-        let cleave_text = apply_bracket_mode(raw_oracle_text, BracketMode::RemoveSpan);
+    let cleave_variant = if let Some(cleave_text) = cleave_text {
         let cleave_parsed =
-            parse_oracle_text(&cleave_text, card_name, keyword_names, types, subtypes);
+            parse_oracle_text(cleave_text, card_name, keyword_names, types, subtypes);
         Some(CleaveVariant {
             abilities: cleave_parsed.abilities,
             triggers: cleave_parsed.triggers,
@@ -10124,11 +10203,7 @@ fn build_oracle_face_inner(
         .as_ref()
         .map(|kws| kws.iter().map(|s| s.to_ascii_lowercase()).collect())
         .unwrap_or_default();
-    let parser_keyword_names: Vec<String> = if skip_mtgjson_keywords {
-        vec!["__force_keyword_extract__".to_string()]
-    } else {
-        mtgjson_keyword_names.clone()
-    };
+    let parser_input = prepare_oracle_parser_input(mtgjson, skip_mtgjson_keywords);
 
     // B8: For multi-face cards, skip MTGJSON-provided keywords entirely.
     // MTGJSON duplicates keywords across both faces of Transform/DFC cards,
@@ -10150,21 +10225,19 @@ fn build_oracle_face_inner(
     };
 
     let raw_oracle_text = mtgjson.text.as_deref().unwrap_or("");
-    let face_name = mtgjson.face_name.as_deref().unwrap_or(&mtgjson.name);
-
-    let types: Vec<String> = mtgjson.types.clone();
-    let subtypes: Vec<String> = mtgjson.subtypes.clone();
+    let face_name = parser_input.card_name.as_str();
 
     // CR 702.148a-b + CR 612: Cleave's text-changing effect removes every
     // square-bracketed span from the spell's rules text. `parse_oracle_with_cleave_brackets`
     // is the single authority for the dual (printed-cost / cleave-cost) parse,
     // shared with the test scenario harness so the two pipelines cannot diverge.
-    let (parsed, cleave_variant) = parse_oracle_with_cleave_brackets(
-        raw_oracle_text,
-        face_name,
-        &parser_keyword_names,
-        &types,
-        &subtypes,
+    let (parsed, cleave_variant) = parse_prepared_oracle_text(
+        &parser_input.oracle_text,
+        parser_input.cleave_oracle_text.as_deref(),
+        &parser_input.card_name,
+        &parser_input.keyword_names,
+        &parser_input.types,
+        &parser_input.subtypes,
     );
 
     let extracted_keywords = parsed.extracted_keywords;
@@ -11224,6 +11297,44 @@ mod cycling_synthesis_tests {
             foreign_data: Vec::new(),
             related_cards: crate::database::mtgjson::SetRelatedCards::default(),
         }
+    }
+
+    #[test]
+    fn oracle_parser_input_uses_face_name_and_multiface_keyword_mode() {
+        let mut card = counter_phrase_card("Combined Name", "Flying", &["Flying"]);
+        card.face_name = Some("Front Face".to_string());
+        let single = prepare_oracle_parser_input(&card, false);
+        let multi = prepare_oracle_parser_input(&card, true);
+        assert_eq!(single.card_name, "Front Face");
+        assert_eq!(single.keyword_names, vec!["flying"]);
+        assert_eq!(multi.keyword_names, vec!["__force_keyword_extract__"]);
+    }
+
+    #[test]
+    fn oracle_parser_input_uses_production_cleave_base_text() {
+        let card = counter_phrase_card("Cleave Test", "Draw [two] cards.", &["Cleave"]);
+        let input = prepare_oracle_parser_input(&card, false);
+        assert_eq!(input.oracle_text, "Draw two cards.");
+        assert!(input.has_cleave_variant);
+        let (production, cleave) = parse_oracle_with_cleave_brackets(
+            card.text.as_deref().expect("fixture text"),
+            &input.card_name,
+            &input.keyword_names,
+            &input.types,
+            &input.subtypes,
+        );
+        assert_eq!(
+            serde_json::to_value(parse_oracle_text(
+                &input.oracle_text,
+                &input.card_name,
+                &input.keyword_names,
+                &input.types,
+                &input.subtypes,
+            ))
+            .expect("serialize prepared parse"),
+            serde_json::to_value(production).expect("serialize production parse")
+        );
+        assert!(cleave.is_some());
     }
 
     /// CR 122.1b: a keyword counter grants its keyword only while the counter is

--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -375,6 +375,10 @@ fn public_gap_details(gaps: &[CoverageGap]) -> Vec<GapDetail> {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CardCoverageResult {
+    /// Internal provenance for associating duplicate printed names with their
+    /// authoritative database face. Coverage JSON remains byte-compatible.
+    #[serde(skip)]
+    pub card_face_key: Option<String>,
     pub card_name: String,
     pub set_code: String,
     pub supported: bool,
@@ -6519,6 +6523,7 @@ pub fn analyze_coverage(card_db: &CardDatabase) -> CoverageSummary {
             .unwrap_or_default();
 
         cards.push(CardCoverageResult {
+            card_face_key: Some(key.to_owned()),
             card_name: face.name.clone(),
             set_code: String::new(),
             supported,

--- a/crates/engine/src/parser/audit_projection.rs
+++ b/crates/engine/src/parser/audit_projection.rs
@@ -1,0 +1,236 @@
+//! Schema-guarded report-only omission of typed definition descriptions.
+
+use serde::Serialize;
+use serde_json::{Map, Value};
+
+const ABILITY_KEYS: &[&str] = &[
+    "kind",
+    "effect",
+    "cost",
+    "sub_ability",
+    "else_ability",
+    "duration",
+    "description",
+    "target_prompt",
+    "activation_restrictions",
+    "activation_mana_payment_restriction",
+    "activator_filter",
+    "activation_zone",
+    "ability_tag",
+    "condition",
+    "optional_targeting",
+    "optional",
+    "optional_player",
+    "optional_for",
+    "multi_target",
+    "target_constraints",
+    "target_choice_timing",
+    "distribute",
+    "unless_pay",
+    "modal",
+    "mode_abilities",
+    "repeat_for",
+    "min_x_value",
+    "announced_x",
+    "cant_be_copied",
+    "cost_reduction",
+    "forward_result",
+    "player_scope",
+    "starting_with",
+    "target_selection_mode",
+    "target_chooser",
+    "repeat_until",
+    "sub_link",
+    "iteration_kind_binding",
+    "sibling_condition",
+    "consumes_source",
+    "is_mana_ability",
+];
+const TRIGGER_KEYS: &[&str] = &[
+    "mode",
+    "execute",
+    "valid_card",
+    "origin",
+    "origin_zones",
+    "zone_change_clauses",
+    "destination",
+    "destination_constraint",
+    "trigger_zones",
+    "phase",
+    "optional",
+    "damage_kind",
+    "secondary",
+    "valid_target",
+    "valid_subject_player",
+    "valid_source",
+    "spell_cast_origin",
+    "description",
+    "constraint",
+    "condition",
+    "counter_filter",
+    "saga_chapter",
+    "unless_pay",
+    "batched",
+    "die_sides",
+    "expend_threshold",
+    "attack_target_filter",
+    "player_actions",
+    "scry_bottom_count",
+    "damage_amount",
+    "life_amount",
+    "coin_flip_result",
+    "die_result",
+    "taps_for_mana_produced",
+    "mana_ability_produced",
+    "clash_result",
+    "room_door",
+];
+const STATIC_KEYS: &[&str] = &[
+    "mode",
+    "affected",
+    "modifications",
+    "condition",
+    "per_player_condition",
+    "affected_zone",
+    "effect_zone",
+    "active_zones",
+    "characteristic_defining",
+    "description",
+    "attack_defended",
+    "source_controller",
+    "source_object",
+    "bypass_beneficiary",
+    "protection_does_not_remove",
+    "room_door",
+];
+const REPLACEMENT_KEYS: &[&str] = &[
+    "event",
+    "execute",
+    "runtime_execute",
+    "mode",
+    "valid_card",
+    "description",
+    "condition",
+    "destination_zone",
+    "damage_modification",
+    "damage_source_filter",
+    "damage_target_filter",
+    "combat_scope",
+    "draw_scope",
+    "die_ignore_rule",
+    "planeswalk_scope",
+    "shield_kind",
+    "quantity_modification",
+    "token_owner_scope",
+    "token_owner_redirect",
+    "valid_player",
+    "consume_on_apply",
+    "is_consumed",
+    "expiry",
+    "redirect_target",
+    "mana_modification",
+    "mana_replacement_scope",
+    "additional_token_spec",
+    "ensure_token_specs",
+    "counter_match",
+    "enters_under",
+    "source_controller",
+    "source_object",
+    "origin",
+    "counter_replacement_subject",
+];
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq, PartialOrd, Ord)]
+pub struct OmittedDefinitionDescription {
+    pub json_pointer: String,
+    pub value: String,
+    pub carrier: &'static str,
+}
+
+fn carrier(map: &Map<String, Value>) -> Option<&'static str> {
+    let schemas: &[(&str, &[&str], &[&str])] = &[
+        (
+            "AbilityDefinition",
+            &["kind", "effect", "sub_ability", "duration", "description"],
+            ABILITY_KEYS,
+        ),
+        (
+            "TriggerDefinition",
+            &[
+                "mode",
+                "execute",
+                "valid_card",
+                "trigger_zones",
+                "description",
+            ],
+            TRIGGER_KEYS,
+        ),
+        (
+            "StaticDefinition",
+            &[
+                "mode",
+                "affected",
+                "modifications",
+                "active_zones",
+                "description",
+            ],
+            STATIC_KEYS,
+        ),
+        (
+            "ReplacementDefinition",
+            &["event", "execute", "mode", "valid_card", "description"],
+            REPLACEMENT_KEYS,
+        ),
+    ];
+    schemas.iter().find_map(|(name, required, allowed)| {
+        (required.iter().all(|key| map.contains_key(*key))
+            && map.keys().all(|key| allowed.contains(&key.as_str())))
+        .then_some(*name)
+    })
+}
+
+fn escape_pointer_segment(segment: &str) -> String {
+    segment.replace('~', "~0").replace('/', "~1")
+}
+
+pub fn omit_definition_descriptions(value: &mut Value) -> Vec<OmittedDefinitionDescription> {
+    omit_definition_descriptions_at(value, "")
+}
+
+pub fn omit_definition_descriptions_at(
+    value: &mut Value,
+    pointer: &str,
+) -> Vec<OmittedDefinitionDescription> {
+    fn walk(value: &mut Value, pointer: &str, omitted: &mut Vec<OmittedDefinitionDescription>) {
+        match value {
+            Value::Array(values) => {
+                for (index, child) in values.iter_mut().enumerate() {
+                    walk(child, &format!("{pointer}/{index}"), omitted);
+                }
+            }
+            Value::Object(map) => {
+                if let Some(name) = carrier(map) {
+                    if let Some(Value::String(description)) = map.remove("description") {
+                        omitted.push(OmittedDefinitionDescription {
+                            json_pointer: format!("{pointer}/description"),
+                            value: description,
+                            carrier: name,
+                        });
+                    }
+                }
+                for (key, child) in map.iter_mut() {
+                    walk(
+                        child,
+                        &format!("{pointer}/{}", escape_pointer_segment(key)),
+                        omitted,
+                    );
+                }
+            }
+            _ => {}
+        }
+    }
+    let mut omitted = Vec::new();
+    walk(value, pointer, &mut omitted);
+    omitted.sort();
+    omitted
+}

--- a/crates/engine/src/parser/mod.rs
+++ b/crates/engine/src/parser/mod.rs
@@ -1,3 +1,4 @@
+pub mod audit_projection;
 pub(crate) mod clause_shell;
 pub mod oracle;
 pub(crate) mod oracle_attraction;
@@ -31,6 +32,7 @@ pub(crate) mod swallow_evidence;
 pub(crate) mod test_support;
 
 pub use oracle::parse_oracle_text;
+pub use oracle::parse_oracle_text_traced;
 
 use thiserror::Error;
 

--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -83,6 +83,10 @@ use super::oracle_ir::feature::ItemIdTracks;
 use super::oracle_ir::relation::{DocumentRelationIr, LinkedChoiceKind, LinkedReturnOutcome};
 use super::oracle_ir::replacement::ReplacementIr;
 use super::oracle_ir::static_ir::StaticIr;
+use super::oracle_ir::trace::{
+    document_candidate, parsed_candidate, OuterRoute, ParseObserver, ParserTrace,
+    PayloadVisibility, TraceStage,
+};
 use super::oracle_ir::trigger::{TriggerIr, TriggerNodeIr};
 pub use super::oracle_keyword::keyword_display_name;
 use super::oracle_keyword::{
@@ -4230,10 +4234,11 @@ struct DocEmitter<'a> {
     /// `*_emitted: Vec<OracleItemId>` stacks (like `spells_emitted`) first.
     last_trigger: Option<TriggerDefinition>,
     last_static: Option<StaticDefinition>,
+    observer: Option<&'a mut ParseObserver>,
 }
 
 impl<'a> DocEmitter<'a> {
-    fn new(lines: &'a [&'a str]) -> Self {
+    fn new(lines: &'a [&'a str], observer: Option<&'a mut ParseObserver>) -> Self {
         let mut line_start = Vec::with_capacity(lines.len());
         let mut acc = 0usize;
         for line in lines {
@@ -4246,6 +4251,7 @@ impl<'a> DocEmitter<'a> {
             line_start,
             last_trigger: None,
             last_static: None,
+            observer,
         }
     }
 
@@ -4267,35 +4273,63 @@ impl<'a> DocEmitter<'a> {
     /// sound: `emit` only rejects a duplicate `(first_line, start_byte, ordinal)`
     /// key or an overlapping same-ordinal sibling, and the single-authority
     /// ordinal makes every same-line item's key distinct.
-    fn emit_at(&mut self, line: usize, node: OracleNodeIr) -> OracleItemId {
+    fn emit_at(&mut self, line: usize, node: OracleNodeIr, route: OuterRoute) -> OracleItemId {
         let span = self.exact_span(line);
+        let visibility = visibility_for_node(&node);
         let fragment = self.lines[line];
-        let slot = self.builder.begin_item(span, Some(fragment));
-        self.builder.emit(slot, node).expect(
+        let slot = self.builder.begin_item(span.clone(), Some(fragment));
+        let id = self.builder.emit(slot, node).expect(
             "single-authority ordinals keep same-line item keys distinct, so emit cannot reject",
-        )
+        );
+        if let Some(observer) = self.observer.as_deref_mut() {
+            observer.record(id, span, route, visibility);
+        }
+        id
     }
 
     /// Emit an item spanning `first_line..=last_line` (a multi-line unit, e.g. a
     /// leveler block-summary static whose span ends at the last
     /// modification-contributing line). Ordinal is drawn on `first_line`.
-    fn emit_span(&mut self, first_line: usize, last_line: usize, node: OracleNodeIr) {
+    fn emit_span(
+        &mut self,
+        first_line: usize,
+        last_line: usize,
+        node: OracleNodeIr,
+        route: OuterRoute,
+    ) -> OracleItemId {
         let ordinal = self.builder.next_ordinal_for_line(first_line);
         let (start, _) = self.byte_range(first_line);
         let (_, end) = self.byte_range(last_line);
         let span = OracleSourceSpan::exact(first_line, last_line, start, end, ordinal);
         // Fragment must be the verbatim covered slice for an Exact span; the
         // caller passes contiguous lines, so the byte range is honest.
-        let slot = self.builder.begin_item(span, Some(self.lines[first_line]));
-        self.builder
+        let visibility = visibility_for_node(&node);
+        let slot = self
+            .builder
+            .begin_item(span.clone(), Some(self.lines[first_line]));
+        let id = self
+            .builder
             .emit(slot, node)
             .expect("single-authority ordinals keep multi-line item keys distinct");
+        if let Some(observer) = self.observer.as_deref_mut() {
+            observer.record(id, span, route, visibility);
+        }
+        id
     }
 
     fn ability_at(&mut self, line: usize, def: AbilityDefinition) -> OracleItemId {
+        self.ability_at_route(line, def, OuterRoute::ImperativeEffect)
+    }
+
+    fn ability_at_route(
+        &mut self,
+        line: usize,
+        def: AbilityDefinition,
+        route: OuterRoute,
+    ) -> OracleItemId {
         // No ability clone: the ability peek is pop-aware, read from the builder's
         // `spells_emitted` stack (see `last_ability_node`).
-        self.emit_at(line, OracleNodeIr::PreLoweredSpell(def))
+        self.emit_at(line, OracleNodeIr::PreLoweredSpell(def), route)
     }
 
     /// The IR seam for spell/activated bodies — Plan 05b Unit 3b, **phase B**.
@@ -4321,7 +4355,16 @@ impl<'a> DocEmitter<'a> {
     /// finish`'s doc block for why moving it there is order-equivalent to the
     /// `finish()`-time walk it replaced.
     fn ability_ir_at(&mut self, line: usize, ir: AbilityIr) -> OracleItemId {
-        self.emit_at(line, OracleNodeIr::Spell(ir))
+        self.ability_ir_at_route(line, ir, OuterRoute::ImperativeEffect)
+    }
+
+    fn ability_ir_at_route(
+        &mut self,
+        line: usize,
+        ir: AbilityIr,
+        route: OuterRoute,
+    ) -> OracleItemId {
+        self.emit_at(line, OracleNodeIr::Spell(ir), route)
     }
     /// Emit the honest-failure residual for a line the parser could not model.
     ///
@@ -4351,6 +4394,7 @@ impl<'a> DocEmitter<'a> {
                 unsupported,
                 min_x_value,
             },
+            OuterRoute::Unsupported,
         );
     }
     /// Mirrors `static_ir_at`: the peek mirror stores the LOWERED definition, so
@@ -4358,15 +4402,24 @@ impl<'a> DocEmitter<'a> {
     /// nothing reads it from. Lowering here is a clone (`lower_trigger_node_ir`
     /// passes an assembled definition through), exactly what `trigger_at` paid.
     fn trigger_ir_at(&mut self, line: usize, ir: TriggerNodeIr) {
+        self.trigger_ir_at_route(line, ir, OuterRoute::Trigger);
+    }
+    fn trigger_ir_at_route(&mut self, line: usize, ir: TriggerNodeIr, route: OuterRoute) {
         self.last_trigger = Some(lower_trigger_node_ir(&ir));
-        self.emit_at(line, OracleNodeIr::Trigger(ir));
+        self.emit_at(line, OracleNodeIr::Trigger(ir), route);
     }
     fn static_ir_at(&mut self, line: usize, ir: StaticIr) {
+        self.static_ir_at_route(line, ir, OuterRoute::Static);
+    }
+    fn static_ir_at_route(&mut self, line: usize, ir: StaticIr, route: OuterRoute) {
         self.last_static = Some(lower_static_ir(&ir));
-        self.emit_at(line, OracleNodeIr::Static(ir));
+        self.emit_at(line, OracleNodeIr::Static(ir), route);
     }
     fn replacement_ir_at(&mut self, line: usize, ir: ReplacementIr) {
-        self.emit_at(line, OracleNodeIr::Replacement(ir));
+        self.replacement_ir_at_route(line, ir, OuterRoute::Replacement);
+    }
+    fn replacement_ir_at_route(&mut self, line: usize, ir: ReplacementIr, route: OuterRoute) {
+        self.emit_at(line, OracleNodeIr::Replacement(ir), route);
     }
 
     /// Last-emitted node per category — the read-only peeks for
@@ -4404,43 +4457,62 @@ impl<'a> DocEmitter<'a> {
     /// `last_static()` mid-loop, and `drain_result_vectors` (via `static_at`)
     /// maintains it today. Emitting these nodes raw would silently stop
     /// updating it.
-    fn emit_ir_nodes_at(&mut self, item_line: usize, nodes: Vec<OracleNodeIr>) {
+    fn emit_ir_nodes_at(&mut self, item_line: usize, nodes: Vec<OracleNodeIr>, route: OuterRoute) {
         for node in nodes {
             match node {
-                OracleNodeIr::Static(ir) => self.static_ir_at(item_line, ir),
-                OracleNodeIr::Trigger(ir) => self.trigger_ir_at(item_line, ir),
+                OracleNodeIr::Static(ir) => self.static_ir_at_route(item_line, ir, route),
+                OracleNodeIr::Trigger(ir) => self.trigger_ir_at_route(item_line, ir, route),
                 OracleNodeIr::RelationSynthesis(_) => {
                     panic!(
                         "relation synthesis is finalization-only and cannot be forwarded by DocEmitter"
                     );
                 }
                 other => {
-                    self.emit_at(item_line, other);
+                    self.emit_at(item_line, other, route);
                 }
             }
         }
     }
 
     fn keyword_at(&mut self, line: usize, kw: Keyword) {
-        self.emit_at(line, OracleNodeIr::Keyword(kw));
+        self.keyword_at_route(line, kw, OuterRoute::Keyword);
+    }
+    fn keyword_at_route(&mut self, line: usize, kw: Keyword, route: OuterRoute) {
+        self.emit_at(line, OracleNodeIr::Keyword(kw), route);
     }
     fn casting_restriction_at(&mut self, line: usize, r: CastingRestriction) {
-        self.emit_at(line, OracleNodeIr::CastingRestriction(r));
+        self.emit_at(
+            line,
+            OracleNodeIr::CastingRestriction(r),
+            OuterRoute::CastingRestriction,
+        );
     }
     fn casting_option_at(&mut self, line: usize, o: SpellCastingOption) {
-        self.emit_at(line, OracleNodeIr::CastingOption(o));
+        self.emit_at(
+            line,
+            OracleNodeIr::CastingOption(o),
+            OuterRoute::CastingOption,
+        );
     }
     fn additional_cost_at(&mut self, line: usize, c: AdditionalCost) {
-        self.emit_at(line, OracleNodeIr::AdditionalCost(c));
+        self.emit_at(
+            line,
+            OracleNodeIr::AdditionalCost(c),
+            OuterRoute::AdditionalCost,
+        );
     }
     fn solve_condition_at(&mut self, line: usize, c: SolveCondition) {
-        self.emit_at(line, OracleNodeIr::SolveCondition(c));
+        self.emit_at(line, OracleNodeIr::SolveCondition(c), OuterRoute::Solve);
     }
     fn strive_cost_at(&mut self, line: usize, c: ManaCost) {
-        self.emit_at(line, OracleNodeIr::StriveCost(c));
+        self.emit_at(
+            line,
+            OracleNodeIr::StriveCost(c),
+            OuterRoute::StriveSingleton,
+        );
     }
     fn modal_at(&mut self, line: usize, m: ModalChoice) {
-        self.emit_at(line, OracleNodeIr::Modal(m));
+        self.emit_at(line, OracleNodeIr::Modal(m), OuterRoute::Modal);
     }
 
     /// Re-emit a node at a template item's ORIGINAL span — same `first_line`,
@@ -4465,12 +4537,23 @@ impl<'a> DocEmitter<'a> {
     /// here any more. `pop_last_spell`, the wrapper that served only that fold,
     /// went with it; `take_last_spell` itself is still live beneath this method.
     fn reemit_node(&mut self, source: &OracleUnitSource, node: OracleNodeIr) {
+        let old_id = source.id().item;
         let span = source.span().clone();
         let fragment = source.fragment();
         let slot = self.builder.begin_item(span, fragment);
-        self.builder
+        let new_id = self
+            .builder
             .emit(slot, node)
             .expect("re-emitting at the just-freed original key cannot collide");
+        if let Some(observer) = self.observer.as_deref_mut() {
+            if let Some(event) = observer
+                .events
+                .iter_mut()
+                .find(|event| event.item_id == old_id)
+            {
+                event.item_id = new_id;
+            }
+        }
     }
 
     /// CR 601.2b: raise the floor on the last emitted spell's announced X, for a
@@ -4514,6 +4597,19 @@ impl<'a> DocEmitter<'a> {
     }
 }
 
+fn visibility_for_node(node: &OracleNodeIr) -> PayloadVisibility {
+    match node {
+        OracleNodeIr::Unsupported { .. } => PayloadVisibility::Unsupported,
+        OracleNodeIr::PreLoweredTrigger(_) | OracleNodeIr::PreLoweredSpell(_) => {
+            PayloadVisibility::AssembledOrPrelowered
+        }
+        OracleNodeIr::Trigger(TriggerNodeIr::Assembled { .. }) => {
+            PayloadVisibility::AssembledOrPrelowered
+        }
+        _ => PayloadVisibility::NativeIr,
+    }
+}
+
 /// Attaches a following die-result table to every terminal die-roll trigger
 /// produced from one printed line. Compound triggers share that line's table.
 ///
@@ -4547,12 +4643,34 @@ fn attach_trigger_die_result_branches(
 /// variants. Pre-processors and complex dispatch paths use `PreLowered*` variants
 /// carrying already-assembled engine types; future phases will incrementally
 /// migrate these to proper IR types.
+#[cfg_attr(not(test), allow(dead_code))] // Test-facing two-layer IR facade; production uses the shared pipeline below.
 pub(crate) fn parse_oracle_ir(
     oracle_text: &str,
     card_name: &str,
     mtgjson_keyword_names: &[String],
     types: &[String],
     subtypes: &[String],
+) -> OracleDocIr {
+    let normalized = normalize_card_name_refs(oracle_text, card_name);
+    parse_normalized_oracle_ir(
+        oracle_text,
+        &normalized,
+        card_name,
+        mtgjson_keyword_names,
+        types,
+        subtypes,
+        None,
+    )
+}
+
+fn parse_normalized_oracle_ir(
+    original_oracle_text: &str,
+    normalized_oracle_text: &str,
+    card_name: &str,
+    mtgjson_keyword_names: &[String],
+    types: &[String],
+    subtypes: &[String],
+    observer: Option<&mut ParseObserver>,
 ) -> OracleDocIr {
     let is_spell = types.iter().any(|t| t == "Instant" || t == "Sorcery");
 
@@ -4600,8 +4718,7 @@ pub(crate) fn parse_oracle_ir(
     // `normalize_card_name_refs` on this pre-normalized text; strategies 1-4
     // find nothing to replace and strategy 5 is short-circuited by its
     // `!result.contains('~')` guard, making re-entry an idempotent no-op.
-    let oracle_text_owned = normalize_card_name_refs(oracle_text, card_name);
-    let lines: Vec<&str> = oracle_text_owned.split('\n').collect();
+    let lines: Vec<&str> = normalized_oracle_text.split('\n').collect();
 
     // u4-c2 source-order emission: the document builder, wrapped in the emitter
     // that owns the single per-line ordinal authority. Every non-Class emission —
@@ -4611,7 +4728,7 @@ pub(crate) fn parse_oracle_ir(
     // which need mid-loop read-back/merge/dedup; its VECTOR fields stay empty and
     // are emitted through the builder instead. The singletons are emitted post-loop
     // at their captured source line.
-    let mut emitter = DocEmitter::new(&lines);
+    let mut emitter = DocEmitter::new(&lines, observer);
     let mut document_relations = Vec::new();
     let mut additional_cost_line: Option<usize> = None;
     let mut solve_condition_line: Option<usize> = None;
@@ -4631,13 +4748,17 @@ pub(crate) fn parse_oracle_ir(
     // dispatch loop runs on a Class card.
     if subtypes.iter().any(|s| s == "Class") {
         for (line, node) in parse_class_oracle_text(&lines, card_name, mtgjson_keyword_names) {
-            emitter.emit_at(line, node);
+            emitter.emit_at(line, node, OuterRoute::Class);
         }
         // `oracle_text` (the ORIGINAL, un-normalized text), not `oracle_text_owned`
         // — matching the main path's `finish` below. `OracleDocIr.source_text` is
         // the swallow audit's input, so normalizing it here would change which
         // clauses the audit sees.
-        let doc = emitter.finish(oracle_text, card_name, std::mem::take(&mut ctx.diagnostics));
+        let doc = emitter.finish(
+            original_oracle_text,
+            card_name,
+            std::mem::take(&mut ctx.diagnostics),
+        );
         return finalize_document_relations(doc, types);
     }
 
@@ -4656,9 +4777,13 @@ pub(crate) fn parse_oracle_ir(
             // the preprocessor stamps `"Chapter {n}"`, NOT the printed line,
             // and `lower_trigger_node_ir` never runs the `lower_trigger_ir`
             // overwrite that would replace it with `source_text`.
-            emitter.trigger_ir_at(line, TriggerNodeIr::from_definition(lines[line], trigger));
+            emitter.trigger_ir_at_route(
+                line,
+                TriggerNodeIr::from_definition(lines[line], trigger),
+                OuterRoute::Saga,
+            );
         }
-        emitter.replacement_ir_at(etb_line, etb_replacement);
+        emitter.replacement_ir_at_route(etb_line, etb_replacement, OuterRoute::Saga);
         consumed
     } else {
         std::collections::HashSet::new()
@@ -4674,7 +4799,11 @@ pub(crate) fn parse_oracle_ir(
             // at `None`, the exact opposite of Saga's `"Chapter {n}"` stamp.
             // Routing either through `lower_trigger_ir` would overwrite one and
             // invent the other from `source_text`.
-            emitter.trigger_ir_at(line, TriggerNodeIr::from_definition(lines[line], trigger));
+            emitter.trigger_ir_at_route(
+                line,
+                TriggerNodeIr::from_definition(lines[line], trigger),
+                OuterRoute::Attraction,
+            );
         }
         preparsed_consumed.extend(consumed);
     }
@@ -4688,7 +4817,12 @@ pub(crate) fn parse_oracle_ir(
     // `first..=last` range is load-bearing, and `static_ir_at` would also write
     // the `last_static` peek mirror, which the leveler deliberately does not.
     for (ir, first_line, last_line) in level_statics {
-        emitter.emit_span(first_line, last_line, OracleNodeIr::Static(ir));
+        emitter.emit_span(
+            first_line,
+            last_line,
+            OracleNodeIr::Static(ir),
+            OuterRoute::Leveler,
+        );
     }
     // CR 711.2a + CR 711.2b: Re-parse ability lines found within LEVEL blocks through
     // the normal trigger/activated/static pipeline, then attach the level counter condition.
@@ -4782,7 +4916,7 @@ pub(crate) fn parse_oracle_ir(
                 ShellStage::ExtractCostReduction,
                 ShellStage::ExtractManaSpendTrigger,
             ];
-            emitter.ability_ir_at(*level_line, ir);
+            emitter.ability_ir_at_route(*level_line, ir, OuterRoute::Leveler);
             continue;
         }
 
@@ -4824,9 +4958,10 @@ pub(crate) fn parse_oracle_ir(
             // post-lowering graft yields the flat `And[gate, x, y]`, and
             // `trigger_condition_source_zones` would additionally start deriving
             // `trigger_zones` from the level gate. Identity lowering keeps both.
-            emitter.trigger_ir_at(
+            emitter.trigger_ir_at_route(
                 *level_line,
                 TriggerNodeIr::from_definition(ability_text, trigger),
+                OuterRoute::Leveler,
             );
         }
     }
@@ -4844,20 +4979,24 @@ pub(crate) fn parse_oracle_ir(
         let (sc_statics, sc_triggers, sc_abilities, consumed) =
             parse_spacecraft_threshold_lines(&lines, card_name, PrintedTriggerIndex::placeholder());
         for (line, ir) in sc_statics {
-            emitter.static_ir_at(line, ir);
+            emitter.static_ir_at_route(line, ir, OuterRoute::Spacecraft);
         }
         for (line, trigger) in sc_triggers {
             // CR 702.184a + CR 721.2 station gate, same shape as the leveler
             // graft above: the condition is stamped inside the preprocessor on
             // the lowered definition, so identity lowering is what keeps it.
-            emitter.trigger_ir_at(line, TriggerNodeIr::from_definition(lines[line], trigger));
+            emitter.trigger_ir_at_route(
+                line,
+                TriggerNodeIr::from_definition(lines[line], trigger),
+                OuterRoute::Spacecraft,
+            );
         }
         // Post-processing runs here (pre-emit), exactly as before — the (B)
         // tuple-return design obviates moving it inside the preprocessor.
         for (line, mut def) in sc_abilities {
             extract_cost_reduction_from_chain(&mut def);
             extract_mana_spend_trigger_from_chain(&mut def);
-            emitter.ability_at(line, def);
+            emitter.ability_at_route(line, def, OuterRoute::Spacecraft);
         }
         consumed
             .into_iter()
@@ -4978,14 +5117,15 @@ pub(crate) fn parse_oracle_ir(
             match lower_oracle_block_ir(block, card_name, ctx.host_self_reference.clone(), &mut ctx)
             {
                 OracleBlockIr::Activated(ability) => {
-                    emitter.ability_ir_at(item_line, ability);
+                    emitter.ability_ir_at_route(item_line, ability, OuterRoute::Modal);
                 }
                 OracleBlockIr::Modal { choice, modes } => {
                     for mode in modes {
-                        emitter.ability_ir_at(
+                        emitter.ability_ir_at_route(
                             mode.source_line
                                 .expect("collected modal bullets have source lines"),
                             *mode.ability,
+                            OuterRoute::Modal,
                         );
                     }
                     emitter.modal_at(item_line, choice);
@@ -4997,25 +5137,31 @@ pub(crate) fn parse_oracle_ir(
                     // lowering can attach them to the chain that owns the roll.
                     next_i = attach_trigger_die_result_branches(&mut triggers, &lines, next_i);
                     for trigger in triggers {
-                        emitter.trigger_ir_at(item_line, TriggerNodeIr::Parsed(Box::new(trigger)));
+                        emitter.trigger_ir_at_route(
+                            item_line,
+                            TriggerNodeIr::Parsed(Box::new(trigger)),
+                            OuterRoute::Modal,
+                        );
                     }
                 }
                 OracleBlockIr::AsEnters {
                     replacement,
                     children,
                 } => {
-                    emitter.replacement_ir_at(item_line, replacement);
+                    emitter.replacement_ir_at_route(item_line, replacement, OuterRoute::Modal);
                     for (line, children) in children {
                         for child in children {
                             match child {
-                                AnchorModeIr::Trigger(trigger) => {
-                                    emitter.trigger_ir_at(line, TriggerNodeIr::Parsed(trigger))
-                                }
+                                AnchorModeIr::Trigger(trigger) => emitter.trigger_ir_at_route(
+                                    line,
+                                    TriggerNodeIr::Parsed(trigger),
+                                    OuterRoute::Modal,
+                                ),
                                 AnchorModeIr::Static(static_ir) => {
-                                    emitter.static_ir_at(line, *static_ir)
+                                    emitter.static_ir_at_route(line, *static_ir, OuterRoute::Modal)
                                 }
                                 AnchorModeIr::Unsupported(ability) => {
-                                    emitter.ability_ir_at(line, *ability);
+                                    emitter.ability_ir_at_route(line, *ability, OuterRoute::Modal);
                                 }
                             }
                         }
@@ -5046,7 +5192,7 @@ pub(crate) fn parse_oracle_ir(
                     .collect();
                 if let Some(routed) = routed {
                     for keyword in routed.into_iter().flatten() {
-                        emitter.keyword_at(item_line, keyword);
+                        emitter.keyword_at_route(item_line, keyword, OuterRoute::SplitKeyword);
                     }
                     i += 1;
                     continue;
@@ -5061,7 +5207,7 @@ pub(crate) fn parse_oracle_ir(
         // ability and still needs the synthesized activation body.
         if lower_starts_with(&lower, "equip") && !lower_starts_with(&lower, "equipped") {
             if let Some(ability) = try_parse_equip(&line) {
-                emitter.ability_ir_at(item_line, ability);
+                emitter.ability_ir_at_route(item_line, ability, OuterRoute::Activated);
                 i += 1;
                 continue;
             }
@@ -5228,14 +5374,14 @@ pub(crate) fn parse_oracle_ir(
                 .trim_start_matches(" \u{2014} ")
                 .trim_start_matches(" - ");
             if let Some(ability) = try_parse_equip(equip_part) {
-                emitter.ability_ir_at(item_line, ability);
+                emitter.ability_ir_at_route(item_line, ability, OuterRoute::Activated);
                 i += 1;
                 continue;
             }
         }
         // Priority 11: Planeswalker loyalty abilities: +N:, −N:, 0:, [+N]:, [−N]:, [0]:
         if let Some(ability) = try_parse_loyalty_line(&line, &mut ctx) {
-            emitter.ability_ir_at(item_line, ability);
+            emitter.ability_ir_at_route(item_line, ability, OuterRoute::Activated);
             i += 1;
             continue;
         }
@@ -5325,7 +5471,7 @@ pub(crate) fn parse_oracle_ir(
                 // sorcery"; extending preserves it so the legality gate fires.
                 activation_restrictions.extend(constraints.restrictions);
                 ir.shell.activation_restrictions = activation_restrictions;
-                emitter.ability_ir_at(item_line, ir);
+                emitter.ability_ir_at_route(item_line, ir, OuterRoute::Activated);
                 i += 1;
                 continue;
             }
@@ -5370,7 +5516,7 @@ pub(crate) fn parse_oracle_ir(
                     ShellStage::ExtractCostReduction,
                     ShellStage::ExtractManaSpendTrigger,
                 ];
-                emitter.ability_ir_at(item_line, ir);
+                emitter.ability_ir_at_route(item_line, ir, OuterRoute::Activated);
                 i += 1;
                 continue;
             }
@@ -5418,7 +5564,7 @@ pub(crate) fn parse_oracle_ir(
                     ShellStage::ExtractCostReduction,
                     ShellStage::ExtractManaSpendTrigger,
                 ];
-                emitter.ability_ir_at(item_line, ir);
+                emitter.ability_ir_at_route(item_line, ir, OuterRoute::Activated);
                 i += 1;
                 continue;
             }
@@ -5453,7 +5599,7 @@ pub(crate) fn parse_oracle_ir(
                     ShellStage::ExtractCostReduction,
                     ShellStage::ExtractManaSpendTrigger,
                 ];
-                emitter.ability_ir_at(item_line, ir);
+                emitter.ability_ir_at_route(item_line, ir, OuterRoute::Activated);
                 i += 1;
                 continue;
             }
@@ -5507,7 +5653,7 @@ pub(crate) fn parse_oracle_ir(
                     },
                     condition: Some(ParsedCondition::SourceEnteredThisTurn),
                 });
-                emitter.ability_ir_at(item_line, ir);
+                emitter.ability_ir_at_route(item_line, ir, OuterRoute::Activated);
                 i += 1;
                 continue;
             }
@@ -5550,7 +5696,7 @@ pub(crate) fn parse_oracle_ir(
                     ShellStage::ExtractCostReduction,
                     ShellStage::ExtractManaSpendTrigger,
                 ];
-                emitter.ability_ir_at(item_line, ir);
+                emitter.ability_ir_at_route(item_line, ir, OuterRoute::Activated);
                 i += 1;
                 continue;
             }
@@ -5603,7 +5749,7 @@ pub(crate) fn parse_oracle_ir(
                     i = next_line;
                 }
             }
-            emitter.ability_ir_at(item_line, ir);
+            emitter.ability_ir_at_route(item_line, ir, OuterRoute::Activated);
             continue;
         }
 
@@ -5668,7 +5814,11 @@ pub(crate) fn parse_oracle_ir(
             // "if ~ was kicked, it enters with …", external "[type] enters
             // with …", etc.) is a genuine CR 614.1c object-hosted replacement.
             if let Some(replacement_ir) = parse_replacement_line_ir(&line, card_name) {
-                emitter.emit_at(item_line, OracleNodeIr::Replacement(replacement_ir));
+                emitter.emit_at(
+                    item_line,
+                    OracleNodeIr::Replacement(replacement_ir),
+                    OuterRoute::Replacement,
+                );
                 i += 1;
                 continue;
             }
@@ -5736,7 +5886,7 @@ pub(crate) fn parse_oracle_ir(
                         Some(PrintedAbilityIndex::placeholder()),
                         &mut ctx,
                     );
-                    emitter.ability_ir_at(item_line, ir);
+                    emitter.ability_ir_at_route(item_line, ir, OuterRoute::Activated);
                     i += 1;
                     continue;
                 }
@@ -5961,7 +6111,11 @@ pub(crate) fn parse_oracle_ir(
         if is_enters_tapped_cant_untap_compound(&lower) {
             let mut consumed = false;
             if let Some(replacement_ir) = parse_replacement_line_ir(&line, card_name) {
-                emitter.emit_at(item_line, OracleNodeIr::Replacement(replacement_ir));
+                emitter.emit_at(
+                    item_line,
+                    OracleNodeIr::Replacement(replacement_ir),
+                    OuterRoute::Replacement,
+                );
                 consumed = true;
             }
             let defs = parse_static_line_with_graveyard_keyword_continuation(
@@ -6010,7 +6164,11 @@ pub(crate) fn parse_oracle_ir(
                 emitter.static_ir_at(item_line, StaticIr::from_definition(&static_line, __item));
             }
             for replacement_ir in replacements {
-                emitter.emit_at(item_line, OracleNodeIr::Replacement(replacement_ir));
+                emitter.emit_at(
+                    item_line,
+                    OracleNodeIr::Replacement(replacement_ir),
+                    OuterRoute::Replacement,
+                );
             }
             i += 1;
             continue;
@@ -6160,19 +6318,31 @@ pub(crate) fn parse_oracle_ir(
                     parse_replacement_sentence_sequence_ir(&line, card_name)
                 {
                     for replacement_ir in replacement_irs {
-                        emitter.emit_at(item_line, OracleNodeIr::Replacement(replacement_ir));
+                        emitter.emit_at(
+                            item_line,
+                            OracleNodeIr::Replacement(replacement_ir),
+                            OuterRoute::Replacement,
+                        );
                     }
                     i += 1;
                     continue;
                 }
                 if let Some(replacement_ir) = parse_replacement_line_ir(&line, card_name) {
-                    emitter.emit_at(item_line, OracleNodeIr::Replacement(replacement_ir));
+                    emitter.emit_at(
+                        item_line,
+                        OracleNodeIr::Replacement(replacement_ir),
+                        OuterRoute::Replacement,
+                    );
                     i += 1;
                     continue;
                 }
             } else if lower_starts_with(&lower, "as long as ") && is_replacement_pattern(&lower) {
                 if let Some(replacement_ir) = parse_replacement_line_ir(&line, card_name) {
-                    emitter.emit_at(item_line, OracleNodeIr::Replacement(replacement_ir));
+                    emitter.emit_at(
+                        item_line,
+                        OracleNodeIr::Replacement(replacement_ir),
+                        OuterRoute::Replacement,
+                    );
                     i += 1;
                     continue;
                 }
@@ -6186,7 +6356,11 @@ pub(crate) fn parse_oracle_ir(
                 // enters-with-counter replacement returns `None` and falls
                 // through to the static parser below.
                 if let Some(replacement_ir) = parse_replacement_line_ir(&line, card_name) {
-                    emitter.emit_at(item_line, OracleNodeIr::Replacement(replacement_ir));
+                    emitter.emit_at(
+                        item_line,
+                        OracleNodeIr::Replacement(replacement_ir),
+                        OuterRoute::Replacement,
+                    );
                     i += 1;
                     continue;
                 }
@@ -6419,7 +6593,7 @@ pub(crate) fn parse_oracle_ir(
                     if let Some(residual) = modal_ir.face_up_residual {
                         emitter.ability_at(item_line, residual);
                     }
-                    emitter.emit_ir_nodes_at(item_line, modal_ir.nodes);
+                    emitter.emit_ir_nodes_at(item_line, modal_ir.nodes, OuterRoute::Modal);
                     if result.modal.is_some() {
                         modal_line.get_or_insert(item_line);
                     }
@@ -6485,13 +6659,21 @@ pub(crate) fn parse_oracle_ir(
             if let Some(replacement_irs) = parse_replacement_sentence_sequence_ir(&line, card_name)
             {
                 for replacement_ir in replacement_irs {
-                    emitter.emit_at(item_line, OracleNodeIr::Replacement(replacement_ir));
+                    emitter.emit_at(
+                        item_line,
+                        OracleNodeIr::Replacement(replacement_ir),
+                        OuterRoute::Replacement,
+                    );
                 }
                 i += 1;
                 continue;
             }
             if let Some(replacement_ir) = parse_replacement_line_ir(&line, card_name) {
-                emitter.emit_at(item_line, OracleNodeIr::Replacement(replacement_ir));
+                emitter.emit_at(
+                    item_line,
+                    OracleNodeIr::Replacement(replacement_ir),
+                    OuterRoute::Replacement,
+                );
                 i += 1;
                 continue;
             }
@@ -6508,13 +6690,21 @@ pub(crate) fn parse_oracle_ir(
                     parse_replacement_sentence_sequence_ir(&effect_text, card_name)
                 {
                     for replacement_ir in replacement_irs {
-                        emitter.emit_at(item_line, OracleNodeIr::Replacement(replacement_ir));
+                        emitter.emit_at(
+                            item_line,
+                            OracleNodeIr::Replacement(replacement_ir),
+                            OuterRoute::Replacement,
+                        );
                     }
                     i += 1;
                     continue;
                 }
                 if let Some(replacement_ir) = parse_replacement_line_ir(&effect_text, card_name) {
-                    emitter.emit_at(item_line, OracleNodeIr::Replacement(replacement_ir));
+                    emitter.emit_at(
+                        item_line,
+                        OracleNodeIr::Replacement(replacement_ir),
+                        OuterRoute::Replacement,
+                    );
                     i += 1;
                     continue;
                 }
@@ -7260,7 +7450,7 @@ pub(crate) fn parse_oracle_ir(
         match dispatch_line_nom(&line, card_name, ctx.host_self_reference.clone()) {
             NomDispatchIr::Spell(mut ir) => {
                 ir.shell.min_x_value = ir.shell.min_x_value.max(min_x_value);
-                emitter.ability_ir_at(item_line, ir);
+                emitter.ability_ir_at_route(item_line, ir, OuterRoute::NomDispatch);
             }
             NomDispatchIr::Unsupported(unsupported) => {
                 emitter.unsupported_ir_at(item_line, unsupported, min_x_value)
@@ -7290,7 +7480,11 @@ pub(crate) fn parse_oracle_ir(
         emitter.strive_cost_at(strive_cost_line.unwrap_or(0), cost);
     }
 
-    let mut doc = emitter.finish(oracle_text, card_name, std::mem::take(&mut ctx.diagnostics));
+    let mut doc = emitter.finish(
+        original_oracle_text,
+        card_name,
+        std::mem::take(&mut ctx.diagnostics),
+    );
     doc.relations = document_relations;
     finalize_document_relations(doc, types)
 }
@@ -7548,14 +7742,43 @@ pub fn parse_oracle_text(
     types: &[String],
     subtypes: &[String],
 ) -> ParsedAbilities {
-    let mut ir = parse_oracle_ir(
+    parse_oracle_pipeline(
         oracle_text,
         card_name,
         mtgjson_keyword_names,
         types,
         subtypes,
+        None,
+        false,
+    )
+    .0
+}
+
+fn parse_oracle_pipeline(
+    oracle_text: &str,
+    card_name: &str,
+    mtgjson_keyword_names: &[String],
+    types: &[String],
+    subtypes: &[String],
+    observer: Option<&mut ParseObserver>,
+    capture_stages: bool,
+) -> (
+    ParsedAbilities,
+    Option<(OracleDocIr, ParsedAbilities, String)>,
+) {
+    let normalized = normalize_card_name_refs(oracle_text, card_name);
+    let mut ir = parse_normalized_oracle_ir(
+        oracle_text,
+        &normalized,
+        card_name,
+        mtgjson_keyword_names,
+        types,
+        subtypes,
+        observer,
     );
+    let document_ir = capture_stages.then(|| ir.clone());
     let mut parsed = lower_oracle_ir(&mut ir);
+    let raw_lowered = capture_stages.then(|| parsed.clone());
     render_granting_self_descriptions(&mut parsed, card_name);
     demote_unbound_delayed_sweeps(&mut parsed);
     demote_unenforceable_replacement_lifetimes(&mut parsed);
@@ -7563,7 +7786,54 @@ pub fn parse_oracle_text(
     crate::parser::oracle_effect::debug_assert_exile_top_opponent_sentinel_lifted(
         &parsed, card_name,
     );
-    parsed
+    let stages = document_ir
+        .zip(raw_lowered)
+        .map(|(document, raw)| (document, raw, normalized));
+    (parsed, stages)
+}
+
+/// Parse once through the production pipeline while retaining report-only stage views.
+pub fn parse_oracle_text_traced(
+    oracle_text: &str,
+    card_name: &str,
+    mtgjson_keyword_names: &[String],
+    types: &[String],
+    subtypes: &[String],
+) -> ParserTrace {
+    let mut observer = ParseObserver::default();
+    let (production_output, stages) = parse_oracle_pipeline(
+        oracle_text,
+        card_name,
+        mtgjson_keyword_names,
+        types,
+        subtypes,
+        Some(&mut observer),
+        true,
+    );
+    let (document_ir, raw_lowered, normalized_source) =
+        stages.expect("traced pipeline captures every requested stage");
+    let mut omitted_evidence = Vec::new();
+    let document_ir_candidate = document_candidate(&document_ir, &mut omitted_evidence);
+    let raw_lowered_candidate = parsed_candidate(
+        &raw_lowered,
+        TraceStage::RawLoweredIr,
+        &mut omitted_evidence,
+    );
+    let production_candidate = parsed_candidate(
+        &production_output,
+        TraceStage::ProductionParsedOutput,
+        &mut omitted_evidence,
+    );
+    ParserTrace {
+        original_source: oracle_text.to_string(),
+        normalized_source,
+        document_ir_candidate,
+        raw_lowered_candidate,
+        production_candidate,
+        events: observer.events,
+        omitted_evidence,
+        production_output,
+    }
 }
 
 /// CR 611.2a: Post-lowering coverage-honesty net for an `AddTargetReplacement`

--- a/crates/engine/src/parser/oracle_ir/mod.rs
+++ b/crates/engine/src/parser/oracle_ir/mod.rs
@@ -13,6 +13,7 @@ pub(crate) mod feature;
 pub(crate) mod relation;
 pub(crate) mod replacement;
 pub(crate) mod static_ir;
+pub mod trace;
 pub(crate) mod trigger;
 
 #[cfg(test)]

--- a/crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+++ b/crates/engine/src/parser/oracle_ir/snapshot_tests.rs
@@ -7,7 +7,9 @@
 use crate::parser::oracle::{lower_oracle_ir, parse_oracle_ir, ParsedAbilities};
 use crate::parser::oracle_ir::diagnostic::OracleDiagnostic;
 use crate::parser::oracle_ir::doc::{OracleDocIr, OracleNodeIr};
+use crate::parser::oracle_ir::trace::OuterRoute;
 use crate::parser::oracle_ir::trigger::TriggerNodeIr;
+use crate::parser::{parse_oracle_text, parse_oracle_text_traced};
 use crate::types::ability::MultiTargetSpec;
 use crate::types::ability::{
     AbilityCost, ActivationRestriction, Effect, TargetChoiceTiming, TriggerCondition,
@@ -49,6 +51,95 @@ fn parse_two_layer_with_keywords(
     let mut ir = parse_oracle_ir(oracle_text, card_name, &keywords, &types, &subtypes);
     let lowered = lower_oracle_ir(&mut ir);
     (ir, lowered)
+}
+
+#[test]
+fn parser_trace_uses_production_output_and_records_real_item_routes() {
+    let text = "Exploit (When this creature enters, you may sacrifice a creature.)\nWhenever a creature you control exploits a nontoken creature, create a 2/2 black Zombie creature token.";
+    let keywords = vec!["Exploit".to_string()];
+    let types = vec!["Creature".to_string()];
+    let subtypes = vec!["Zombie".to_string()];
+    let traced = parse_oracle_text_traced(text, "Skull Skaab", &keywords, &types, &subtypes);
+    let ordinary = parse_oracle_text(text, "Skull Skaab", &keywords, &types, &subtypes);
+
+    assert_eq!(
+        serde_json::to_value(&traced.production_output).expect("serialize traced output"),
+        serde_json::to_value(&ordinary).expect("serialize ordinary output")
+    );
+    assert!(traced
+        .events
+        .iter()
+        .any(|event| event.route == OuterRoute::Trigger));
+    assert!(traced
+        .events
+        .iter()
+        .all(|event| event.span.first_line <= event.span.last_line));
+    let unique_items = traced
+        .events
+        .iter()
+        .map(|event| event.item_id)
+        .collect::<std::collections::BTreeSet<_>>();
+    assert_eq!(
+        unique_items.len(),
+        traced.events.len(),
+        "one outer event per emitted item"
+    );
+}
+
+#[test]
+fn parser_trace_skull_skaab_pair_preserves_input_difference_and_omits_trigger_carrier() {
+    let left_text = "Exploit (When this creature enters, you may sacrifice a creature.)\nWhenever a creature you control exploits a nontoken creature, create a 2/2 black Zombie creature token.";
+    let right_text = "Exploit (When this creature enters, you may sacrifice a creature.)\nWhenever a creature you control exploits a creature, create a 2/2 black Zombie creature token.";
+    let keywords = vec!["Exploit".to_string()];
+    let types = vec!["Creature".to_string()];
+    let subtypes = vec!["Zombie".to_string()];
+    let left = parse_oracle_text_traced(left_text, "Skull Skaab", &keywords, &types, &subtypes);
+    let right = parse_oracle_text_traced(right_text, "A-Skull Skaab", &keywords, &types, &subtypes);
+
+    assert_ne!(left.normalized_source, right.normalized_source);
+    assert!(left
+        .events
+        .iter()
+        .any(|event| event.route == OuterRoute::Trigger));
+    assert!(right
+        .events
+        .iter()
+        .any(|event| event.route == OuterRoute::Trigger));
+    assert!(left
+        .omitted_evidence
+        .iter()
+        .any(|evidence| evidence.identity_sensitive_omission));
+    assert!(right
+        .omitted_evidence
+        .iter()
+        .any(|evidence| evidence.identity_sensitive_omission));
+}
+
+#[test]
+fn parser_trace_distinguishes_routes_that_emit_spell_ir() {
+    let activated = parse_oracle_text_traced(
+        "{T}: Add {G}.",
+        "Test Druid",
+        &[],
+        &["Creature".to_string()],
+        &[],
+    );
+    let imperative = parse_oracle_text_traced(
+        "Draw a card.",
+        "Test Spell",
+        &[],
+        &["Sorcery".to_string()],
+        &[],
+    );
+
+    assert!(activated
+        .events
+        .iter()
+        .any(|event| event.route == OuterRoute::Activated));
+    assert!(imperative
+        .events
+        .iter()
+        .any(|event| event.route == OuterRoute::ImperativeEffect));
 }
 
 /// CR 707.9a + CR 602.1a: generic activated abilities are emitted as native

--- a/crates/engine/src/parser/oracle_ir/trace.rs
+++ b/crates/engine/src/parser/oracle_ir/trace.rs
@@ -1,0 +1,387 @@
+//! Deterministic, opt-in observation of the Oracle parser's document pipeline.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use sha2::{Digest, Sha256};
+
+use super::doc::{OracleDocIr, OracleItemId, OracleSourceSpan};
+use crate::parser::audit_projection::omit_definition_descriptions;
+use crate::parser::oracle::ParsedAbilities;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PayloadVisibility {
+    NativeIr,
+    AssembledOrPrelowered,
+    Unsupported,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+pub enum OuterRoute {
+    #[serde(rename = "preprocessor.class")]
+    Class,
+    #[serde(rename = "preprocessor.saga")]
+    Saga,
+    #[serde(rename = "preprocessor.attraction")]
+    Attraction,
+    #[serde(rename = "preprocessor.leveler")]
+    Leveler,
+    #[serde(rename = "preprocessor.spacecraft")]
+    Spacecraft,
+    #[serde(rename = "preprocessor.strive")]
+    Strive,
+    #[serde(rename = "router.keyword")]
+    Keyword,
+    #[serde(rename = "router.split_keyword")]
+    SplitKeyword,
+    #[serde(rename = "router.trigger")]
+    Trigger,
+    #[serde(rename = "router.activated")]
+    Activated,
+    #[serde(rename = "router.static")]
+    Static,
+    #[serde(rename = "router.replacement")]
+    Replacement,
+    #[serde(rename = "router.imperative_effect")]
+    ImperativeEffect,
+    #[serde(rename = "router.nom_dispatch")]
+    NomDispatch,
+    #[serde(rename = "router.unsupported")]
+    Unsupported,
+    #[serde(rename = "singleton.modal")]
+    Modal,
+    #[serde(rename = "singleton.additional_cost")]
+    AdditionalCost,
+    #[serde(rename = "singleton.casting_restriction")]
+    CastingRestriction,
+    #[serde(rename = "singleton.casting_option")]
+    CastingOption,
+    #[serde(rename = "singleton.solve")]
+    Solve,
+    #[serde(rename = "singleton.strive")]
+    StriveSingleton,
+}
+
+impl OuterRoute {
+    pub fn stable_id(self) -> &'static str {
+        match self {
+            Self::Class => "preprocessor.class",
+            Self::Saga => "preprocessor.saga",
+            Self::Attraction => "preprocessor.attraction",
+            Self::Leveler => "preprocessor.leveler",
+            Self::Spacecraft => "preprocessor.spacecraft",
+            Self::Strive => "preprocessor.strive",
+            Self::Keyword => "router.keyword",
+            Self::SplitKeyword => "router.split_keyword",
+            Self::Trigger => "router.trigger",
+            Self::Activated => "router.activated",
+            Self::Static => "router.static",
+            Self::Replacement => "router.replacement",
+            Self::ImperativeEffect => "router.imperative_effect",
+            Self::NomDispatch => "router.nom_dispatch",
+            Self::Unsupported => "router.unsupported",
+            Self::Modal => "singleton.modal",
+            Self::AdditionalCost => "singleton.additional_cost",
+            Self::CastingRestriction => "singleton.casting_restriction",
+            Self::CastingOption => "singleton.casting_option",
+            Self::Solve => "singleton.solve",
+            Self::StriveSingleton => "singleton.strive",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct OuterRouteEvent {
+    #[serde(skip)]
+    pub(crate) item_id: OracleItemId,
+    pub item: String,
+    pub span: OracleSourceSpan,
+    pub route: OuterRoute,
+    pub payload_visibility: PayloadVisibility,
+}
+
+#[derive(Default)]
+pub(crate) struct ParseObserver {
+    pub(crate) events: Vec<OuterRouteEvent>,
+}
+
+impl ParseObserver {
+    pub(crate) fn record(
+        &mut self,
+        item_id: OracleItemId,
+        span: OracleSourceSpan,
+        route: OuterRoute,
+        payload_visibility: PayloadVisibility,
+    ) {
+        self.events.push(OuterRouteEvent {
+            item_id,
+            item: String::new(),
+            span,
+            route,
+            payload_visibility,
+        });
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct OmittedEvidence {
+    pub stage: TraceStage,
+    pub path: String,
+    pub carrier: DefinitionCarrier,
+    pub value: String,
+    #[serde(skip_serializing_if = "is_false")]
+    pub identity_sensitive_omission: bool,
+}
+
+fn is_false(value: &bool) -> bool {
+    !value
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DefinitionCarrier {
+    AbilityDefinition,
+    TriggerDefinition,
+    StaticDefinition,
+    ReplacementDefinition,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TraceStage {
+    OriginalSource,
+    NormalizedSource,
+    DocumentIr,
+    RawLoweredIr,
+    ProductionParsedOutput,
+}
+
+#[derive(Debug, Clone)]
+pub struct ParserTrace {
+    pub original_source: String,
+    pub normalized_source: String,
+    pub document_ir_candidate: Value,
+    pub raw_lowered_candidate: Value,
+    pub production_candidate: Value,
+    pub events: Vec<OuterRouteEvent>,
+    pub omitted_evidence: Vec<OmittedEvidence>,
+    pub production_output: ParsedAbilities,
+}
+
+pub(crate) fn document_candidate(doc: &OracleDocIr, evidence: &mut Vec<OmittedEvidence>) -> Value {
+    let mut value = serde_json::to_value(doc).expect("OracleDocIr serialization is infallible");
+    if let Value::Object(root) = &mut value {
+        root.remove("source_text");
+        root.remove("card_name");
+        if let Some(Value::Array(items)) = root.get_mut("items") {
+            for item in items.iter_mut() {
+                if let Value::Object(item) = item {
+                    item.remove("source");
+                }
+            }
+        }
+    }
+    append_shared_omissions(&mut value, TraceStage::DocumentIr, evidence);
+    value
+}
+
+pub(crate) fn parsed_candidate(
+    parsed: &ParsedAbilities,
+    stage: TraceStage,
+    evidence: &mut Vec<OmittedEvidence>,
+) -> Value {
+    let mut value =
+        serde_json::to_value(parsed).expect("ParsedAbilities serialization is infallible");
+    append_shared_omissions(&mut value, stage, evidence);
+    value
+}
+
+fn append_shared_omissions(
+    value: &mut Value,
+    stage: TraceStage,
+    evidence: &mut Vec<OmittedEvidence>,
+) {
+    evidence.extend(
+        omit_definition_descriptions(value)
+            .into_iter()
+            .map(|omission| {
+                let carrier = match omission.carrier {
+                    // allow-noncombinator: closed report-schema label, not Oracle text dispatch.
+                    "AbilityDefinition" => DefinitionCarrier::AbilityDefinition,
+                    // allow-noncombinator: closed report-schema label, not Oracle text dispatch.
+                    "TriggerDefinition" => DefinitionCarrier::TriggerDefinition,
+                    // allow-noncombinator: closed report-schema label, not Oracle text dispatch.
+                    "StaticDefinition" => DefinitionCarrier::StaticDefinition,
+                    // allow-noncombinator: closed report-schema label, not Oracle text dispatch.
+                    "ReplacementDefinition" => DefinitionCarrier::ReplacementDefinition,
+                    _ => unreachable!("schema projector has a closed carrier vocabulary"),
+                };
+                OmittedEvidence {
+                    stage,
+                    path: omission.json_pointer,
+                    value: omission.value,
+                    carrier,
+                    identity_sensitive_omission: carrier == DefinitionCarrier::TriggerDefinition,
+                }
+            }),
+    );
+}
+
+pub fn sha256_json(value: &Value) -> String {
+    sha256_bytes(&serde_json::to_vec(value).expect("JSON value serialization is infallible"))
+}
+pub fn sha256_string(value: &str) -> String {
+    sha256_bytes(&serde_json::to_vec(value).expect("string serialization is infallible"))
+}
+pub fn sha256_bytes(value: &[u8]) -> String {
+    format!("{:x}", Sha256::digest(value))
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct PairManifest {
+    pub schema_version: u32,
+    pub pairs: Vec<PairManifestEntry>,
+}
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct PairManifestEntry {
+    pub left_card_face_key: String,
+    pub right_card_face_key: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct FaceRef {
+    pub card_face_key: String,
+    pub name: String,
+}
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct StageComparison {
+    pub stage: TraceStage,
+    pub left_sha256: String,
+    pub right_sha256: String,
+    pub candidate_equal: bool,
+}
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct Collapse {
+    pub kind: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub from: Option<TraceStage>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub to: Option<TraceStage>,
+    pub non_monotonic: bool,
+}
+
+pub fn classify_collapse(stages: &[StageComparison]) -> Collapse {
+    if stages.first().is_some_and(|s| s.candidate_equal) {
+        return Collapse {
+            kind: "already_equal_at_input".into(),
+            from: None,
+            to: None,
+            non_monotonic: stages.iter().any(|s| !s.candidate_equal),
+        };
+    }
+    let first = stages
+        .windows(2)
+        .find(|w| !w[0].candidate_equal && w[1].candidate_equal);
+    let (kind, from, to) = first.map_or(("no_collapse", None, None), |w| {
+        ("first_false_to_true", Some(w[0].stage), Some(w[1].stage))
+    });
+    let non_monotonic = first.is_some_and(|w| {
+        let start = stages.iter().position(|s| s.stage == w[1].stage).unwrap();
+        stages[start + 1..].iter().any(|s| !s.candidate_equal)
+    });
+    Collapse {
+        kind: kind.into(),
+        from,
+        to,
+        non_monotonic,
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct PairReport {
+    pub left: FaceRef,
+    pub right: FaceRef,
+    pub stages: Vec<StageComparison>,
+    pub collapse: Collapse,
+    pub left_outer_route_events: Vec<OuterRouteEvent>,
+    pub right_outer_route_events: Vec<OuterRouteEvent>,
+    pub shared_outer_routes: Vec<OuterRoute>,
+    pub location_precision: &'static str,
+    pub limitation_codes: BTreeSet<String>,
+    pub omitted_evidence: PairOmittedEvidence,
+}
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct PairOmittedEvidence {
+    pub left: Vec<OmittedEvidence>,
+    pub right: Vec<OmittedEvidence>,
+}
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct CensusFace {
+    pub card_face_key: String,
+    pub name: String,
+}
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct OuterRouteCensusRow {
+    pub route: OuterRoute,
+    pub event_count: usize,
+    pub face_count: usize,
+    pub card_faces: Vec<CensusFace>,
+}
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct FaceCounts {
+    pub winning_faces: usize,
+    pub traced_faces: usize,
+    pub unavailable_events: usize,
+    pub faces_with_unavailable_events: usize,
+}
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ParserTraceReport {
+    pub schema_version: u32,
+    pub algorithm_version: &'static str,
+    pub card_data_sha256: String,
+    pub faces: FaceCounts,
+    pub pairs: Vec<PairReport>,
+    pub outer_route_census: Vec<OuterRouteCensusRow>,
+}
+
+pub fn canonicalize_events(side: &str, events: &mut [OuterRouteEvent]) {
+    let mut ids = BTreeMap::new();
+    for event in events.iter() {
+        let next = ids.len();
+        ids.entry(event.item_id).or_insert(next);
+    }
+    for event in events.iter_mut() {
+        event.item = format!("{side}/item:{}", ids[&event.item_id]);
+    }
+    events.sort_by(|a, b| {
+        a.item
+            .cmp(&b.item)
+            .then(a.route.stable_id().cmp(b.route.stable_id()))
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn parser_trace_collapse_classification_is_non_monotonic_aware() {
+        let mk = |stage, equal| StageComparison {
+            stage,
+            left_sha256: String::new(),
+            right_sha256: String::new(),
+            candidate_equal: equal,
+        };
+        let stages = vec![
+            mk(TraceStage::OriginalSource, false),
+            mk(TraceStage::NormalizedSource, true),
+            mk(TraceStage::DocumentIr, false),
+        ];
+        let collapse = classify_collapse(&stages);
+        assert_eq!(collapse.kind, "first_false_to_true");
+        assert!(collapse.non_monotonic);
+    }
+}

--- a/scripts/prelowered-ratchet.txt
+++ b/scripts/prelowered-ratchet.txt
@@ -12,7 +12,8 @@
 # real IR nodes. Every tranche that converts a producer must lower its number
 # in the same commit, which is what makes the burn-down visible in `git log`
 # on this one file.
-crates/engine/src/parser/oracle.rs          5
+# Includes two read-only trace visibility match arms; no new producers.
+crates/engine/src/parser/oracle.rs          7
 crates/engine/src/parser/oracle_class.rs    3
 
 # --- infrastructure: NOT burn-down targets ----------------------------------


### PR DESCRIPTION
Adds deterministic parser diagnostics for finding likely semantic misparses among cards currently reported as supported.

- `set-check --structural-collisions` finds similar Oracle texts that collapse to the same structural parse.
- `oracle_contrastive_audit` checks bounded text mutations for the expected typed AST change.
- `oracle-gen --parser-trace-pairs ... --parser-trace-out ...` traces selected pairs through parser stages and reports the outer-route census.

Validation:
- 58 focused tests passed.
- Tool-profile check, clippy with warnings denied, and executable build passed.
- Parser combinator, PreLowered ratchet, and CR citation gates passed.
- Full generated card data was byte-identical with tracing disabled and enabled.
- Repeated deterministic reports were byte-identical across runs.

Pipeline-reviewed head: ee4c32b207af158f73d3733db2a2006e882663ed
Current branch head: 9c3c67ab0cbe80ee4cc08bf1880e8f0256c1f8eb
Pipeline status: historical — cherry-picked onto current origin/main for shipment
Current-head review: none


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added deterministic auditing for semantic collisions and structural overlaps in card data.
  - Added optional parser tracing and comparison reports to help inspect differences across processing stages.
  - Improved handling and matching of individual card faces in coverage and analysis reports.

- **Bug Fixes**
  - Improved Oracle text preparation, including keyword normalization, face-name resolution, and Cleave text handling.
  - Preserved compatibility of existing coverage output while improving internal face identification.

- **Tests**
  - Added broad regression coverage for parsing, tracing, collision detection, report ordering, and input validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->