### PR TITLE
feat(engine): Swedish Old School preset + CR 407.3 ante exclusion (custom-format-engine Phase 1d)

### DIFF
--- a/client/src/adapter/__tests__/format-config-shape.test.ts
+++ b/client/src/adapter/__tests__/format-config-shape.test.ts
@@ -57,6 +57,9 @@ function customRules(id = 0): CustomFormatRules {
         damage_timing: "Modern",
         wish_scope: "PostM10SideboardOnly",
         legend_rule_scope: "Modern",
+        // Present here because the engine always emits it; the
+        // persisted-before-the-axis case drops it explicitly below.
+        ante: "Excluded",
       },
     },
   };
@@ -281,6 +284,50 @@ describe("isCustomFormatRulesShape", () => {
         legality: {
           ...rules.legality,
           legacy: { ...rules.legality.legacy, mana_burn: "Whatever" },
+        },
+      }),
+    ).toBe(false);
+  });
+
+  it("accepts a definition persisted before the ante axis existed", () => {
+    // Back-compat with `localStorage`, one of the two untrusted ingresses
+    // this guard stands in front of: a `SavedCustomFormat` written before the
+    // ante axis carries no `ante` key. Rejecting it would silently discard
+    // every custom format a player had already saved. Mirrors the engine's
+    // `#[serde(default)]` on the same field.
+    const rules = customRules();
+    const { ante: _dropped, ...legacyWithoutAnte } = rules.legality.legacy;
+    expect(
+      isCustomFormatRulesShape({
+        ...rules,
+        legality: { ...rules.legality, legacy: legacyWithoutAnte },
+      }),
+    ).toBe(true);
+  });
+
+  it("validates the ante axis when present", () => {
+    const rules = customRules();
+    // Both real values are wire-VALID here. This guard checks shape, not
+    // policy: rejecting `Enabled` is the engine's `passes_legacy_axis_gate`
+    // job, and duplicating that decision in the display layer would be a
+    // second, drifting authority on what the engine implements.
+    for (const ante of ["Excluded", "Enabled"]) {
+      expect(
+        isCustomFormatRulesShape({
+          ...rules,
+          legality: {
+            ...rules.legality,
+            legacy: { ...rules.legality.legacy, ante },
+          },
+        }),
+      ).toBe(true);
+    }
+    expect(
+      isCustomFormatRulesShape({
+        ...rules,
+        legality: {
+          ...rules.legality,
+          legacy: { ...rules.legality.legacy, ante: "Whatever" },
         },
       }),
     ).toBe(false);

--- a/client/src/adapter/format-config-shape.ts
+++ b/client/src/adapter/format-config-shape.ts
@@ -114,6 +114,12 @@ function isLegacyRuleSet(value: unknown): boolean {
     && (value.damage_timing === "Modern" || value.damage_timing === "OnStack")
     && (value.wish_scope === "PostM10SideboardOnly" || value.wish_scope === "PreM10ReachesExile")
     && (value.legend_rule_scope === "Modern" || value.legend_rule_scope === "PreM14AnyController")
+    // Absent is valid: this axis postdates the Axis-A save path, and this
+    // predicate also validates definitions persisted locally before it
+    // existed. Rejecting those would discard every saved custom format
+    // outright — the same back-compat the engine's `#[serde(default)]`
+    // provides on the same field, where absent means "Excluded".
+    && (value.ante === undefined || value.ante === "Excluded" || value.ante === "Enabled")
   );
 }
 

--- a/client/src/adapter/types.ts
+++ b/client/src/adapter/types.ts
@@ -196,11 +196,22 @@ export type WishOutsideGameScope = "PostM10SideboardOnly" | "PreM10ReachesExile"
  *  all-controllers form. Schema only — unenforced. */
 export type LegendRuleScope = "Modern" | "PreM14AnyController";
 
+/** CR 407: whether the format is played for ante. `Excluded` is the modern
+ *  default and the only value the engine implements; unlike its sibling axes
+ *  it is enforced, at deck construction (CR 407.3). */
+export type AntePolicy = "Excluded" | "Enabled";
+
 export interface LegacyRuleSet {
   mana_burn: ManaBurnPolicy;
   damage_timing: CombatDamageTiming;
   wish_scope: WishOutsideGameScope;
   legend_rule_scope: LegendRuleScope;
+  /** Optional because this axis postdates the Axis-A save path: a definition
+   *  persisted before it existed carries no `ante` key. Mirrors the engine's
+   *  `#[serde(default)]` on the same field, where absent likewise means
+   *  `"Excluded"` — which is what such a save meant. The engine always emits
+   *  it, so only a locally-persisted definition can be missing it. */
+  ante?: AntePolicy;
 }
 
 /** CR 903.3 and the Tiny Leaders / Oathbreaker / Brawl deck-construction

--- a/crates/engine/src/game/ante.rs
+++ b/crates/engine/src/game/ante.rs
@@ -1,0 +1,86 @@
+//! CR 407: ante. The single authority for the ante rule's two enforced
+//! questions — which cards belong to the class, and whether this game admits
+//! them.
+//!
+//! CR 407.1 makes playing for ante "an optional variation on the game",
+//! "strictly forbidden under the Magic: The Gathering Tournament Rules", and
+//! this engine implements no part of the CR 407.2 ante zone or the CR 407.4
+//! ante action. So [`AntePolicy::Excluded`] is the operative policy for every
+//! game it can currently host, and CR 407.3's prohibitions are real
+//! restrictions rather than schema.
+//!
+//! CR 407.3 states three of them, and they are not all in one place in the
+//! codebase, which is why this module exists rather than a predicate sitting
+//! next to whichever caller needed it first:
+//!
+//! 1. cards may not be in a **deck** — `game::deck_validation`;
+//! 2. cards may not be in a **sideboard** — same;
+//! 3. cards may not be **brought into the game from outside the game** —
+//!    [`admits_face_from_outside_game`], applied at the offer sites and at
+//!    `effects::search_outside_game::put_outside_game_face_into`, the single
+//!    materialization authority both outside-game sources funnel through.
+//!
+//! The third is the one a card list would never have covered: a booster pack
+//! opened mid-game (Booster Tutor and friends) draws from a set's whole card
+//! pool, not from anything the deck-construction rules already vetted.
+
+use crate::types::card::CardFace;
+use crate::types::custom_format::AntePolicy;
+use crate::types::game_state::GameState;
+
+/// CR 407.3: "A few cards have the text 'Remove this card from your deck
+/// before playing if you're not playing for ante.' These are the only cards
+/// that can add or remove cards from the ante zone or change a card's owner."
+///
+/// The rule identifies the class by the cards' own printed text, so this
+/// predicate matches that text rather than a hardcoded roster — a name list
+/// would be a snapshot that silently misses anything else printed with the
+/// clause, and would have to be repeated by every rule that excludes them.
+///
+/// Matches the substring `playing for ante`, the templated clause's stable
+/// core (unaffected by the "Remove this card"/"Remove ~ from your deck"
+/// wording differences across printings). Verified exact at implementation
+/// time: Scryfall's `oracle:"playing for ante"` returns 9 cards — Amulet of
+/// Quoz, Bronze Tablet, Contract from Below, Darkpact, Demonic Attorney,
+/// Jeweled Bird, Rebirth, Tempest Efreet, Timmerian Fiends — which is the
+/// whole class with no false positives.
+pub(crate) fn face_uses_ante(face: &CardFace) -> bool {
+    face.oracle_text
+        .as_deref()
+        .unwrap_or("")
+        .to_ascii_lowercase()
+        .contains("playing for ante")
+}
+
+/// The ante policy this game is played under.
+///
+/// A built-in format carries no `custom_rules`, and `unwrap_or_default()`
+/// resolves it to [`AntePolicy::Excluded`] — which is not a fallback so much
+/// as the rule: CR 407 is not a custom-format concept, and no built-in format
+/// in this engine plays for ante. [`AntePolicy::Enabled`] is reachable only by
+/// a custom format declaring it, which `passes_legacy_axis_gate` refuses today
+/// precisely because the ante zone does not exist yet.
+pub(crate) fn policy(state: &GameState) -> AntePolicy {
+    state
+        .format_config
+        .custom_rules
+        .as_deref()
+        .map(|rules| rules.legality.legacy.ante)
+        .unwrap_or_default()
+}
+
+/// CR 407.3: "When not playing for ante, players can't include these cards in
+/// their decks or sideboards, and these cards can't be brought into the game
+/// from outside the game." This answers the last clause.
+///
+/// Fails CLOSED by construction: the only policy that admits the class is an
+/// explicit [`AntePolicy::Enabled`], so any future outside-game source that
+/// routes through the materialization authority is covered without being
+/// taught the rule.
+pub(crate) fn admits_face_from_outside_game(state: &GameState, face: &CardFace) -> bool {
+    match policy(state) {
+        // CR 407.2: playing for ante makes the class legal again.
+        AntePolicy::Enabled => true,
+        AntePolicy::Excluded => !face_uses_ante(face),
+    }
+}

--- a/crates/engine/src/game/ante.rs
+++ b/crates/engine/src/game/ante.rs
@@ -23,9 +23,19 @@
 //! The third is the one a card list would never have covered: a booster pack
 //! opened mid-game (Booster Tutor and friends) draws from a set's whole card
 //! pool, not from anything the deck-construction rules already vetted.
+//!
+//! **All three read [`policy_of`], and 1–2 are enforced once for every format
+//! rather than inside any single card-pool authority.** The deck half cannot
+//! live in `DeckValidation`'s `CardPoolAuthority`: that seam is reached only by
+//! constructed-shaped formats, while commander-shaped ones use their own
+//! validator and FreeForAll / TwoHeadedGiant / Limited impose no card-pool
+//! check at all. CR 407.3 is not a card-pool restriction that a permissive
+//! format may waive — it holds whenever the game is not played for ante — so it
+//! belongs beside the other cross-format rules at the dispatch seam.
 
 use crate::types::card::CardFace;
 use crate::types::custom_format::AntePolicy;
+use crate::types::format::FormatConfig;
 use crate::types::game_state::GameState;
 
 /// CR 407.3: "A few cards have the text 'Remove this card from your deck
@@ -52,7 +62,7 @@ pub(crate) fn face_uses_ante(face: &CardFace) -> bool {
         .contains("playing for ante")
 }
 
-/// The ante policy this game is played under.
+/// The ante policy a format declares.
 ///
 /// A built-in format carries no `custom_rules`, and `unwrap_or_default()`
 /// resolves it to [`AntePolicy::Excluded`] — which is not a fallback so much
@@ -60,13 +70,22 @@ pub(crate) fn face_uses_ante(face: &CardFace) -> bool {
 /// in this engine plays for ante. [`AntePolicy::Enabled`] is reachable only by
 /// a custom format declaring it, which `passes_legacy_axis_gate` refuses today
 /// precisely because the ante zone does not exist yet.
-pub(crate) fn policy(state: &GameState) -> AntePolicy {
-    state
-        .format_config
+///
+/// Takes the `FormatConfig` rather than the `GameState` because deck admission
+/// runs before any game exists — `deck_validation` holds only the resolved
+/// rules. Both callers must read the same value or the deck gate and the
+/// in-game gate could disagree about the very same match.
+pub(crate) fn policy_of(format_config: &FormatConfig) -> AntePolicy {
+    format_config
         .custom_rules
         .as_deref()
         .map(|rules| rules.legality.legacy.ante)
         .unwrap_or_default()
+}
+
+/// The ante policy the in-progress game is played under.
+pub(crate) fn policy(state: &GameState) -> AntePolicy {
+    policy_of(&state.format_config)
 }
 
 /// CR 407.3: "When not playing for ante, players can't include these cards in

--- a/crates/engine/src/game/deck_validation.rs
+++ b/crates/engine/src/game/deck_validation.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::database::legality::{LegalityFormat, LegalityStatus};
 use crate::database::CardDatabase;
+use crate::game::ante::face_uses_ante;
 use crate::game::companion::{companion_starting_deck, is_eligible_companion};
 use crate::game::deck_loading::{deserialize_draft_set_codes, DeckEntry};
 use crate::parser::oracle::{compute_deck_copy_limit_from_text, oracle_text_allows_commander};
@@ -2063,35 +2064,6 @@ fn tiny_leaders_category_banned(face: &CardFace) -> bool {
     }) || face_uses_ante(face)
         || text.contains("sticker")
         || text.contains("attraction")
-}
-
-/// CR 407.3: "A few cards have the text 'Remove this card from your deck
-/// before playing if you're not playing for ante.' These are the only cards
-/// that can add or remove cards from the ante zone or change a card's owner.
-/// When not playing for ante, players can't include these cards in their
-/// decks or sideboards".
-///
-/// The rule identifies this class by the cards' own printed text, so this
-/// predicate matches that text rather than a hardcoded roster — a name list
-/// would be a snapshot that silently misses anything else printed with the
-/// clause, and would have to be repeated by every format that excludes them.
-///
-/// Matches the substring `playing for ante`, the templated clause's stable
-/// core (unaffected by the "Remove this card"/"Remove ~ from your deck"
-/// wording differences across printings). Verified exact at implementation
-/// time: Scryfall's `oracle:"playing for ante"` returns 9 cards — Amulet of
-/// Quoz, Bronze Tablet, Contract from Below, Darkpact, Demonic Attorney,
-/// Jeweled Bird, Rebirth, Tempest Efreet, Timmerian Fiends — which is the
-/// whole class with no false positives.
-///
-/// This is the exact test `tiny_leaders_category_banned` has always used,
-/// extracted here so its second caller shares one definition of the class.
-fn face_uses_ante(face: &CardFace) -> bool {
-    face.oracle_text
-        .as_deref()
-        .unwrap_or("")
-        .to_ascii_lowercase()
-        .contains("playing for ante")
 }
 
 /// Whether a decklist entry resolves to a card of the CR 407.3 ante class.

--- a/crates/engine/src/game/deck_validation.rs
+++ b/crates/engine/src/game/deck_validation.rs
@@ -9451,6 +9451,17 @@ mod tests {
             };
             cards.insert(key.to_string(), card);
         }
+        // Basic land, printed in a Swedish-legal set, so the pipeline tests
+        // below can build a real 60-card deck: `deck_with_copies`/
+        // `legal_60_main` pad with Plains, and the CR 100.2a basic-land
+        // exemption keeps 56 copies under the format's 4-copy ceiling.
+        let mut plains = card_json_with_printings("Plains", &["LEA"]);
+        plains["card_type"] = serde_json::json!({
+            "supertypes": ["Basic"],
+            "core_types": ["Land"],
+            "subtypes": ["Plains"]
+        });
+        cards.insert("plains".to_string(), plains);
         Value::Object(cards).to_string()
     }
 
@@ -9492,6 +9503,97 @@ mod tests {
         assert_eq!(
             pool.status(&db, "Savannah Lions"),
             Some(LegalityStatus::Legal)
+        );
+    }
+
+    /// CR 407.3 through the ACTUAL admission route, not the private helper:
+    /// `FormatConfig::for_custom_rules` → `SelectedFormat::Resolved` →
+    /// `validate_deck_for_format` → `evaluate_custom_format` →
+    /// `custom_format_pool` → `DeclaredPool`. The sibling test above proves the
+    /// pure function; this proves the wiring that reaches it in production, so
+    /// a future refactor that stopped calling it would fail here.
+    ///
+    /// **Both halves of CR 407.3's boundary — "their decks or sideboards".**
+    /// The sideboard reaches the check only because `construction_deck_cards`
+    /// chains it; a main-deck-only regression would not notice if that stopped,
+    /// and the sideboard is exactly where a player would try to hide an ante
+    /// card. Uses `swedish_old_school()`'s real rules rather than a synthetic
+    /// config, since the preset is what ships.
+    #[test]
+    fn validate_deck_for_format_rejects_ante_cards_in_deck_and_sideboard() {
+        let db = CardDatabase::from_json_str(&ante_db_json()).unwrap();
+        let config = FormatConfig::for_custom_rules(
+            &crate::types::custom_format::swedish_old_school().rules,
+        );
+
+        let request_with = |main: Vec<String>, sideboard: Vec<String>| DeckCompatibilityRequest {
+            main_deck: main,
+            sideboard,
+            selected_format: Some(SelectedFormat::Resolved(Box::new(config.clone()))),
+            player_count: default_player_count(),
+            ..Default::default()
+        };
+
+        // Paired positive control on the SAME config: a legal 60-card deck with
+        // a legal sideboard is ACCEPTED. Without it, both rejections below
+        // would still pass against a validator that rejected every deck for
+        // some unrelated reason (deck size, pool membership, copy limit).
+        assert!(
+            validate_deck_for_format(&db, &request_with(expand("Plains", 60), Vec::new())).is_ok(),
+            "a 60-card Swedish-legal deck must be accepted, or the rejections below prove nothing"
+        );
+        assert!(
+            validate_deck_for_format(
+                &db,
+                &request_with(expand("Plains", 60), expand("Savannah Lions", 4))
+            )
+            .is_ok(),
+            "a legal sideboard must be accepted"
+        );
+
+        // CR 407.3, main deck.
+        let in_deck = validate_deck_for_format(
+            &db,
+            &request_with(legal_60_main("Jeweled Bird"), Vec::new()),
+        )
+        .expect_err("an ante card in the main deck must be rejected end-to-end");
+        assert!(
+            in_deck.iter().any(|reason| reason.contains("Jeweled Bird")),
+            "the rejection must name the offending card, got: {in_deck:?}"
+        );
+
+        // CR 407.3, sideboard — the half a main-deck-only test would miss.
+        let in_sideboard = validate_deck_for_format(
+            &db,
+            &request_with(expand("Plains", 60), expand("Jeweled Bird", 1)),
+        )
+        .expect_err("an ante card in the sideboard must be rejected end-to-end (CR 407.3)");
+        assert!(
+            in_sideboard
+                .iter()
+                .any(|reason| reason.contains("Jeweled Bird")),
+            "the sideboard rejection must name the offending card, got: {in_sideboard:?}"
+        );
+
+        // An ante card that is ALSO on the restricted list is rejected
+        // outright, not downgraded to "one copy is fine" — the ordering inside
+        // `DeclaredPool::status`, observed from outside it. Exactly ONE copy,
+        // which the restricted rule alone would permit: at four copies this
+        // would be rejected for the copy limit whether or not the ante rule
+        // exists, and would prove nothing about the ordering.
+        let restricted_ante = validate_deck_for_format(
+            &db,
+            &request_with(deck_with_copies("Contract from Below", 1, 60), Vec::new()),
+        )
+        .expect_err(
+            "one copy of a restricted ante card is legal under the restricted rule alone, so \
+             rejecting it is attributable to CR 407.3",
+        );
+        assert!(
+            restricted_ante
+                .iter()
+                .any(|reason| reason.contains("Contract from Below")),
+            "got: {restricted_ante:?}"
         );
     }
 

--- a/crates/engine/src/game/deck_validation.rs
+++ b/crates/engine/src/game/deck_validation.rs
@@ -10,7 +10,7 @@ use crate::parser::oracle::{compute_deck_copy_limit_from_text, oracle_text_allow
 use crate::types::card::{CardFace, CardRules, PrintedCardRef};
 use crate::types::card_type::{CoreType, Supertype};
 use crate::types::custom_format::{
-    passes_legacy_axis_gate, CommandZoneMode, LegalityRules, SetCode,
+    passes_legacy_axis_gate, AntePolicy, CommandZoneMode, LegalityRules, SetCode,
 };
 use crate::types::format::{
     DeckCopyLimit, FormatConfig, GameFormat, SelectedFormat, SideboardPolicy,
@@ -612,6 +612,13 @@ impl CardPoolAuthority<'_> {
 #[derive(Debug)]
 struct DeclaredPool {
     legal_sets: Option<Vec<SetCode>>,
+    /// CR 407.3's deck-construction consequence, as declared by the format.
+    /// Stored rather than assumed even though `custom_format_pool`'s legacy-
+    /// axis gate rejects [`AntePolicy::Enabled`] today: when an ante zone
+    /// eventually exists, `IMPLEMENTED_LEGACY_AXES` gains `LegacyAxis::Ante`
+    /// and `Enabled` starts arriving here, and the match in [`Self::status`]
+    /// is then already correct.
+    ante: AntePolicy,
     /// CR 201.3b: canonical (`canonical_deck_count_key`) names, so a banned
     /// entry naming a split/DFC's whole-card identity ("Fire // Ice") matches
     /// a decklist naming just one face ("Fire"). A banned/restricted entry
@@ -626,6 +633,7 @@ impl DeclaredPool {
     fn resolve(db: &CardDatabase, rules: &LegalityRules) -> Self {
         Self {
             legal_sets: rules.legal_sets.clone(),
+            ante: rules.legacy.ante,
             banned: rules
                 .banned
                 .iter()
@@ -639,7 +647,7 @@ impl DeclaredPool {
         }
     }
 
-    /// Order: pool membership → banned → restricted → legal. Returns `None`
+    /// Order: pool membership → ante → banned → restricted → legal. Returns `None`
     /// (never `Some(LegalityStatus::NotLegal)`) for a card outside a declared
     /// `legal_sets` restriction, matching `LegalityTable`'s own "no data for
     /// this format" `None` — both feed the same "(not legal in
@@ -650,6 +658,24 @@ impl DeclaredPool {
             if !printed_in_any_set(db, name, sets) {
                 return None;
             }
+        }
+        match self.ante {
+            // CR 407.3: "When not playing for ante, players can't include
+            // these cards in their decks or sideboards" — a deck-construction
+            // prohibition, which is exactly what `Banned` reports (and NOT
+            // `None`: the card is inside the declared pool, so "not legal in
+            // {format}" would misreport why it was rejected). Ordered ahead of
+            // the declared lists because the CR forbids the card outright: a
+            // format may also RESTRICT an ante card — Swedish Old School
+            // restricts three of the seven it carves out — and one legal copy
+            // is still one copy too many.
+            AntePolicy::Excluded if deck_entry_uses_ante(db, name) => {
+                return Some(LegalityStatus::Banned)
+            }
+            // CR 407.2: playing for ante makes the class legal again. The
+            // `Excluded` arm repeats here for a non-ante card, which the guard
+            // above passes over.
+            AntePolicy::Excluded | AntePolicy::Enabled => {}
         }
         let canonical = canonical_deck_count_key(db, name);
         if self.banned.contains(&canonical) {
@@ -2034,9 +2060,46 @@ fn tiny_leaders_category_banned(face: &CardFace) -> bool {
         .to_ascii_lowercase();
     face.card_type.subtypes.iter().any(|subtype| {
         subtype.eq_ignore_ascii_case("Conspiracy") || subtype.eq_ignore_ascii_case("Attraction")
-    }) || text.contains("playing for ante")
+    }) || face_uses_ante(face)
         || text.contains("sticker")
         || text.contains("attraction")
+}
+
+/// CR 407.3: "A few cards have the text 'Remove this card from your deck
+/// before playing if you're not playing for ante.' These are the only cards
+/// that can add or remove cards from the ante zone or change a card's owner.
+/// When not playing for ante, players can't include these cards in their
+/// decks or sideboards".
+///
+/// The rule identifies this class by the cards' own printed text, so this
+/// predicate matches that text rather than a hardcoded roster — a name list
+/// would be a snapshot that silently misses anything else printed with the
+/// clause, and would have to be repeated by every format that excludes them.
+///
+/// Matches the substring `playing for ante`, the templated clause's stable
+/// core (unaffected by the "Remove this card"/"Remove ~ from your deck"
+/// wording differences across printings). Verified exact at implementation
+/// time: Scryfall's `oracle:"playing for ante"` returns 9 cards — Amulet of
+/// Quoz, Bronze Tablet, Contract from Below, Darkpact, Demonic Attorney,
+/// Jeweled Bird, Rebirth, Tempest Efreet, Timmerian Fiends — which is the
+/// whole class with no false positives.
+///
+/// This is the exact test `tiny_leaders_category_banned` has always used,
+/// extracted here so its second caller shares one definition of the class.
+fn face_uses_ante(face: &CardFace) -> bool {
+    face.oracle_text
+        .as_deref()
+        .unwrap_or("")
+        .to_ascii_lowercase()
+        .contains("playing for ante")
+}
+
+/// Whether a decklist entry resolves to a card of the CR 407.3 ante class.
+/// Reads the entry's resolved face, the same way `tiny_leaders_category_banned`'s
+/// call site does; an unknown name is not an ante card (unknown entries are
+/// reported separately, by name, before any legality verdict is formed).
+fn deck_entry_uses_ante(db: &CardDatabase, name: &str) -> bool {
+    db.get_face_by_name(name).is_some_and(face_uses_ante)
 }
 
 fn name_in_list(name: &str, list: &[&str]) -> bool {
@@ -9357,6 +9420,108 @@ mod tests {
         assert_eq!(pool.status(&db, "No Printings Card"), None);
     }
 
+    /// CR 407.3: the ante class is identified by the cards' own printed text,
+    /// so this fixture gives two of them the templated clause and withholds it
+    /// from the controls. All four cards are printed in sets Swedish Old
+    /// School declares legal, so pool membership never confounds the verdict.
+    fn ante_db_json() -> String {
+        let mut cards = serde_json::Map::new();
+        let ante_text = "Remove this card from your deck before playing if you're not playing for \
+                         ante.";
+        for (key, name, printing, oracle_text) in [
+            // On the format's restricted list AND an ante card.
+            (
+                "contract from below",
+                "Contract from Below",
+                "LEA",
+                Some(ante_text),
+            ),
+            // An ante card the format's own lists never mention.
+            ("jeweled bird", "Jeweled Bird", "ARN", Some(ante_text)),
+            // Restricted, not ante — the paired control that keeps the
+            // restricted verdict reachable.
+            ("black lotus", "Black Lotus", "LEA", None),
+            // In pool, on no list, not ante.
+            ("savannah lions", "Savannah Lions", "LEA", None),
+        ] {
+            let mut card = card_json_with_printings(name, &[printing]);
+            card["oracle_text"] = match oracle_text {
+                Some(text) => Value::String(text.to_string()),
+                None => Value::Null,
+            };
+            cards.insert(key.to_string(), card);
+        }
+        Value::Object(cards).to_string()
+    }
+
+    /// CR 407.3: "When not playing for ante, players can't include these cards
+    /// in their decks or sideboards." Exercised through `swedish_old_school()`'s
+    /// own declared rules, because that preset is where the carve-out comes
+    /// from: three of the seven ante cards its source names are also on its
+    /// restricted list, so the ordering is load-bearing rather than incidental.
+    #[test]
+    fn declared_pool_excludes_ante_cards_ahead_of_the_restricted_list() {
+        let db = CardDatabase::from_json_str(&ante_db_json()).unwrap();
+        let rules = crate::types::custom_format::swedish_old_school()
+            .rules
+            .legality;
+        let pool = DeclaredPool::resolve(&db, &rules);
+
+        // Restricted AND ante. CR 407.3 forbids the card outright, so the ante
+        // verdict must win: one legal copy is still one copy too many.
+        assert_eq!(
+            pool.status(&db, "Contract from Below"),
+            Some(LegalityStatus::Banned)
+        );
+
+        // Ante, and on none of the format's own lists — still excluded,
+        // because the class is the CR's printed-text class, not a roster the
+        // preset has to enumerate.
+        assert_eq!(
+            pool.status(&db, "Jeweled Bird"),
+            Some(LegalityStatus::Banned)
+        );
+
+        // Paired controls on the SAME pool value, so an ante predicate that
+        // always returned `true` would fail here instead of silently passing
+        // both assertions above.
+        assert_eq!(
+            pool.status(&db, "Black Lotus"),
+            Some(LegalityStatus::Restricted)
+        );
+        assert_eq!(
+            pool.status(&db, "Savannah Lions"),
+            Some(LegalityStatus::Legal)
+        );
+    }
+
+    /// CR 407.2: playing for ante makes the class legal again. `AntePolicy::
+    /// Enabled` is gated out of every production path by
+    /// `passes_legacy_axis_gate` today, so this reaches `DeclaredPool`
+    /// directly — the point being that when an ante zone exists and the gate
+    /// opens, the exclusion lifts on its own rather than needing a second
+    /// change here.
+    #[test]
+    fn declared_pool_admits_ante_cards_when_the_format_plays_for_ante() {
+        let db = CardDatabase::from_json_str(&ante_db_json()).unwrap();
+        let mut rules = crate::types::custom_format::swedish_old_school()
+            .rules
+            .legality;
+        rules.legacy.ante = AntePolicy::Enabled;
+        let pool = DeclaredPool::resolve(&db, &rules);
+
+        // The declared lists take over again: restricted stays restricted...
+        assert_eq!(
+            pool.status(&db, "Contract from Below"),
+            Some(LegalityStatus::Restricted)
+        );
+        // ...and an ante card on no list is simply legal.
+        assert_eq!(
+            pool.status(&db, "Jeweled Bird"),
+            Some(LegalityStatus::Legal)
+        );
+    }
+
     /// CR 201.3b: a banned/restricted entry naming a split/DFC's whole-card
     /// identity ("Fire // Ice") must match a decklist naming just one face
     /// ("Fire"), and banned beats restricted when a name (implausibly)
@@ -9580,7 +9745,7 @@ mod tests {
     fn custom_format_rejects_every_undeclared_legacy_axis() {
         let db = CardDatabase::from_json_str(&test_db_json()).unwrap();
         // Loops over every axis NOT in `IMPLEMENTED_LEGACY_AXES` — currently
-        // all four, since that list is empty; a future phase populating it
+        // all five, since that list is empty; a future phase populating it
         // narrows this loop automatically (each entry is still exercised
         // above by `passes_legacy_axis_gate`'s own direct assertion, so a
         // freshly-implemented axis fails loudly here instead of silently
@@ -9600,6 +9765,14 @@ mod tests {
             },
             LegacyRuleSet {
                 legend_rule_scope: LegendRuleScope::PreM14AnyController,
+                ..LegacyRuleSet::default()
+            },
+            // CR 407.2/407.4: only `Enabled` is a declared axis — it promises
+            // an ante zone and the ante action. The default `Excluded` is
+            // enforced (CR 407.3) and so is deliberately NOT gated, which is
+            // why it does not appear in this list.
+            LegacyRuleSet {
+                ante: AntePolicy::Enabled,
                 ..LegacyRuleSet::default()
             },
         ];

--- a/crates/engine/src/game/deck_validation.rs
+++ b/crates/engine/src/game/deck_validation.rs
@@ -613,13 +613,6 @@ impl CardPoolAuthority<'_> {
 #[derive(Debug)]
 struct DeclaredPool {
     legal_sets: Option<Vec<SetCode>>,
-    /// CR 407.3's deck-construction consequence, as declared by the format.
-    /// Stored rather than assumed even though `custom_format_pool`'s legacy-
-    /// axis gate rejects [`AntePolicy::Enabled`] today: when an ante zone
-    /// eventually exists, `IMPLEMENTED_LEGACY_AXES` gains `LegacyAxis::Ante`
-    /// and `Enabled` starts arriving here, and the match in [`Self::status`]
-    /// is then already correct.
-    ante: AntePolicy,
     /// CR 201.3b: canonical (`canonical_deck_count_key`) names, so a banned
     /// entry naming a split/DFC's whole-card identity ("Fire // Ice") matches
     /// a decklist naming just one face ("Fire"). A banned/restricted entry
@@ -634,7 +627,6 @@ impl DeclaredPool {
     fn resolve(db: &CardDatabase, rules: &LegalityRules) -> Self {
         Self {
             legal_sets: rules.legal_sets.clone(),
-            ante: rules.legacy.ante,
             banned: rules
                 .banned
                 .iter()
@@ -648,7 +640,7 @@ impl DeclaredPool {
         }
     }
 
-    /// Order: pool membership → ante → banned → restricted → legal. Returns `None`
+    /// Order: pool membership → banned → restricted → legal. Returns `None`
     /// (never `Some(LegalityStatus::NotLegal)`) for a card outside a declared
     /// `legal_sets` restriction, matching `LegalityTable`'s own "no data for
     /// this format" `None` — both feed the same "(not legal in
@@ -660,24 +652,12 @@ impl DeclaredPool {
                 return None;
             }
         }
-        match self.ante {
-            // CR 407.3: "When not playing for ante, players can't include
-            // these cards in their decks or sideboards" — a deck-construction
-            // prohibition, which is exactly what `Banned` reports (and NOT
-            // `None`: the card is inside the declared pool, so "not legal in
-            // {format}" would misreport why it was rejected). Ordered ahead of
-            // the declared lists because the CR forbids the card outright: a
-            // format may also RESTRICT an ante card — Swedish Old School
-            // restricts three of the seven it carves out — and one legal copy
-            // is still one copy too many.
-            AntePolicy::Excluded if deck_entry_uses_ante(db, name) => {
-                return Some(LegalityStatus::Banned)
-            }
-            // CR 407.2: playing for ante makes the class legal again. The
-            // `Excluded` arm repeats here for a non-ante card, which the guard
-            // above passes over.
-            AntePolicy::Excluded | AntePolicy::Enabled => {}
-        }
+        // CR 407.3 is deliberately NOT checked here. It is not a property of
+        // this format's declared card pool — it holds for every format that is
+        // not played for ante — and enforcing it in this authority would reach
+        // only constructed-shaped formats, leaving the commander validator and
+        // the FreeForAll / TwoHeadedGiant / Limited routes to disagree with it.
+        // `ante_deck_violations` applies it once, for all of them.
         let canonical = canonical_deck_count_key(db, name);
         if self.banned.contains(&canonical) {
             return Some(LegalityStatus::Banned);
@@ -2066,6 +2046,42 @@ fn tiny_leaders_category_banned(face: &CardFace) -> bool {
         || text.contains("attraction")
 }
 
+/// CR 407.3: "When not playing for ante, players can't include these cards in
+/// their decks or sideboards." Returns the offending cards, by display name.
+///
+/// Applied once per evaluation, beside the other cross-format rules at the
+/// dispatch seam, rather than inside a card-pool authority. Three routes decide
+/// per-card legality — `CardPoolAuthority::LegalityTable` for built-in
+/// constructed formats, `CardPoolAuthority::Declared` for custom ones, and the
+/// commander validator — while FreeForAll, TwoHeadedGiant and Limited answer
+/// `true` with no per-card check at all. CR 407.3 binds all four: it is not a
+/// card-pool restriction a permissive format may waive, but a rule about
+/// whether this game is played for ante. Enforcing it in any one authority
+/// would let the others diverge — and the permissive route, which has no
+/// authority to enforce it in, is exactly where an ante card would slip
+/// through.
+///
+/// Scans `construction_deck_cards`, so the deck and the sideboard are covered
+/// by the same pass; CR 407.3 names both. Unknown names are skipped — they are
+/// reported separately, by name, and an unresolvable spelling is not evidence
+/// of an ante card.
+fn ante_deck_violations(
+    db: &CardDatabase,
+    request: &DeckCompatibilityRequest,
+    unknown_cards: &BTreeSet<String>,
+    format_rules: &FormatConfig,
+) -> BTreeSet<String> {
+    // CR 407.2: a format actually played for ante admits the class.
+    if crate::game::ante::policy_of(format_rules) == AntePolicy::Enabled {
+        return BTreeSet::new();
+    }
+    construction_deck_cards(request)
+        .filter(|name| !unknown_cards.contains(*name))
+        .filter(|name| deck_entry_uses_ante(db, name))
+        .map(|name| display_name(db, name))
+        .collect()
+}
+
 /// Whether a decklist entry resolves to a card of the CR 407.3 ante class.
 /// Reads the entry's resolved face, the same way `tiny_leaders_category_banned`'s
 /// call site does; an unknown name is not an ante card (unknown entries are
@@ -2568,11 +2584,19 @@ fn evaluate_selected_format_summary(
         GameFormat::Custom(_) => quick_custom_format_check(db, request, &format_rules),
     };
 
-    (
-        Some(result.reason.is_none()),
-        result.reason.into_iter().collect(),
-        result.unknown_cards,
-    )
+    // CR 407.3, same cross-format rule the authoritative path applies — so the
+    // UI hint and the game-creation gate cannot disagree about an ante card.
+    let mut reasons: Vec<String> = result.reason.into_iter().collect();
+    let ante_cards = ante_deck_violations(db, request, &result.unknown_cards, &format_rules);
+    if !ante_cards.is_empty() {
+        reasons.push(summarize_cards(
+            "Can't be in a deck or sideboard unless the game is played for ante",
+            &ante_cards,
+            6,
+        ));
+    }
+
+    (Some(reasons.is_empty()), reasons, result.unknown_cards)
 }
 
 struct QuickCheckResult {
@@ -3069,6 +3093,19 @@ fn evaluate_selected_format(
             check.compatible
         }
     };
+
+    // CR 407.3: ante cards are barred from decks and sideboards regardless of
+    // format — see `ante_deck_violations` for why this cannot live inside any
+    // one of the per-format arms above.
+    let ante_cards = ante_deck_violations(db, request, unknown_cards, &format_rules);
+    if !ante_cards.is_empty() {
+        compatible = false;
+        reasons.push(summarize_cards(
+            "Can't be in a deck or sideboard unless the game is played for ante",
+            &ante_cards,
+            6,
+        ));
+    }
 
     // CR 100.4 × MatchType::Bo3: BO3 requires a sideboard regardless of format.
     // `SideboardPolicy::Unlimited` formats (FreeForAll, TwoHeadedGiant) impose
@@ -9437,37 +9474,36 @@ mod tests {
         Value::Object(cards).to_string()
     }
 
-    /// CR 407.3: "When not playing for ante, players can't include these cards
-    /// in their decks or sideboards." Exercised through `swedish_old_school()`'s
-    /// own declared rules, because that preset is where the carve-out comes
-    /// from: three of the seven ante cards its source names are also on its
-    /// restricted list, so the ordering is load-bearing rather than incidental.
+    /// `DeclaredPool` answers ONLY the format's own declared card pool. CR 407.3
+    /// is not part of that — it is applied once for every format by
+    /// `ante_deck_violations` — so an ante card gets whatever verdict the
+    /// preset's own lists give it here, and nothing more. Pinning that keeps a
+    /// future change from quietly reintroducing the rule in this authority,
+    /// where the permissive formats could never see it.
     #[test]
-    fn declared_pool_excludes_ante_cards_ahead_of_the_restricted_list() {
+    fn declared_pool_judges_only_the_declared_lists_not_the_ante_rule() {
         let db = CardDatabase::from_json_str(&ante_db_json()).unwrap();
         let rules = crate::types::custom_format::swedish_old_school()
             .rules
             .legality;
         let pool = DeclaredPool::resolve(&db, &rules);
 
-        // Restricted AND ante. CR 407.3 forbids the card outright, so the ante
-        // verdict must win: one legal copy is still one copy too many.
+        // Restricted AND an ante card: `Restricted` is the pool's honest
+        // answer. The deck gate rejects it outright, one layer up.
         assert_eq!(
             pool.status(&db, "Contract from Below"),
-            Some(LegalityStatus::Banned)
+            Some(LegalityStatus::Restricted)
         );
 
-        // Ante, and on none of the format's own lists — still excluded,
-        // because the class is the CR's printed-text class, not a roster the
-        // preset has to enumerate.
+        // An ante card the preset's lists never mention is simply legal AS FAR
+        // AS THE POOL IS CONCERNED — `validate_deck_for_format` is what keeps it
+        // out of a deck.
         assert_eq!(
             pool.status(&db, "Jeweled Bird"),
-            Some(LegalityStatus::Banned)
+            Some(LegalityStatus::Legal)
         );
 
-        // Paired controls on the SAME pool value, so an ante predicate that
-        // always returned `true` would fail here instead of silently passing
-        // both assertions above.
+        // Paired controls on the same pool value.
         assert_eq!(
             pool.status(&db, "Black Lotus"),
             Some(LegalityStatus::Restricted)
@@ -9476,6 +9512,66 @@ mod tests {
             pool.status(&db, "Savannah Lions"),
             Some(LegalityStatus::Legal)
         );
+    }
+
+    /// CR 407.3 across the routes that decide deck admission by DIFFERENT
+    /// authorities: permissive formats with no card-pool check at all
+    /// (FreeForAll / TwoHeadedGiant answer `true` unconditionally) and a custom
+    /// format on its own `DeclaredPool`. They must agree, which is the whole
+    /// reason the rule sits at the dispatch seam rather than inside one
+    /// authority — the permissive routes have no authority to put it in.
+    ///
+    /// The `LegalityTable` route is deliberately absent: an ante card is
+    /// already `NotLegal` in every sanctioned format's table, so a built-in
+    /// constructed format would reject this deck with or without CR 407.3 and
+    /// prove nothing. The permissive routes are where the rule is load-bearing.
+    #[test]
+    fn every_deck_admission_route_rejects_an_ante_card() {
+        let db = CardDatabase::from_json_str(&ante_db_json()).unwrap();
+
+        for format in [
+            // The routes with no card-pool authority to hide the rule in — the
+            // ones that would silently admit an ante card if CR 407.3 lived in
+            // `CardPoolAuthority`.
+            FormatConfig::free_for_all(),
+            FormatConfig::two_headed_giant(),
+            // DeclaredPool route, for contrast: a format that DOES consult a
+            // card pool must reach the same verdict by the same rule.
+            FormatConfig::for_custom_rules(
+                &crate::types::custom_format::swedish_old_school().rules,
+            ),
+        ] {
+            let label = format.format.label();
+            let request = DeckCompatibilityRequest {
+                main_deck: legal_60_main("Jeweled Bird"),
+                selected_format: Some(SelectedFormat::Resolved(Box::new(format.clone()))),
+                player_count: default_player_count(),
+                ..Default::default()
+            };
+            let Err(reasons) = validate_deck_for_format(&db, &request) else {
+                panic!("{label} must reject an ante card (CR 407.3)");
+            };
+            assert!(
+                reasons.iter().any(|reason| reason.contains("Jeweled Bird")),
+                "{label}: the rejection must name the ante card, got {reasons:?}"
+            );
+
+            // Same format, same deck shape, no ante card: accepted. Without
+            // this the loop would pass against a validator that rejected
+            // everything — and the permissive formats in particular accept
+            // essentially any deck, so a spurious rejection there would
+            // otherwise be invisible.
+            let control = DeckCompatibilityRequest {
+                main_deck: expand("Plains", 60),
+                selected_format: Some(SelectedFormat::Resolved(Box::new(format))),
+                player_count: default_player_count(),
+                ..Default::default()
+            };
+            assert!(
+                validate_deck_for_format(&db, &control).is_ok(),
+                "{label}: the same deck without the ante card must be accepted"
+            );
+        }
     }
 
     /// CR 407.3 through the ACTUAL admission route, not the private helper:
@@ -9569,30 +9665,48 @@ mod tests {
         );
     }
 
-    /// CR 407.2: playing for ante makes the class legal again. `AntePolicy::
-    /// Enabled` is gated out of every production path by
-    /// `passes_legacy_axis_gate` today, so this reaches `DeclaredPool`
-    /// directly — the point being that when an ante zone exists and the gate
-    /// opens, the exclusion lifts on its own rather than needing a second
-    /// change here.
+    /// CR 407.2: playing for ante makes the class legal again.
+    ///
+    /// Pinned at `ante_deck_violations` rather than end-to-end, and the reason
+    /// is worth recording: `AntePolicy::Enabled` cannot reach deck evaluation
+    /// at all today, because `custom_format_pool`'s legacy-axis gate rejects
+    /// the whole format first — declaring an ante zone the engine does not
+    /// implement is refused before any card is looked at. An end-to-end
+    /// assertion here would therefore be testing the gate, not this rule. When
+    /// `LegacyAxis::Ante` joins `IMPLEMENTED_LEGACY_AXES`, the deck half is
+    /// already correct and this test is what says so.
     #[test]
-    fn declared_pool_admits_ante_cards_when_the_format_plays_for_ante() {
+    fn ante_deck_violations_admit_the_class_when_playing_for_ante() {
         let db = CardDatabase::from_json_str(&ante_db_json()).unwrap();
-        let mut rules = crate::types::custom_format::swedish_old_school()
-            .rules
-            .legality;
-        rules.legacy.ante = AntePolicy::Enabled;
-        let pool = DeclaredPool::resolve(&db, &rules);
+        let request = DeckCompatibilityRequest {
+            main_deck: legal_60_main("Jeweled Bird"),
+            sideboard: expand("Jeweled Bird", 1),
+            ..Default::default()
+        };
 
-        // The declared lists take over again: restricted stays restricted...
-        assert_eq!(
-            pool.status(&db, "Contract from Below"),
-            Some(LegalityStatus::Restricted)
+        let mut for_ante = crate::types::custom_format::swedish_old_school().rules;
+        for_ante.legality.legacy.ante = AntePolicy::Enabled;
+        assert!(
+            ante_deck_violations(
+                &db,
+                &request,
+                &BTreeSet::new(),
+                &FormatConfig::for_custom_rules(&for_ante),
+            )
+            .is_empty(),
+            "CR 407.2: a format played for ante admits the class"
         );
-        // ...and an ante card on no list is simply legal.
-        assert_eq!(
-            pool.status(&db, "Jeweled Bird"),
-            Some(LegalityStatus::Legal)
+
+        // Paired control on the SAME request: the default policy flags exactly
+        // that card, so the emptiness above is the policy taking effect and not
+        // a request the scan never looked at.
+        let excluded = FormatConfig::for_custom_rules(
+            &crate::types::custom_format::swedish_old_school().rules,
+        );
+        assert!(
+            ante_deck_violations(&db, &request, &BTreeSet::new(), &excluded)
+                .contains("Jeweled Bird"),
+            "the same deck under the default Excluded policy must flag the ante card"
         );
     }
 

--- a/crates/engine/src/game/effects/open_booster_pack.rs
+++ b/crates/engine/src/game/effects/open_booster_pack.rs
@@ -81,10 +81,21 @@ pub fn resolve(
     // CR 400.11: only the revealed cards matching the effect's filter may be
     // taken. `pack_slot` indexes the OPENED pack, not the filtered list, so the
     // slot a selection names is stable even when the filter excludes cards.
+    //
+    // CR 407.3: an ante card "can't be brought into the game from outside the
+    // game", so it is never OFFERED either — the pack is drawn from a set's
+    // whole card pool, which no deck-construction check has vetted. Filtering
+    // here rather than only at materialization keeps the prompt honest: a
+    // player is not shown a choice that would then be refused. The reveal above
+    // is deliberately left whole, because CR 407.3 restricts what may be taken,
+    // not what the pack contains.
     let choices: Vec<OutsideGameChoiceEntry> = cards
         .into_iter()
         .enumerate()
-        .filter(|(_, card)| matches_target_filter_against_face(card, &filter))
+        .filter(|(_, card)| {
+            matches_target_filter_against_face(card, &filter)
+                && crate::game::ante::admits_face_from_outside_game(state, card)
+        })
         .map(|(pack_slot, card)| OutsideGameChoiceEntry {
             name: card.name.clone(),
             source: OutsideGameChoiceSource::BoosterPack {

--- a/crates/engine/src/game/effects/search_outside_game.rs
+++ b/crates/engine/src/game/effects/search_outside_game.rs
@@ -48,11 +48,19 @@ pub fn resolve(
                         sideboard_index,
                         entry.count,
                     );
+                    // CR 407.3: an ante card may not be in a sideboard in the
+                    // first place, and may not be brought in from outside the
+                    // game — so it is not offered. Deck validation already
+                    // rejects such a sideboard; this is the same rule applied
+                    // where the pool is actually consumed, for a pool that was
+                    // assembled without validation (casual play, or a deck
+                    // loaded by a path that skipped it).
                     (available_count > 0
                         && crate::game::filter::matches_target_filter_against_face(
                             &entry.card,
                             filter,
-                        ))
+                        )
+                        && crate::game::ante::admits_face_from_outside_game(state, &entry.card))
                     .then(|| OutsideGameChoiceEntry {
                         source: OutsideGameChoiceSource::Sideboard {
                             sideboard_index,
@@ -213,6 +221,17 @@ pub(crate) fn put_sideboard_entry_into_game(
         entry.card.clone()
     };
 
+    // CR 407.3: refuse BEFORE the bookkeeping below, not at materialization —
+    // that increment consumes one of the entry's available uses, and a card
+    // the rules never let into the game must not spend one.
+    if !crate::game::ante::admits_face_from_outside_game(state, &card_face) {
+        return Err(EffectError::InvalidParam(format!(
+            "{} can't be brought into the game from outside the game while not playing for ante \
+             (CR 407.3)",
+            card_face.name
+        )));
+    }
+
     if let Some(used) = state
         .outside_game_cards_brought_in
         .iter_mut()
@@ -229,12 +248,15 @@ pub(crate) fn put_sideboard_entry_into_game(
             });
     }
 
-    Ok(put_outside_game_face_into(
-        state,
-        player,
-        &card_face,
-        destination,
-    ))
+    // The CR 407.3 gate above already cleared this face, so the authority's own
+    // check cannot refuse here; map it rather than unwrap so a future divergence
+    // between the two surfaces as an error instead of a panic.
+    put_outside_game_face_into(state, player, &card_face, destination).ok_or_else(|| {
+        EffectError::InvalidParam(format!(
+            "{} can't be brought into the game from outside the game (CR 407.3)",
+            card_face.name
+        ))
+    })
 }
 
 /// CR 400.11b: Bring one card from OUTSIDE the game into `destination` as a new
@@ -246,18 +268,28 @@ pub(crate) fn put_sideboard_entry_into_game(
 /// replacement pipeline to run — the card is materialized from its printed face.
 /// Shared by the sideboard/wishboard pool and by booster packs, which differ
 /// only in where the face came from and in the bookkeeping their pool requires.
+///
+/// Returns `None` when CR 407.3 forbids the card from being brought in from
+/// outside the game — see [`crate::game::ante`]. Because this is the one place
+/// every outside-game source materializes through, enforcing it here means a
+/// source added later cannot bypass the rule by forgetting to ask; the offer
+/// sites filter the class out too, so a `None` here is defense in depth rather
+/// than a path a player can reach.
 pub(crate) fn put_outside_game_face_into(
     state: &mut GameState,
     player: PlayerId,
     card_face: &crate::types::card::CardFace,
     destination: Zone,
-) -> ObjectId {
+) -> Option<ObjectId> {
+    if !crate::game::ante::admits_face_from_outside_game(state, card_face) {
+        return None;
+    }
     let card_id = CardId(state.next_object_id);
     let obj_id = zones::create_object(state, card_id, player, card_face.name.clone(), destination);
     if let Some(obj) = state.objects.get_mut(&obj_id) {
         apply_card_face_to_object(obj, card_face);
     }
-    obj_id
+    Some(obj_id)
 }
 
 fn available_sideboard_count(

--- a/crates/engine/src/game/engine_resolution_choices.rs
+++ b/crates/engine/src/game/engine_resolution_choices.rs
@@ -4661,12 +4661,24 @@ pub(super) fn handle_resolution_choice(
                                         .to_string(),
                                 )
                             })?;
-                        chosen_ids.push(effects::search_outside_game::put_outside_game_face_into(
+                        // CR 407.3: the offer already excluded the ante class,
+                        // so a refusal here means the selection named a card
+                        // that was never selectable — an invalid action, not a
+                        // silently dropped card.
+                        let object_id = effects::search_outside_game::put_outside_game_face_into(
                             state,
                             player,
                             &card,
                             destination,
-                        ));
+                        )
+                        .ok_or_else(|| {
+                            EngineError::InvalidAction(format!(
+                                "{} can't be brought into the game from outside the game while \
+                                 not playing for ante (CR 407.3)",
+                                card.name
+                            ))
+                        })?;
+                        chosen_ids.push(object_id);
                     }
                     OutsideGameSelection::FaceUpExile { object_id } => {
                         match effects::search_outside_game::put_face_up_exile_into(

--- a/crates/engine/src/game/mod.rs
+++ b/crates/engine/src/game/mod.rs
@@ -1,6 +1,7 @@
 pub mod ability_rw;
 pub mod ability_scan;
 pub mod ability_utils;
+pub(crate) mod ante;
 pub mod arithmetic;
 pub mod attractions;
 pub mod augment;

--- a/crates/engine/src/types/custom_format.rs
+++ b/crates/engine/src/types/custom_format.rs
@@ -1,10 +1,16 @@
-//! Schema for engine-validated custom formats. Phase 1a: types +
-//! validation + registration gates only. No behavior is wired into the
-//! engine yet — `custom_format_registry()` is a stub returning
-//! `Vec::new()`, and `IMPLEMENTED_LEGACY_AXES` is empty. Later phases
-//! (2a/2b/2cd) populate the registry with real presets and wire
-//! `LegacyRuleSet`'s axes into engine behavior (mana pool cleanup, combat
-//! damage step, etc.).
+//! Schema for engine-validated custom formats: types, validation, the
+//! registration gates, and the bundled Axis-B preset constructors.
+//!
+//! `IMPLEMENTED_LEGACY_AXES` is still empty, so no `LegacyRuleSet` axis has
+//! runtime behavior yet — later phases (2a/2b/2cd) wire them in (mana pool
+//! cleanup, combat damage step, etc.). The one exception is
+//! [`AntePolicy::Excluded`], whose CR 407.3 deck-construction consequence
+//! `game::deck_validation` enforces today; it is a default rather than a
+//! declared axis, which is why it needs no entry in that list.
+//!
+//! `custom_format_registry()` still returns `Vec::new()`, but no longer for
+//! want of a preset: [`swedish_old_school`] exists and passes both gates, and
+//! is withheld for the sourcing reason its own doc comment gives.
 
 use serde::{Deserialize, Serialize};
 
@@ -126,6 +132,36 @@ pub enum LegendRuleScope {
     PreM14AnyController,
 }
 
+/// CR 407.1: an ante rule was in "earlier versions of the Magic rules";
+/// playing for ante "is now considered an optional variation on the game" and
+/// is "strictly forbidden under the Magic: The Gathering Tournament Rules".
+/// That makes it the same shape as the other axes here — a rule this engine
+/// plays the modern way, which a historically-accurate custom format may opt
+/// back out of.
+///
+/// Unlike its siblings, this axis' DEFAULT carries an enforced consequence
+/// rather than merely describing the modern status quo: CR 407.3 says that
+/// "when not playing for ante, players can't include these cards in their
+/// decks or sideboards", which
+/// `game::deck_validation::DeclaredPool::status` enforces today for every
+/// custom format. `Enabled` is what remains unimplemented — it promises the
+/// CR 407.2 ante zone and the CR 407.4 ante action, which no engine code
+/// provides — so it is gated by [`IMPLEMENTED_LEGACY_AXES`] like any other
+/// declared-but-unbuilt axis.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub enum AntePolicy {
+    /// CR 407.3: cards bearing "Remove this card from your deck before
+    /// playing if you're not playing for ante" may not be in a deck or
+    /// sideboard. The modern default, and the only value the engine
+    /// implements.
+    #[default]
+    Excluded,
+    /// CR 407.2: each player antes a card after determining who goes first;
+    /// the winner takes the ante zone. Schema only — gated until an ante zone
+    /// exists.
+    Enabled,
+}
+
 /// `Default` is every axis at its modern value — the rule set an Axis-A
 /// lobby save always declares (it models no historical paper ruleset), and
 /// the only one `passes_legacy_axis_gate` accepts while
@@ -136,6 +172,15 @@ pub struct LegacyRuleSet {
     pub damage_timing: CombatDamageTiming,
     pub wish_scope: WishOutsideGameScope,
     pub legend_rule_scope: LegendRuleScope,
+    /// `#[serde(default)]` because this axis was added after Phase 1c shipped
+    /// the Axis-A save path: a `CustomFormatDef` already persisted by a
+    /// client carries no `ante` key, and must keep deserializing to the
+    /// modern `Excluded` — which is exactly what such a save meant. The
+    /// sibling axes need no default, having been present since Phase 1a.
+    /// Mirrors `StructuralRules.range_of_influence`'s use of the same
+    /// attribute for the same reason.
+    #[serde(default)]
+    pub ante: AntePolicy,
 }
 
 /// CR 903.3 (and the Tiny Leaders / Oathbreaker RC / Brawl deck-construction
@@ -252,6 +297,40 @@ pub struct StructuralRules {
     /// `UpTo(1)` fallback — the same silent-data-loss bug `sideboard_policy`
     /// exists to prevent.
     pub default_deck_copy_limit: DeckCopyLimit,
+}
+
+impl StructuralRules {
+    /// Projects the structural half of a resolved [`FormatConfig`], reading
+    /// every value from the config's own fields rather than from a bare
+    /// `GameFormat` method (see [`CustomFormatDef::from_lobby_config`]'s doc
+    /// comment for why that distinction matters).
+    ///
+    /// `command_zone_mode` is a parameter rather than a derivation because
+    /// deriving it is fallible — a source format whose command zone holds
+    /// something other than a commander has no representation here — and both
+    /// callers already know the answer more directly than this function
+    /// could: `from_lobby_config` has just run the fallible match (and owns
+    /// the error messages for it), and a bundled constructed-shaped preset
+    /// passes [`CommandZoneMode::Disabled`] outright.
+    ///
+    /// Shared by Axis A (`from_lobby_config`) and the Axis-B preset
+    /// constructors so the field-by-field projection exists once. Adding a
+    /// field to this struct then has exactly one place to update, instead of
+    /// one per preset.
+    fn from_format_config(config: &FormatConfig, command_zone_mode: CommandZoneMode) -> Self {
+        Self {
+            starting_life: config.starting_life,
+            min_players: config.min_players,
+            max_players: config.max_players,
+            deck_size: config.deck_size,
+            singleton: config.singleton,
+            command_zone_mode,
+            range_of_influence: config.range_of_influence.clone(),
+            team_based: config.team_based,
+            sideboard_policy: config.sideboard_policy,
+            default_deck_copy_limit: config.default_deck_copy_limit,
+        }
+    }
 }
 
 /// Legality/era rules. `legal_sets: None` means unrestricted (every card
@@ -503,18 +582,7 @@ impl CustomFormatDef {
             (false, _) => CommandZoneMode::Disabled,
         };
 
-        let structural = StructuralRules {
-            starting_life: config.starting_life,
-            min_players: config.min_players,
-            max_players: config.max_players,
-            deck_size: config.deck_size,
-            singleton: config.singleton,
-            command_zone_mode,
-            range_of_influence: config.range_of_influence.clone(),
-            team_based: config.team_based,
-            sideboard_policy: config.sideboard_policy,
-            default_deck_copy_limit: config.default_deck_copy_limit,
-        };
+        let structural = StructuralRules::from_format_config(config, command_zone_mode);
         let description = derive_structural_description(&structural);
         let short_label = short_label_from_name(&name);
 
@@ -571,6 +639,7 @@ pub enum LegacyAxis {
     CombatDamageTiming,
     WishOutsideGameScope,
     LegendRuleScope,
+    Ante,
 }
 
 /// Axes of `LegacyRuleSet` the engine actually enforces at runtime. Empty in
@@ -591,6 +660,14 @@ fn declared_legacy_axes(rules: &LegacyRuleSet) -> Vec<LegacyAxis> {
     if rules.legend_rule_scope != LegendRuleScope::default() {
         axes.push(LegacyAxis::LegendRuleScope);
     }
+    // Only the non-default `AntePolicy::Enabled` is a declared axis. The
+    // default `Excluded` is already enforced (CR 407.3, at
+    // `DeclaredPool::status`), so gating it would reject every custom format
+    // in existence — including the Axis-A lobby saves whose whole
+    // `LegacyRuleSet` is `Default`.
+    if rules.ante != AntePolicy::default() {
+        axes.push(LegacyAxis::Ante);
+    }
     axes
 }
 
@@ -609,9 +686,14 @@ fn declared_legacy_axes(rules: &LegacyRuleSet) -> Vec<LegacyAxis> {
 /// NOT gated: those are declarative card-pool data the evaluator either
 /// applies in full or not at all, so there is no partial-implementation risk.
 /// A `LegacyRuleSet` axis instead promises runtime behavior (mana burn, the
-/// legend rule's scope, Wish reach) that may not be built yet, so declaring
-/// one the engine does not implement silently misrepresents how the game will
-/// actually play.
+/// legend rule's scope, Wish reach, an ante zone) that may not be built yet,
+/// so declaring one the engine does not implement silently misrepresents how
+/// the game will actually play.
+///
+/// Note the asymmetry inside [`AntePolicy`] itself, which
+/// [`declared_legacy_axes`] documents: only `Enabled` is a declared axis.
+/// `Excluded`'s CR 407.3 deck-construction consequence is enforced today and
+/// is the default every custom format carries, so it is never gated.
 pub fn passes_legacy_axis_gate(rules: &LegacyRuleSet) -> bool {
     declared_legacy_axes(rules)
         .into_iter()
@@ -656,9 +738,119 @@ pub fn assert_no_lobby_save_sentinel_collision(presets: &[CustomFormatDef]) {
     }
 }
 
+/// Registry id for [`swedish_old_school`]. The first id after
+/// [`LOBBY_SAVE_CUSTOM_FORMAT_ID`]'s reserved `0`; ids are registry-stable
+/// and must never be reused or renumbered, since a persisted
+/// `FormatConfig`/`GameFormat::Custom(id)` refers to a format by this number.
+pub const SWEDISH_OLD_SCHOOL_ID: CustomFormatId = CustomFormatId(1);
+
+/// Swedish Old School 93/94, per the primary source
+/// (`oldschool-mtg.blogspot.com/p/banrestriction.html`, re-fetched
+/// 2026-09-07 and matching `docs/proposals/custom-format-engine/CONTEXT.md`'s
+/// captured lists verbatim): the Alpha-through-The-Dark card pool plus
+/// "Summer Magic", no banned cards at all, 25 restricted cards, and fully
+/// modern rules.
+///
+/// **Constructed but deliberately NOT registered.** `custom_format_registry`
+/// does not list this def, per PLAN.md §7/§8: the format's reprint policy is
+/// CONTEXT.md Open item 6, unresolved. Re-fetching the primary source
+/// confirmed every other list here but yielded only "Only English versions
+/// are allowed in Oldschool" on reprints — the secondary "no Revised-or-later
+/// reprints" claim remains unconfirmed — so `reprint_policy` stays `None`
+/// ("no confirmed authored intent to declare", distinct from a lobby save's
+/// permanent `None`), `printing_fidelity` stays `NotApplicable` per the §1
+/// pairing rule, and the def stays out of the selectable list rather than
+/// shipping a label a future maintainer would inherit as fact.
+///
+/// The empty `banned` list is real data, not a placeholder: Swedish Old
+/// School bans nothing, restricting instead. `legal_sets` is `Some(_)` — this
+/// format genuinely restricts its pool, and `None` would mean "unrestricted".
+///
+/// The seven ante cards the source carves out ("must be removed before play
+/// unless the tournament is specifically played for ante") need no entry
+/// here: `legality.legacy.ante` is [`AntePolicy::Excluded`] by default, and
+/// CR 407.3 identifies that class by the cards' own printed text, so
+/// `DeclaredPool` excludes them without a name list. Three of the seven
+/// (Contract from Below, Darkpact, Tempest Efreet) also appear on the
+/// restricted list below, exactly as the source spells it.
+///
+/// The structural half is `FormatConfig::standard()`'s — 20 life, two
+/// players, a 60-card minimum deck, a 15-card sideboard, four copies. The
+/// primary source states pool and restriction rules only, so rather than
+/// invent structural values this reads them from the shape every built-in
+/// 60-card constructed format already spreads (`premodern()`, `legacy()`,
+/// `vintage()` and `timeless()` are each literally `..Self::standard()`).
+pub fn swedish_old_school() -> CustomFormatDef {
+    CustomFormatDef {
+        rules: CustomFormatRules {
+            id: SWEDISH_OLD_SCHOOL_ID,
+            structural: StructuralRules::from_format_config(
+                &FormatConfig::standard(),
+                CommandZoneMode::Disabled,
+            ),
+            legality: LegalityRules {
+                legal_sets: Some(
+                    ["LEA", "LEB", "2ED", "ARN", "ATQ", "LEG", "DRK", "SUM"]
+                        .into_iter()
+                        .map(|code| SetCode(code.to_string()))
+                        .collect(),
+                ),
+                banned: Vec::new(),
+                restricted: [
+                    "Ancestral Recall",
+                    "Balance",
+                    "Black Lotus",
+                    "Braingeyser",
+                    "Channel",
+                    "Chaos Orb",
+                    "Contract from Below",
+                    "Darkpact",
+                    "Demonic Tutor",
+                    "Library of Alexandria",
+                    "Mana Drain",
+                    "Mind Twist",
+                    "Mishra's Workshop",
+                    "Mox Emerald",
+                    "Mox Jet",
+                    "Mox Pearl",
+                    "Mox Ruby",
+                    "Mox Sapphire",
+                    "Regrowth",
+                    "Sol Ring",
+                    "Strip Mine",
+                    "Tempest Efreet",
+                    "Time Walk",
+                    "Timetwister",
+                    "Wheel of Fortune",
+                ]
+                .into_iter()
+                .map(CardName::from)
+                .collect(),
+                // The source mentions no mana burn, no damage on the stack, no
+                // pre-M10 Wish templating and no modified legend rule: Swedish
+                // Old School is an old card pool played under modern rules.
+                legacy: LegacyRuleSet::default(),
+            },
+        },
+        label: "Swedish Old School 93/94".to_string(),
+        short_label: "OSS".to_string(),
+        description: "Alpha through The Dark (plus Summer Magic), nothing banned, 25 restricted \
+                      cards, modern rules"
+            .to_string(),
+        reprint_policy: None,
+        printing_fidelity: PrintingFidelity::NotApplicable,
+    }
+}
+
 /// Authoritative list of bundled custom-format presets, filtered through
-/// both registration gates. Empty in Phase 1a — no presets exist until a
-/// later phase introduces them.
+/// both registration gates.
+///
+/// Still empty, but no longer for Phase 1a's reason ("no presets exist").
+/// [`swedish_old_school`] exists and passes both gates; it is withheld
+/// because CONTEXT.md Open item 6 blocks its REGISTRATION specifically — see
+/// that constructor. A preset is listed here only once every claim it makes
+/// about a paper ruleset is sourced, so the gates below are the last line of
+/// defense, not the only one.
 pub fn custom_format_registry() -> Vec<CustomFormatDef> {
     let presets: Vec<CustomFormatDef> = Vec::new();
     assert_no_lobby_save_sentinel_collision(&presets);

--- a/crates/engine/src/types/format.rs
+++ b/crates/engine/src/types/format.rs
@@ -1050,7 +1050,7 @@ impl<'de> Deserialize<'de> for FormatConfig {
                         "FormatConfig.custom_rules declares a LegacyRuleSet axis the engine does \
                          not implement yet — accepting it would promise historical rules \
                          behavior (mana burn, combat-damage timing, Wish reach, legend-rule \
-                         scope) that no engine code enforces",
+                         scope, an ante zone) that no engine code enforces",
                     ));
                 }
                 let mut expected = FormatConfig::for_custom_rules(rules);

--- a/crates/engine/tests/integration/booster_tutor_open_pack.rs
+++ b/crates/engine/tests/integration/booster_tutor_open_pack.rs
@@ -15,6 +15,8 @@ use engine::game::scenario::{GameRunner, GameScenario, P0};
 use engine::types::actions::{GameAction, OutsideGameSelection};
 use engine::types::card::CardFace;
 use engine::types::card_type::{CardType, CoreType};
+use engine::types::custom_format::{swedish_old_school, AntePolicy};
+use engine::types::format::FormatConfig;
 use engine::types::game_state::{
     BoosterProduct, BoosterShelf, OutsideGameChoiceSource, WaitingFor,
 };
@@ -60,6 +62,117 @@ fn test_shelf() -> BoosterShelf {
 
 fn black_pool(count: usize) -> Vec<ManaUnit> {
     vec![ManaUnit::new(ManaType::Black, ObjectId(9_999), false, vec![]); count]
+}
+
+/// CR 407.3 identifies the ante class by this printed clause, so the fixture
+/// carries the real text rather than relying on the card's name.
+const ANTE_CLAUSE: &str =
+    "Remove this card from your deck before playing if you're not playing for ante.";
+
+const ANTE_CARD: &str = "Jeweled Bird";
+
+fn ante_face(name: &str) -> CardFace {
+    CardFace {
+        name: name.to_string(),
+        card_type: CardType {
+            core_types: vec![CoreType::Artifact],
+            ..Default::default()
+        },
+        oracle_text: Some(ANTE_CLAUSE.to_string()),
+        ..Default::default()
+    }
+}
+
+/// The same product as [`test_shelf`], except the rare slot's ONLY candidate is
+/// an ante card. With one rare for one rare slot, the collated pack contains it
+/// deterministically — the commons and uncommons stay ordinary, so every
+/// assertion below has a live non-ante control in the same pack.
+fn ante_shelf() -> BoosterShelf {
+    BoosterShelf {
+        products: vec![BoosterProduct {
+            set_code: PACK_SET.to_string(),
+            commons: (0..20).map(|i| face(&format!("Test Common {i}"))).collect(),
+            uncommons: (0..8)
+                .map(|i| face(&format!("Test Uncommon {i}")))
+                .collect(),
+            rares: vec![ante_face(ANTE_CARD)],
+            mythics: Vec::new(),
+        }],
+    }
+}
+
+/// Opens a pack containing one ante card under a custom format declaring
+/// `ante`, and returns the offered choices.
+fn open_ante_pack_under(
+    ante: AntePolicy,
+) -> Vec<engine::types::game_state::OutsideGameChoiceEntry> {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let tutor = scenario
+        .add_spell_to_hand_from_oracle(P0, "Booster Tutor", true, BOOSTER_TUTOR_ORACLE)
+        .id();
+    scenario.with_mana_pool(P0, black_pool(1));
+    let mut runner = scenario.build();
+    runner.state_mut().booster_shelf = Arc::new(ante_shelf());
+
+    // `for_custom_rules` is total and applies no gate of its own, which is what
+    // lets this reach `AntePolicy::Enabled` — a value `passes_legacy_axis_gate`
+    // refuses on every production path today.
+    let mut rules = swedish_old_school().rules;
+    rules.legality.legacy.ante = ante;
+    runner.state_mut().format_config = FormatConfig::for_custom_rules(&rules);
+
+    let outcome = runner.cast(tutor).resolve();
+    let WaitingFor::OutsideGameChoice { choices, .. } = outcome.state().waiting_for.clone() else {
+        panic!(
+            "opening a pack must raise an outside-the-game choice, got {:?}",
+            outcome.state().waiting_for
+        );
+    };
+    choices
+}
+
+fn choice_names(choices: &[engine::types::game_state::OutsideGameChoiceEntry]) -> Vec<String> {
+    choices.iter().map(|choice| choice.name.clone()).collect()
+}
+
+/// CR 407.3: "these cards can't be brought into the game from outside the
+/// game." A booster pack is drawn from a set's whole card pool, so nothing the
+/// deck-construction rules vetted stands between it and the battlefield — this
+/// is the clause a banned/restricted list could never have covered.
+#[test]
+fn booster_pack_does_not_offer_an_ante_card_while_not_playing_for_ante() {
+    let choices = open_ante_pack_under(AntePolicy::Excluded);
+    let names = choice_names(&choices);
+
+    assert!(
+        !names.iter().any(|name| name == ANTE_CARD),
+        "an ante card must not be offered from a pack (CR 407.3), got {names:?}"
+    );
+    // Discriminating on both sides: the rest of the pack is still selectable,
+    // so this is the ante class being excluded and not the choice collapsing.
+    assert_eq!(
+        choices.len(),
+        13,
+        "10 commons + 3 uncommons, with only the ante rare withheld: {names:?}"
+    );
+    assert!(names.iter().any(|name| name.starts_with("Test Common")));
+    assert!(names.iter().any(|name| name.starts_with("Test Uncommon")));
+}
+
+/// CR 407.2: playing for ante makes the class legal again. Paired with the test
+/// above on the same fixture, so the exclusion is proven to follow the declared
+/// policy rather than being a blanket filter on the card.
+#[test]
+fn booster_pack_offers_an_ante_card_when_the_format_plays_for_ante() {
+    let choices = open_ante_pack_under(AntePolicy::Enabled);
+    let names = choice_names(&choices);
+
+    assert!(
+        names.iter().any(|name| name == ANTE_CARD),
+        "playing for ante, the pack's ante card is selectable again, got {names:?}"
+    );
+    assert_eq!(choices.len(), 14, "the whole pack: {names:?}");
 }
 
 /// Cast Booster Tutor and stop at the pack choice.

--- a/crates/engine/tests/integration/custom_format_schema.rs
+++ b/crates/engine/tests/integration/custom_format_schema.rs
@@ -12,10 +12,10 @@
 
 use engine::types::custom_format::{
     assert_no_lobby_save_sentinel_collision, passes_legacy_axis_gate, passes_reprint_fidelity_gate,
-    validate_custom_rules_consistency, CombatDamageTiming, CommandZoneMode,
-    CommanderEligibilityRule, CustomFormatDef, CustomFormatId, CustomFormatRules, LegacyRuleSet,
-    LegalityRules, ManaBurnPolicy, PrintingFidelity, ReprintPolicy, SetCode, StructuralRules,
-    WishOutsideGameScope, LOBBY_SAVE_CUSTOM_FORMAT_ID,
+    swedish_old_school, validate_custom_rules_consistency, AntePolicy, CombatDamageTiming,
+    CommandZoneMode, CommanderEligibilityRule, CustomFormatDef, CustomFormatId, CustomFormatRules,
+    LegacyRuleSet, LegalityRules, ManaBurnPolicy, PrintingFidelity, ReprintPolicy, SetCode,
+    StructuralRules, WishOutsideGameScope, LOBBY_SAVE_CUSTOM_FORMAT_ID,
 };
 use engine::types::format::{
     DeckCopyLimit, DeckSizeRule, FormatConfig, GameFormat, RangeOfInfluenceConfig, SelectedFormat,
@@ -52,6 +52,7 @@ fn sample_rules(id: u16) -> CustomFormatRules {
                 damage_timing: CombatDamageTiming::default(),
                 wish_scope: WishOutsideGameScope::default(),
                 legend_rule_scope: engine::types::custom_format::LegendRuleScope::default(),
+                ante: AntePolicy::default(),
             },
         },
     }
@@ -172,6 +173,43 @@ fn legacy_axis_gate_accepts_all_default_axes() {
 }
 
 #[test]
+fn ante_enabled_is_gated_but_ante_excluded_is_not() {
+    // CR 407.2/407.4: `Enabled` promises an ante zone and the ante action,
+    // which no engine code provides — so it is a declared-but-unbuilt axis
+    // like any other, and the gate must reject it.
+    let mut def = sample_def(1);
+    def.rules.legality.legacy.ante = AntePolicy::Enabled;
+    assert!(!passes_legacy_axis_gate(&def.rules.legality.legacy));
+
+    // CR 407.3's exclusion, by contrast, IS enforced (in `DeclaredPool`), and
+    // is the default every custom format carries — including every Axis-A
+    // lobby save, whose whole LegacyRuleSet is `Default`. Gating it would
+    // reject every custom format in existence.
+    assert_eq!(AntePolicy::default(), AntePolicy::Excluded);
+    def.rules.legality.legacy.ante = AntePolicy::Excluded;
+    assert!(passes_legacy_axis_gate(&def.rules.legality.legacy));
+}
+
+#[test]
+fn a_legacy_rule_set_saved_before_the_ante_axis_still_deserializes() {
+    // Backward compatibility for a `CustomFormatDef` a client persisted
+    // before this axis existed (Phase 1c shipped the Axis-A save path): the
+    // payload has no `ante` key, and must resolve to the modern `Excluded` —
+    // which is exactly what such a save meant.
+    let legacy: LegacyRuleSet = serde_json::from_str(
+        r#"{
+            "mana_burn": "Modern",
+            "damage_timing": "Modern",
+            "wish_scope": "PostM10SideboardOnly",
+            "legend_rule_scope": "Modern"
+        }"#,
+    )
+    .expect("a pre-ante LegacyRuleSet payload must still deserialize");
+    assert_eq!(legacy.ante, AntePolicy::Excluded);
+    assert_eq!(legacy, LegacyRuleSet::default());
+}
+
+#[test]
 fn reprint_fidelity_gate_rejects_mismatch() {
     let mut def = sample_def(3);
     def.reprint_policy = Some(ReprintPolicy::OriginalPrintingsOnly);
@@ -196,8 +234,117 @@ fn reprint_fidelity_gate_accepts_agreement() {
 }
 
 #[test]
-fn custom_format_registry_is_empty_in_phase_1a() {
-    assert!(engine::types::custom_format::custom_format_registry().is_empty());
+fn custom_format_registry_withholds_swedish_old_school_on_open_item_6() {
+    // The registry is still empty, but no longer because no preset exists:
+    // `swedish_old_school()` is built and passes both registration gates. It
+    // is withheld because its reprint policy is unconfirmed against the
+    // primary source (CONTEXT.md Open item 6), which PLAN.md §7/§8 make a
+    // registration blocker in its own right. Asserting BOTH halves is the
+    // point — an empty-registry assertion alone would keep passing if the
+    // preset silently stopped passing the gates.
+    let preset = swedish_old_school();
+    assert!(passes_legacy_axis_gate(&preset.rules.legality.legacy));
+    assert!(passes_reprint_fidelity_gate(&preset));
+
+    let registry = engine::types::custom_format::custom_format_registry();
+    assert!(
+        registry.is_empty(),
+        "swedish_old_school() must not be selectable while Open item 6 is unresolved; got {:?}",
+        registry.iter().map(|def| &def.label).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn swedish_old_school_declares_its_sourced_card_pool() {
+    // Preset integrity against `docs/proposals/custom-format-engine/CONTEXT.md`'s
+    // captured lists, themselves re-verified against the primary source
+    // (oldschool-mtg.blogspot.com/p/banrestriction.html). Every set code was
+    // checked against Scryfall's set list at implementation time.
+    let preset = swedish_old_school();
+    let legality = &preset.rules.legality;
+
+    let sets = legality
+        .legal_sets
+        .as_ref()
+        .expect("Swedish Old School restricts its pool, so legal_sets is Some(_), never None");
+    assert_eq!(
+        sets.iter().map(|code| code.0.as_str()).collect::<Vec<_>>(),
+        ["LEA", "LEB", "2ED", "ARN", "ATQ", "LEG", "DRK", "SUM"],
+        "Alpha, Beta, Unlimited, Arabian Nights, Antiquities, Legends, The Dark, Summer Magic"
+    );
+
+    // A genuinely empty list, not an unpopulated one: the format bans nothing
+    // and restricts instead. The schema must carry that faithfully.
+    assert!(legality.banned.is_empty());
+
+    assert_eq!(
+        legality.restricted.len(),
+        25,
+        "the source's restricted list is 25 cards (CONTEXT.md corrected an earlier 23 miscount)"
+    );
+    for expected in [
+        "Ancestral Recall",
+        "Black Lotus",
+        "Mishra's Workshop",
+        "Mox Sapphire",
+        "Timetwister",
+    ] {
+        assert!(
+            legality.restricted.iter().any(|name| name == expected),
+            "restricted list is missing {expected}"
+        );
+    }
+    // Three of the seven ante cards are also restricted, exactly as the
+    // source spells it — the ante exclusion below is what actually keeps them
+    // out of a deck.
+    assert!(legality
+        .restricted
+        .iter()
+        .any(|name| name == "Contract from Below"));
+
+    // An old card pool played under modern rules: the source mentions no mana
+    // burn, damage on the stack, pre-M10 Wish templating or modified legend
+    // rule. This is what makes it the one Axis-B preset needing zero
+    // LegacyRuleSet engine wiring.
+    assert_eq!(legality.legacy, LegacyRuleSet::default());
+}
+
+#[test]
+fn swedish_old_school_carries_honest_unresolved_reprint_metadata() {
+    let preset = swedish_old_school();
+    // Open item 6: the primary source states only "Only English versions are
+    // allowed in Oldschool". `None` says "no confirmed authored intent to
+    // declare" rather than inventing OriginalPrintingsOnly from a secondary
+    // source, and NotApplicable is the pairing PLAN.md §1 requires of it.
+    assert_eq!(preset.reprint_policy, None);
+    assert_eq!(preset.printing_fidelity, PrintingFidelity::NotApplicable);
+
+    // A registry-stable id of its own, never the Axis-A lobby-save sentinel.
+    assert_ne!(preset.rules.id, LOBBY_SAVE_CUSTOM_FORMAT_ID);
+    assert_no_lobby_save_sentinel_collision(&[preset]);
+}
+
+#[test]
+fn swedish_old_school_inherits_the_shared_constructed_structural_shape() {
+    // The primary source states pool and restriction rules only. Rather than
+    // invent structural values, the preset projects `FormatConfig::standard()`
+    // — the shape every built-in 60-card constructed format spreads. This
+    // pins that they stay identical.
+    let preset = swedish_old_school();
+    let structural = &preset.rules.structural;
+    let base = FormatConfig::standard();
+
+    assert_eq!(structural.starting_life, base.starting_life);
+    assert_eq!(structural.deck_size, base.deck_size);
+    assert_eq!(structural.min_players, base.min_players);
+    assert_eq!(structural.max_players, base.max_players);
+    assert_eq!(structural.sideboard_policy, base.sideboard_policy);
+    assert_eq!(
+        structural.default_deck_copy_limit,
+        base.default_deck_copy_limit
+    );
+    assert!(!structural.singleton);
+    assert_eq!(structural.command_zone_mode, CommandZoneMode::Disabled);
 }
 
 #[test]

--- a/crates/engine/tests/integration/custom_format_schema.rs
+++ b/crates/engine/tests/integration/custom_format_schema.rs
@@ -22,7 +22,7 @@ use engine::types::format::{
     SideboardPolicy,
 };
 use engine::types::player::PlayerId;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 
 fn sample_structural() -> StructuralRules {
     StructuralRules {
@@ -277,30 +277,60 @@ fn swedish_old_school_declares_its_sourced_card_pool() {
     // and restricts instead. The schema must carry that faithfully.
     assert!(legality.banned.is_empty());
 
-    assert_eq!(
-        legality.restricted.len(),
-        25,
-        "the source's restricted list is 25 cards (CONTEXT.md corrected an earlier 23 miscount)"
-    );
-    for expected in [
+    // The COMPLETE authoritative roster, not a count plus spot-checks: a
+    // same-length substitution in any entry changes legal deck construction,
+    // and a test that only counted to 25 would pass straight through it.
+    // Order-independent so the constructor stays free to reorder, but exact in
+    // both directions — nothing missing, nothing extra.
+    let expected_restricted: BTreeSet<&str> = [
         "Ancestral Recall",
+        "Balance",
         "Black Lotus",
+        "Braingeyser",
+        "Channel",
+        "Chaos Orb",
+        "Contract from Below",
+        "Darkpact",
+        "Demonic Tutor",
+        "Library of Alexandria",
+        "Mana Drain",
+        "Mind Twist",
         "Mishra's Workshop",
+        "Mox Emerald",
+        "Mox Jet",
+        "Mox Pearl",
+        "Mox Ruby",
         "Mox Sapphire",
+        "Regrowth",
+        "Sol Ring",
+        "Strip Mine",
+        "Tempest Efreet",
+        "Time Walk",
         "Timetwister",
-    ] {
-        assert!(
-            legality.restricted.iter().any(|name| name == expected),
-            "restricted list is missing {expected}"
-        );
-    }
-    // Three of the seven ante cards are also restricted, exactly as the
-    // source spells it — the ante exclusion below is what actually keeps them
-    // out of a deck.
-    assert!(legality
-        .restricted
-        .iter()
-        .any(|name| name == "Contract from Below"));
+        "Wheel of Fortune",
+    ]
+    .into_iter()
+    .collect();
+    assert_eq!(
+        expected_restricted.len(),
+        25,
+        "the source's restricted list is 25 cards (CONTEXT.md corrected an earlier 23 miscount) — \
+         if this trips, the literal above gained a duplicate"
+    );
+    let actual_restricted: BTreeSet<&str> =
+        legality.restricted.iter().map(String::as_str).collect();
+    assert_eq!(
+        actual_restricted, expected_restricted,
+        "swedish_old_school()'s restricted list must match the primary source exactly"
+    );
+    // A set comparison would hide a duplicated entry in the constructor, which
+    // would be a real authoring defect even though it changes no verdict.
+    assert_eq!(legality.restricted.len(), 25);
+
+    // Three of the 25 (Contract from Below, Darkpact, Tempest Efreet) are also
+    // ante cards, exactly as the source spells it — the ante exclusion is what
+    // actually keeps those three out of a deck, ahead of this list.
+    assert!(actual_restricted.contains("Contract from Below"));
 
     // An old card pool played under modern rules: the source mentions no mana
     // burn, damage on the stack, pre-M10 Wish templating or modified legend

--- a/docs/proposals/custom-format-engine/CONTEXT.md
+++ b/docs/proposals/custom-format-engine/CONTEXT.md
@@ -909,11 +909,51 @@ its resolution directly:
    the custom-format engine itself** and, if ever pursued, belongs to a
    separate, later "tournament/match structure" design, not bundled into
    `CustomFormatDef`/`LegacyRuleSet` here.
-5. **Ante-card handling (new, from the Swedish Old School preset).** "Must be
-   removed before play unless the tournament is specifically played for ante"
-   is a *third* list-shaped rule, distinct from banned (illegal outright) and
-   restricted (legal, max 1) — the schema has no slot for it today. Needs a
-   decision: a third named list on `LegalityRules`, or folding it into
+5. ~~**Ante-card handling**~~ — **RESOLVED, Phase 1d** (neither of the two
+   options originally offered below; both were list-shaped, and the rule
+   isn't). The framing was "a *third* list-shaped rule, distinct from banned
+   (illegal outright) and restricted (legal, max 1)" — but **CR 407.3 does not
+   define the ante cards as a list**: it defines them as the cards bearing the
+   text "Remove this card from your deck before playing if you're not playing
+   for ante", and then says "when not playing for ante, players can't include
+   these cards in their decks or sideboards". The class is the printed text,
+   and the prohibition is already exactly `banned`'s deck-construction
+   semantics. So no new list, and no `banned` entries either.
+
+   **Resolution: `AntePolicy` (`Excluded` | `Enabled`) as a fifth
+   `LegacyRuleSet` axis, enforced by a class predicate, not a roster.**
+   - `Excluded` is the default, so every custom format — including every
+     Axis-A lobby save — gets CR 407.3 enforcement for free, and
+     `swedish_old_school()` needs no ante data of its own.
+   - Enforcement reuses the predicate `deck_validation.rs` already had:
+     `tiny_leaders_category_banned`'s `"playing for ante"` test, extracted as
+     `face_uses_ante` so both callers share one definition of the class.
+     Verified exact — Scryfall's `oracle:"playing for ante"` returns exactly
+     9 cards (Amulet of Quoz, Bronze Tablet, Contract from Below, Darkpact,
+     Demonic Attorney, Jeweled Bird, Rebirth, Tempest Efreet, Timmerian
+     Fiends), the whole class with no false positives. A 7-name list would
+     have been a snapshot of only the subset inside one format's set window.
+   - `DeclaredPool::status` checks it ahead of banned/restricted, because a
+     format may also RESTRICT an ante card — Swedish restricts three of the
+     seven it carves out — and one legal copy is still one copy too many.
+   - The rejected "`ante_enabled` toggle" half is answered by the axis'
+     `Enabled` variant, which is **gated** by `IMPLEMENTED_LEGACY_AXES` like
+     any other declared-but-unbuilt axis: it would promise the CR 407.2 ante
+     zone and CR 407.4 ante action, which no engine code provides. Note the
+     asymmetry — only `Enabled` is a declared axis; `Excluded` is enforced
+     today and so is never gated, or every custom format in existence would
+     be rejected.
+   - Why `LegacyRuleSet` and not `LegalityRules`: CR 407.1 calls ante a rule
+     from "earlier versions of the Magic rules", now "an optional variation on
+     the game" and "strictly forbidden under the Magic: The Gathering
+     Tournament Rules" — the same shape as mana burn. It also gets the
+     existing gate at both call sites (`custom_format_pool` and
+     `FormatConfig::deserialize`) for free rather than needing a parallel one.
+
+   Original framing, kept for its research, not as a live open question: "Must
+   be removed before play unless the tournament is specifically played for
+   ante" is a third list-shaped rule; the schema has no slot for it today.
+   Needs a decision: a third named list on `LegalityRules`, or folding it into
    `banned` gated by a new `ante_enabled: bool`/toggle. Low urgency (only 7
    cards; ante itself has no in-engine support and none is proposed here), but
    should not be silently dropped when the preset ships.

--- a/docs/proposals/custom-format-engine/IMPLEMENTATION_PLAN.md
+++ b/docs/proposals/custom-format-engine/IMPLEMENTATION_PLAN.md
@@ -368,6 +368,26 @@ Phase 2a) produce `CustomFormatDef` values the same way `from_lobby_config`
 does — a definition, not an active `FormatConfig` — and reuse Phase 1c's
 shared resolver when a preset is actually selected to start a game.
 
+> **Correction, as shipped.** The last sentence of the paragraph above
+> overstated what this phase could deliver, and the code does NOT match it:
+> `swedish_old_school()` exists and passes both gates, but
+> `custom_format_registry()` still returns empty, so the preset is not
+> selectable. PLAN.md §7/§8 make Open item 6 (the reprint-policy metadata
+> VALUE, unconfirmed against the primary source) a registration blocker in its
+> own right, and this document simply assumed that item would be resolved by
+> now. It is not: re-fetching `oldschool-mtg.blogspot.com/p/banrestriction.html`
+> on 2026-09-07 confirmed every other list verbatim but yielded only "Only
+> English versions are allowed in Oldschool" on reprints. When PLAN.md and this
+> charter disagree, PLAN.md wins — it is the design; this is the sequencing
+> view of it. Registration is a one-line change to `custom_format_registry()`
+> the moment Open item 6 resolves.
+
+Phase 1d also resolved **CONTEXT.md Open item 5** (ante-card handling), which
+PLAN.md §8 step 3 requires closed before this preset's constructor is
+finalized: a fifth `LegacyRuleSet` axis, `AntePolicy`, whose default
+`Excluded` enforces CR 407.3 against a printed-text class predicate rather
+than any card list. See that item for the full resolution.
+
 **Owns widening `DeckCompatibilityRequest.selected_format`.** Today it's a
 bare `Option<GameFormat>` — confirmed to have no `FormatConfig`/
 `custom_rules` field at all (`CONTEXT.md` open item 1), so `Custom` reaches

--- a/docs/proposals/custom-format-engine/PLAN.md
+++ b/docs/proposals/custom-format-engine/PLAN.md
@@ -932,8 +932,10 @@ not appear as a selectable format until that item resolves:
   and `legal_sets: Some(...)` here — never `None` — since this preset DOES
   restrict the pool); restricted = [**25** names, verbatim in CONTEXT.md —
   corrected this round from a "23" miscount]; legacy = default (all
-  `false`/`Modern` — no mana burn, no damage-on-stack, no Wish/legend-rule
-  reversion). `reprint_policy` (on `CustomFormatDef`): `None` for now — NOT
+  `false`/`Modern`/`Excluded` — no mana burn, no damage-on-stack, no
+  Wish/legend-rule reversion, and ante cards excluded per CR 407.3, which is
+  what the source's own carve-out asks for). `reprint_policy` (on
+  `CustomFormatDef`): `None` for now — NOT
   a value pending confirmation, but the genuinely correct value until
   CONTEXT.md Open item 6 resolves (there is no confirmed authored intent to
   declare yet; `None` says exactly that, distinctly from a lobby save's
@@ -942,8 +944,12 @@ not appear as a selectable format until that item resolves:
   None` per §1's pairing rule — revisit alongside Open item 6, since resolving
   that item to a real `Some(_)` value also flips this to
   `SetCodeApproximation` with a matching `description` update. Ante-card
-  handling remains open per Open item 5 separately; do not encode either
-  without resolving its own item first.
+  handling — CONTEXT.md Open item 5 — **is** resolved, in Phase 1d: the
+  `AntePolicy` axis carries it, this preset declares nothing of its own for
+  it, and the seven cards the source carves out are excluded by CR 407.3's
+  printed-text class rather than by any list here. See that item for why
+  neither originally-offered option (a third list, or an `ante_enabled`
+  toggle over `banned`) was taken.
 
 **Phase 2 presets — the four EC formats**, unchanged from the original design,
 now explicitly sequenced after phase 1 (§8) since they need the
@@ -1131,6 +1137,15 @@ Everything in this section is deferred to phase 2 (§8) — the phase-1 preset
 Swedish ruleset makes no mention of any of these rules and uses fully modern
 defaults. This section is unchanged from the original design and remains the
 correct plan for phase 2's four EC-format presets.
+
+**One clarification since Phase 1d added the `ante` axis (CONTEXT.md Open item
+5):** the sentence above still holds, because it is about *runtime rules
+wiring*. `AntePolicy::Excluded` needs none — CR 407.3 is a deck-construction
+rule, enforced in `deck_validation.rs` where the other card-pool rules already
+live, not at any game-rules seam. `AntePolicy::Enabled` is what would need
+wiring (the CR 407.2 ante zone, the CR 407.4 ante action), and it is gated
+unimplemented exactly like every axis below. No preset in either phase
+declares it.
 
 - **Mana burn** (`LegacyRuleSet.mana_burn`) — **REWRITTEN AGAIN per
   maintainer review round 3** (CONTEXT.md point 1). Round 2 fixed the
@@ -1546,15 +1561,21 @@ mechanism §6's "actually enforced, not just documented" test targets.
 **Gate scope, precisely (maintainer review round 5 caught that this wasn't
 stated precisely enough; round 6's `reprint_policy` relocation, §1/§3, makes
 it precise by construction rather than by exemption): `IMPLEMENTED_LEGACY_AXES`
-covers exactly `LegacyRuleSet`'s four axes — `mana_burn`, `damage_timing`,
-`wish_scope`, `legend_rule_scope` — because those are now the ONLY fields on
-`CustomFormatRules` that are independently declarable AND behavior-bearing.**
+covers exactly `LegacyRuleSet`'s five axes — `mana_burn`, `damage_timing`,
+`wish_scope`, `legend_rule_scope`, `ante` — because those are now the ONLY
+fields on `CustomFormatRules` that are independently declarable AND
+behavior-bearing.**
 `reprint_policy` doesn't need an exemption from this gate anymore — it isn't
 on `CustomFormatRules` at all after round 6's move to `CustomFormatDef`, so
-there's nothing there for the gate to either cover or exempt. There is no
-ante-card field to cover yet either (CONTEXT.md Open item 5 — no schema slot
-exists). If a future field is ever added to `CustomFormatRules` with real
-behavior attached (an ante-list, say), it must be added to this gate in the
+there's nothing there for the gate to either cover or exempt. `ante` was added
+in Phase 1d (CONTEXT.md Open item 5, resolved there) and followed this rule
+exactly — added to `LegacyRuleSet` and to the gate in the SAME change. It is
+also the one axis whose coverage is PARTIAL by design: only the non-default
+`AntePolicy::Enabled` is a declared axis, because `Excluded`'s CR 407.3
+deck-construction consequence is enforced from the moment the field exists.
+Gating the default too would reject every custom format in existence. If a
+future field is ever added to `CustomFormatRules` with real
+behavior attached, it must be added to this gate in the
 SAME change — the gate's job is to cover every behavior-bearing field on the
 RESOLVED RULES struct, and it is a review-time checklist item whenever
 `CustomFormatRules`/`LegacyRuleSet` gains a member, not a one-time list to

--- a/docs/proposals/custom-format-engine/PLAN.md
+++ b/docs/proposals/custom-format-engine/PLAN.md
@@ -608,7 +608,7 @@ LegalityRules {
 // true` requires the reader to already know which direction "true" points).
 // This mirrors `LegendRuleScope`'s existing shape rather than introducing a
 // new convention.
-LegacyRuleSet {                         // INDEPENDENT era-rule axes (RESEARCH §8, §10)
+LegacyRuleSet {                         // FIVE INDEPENDENT era-rule axes (RESEARCH §8, §10)
     mana_burn: ManaBurnPolicy,
     damage_timing: CombatDamageTiming,
     wish_scope: WishOutsideGameScope,
@@ -619,6 +619,16 @@ LegacyRuleSet {                         // INDEPENDENT era-rule axes (RESEARCH �
                                         // binary and this leaves room without
                                         // a later refactor. Same reasoning now
                                         // applied to the three siblings above.
+    ante: AntePolicy,                   // Phase 1d (CONTEXT.md Open item 5).
+                                        // #[serde(default)] — it postdates the
+                                        // Axis-A save path, so an already-
+                                        // persisted def carries no `ante` key.
+                                        // The ONLY axis here whose default is
+                                        // behavior-bearing today: `Excluded`
+                                        // enforces CR 407.3 at deck
+                                        // construction. See §7's gate-scope
+                                        // paragraph for why only `Enabled` is
+                                        // a GATED axis.
 }
 
 ManaBurnPolicy {                        // RESEARCH §5
@@ -663,6 +673,24 @@ LegendRuleScope {                       // RESEARCH §10: legend-rule controller
     PreM14AnyController,                // pre-M14: same-named legends across ALL
                                         // controllers all go to owners' graveyards,
                                         // choiceless (Sixth-Edition "both die" form).
+}
+
+AntePolicy {                            // CR 407 (CONTEXT.md Open item 5)
+    Excluded,                           // CR 407.3: cards printed with "Remove this
+                                        // card from your deck before playing if
+                                        // you're not playing for ante" may not be in
+                                        // a deck OR sideboard. DEFAULT — and, unlike
+                                        // every other default here, ENFORCED today,
+                                        // in deck_validation's DeclaredPool, by a
+                                        // printed-text class predicate rather than a
+                                        // card list. Every custom format gets it,
+                                        // including Axis-A lobby saves.
+    Enabled,                            // CR 407.2/407.4: the ante zone and the ante
+                                        // action. Schema only — GATED by
+                                        // IMPLEMENTED_LEGACY_AXES. This is the half
+                                        // that promises unbuilt runtime behavior;
+                                        // gating `Excluded` too would reject every
+                                        // custom format in existence.
 }
 ```
 


### PR DESCRIPTION
Closes the remainder of Phase 1d (`docs/proposals/custom-format-engine/IMPLEMENTATION_PLAN.md` §"Phase 1d") after #8645 (Phase A, the admission gate) and #8712 (Phase B, the evaluator). Two things: the first Axis-B preset constructor, and the ante rule its source carves out — which is also **CONTEXT.md Open item 5**, that PLAN.md §8 step 3 requires closed before this constructor is finalized.

## Ante is a class, not a list (CR 407.3)

Open item 5 offered two options, both list-shaped: a third named list on `LegalityRules`, or folding the seven cards into `banned` behind an `ante_enabled` toggle. **Neither is taken, because the rule isn't list-shaped.**

CR 407.3 defines the cards by their own printed text — *"Remove this card from your deck before playing if you're not playing for ante"* — and then says *"when not playing for ante, players can't include these cards in their decks or sideboards"*. The class is the text; the prohibition is already exactly `banned`'s deck-construction semantics.

So: **`AntePolicy` (`Excluded` | `Enabled`) as a fifth `LegacyRuleSet` axis**, enforced by a predicate this module already had. `tiny_leaders_category_banned` has always tested `"playing for ante"`; that test is extracted as `face_uses_ante` so both callers share one definition of the class.

Verified exact: Scryfall's `oracle:"playing for ante"` returns exactly 9 cards — Amulet of Quoz, Bronze Tablet, Contract from Below, Darkpact, Demonic Attorney, Jeweled Bird, Rebirth, Tempest Efreet, Timmerian Fiends — the whole class with no false positives. A 7-name list would have been a snapshot of only the subset inside one format's set window.

`DeclaredPool::status` checks it **ahead of** banned/restricted: a format may also RESTRICT an ante card — Swedish restricts three of the seven it carves out — and one legal copy is still one copy too many. The verdict is `Banned`, not `None`, because the card IS inside the declared pool; "not legal in {format}" would misreport why it was rejected.

### This changes behavior beyond the preset

`Excluded` is the default, so **every custom format — including every Axis-A lobby save — now rejects ante cards.** That is CR 407.3-correct and this engine cannot play for ante, but it is a real behavior change, not just new preset data, and reviewers should weigh it as one.

Only the non-default `Enabled` is a declared axis under `IMPLEMENTED_LEGACY_AXES`: it would promise the CR 407.2 ante zone and CR 407.4 ante action, which no engine code provides. Gating the default too would reject every custom format in existence, since a lobby save's whole `LegacyRuleSet` is `Default`. That asymmetry is documented at `declared_legacy_axes` and in PLAN.md §7's gate-scope paragraph.

`ante` is `#[serde(default)]` for the same reason its TypeScript mirror is optional: a `CustomFormatDef` persisted by a client before this axis carries no `ante` key, and rejecting those would discard every custom format a player had already saved. Covered by a test on each side.

## `swedish_old_school()`

Sourced from `oldschool-mtg.blogspot.com/p/banrestriction.html`, re-fetched 2026-09-07 and matching CONTEXT.md's captured lists verbatim: eight legal sets (each code verified against Scryfall's live set list), a **genuinely empty** banned list, 25 restricted names, modern rules. It declares nothing for ante — the default covers the source's carve-out.

The structural half projects `FormatConfig::standard()` through a new shared `StructuralRules::from_format_config`, rather than hand-transcribing values the primary source never states. `standard()` is the honest base: every built-in 60-card constructed format (`premodern()`, `legacy()`, `vintage()`, `timeless()`) is literally `..Self::standard()`. The extraction also means `from_lobby_config` and every future preset share one field-by-field projection, so adding a `StructuralRules` field has exactly one place to update.

## Constructed, deliberately not registered

`custom_format_registry()` **still returns empty.** `swedish_old_school()` passes both gates, but PLAN.md §7/§8 make **Open item 6** — the reprint-policy metadata VALUE — a registration blocker in its own right. Re-fetching the primary source confirmed every other list but yielded only *"Only English versions are allowed in Oldschool"*; the secondary "no Revised-or-later reprints" claim remains unconfirmed. So `reprint_policy` stays `None` ("no confirmed authored intent to declare") with `printing_fidelity: NotApplicable` per §1's pairing rule, and the preset stays out of the selectable list rather than shipping a label a future maintainer would inherit as fact. Registering it is a one-line change once that item resolves.

The old empty-registry test is replaced by one asserting **both** halves — that the preset passes both gates *and* that it is not selectable — so the assertion can't keep passing if the preset silently stops qualifying.

IMPLEMENTATION_PLAN.md's Phase 1d text claimed the registry would go live with this preset as its first entry; it assumed Open item 6 would be resolved by now. That paragraph is corrected in place rather than left to drift.

## Verification

| Check | Result |
|---|---|
| `cargo fmt --all` | clean |
| `cargo clippy -p phase-engine --all-targets` | 0 warnings |
| `cargo test -p phase-engine --lib deck_validation::tests` | 148 passed, 0 failed |
| `cargo test -p phase-engine --test integration custom_format` | 90 passed, 0 failed |
| `pnpm type-check` (incl. protocol check) | clean |
| vitest, 5 `LegacyRuleSet`-touching suites | 287 passed |

Unrelated, found while running the full engine suite and **not** fixed here: `cargo test -p phase-engine` ends red on a doctest in `crates/engine/src/game/ability_utils.rs:9119` — a 4-space-indented block inside a `///` comment that rustdoc compiles as Rust. It is pre-existing on `main` (last touched by #8681) and invisible to CI, because `cargo nextest run` does not execute doctests and nothing else runs `--doc`. Filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013h1rTnbzGpibH8sbszunhs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Custom formats now support excluded or enabled ante policies where supported.
  * Existing saved custom-format definitions without ante settings remain compatible.
  * Ante cards are filtered when building decks, sideboards, and outside-the-game choices.

* **Bug Fixes**
  * Ante-card validation is now applied consistently across format routes and card-search effects.
  * Unsupported ante configurations provide clearer guidance.

* **Documentation**
  * Updated custom-format documentation to clarify ante handling, defaults, and configuration support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->