### PR TITLE
docs(engine): fence a prose snippet rustdoc was compiling as a doctest

### DIFF
--- a/crates/engine/src/game/ability_utils.rs
+++ b/crates/engine/src/game/ability_utils.rs
@@ -9116,8 +9116,10 @@ fn node_slot_filters(ability: &ResolvedAbility) -> NodeSlotFilters {
 ///     condition is a DIFFERENT authority from the one that produced `Legacy`.
 ///     BASE's `retarget_slot_violation` is a no-op at a position exactly when
 ///
-///         mana_multi_role(&ability.effect).is_none()
-///             && paired_subject_slot_filters(&ability.effect).next().is_none()
+///     ```text
+///     mana_multi_role(&ability.effect).is_none()
+///         && paired_subject_slot_filters(&ability.effect).next().is_none()
+///     ```
 ///
 ///     (its `filters.is_empty()` early-out). `Legacy` is produced by
 ///     `node_slot_filters`' `NotDerivable` verdict or by its arity gate


### PR DESCRIPTION
`cargo test -p phase-engine` currently fails on `main`.

The `SlotEnforcement` doc comment in `ability_utils.rs` illustrates a predicate with a 4-space-indented block:

```
///     BASE's `retarget_slot_violation` is a no-op at a position exactly when
///
///         mana_multi_role(&ability.effect).is_none()
///             && paired_subject_slot_filters(&ability.effect).next().is_none()
```

rustdoc treats an indented block in a doc comment as a Rust code block and tries to compile it. It references `ability` and `paired_subject_slot_filters`, neither in scope, so it fails with 5 errors and takes the whole doctest target down:

```
error[E0425]: cannot find value `ability` in this scope
error[E0425]: cannot find function `paired_subject_slot_filters` in this scope
error[E0308]: mismatched types
error: aborting due to 5 previous errors

failures:
    crates/engine/src/game/ability_utils.rs - game::ability_utils::SlotEnforcement (line 9119)

test result: FAILED. 0 passed; 1 failed; 7 ignored
```

Fencing it as ` ```text ` keeps the rendering identical and stops rustdoc collecting it as a doctest. **No prose or code changes** — the diff is two fence lines plus a 4-space dedent of the snippet so it sits at the body indent.

## Why this reached main, and why CI won't confirm the fix either

CI runs `cargo nextest run --profile ci --partition count:N/4 --workspace`, and **cargo-nextest does not execute doctests at all.** Nothing else in `ci.yml` runs `--doc`. So this class of breakage is invisible to CI in both directions: it could land, and this fix will go green without actually being exercised.

Worth considering as a follow-up: a `cargo test -p phase-engine --doc` step, which is cheap next to the existing shards and would close the gap permanently. Not included here to keep this diff to the bug.

## Verification status — please read

**I was not able to run `cargo test -p phase-engine --doc` locally.** Three attempts were killed by the machine's OOM reaper while rustdoc rebuilt the crate. The reasoning is analytic rather than empirical: a ` ```text ` block is never compiled by rustdoc, so the target should go from `1 failed; 7 ignored` to `0 failed; 7 ignored`. That is high-confidence but unproven, and since CI won't exercise it either, it deserves a maintainer's local run before merge. Flagging rather than implying a green run I did not get.

Found while verifying #8736; unrelated to that PR's changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013h1rTnbzGpibH8sbszunhs
