### PR TITLE
Preserve opponent-only edict targets

### DIFF
--- a/crates/engine/src/game/effects/sacrifice.rs
+++ b/crates/engine/src/game/effects/sacrifice.rs
@@ -636,6 +636,7 @@ pub fn resolve(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::game::ability_utils::build_target_slots;
     use crate::game::effects::resolve_ability_chain;
     use crate::game::zones::create_object;
     use crate::types::ability::{
@@ -1063,7 +1064,8 @@ mod tests {
     }
 
     // CR 701.21a: When the target filter scopes sacrifice to opponents
-    // (ControllerRef::Opponent) or a target player (ControllerRef::TargetPlayer),
+    // (ControllerRef::Opponent) or a target player/opponent
+    // (ControllerRef::TargetPlayer/TargetOpponent),
     // the affected player — not the ability controller — both provides the
     // eligible permanent pool and makes the choice.
     fn make_scoped_sacrifice_ability(
@@ -1163,6 +1165,58 @@ mod tests {
             WaitingFor::EffectZoneChoice { player, cards, .. } => {
                 assert_eq!(*player, PlayerId(1));
                 assert!(cards.contains(&tp_a) && cards.contains(&tp_b));
+                assert_eq!(cards.len(), 2);
+            }
+            other => panic!("expected EffectZoneChoice, got {other:?}"),
+        }
+    }
+
+    /// CR 115.1a/c/d + CR 701.21a: A targeted-opponent edict exposes only the
+    /// opponent as its player target, then routes the sacrifice choice to that
+    /// selected opponent.
+    #[test]
+    fn target_opponent_scope_excludes_self_and_routes_choice_to_target() {
+        let mut state = GameState::new_two_player(42);
+        let own = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Mine".to_string(),
+            Zone::Battlefield,
+        );
+        let opp_a = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(1),
+            "OppA".to_string(),
+            Zone::Battlefield,
+        );
+        let opp_b = create_object(
+            &mut state,
+            CardId(3),
+            PlayerId(1),
+            "OppB".to_string(),
+            Zone::Battlefield,
+        );
+        let mut ability = make_scoped_sacrifice_ability(ControllerRef::TargetOpponent, vec![]);
+
+        let slots = build_target_slots(&state, &ability).expect("target slots build");
+        assert_eq!(slots.len(), 1, "the edict has one player target slot");
+        assert_eq!(
+            slots[0].legal_targets,
+            vec![TargetRef::Player(PlayerId(1))],
+            "the ability controller must not be a legal target opponent"
+        );
+
+        ability.targets = vec![TargetRef::Player(PlayerId(1))];
+        let mut events = Vec::new();
+        resolve(&mut state, &ability, &mut events).unwrap();
+
+        match &state.waiting_for {
+            WaitingFor::EffectZoneChoice { player, cards, .. } => {
+                assert_eq!(*player, PlayerId(1), "the targeted opponent chooses");
+                assert!(cards.contains(&opp_a) && cards.contains(&opp_b));
+                assert!(!cards.contains(&own));
                 assert_eq!(cards.len(), 2);
             }
             other => panic!("expected EffectZoneChoice, got {other:?}"),

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -16884,7 +16884,7 @@ fn thread_for_each_subject(effect: Effect, original: &str, ctx: &mut ParseContex
         // early, so the fixed-count `inject_subject_target` Sacrifice arm never ran
         // and the controller stayed null (→ the source's controller sacrifices).
         // Mirror that arm here: stamp the subject player's controller onto the
-        // object filter (TargetPlayer for targeted subjects → surfaces a player
+        // object filter (TargetPlayer/TargetOpponent for targeted subjects → surfaces a player
         // target slot, read by `resolve_sacrifice_scope` at resolution) and rewrite
         // any "they control" refs inside the count to the same player.
         Effect::Sacrifice {
@@ -16893,11 +16893,7 @@ fn thread_for_each_subject(effect: Effect, original: &str, ctx: &mut ParseContex
             min_count,
         } if player_filter_as_controller_ref(&target).is_some() => {
             let ctrl = player_filter_as_controller_ref(&target).expect("guarded is_some");
-            let effective_ctrl = if is_targeted {
-                ControllerRef::TargetPlayer
-            } else {
-                ctrl
-            };
+            let effective_ctrl = sacrifice_subject_controller(ctrl, is_targeted);
             force_controller(&mut sac_target, effective_ctrl.clone());
             rewrite_quantity_controller(
                 &mut sac_count,
@@ -23810,6 +23806,21 @@ fn player_filter_as_controller_ref(filter: &TargetFilter) -> Option<ControllerRe
     }
 }
 
+/// CR 115.1a/c/d: Preserve whether a targeted sacrifice subject is
+/// any player or specifically an opponent while converting the player subject
+/// into the sacrificed permanent filter's controller reference.
+fn sacrifice_subject_controller(controller: ControllerRef, is_targeted: bool) -> ControllerRef {
+    if !is_targeted {
+        return controller;
+    }
+
+    if controller == ControllerRef::Opponent {
+        ControllerRef::TargetOpponent
+    } else {
+        ControllerRef::TargetPlayer
+    }
+}
+
 pub(crate) fn target_filter_controller_ref(filter: &TargetFilter) -> Option<ControllerRef> {
     match filter {
         TargetFilter::Typed(tf) => tf.controller.clone(),
@@ -24667,7 +24678,8 @@ fn inject_subject_target(effect: &mut Effect, subject: &SubjectPhraseAst) {
         // inject the subject's controller constraint. For non-targeted subjects
         // ("each player sacrifices a non-Elf creature"), this scopes the filter
         // to the acting player's permanents. For targeted subjects ("target
-        // opponent sacrifices..."), use ControllerRef::TargetPlayer so the
+        // opponent sacrifices..."), preserve TargetOpponent rather than widening
+        // it to TargetPlayer so the
         // engine surfaces a player target slot and resolve_sacrifice_scope
         // reads the chosen player from ability.targets at resolution time.
         // Also rewrite "they control" refs inside the count expression so
@@ -24676,11 +24688,8 @@ fn inject_subject_target(effect: &mut Effect, subject: &SubjectPhraseAst) {
             if player_filter_as_controller_ref(&subject_filter).is_some() =>
         {
             if let Some(ctrl) = player_filter_as_controller_ref(&subject_filter) {
-                let effective_ctrl = if subject.target.is_some() {
-                    ControllerRef::TargetPlayer
-                } else {
-                    ctrl
-                };
+                let effective_ctrl =
+                    sacrifice_subject_controller(ctrl, subject.target.is_some());
                 force_controller(target, effective_ctrl.clone());
                 if subject.target.is_some() {
                     rewrite_quantity_controller(count, ControllerRef::ScopedPlayer, effective_ctrl);

--- a/crates/engine/src/parser/oracle_effect/tests.rs
+++ b/crates/engine/src/parser/oracle_effect/tests.rs
@@ -9298,11 +9298,11 @@ fn for_each_pump_other_controlled_creature_with_keyword_production_path() {
 /// creature ... for each <dynamic>" (Urborg Justice). The "for each" path
 /// intercepts before the fixed-count `inject_subject_target` Sacrifice arm,
 /// so without `thread_for_each_subject` rebinding the controller, YOU
-/// sacrificed instead of the targeted opponent. Both the `TargetPlayer`
+/// sacrificed instead of the targeted opponent. Both the `TargetOpponent`
 /// scope AND the dynamic `ZoneChangeCountThisTurn` count must survive.
 /// Regression guard: revert either edit and the controller is `None`.
 #[test]
-fn for_each_sacrifice_target_opponent_dynamic_count_binds_target_player() {
+fn for_each_sacrifice_target_opponent_dynamic_count_binds_target_opponent() {
     let e = parse_effect(
         "Target opponent sacrifices a creature of their choice for each creature put \
              into your graveyard from the battlefield this turn.",
@@ -9311,8 +9311,8 @@ fn for_each_sacrifice_target_opponent_dynamic_count_binds_target_player() {
         Effect::Sacrifice { target, count, .. } => {
             assert_eq!(
                 target_filter_controller_ref(&target),
-                Some(ControllerRef::TargetPlayer),
-                "sacrificed-creature filter must be scoped to TargetPlayer, got {target:?}"
+                Some(ControllerRef::TargetOpponent),
+                "sacrificed-creature filter must be scoped to TargetOpponent, got {target:?}"
             );
             assert!(
                 matches!(
@@ -40499,26 +40499,28 @@ fn inject_subject_target_copy_token_owner() {
     }
 }
 
-/// CR 115.1 + CR 701.21a: Edict parity — "target player sacrifices a
-/// creature" must scope the sacrificed-creature filter to
-/// `ControllerRef::TargetPlayer`, identical to "target opponent sacrifices".
-/// Regression guard for the dropped-controller misparse (#552 / Diabolic
-/// Edict / Chainer's Edict / Geth's Verdict): "target player" lowers to the
-/// unit `TargetFilter::Player`, which `player_filter_as_controller_ref`
-/// previously did not recognize, leaving `controller: None`.
+/// CR 115.1 + CR 701.21a: Edict subjects retain their player-target
+/// restriction. Diabolic Edict can target any player, while Cruel Edict can
+/// target only an opponent.
 #[test]
-fn target_player_sacrifices_scopes_controller_to_target_player() {
-    for text in [
-        "target player sacrifices a creature",
-        "target opponent sacrifices a creature",
+fn targeted_player_sacrifice_preserves_target_scope() {
+    for (text, expected) in [
+        (
+            "Target player sacrifices a creature of their choice.",
+            ControllerRef::TargetPlayer,
+        ),
+        (
+            "Target opponent sacrifices a creature of their choice.",
+            ControllerRef::TargetOpponent,
+        ),
     ] {
-        let clause = parse_effect_clause(text, &mut ParseContext::default());
-        match &clause.effect {
+        let effect = parse_effect(text);
+        match &effect {
             Effect::Sacrifice { target, .. } => {
                 assert_eq!(
                     target_filter_controller_ref(target),
-                    Some(ControllerRef::TargetPlayer),
-                    "{text:?} must scope the sacrificed filter to TargetPlayer, got {0:?}",
+                    Some(expected),
+                    "{text:?} must preserve its player target restriction, got {0:?}",
                     target
                 );
             }

--- a/crates/engine/src/parser/oracle_effect/tests.rs
+++ b/crates/engine/src/parser/oracle_effect/tests.rs
@@ -9362,13 +9362,13 @@ fn for_each_sacrifice_target_player_counters_on_source_binds_target_player() {
 
 /// CR 115.1a/c + CR 701.21a: Din of the Fireherd leading leg — "Target
 /// opponent sacrifices a creature for each black creature you control, then
-/// ...". The first sacrifice leg must bind `TargetPlayer` with its dynamic
+/// ...". The first sacrifice leg must bind `TargetOpponent` with its dynamic
 /// `ObjectCount` count. (The "then sacrifices a land" continuation is an
 /// implicit-subject continuation handled by a separate compound path; see
 /// the deviations note — its land filter is a pre-existing controller gap
 /// out of scope of this AST-only for-each fix.)
 #[test]
-fn for_each_sacrifice_din_first_leg_binds_target_player() {
+fn for_each_sacrifice_din_first_leg_binds_target_opponent() {
     let sorcery = vec!["Sorcery".to_string()];
     let pa = crate::parser::parse_oracle_text(
         "Target opponent sacrifices a creature for each black creature you control, \
@@ -9386,8 +9386,8 @@ fn for_each_sacrifice_din_first_leg_binds_target_player() {
         Effect::Sacrifice { target, count, .. } => {
             assert_eq!(
                 target_filter_controller_ref(target),
-                Some(ControllerRef::TargetPlayer),
-                "Din first leg must scope to TargetPlayer, got {target:?}"
+                Some(ControllerRef::TargetOpponent),
+                "Din first leg must scope to TargetOpponent, got {target:?}"
             );
             assert!(
                 matches!(
@@ -14004,7 +14004,7 @@ fn targeted_player_subject_carries_to_conjugated_predicates() {
     };
     assert_eq!(
         target_filter_controller_ref(target),
-        Some(ControllerRef::TargetPlayer)
+        Some(ControllerRef::TargetOpponent)
     );
 
     // CR 601.2c (#2344): the single "target opponent" is chosen once at

--- a/crates/engine/tests/integration/archon_compound_target_2344.rs
+++ b/crates/engine/tests/integration/archon_compound_target_2344.rs
@@ -34,7 +34,10 @@ fn hand_count(runner: &GameRunner, player: PlayerId) -> usize {
 
 #[test]
 fn compound_target_opponent_chosen_once_and_all_three_effects_apply() {
-    let mut scenario = GameScenario::new_n_player(2, 42);
+    // Three players keep two legal opponents in the target slot. In a duel,
+    // `TargetOpponent` correctly auto-selects the sole legal opponent and the
+    // engine proceeds directly to priority without a selection prompt.
+    let mut scenario = GameScenario::new_n_player(3, 42);
     scenario.at_phase(Phase::PreCombatMain);
     scenario.with_life(P1, 20);
     // The one opponent: a creature to sacrifice and a card to discard.


### PR DESCRIPTION
Cruel Edict and other `target opponent sacrifices` effects were widened to `target player` while the parser injected the acting player's controller into the sacrificed-permanent filter. The parser now preserves `TargetOpponent` for opponent-only subjects in both ordinary and dynamic `for each` sacrifice paths, while unrestricted `target player` edicts keep `TargetPlayer`.

The regression coverage verifies the parsed distinction, opponent-only target legality, and routing of the sacrifice choice to the selected opponent.

Validation:
- `cargo fmt --all`
- parser combinator gate
- `targeted_player_sacrifice_preserves_target_scope`
- `for_each_sacrifice_target_opponent_dynamic_count_binds_target_opponent`
- `target_opponent_scope_excludes_self_and_routes_choice_to_target`
- independent Terra high implementation review (no blocking findings)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected targeted sacrifice effects so “target opponent” consistently excludes the effect’s controller.
  - Ensured sacrifice choices are routed to the selected opponent and limited to that opponent’s eligible permanents.
  - Preserved the distinction between effects targeting any player and those specifically targeting an opponent.
  - Improved multi-player target selection so valid opponent choices are presented and a selected target is applied consistently across related effects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->