### PR TITLE
Exercise second opponent in edict regression

### DIFF
--- a/crates/engine/tests/integration/archon_compound_target_2344.rs
+++ b/crates/engine/tests/integration/archon_compound_target_2344.rs
@@ -87,6 +87,17 @@ fn compound_target_opponent_chosen_once_and_all_three_effects_apply() {
                  target slot, got {}",
                 target_slots.len()
             );
+            assert_eq!(
+                target_slots[0].legal_targets.len(),
+                2,
+                "both opponents, and only opponents, must be legal targets"
+            );
+            assert!(
+                target_slots[0]
+                    .legal_targets
+                    .contains(&TargetRef::Player(P1)),
+                "the first opponent must remain a legal target"
+            );
             assert!(
                 target_slots[0]
                     .legal_targets

--- a/crates/engine/tests/integration/archon_compound_target_2344.rs
+++ b/crates/engine/tests/integration/archon_compound_target_2344.rs
@@ -19,6 +19,8 @@ use engine::types::mana::ManaCost;
 use engine::types::phase::Phase;
 use engine::types::player::PlayerId;
 
+const P2: PlayerId = PlayerId(2);
+
 const ARCHON_EFFECT: &str = "Target opponent sacrifices a creature or planeswalker \
      of their choice, discards a card, and loses 3 life. You draw a card and gain 3 life.";
 
@@ -40,9 +42,13 @@ fn compound_target_opponent_chosen_once_and_all_three_effects_apply() {
     let mut scenario = GameScenario::new_n_player(3, 42);
     scenario.at_phase(Phase::PreCombatMain);
     scenario.with_life(P1, 20);
-    // The one opponent: a creature to sacrifice and a card to discard.
+    // Both opponents have valid choices. Selecting the second proves resolution
+    // follows the announced target instead of defaulting to the first opponent.
     scenario.add_vanilla(P1, 2, 2);
     scenario.with_cards_in_hand(P1, &["Discard Fodder"]);
+    scenario.with_life(P2, 20);
+    scenario.add_vanilla(P2, 2, 2);
+    scenario.with_cards_in_hand(P2, &["Second Discard Fodder"]);
     // P0 needs a library to satisfy the "you draw a card" rider.
     scenario.add_card_to_library_top(P0, "Draw Card");
 
@@ -57,6 +63,9 @@ fn compound_target_opponent_chosen_once_and_all_three_effects_apply() {
     let p1_life_before = runner.life(P1);
     let p1_bf_before = runner.battlefield_count(P1);
     let p1_hand_before = hand_count(&runner, P1);
+    let p2_life_before = runner.life(P2);
+    let p2_bf_before = runner.battlefield_count(P2);
+    let p2_hand_before = hand_count(&runner, P2);
 
     runner
         .act(GameAction::CastSpell {
@@ -81,14 +90,14 @@ fn compound_target_opponent_chosen_once_and_all_three_effects_apply() {
             assert!(
                 target_slots[0]
                     .legal_targets
-                    .contains(&TargetRef::Player(P1)),
-                "the opponent must be a legal target"
+                    .contains(&TargetRef::Player(P2)),
+                "the second opponent must be a legal target"
             );
             runner
                 .act(GameAction::SelectTargets {
-                    targets: vec![TargetRef::Player(P1)],
+                    targets: vec![TargetRef::Player(P2)],
                 })
-                .expect("targeting the single opponent must succeed");
+                .expect("targeting the second opponent must succeed");
         }
         other => panic!("expected a single TargetSelection prompt, got {other:?}"),
     }
@@ -104,7 +113,7 @@ fn compound_target_opponent_chosen_once_and_all_three_effects_apply() {
         );
         match runner.state().waiting_for.clone() {
             WaitingFor::EffectZoneChoice { player, cards, .. } => {
-                assert_eq!(player, P1, "only the chosen opponent sacrifices");
+                assert_eq!(player, P2, "only the chosen opponent sacrifices");
                 runner
                     .act(GameAction::SelectCards {
                         cards: vec![cards[0]],
@@ -112,7 +121,7 @@ fn compound_target_opponent_chosen_once_and_all_three_effects_apply() {
                     .expect("sacrifice choice");
             }
             WaitingFor::DiscardChoice { player, cards, .. } => {
-                assert_eq!(player, P1, "only the chosen opponent discards");
+                assert_eq!(player, P2, "only the chosen opponent discards");
                 runner
                     .act(GameAction::SelectCards {
                         cards: vec![cards[0]],
@@ -132,20 +141,23 @@ fn compound_target_opponent_chosen_once_and_all_three_effects_apply() {
     }
     runner.advance_until_stack_empty();
 
-    // All three effects landed on the one opponent.
+    // All three effects land on the selected second opponent.
     assert_eq!(
-        runner.battlefield_count(P1),
-        p1_bf_before - 1,
+        runner.battlefield_count(P2),
+        p2_bf_before - 1,
         "opponent must sacrifice exactly one creature"
     );
     assert_eq!(
-        hand_count(&runner, P1),
-        p1_hand_before - 1,
+        hand_count(&runner, P2),
+        p2_hand_before - 1,
         "opponent must discard exactly one card"
     );
     assert_eq!(
-        runner.life(P1),
-        p1_life_before - 3,
+        runner.life(P2),
+        p2_life_before - 3,
         "opponent must lose exactly 3 life"
     );
+    assert_eq!(runner.battlefield_count(P1), p1_bf_before);
+    assert_eq!(hand_count(&runner, P1), p1_hand_before);
+    assert_eq!(runner.life(P1), p1_life_before);
 }


### PR DESCRIPTION
The opponent-scope fix in #8729 correctly preserves a selected opponent, but its three-player regression selected the first legal opponent. This follow-up selects the second opponent, gives both opponents valid sacrifice/discard choices, and asserts that every effect applies only to the announced second target.

Validation:
- `cargo fmt --all -- --check`
- parser combinator, PreLowered, and CR citation pre-commit gates
- full CI requested by this PR

Local Tilt watches the main checkout and correctly refused to claim this isolated worktree test as validated. The production change itself passed the full #8729 CI suite; this PR strengthens that regression witness.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Expanded regression coverage for three-player compound-target scenarios.
  - Verifies that the explicitly selected opponent receives sacrifice, discard, and life-loss effects.
  - Confirms that other legal opponents remain unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->