### PR TITLE
Preserve counted graveyard exile costs

### DIFF
--- a/crates/engine/src/game/effects/change_zone.rs
+++ b/crates/engine/src/game/effects/change_zone.rs
@@ -5,8 +5,8 @@ use crate::game::game_object::AttachTarget;
 use crate::game::zones;
 use crate::types::ability::{
     ControllerRef, Duration, Effect, EffectError, EffectKind, EffectResolutionResult, FilterProp,
-    LibraryPosition, QuantityExpr, ResolvedAbility, TargetChoiceTiming, TargetFilter, TargetRef,
-    TargetSelectionMode, TypeFilter, TypedFilter,
+    LibraryPosition, OpponentMayScope, QuantityExpr, ResolvedAbility, TargetChoiceTiming,
+    TargetFilter, TargetRef, TargetSelectionMode, TypeFilter, TypedFilter,
 };
 #[cfg(test)]
 use crate::types::ability::{EffectScope, TapStateChange};
@@ -424,6 +424,115 @@ fn resolution_choice_cardinality(
     }
 }
 
+fn resolution_zone_candidates(
+    state: &GameState,
+    ability: &ResolvedAbility,
+    target_filter: &TargetFilter,
+    filter_controller: PlayerId,
+    scan_zones: &[Zone],
+    destination: Zone,
+) -> Vec<ObjectId> {
+    let ctx = crate::game::filter::FilterContext::from_ability_with_controller(
+        ability,
+        filter_controller,
+    );
+    state
+        .objects
+        .iter()
+        .filter(|(id, object)| {
+            scan_zones.contains(&object.zone)
+                && !object.is_emblem
+                && crate::game::filter::matches_target_filter(state, **id, target_filter, &ctx)
+        })
+        .filter(|(id, object)| {
+            destination != Zone::Exile
+                || !crate::game::static_abilities::triggered_cause_sacrifice_or_exile_muzzled(
+                    state,
+                    ability,
+                    **id,
+                    object.controller,
+                )
+        })
+        .map(|(id, _)| *id)
+        .collect()
+}
+
+/// CR 608.2d + CR 701.13a: report whether this exact optional-for-any-player
+/// graveyard-exile instruction lacks enough legal cards for its exact
+/// resolution-time selection. Adjacent ChangeZone shapes return `None` so the
+/// ordinary optional-effect path retains authority over them.
+pub(crate) fn exact_scoped_graveyard_exile_is_infeasible(
+    state: &GameState,
+    ability: &ResolvedAbility,
+) -> Option<bool> {
+    let Effect::ChangeZone {
+        origin: Some(Zone::Graveyard),
+        destination: Zone::Exile,
+        target:
+            TargetFilter::Typed(TypedFilter {
+                type_filters,
+                controller: None,
+                properties,
+            }),
+        up_to: false,
+        ..
+    } = &ability.effect
+    else {
+        return None;
+    };
+    let Some(spec) = ability.multi_target.as_ref() else {
+        return None;
+    };
+    let Some(max) = spec.max.as_ref() else {
+        return None;
+    };
+    let canonical_properties = [
+        FilterProp::Owned {
+            controller: ControllerRef::ScopedPlayer,
+        },
+        FilterProp::InZone {
+            zone: Zone::Graveyard,
+        },
+    ];
+    if !ability.optional
+        || ability.optional_for != Some(OpponentMayScope::AnyPlayer)
+        || ability
+            .targets
+            .iter()
+            .any(|target| matches!(target, TargetRef::Object(_)))
+        || ability.target_choice_timing != TargetChoiceTiming::Resolution
+        || type_filters.as_slice() != [TypeFilter::Card]
+        || properties.as_slice() != canonical_properties
+        || max != &spec.min
+    {
+        return None;
+    }
+
+    let target_filter = match &ability.effect {
+        Effect::ChangeZone { target, .. } => target,
+        _ => unreachable!("shape matched above"),
+    };
+    let filter_controller =
+        crate::game::effects::controller_for_relative_filter(state, ability, target_filter);
+    let candidates = resolution_zone_candidates(
+        state,
+        ability,
+        target_filter,
+        filter_controller,
+        &[Zone::Graveyard],
+        Zone::Exile,
+    );
+    Some(
+        crate::game::ability_utils::resolve_multi_target_bounds(
+            state,
+            ability,
+            spec,
+            candidates.len(),
+        )
+        .is_err(),
+    )
+}
+
 // PLAN §7 Phase A: the zone-change pipeline (result enums, delivery tail,
 // `execute_zone_move`, `deliver_replaced_zone_change`) now lives in
 // `crate::game::zone_pipeline`. These shims keep every existing
@@ -823,40 +932,14 @@ pub fn resolve(
         // "creature you control" needs "you" to resolve to the *target* player
         // (not the caster), we pass `filter_controller` explicitly. Include the
         // resolving ability so `Owned { ScopedPlayer }` reads `scoped_player`.
-        let ctx = crate::game::filter::FilterContext::from_ability_with_controller(
+        let eligible = resolution_zone_candidates(
+            state,
             ability,
+            target_filter,
             filter_controller,
+            &scan_zones,
+            dest_zone,
         );
-        let eligible: Vec<ObjectId> = state
-            .objects
-            .iter()
-            .filter(|(id, obj)| {
-                scan_zones.contains(&obj.zone)
-                    && !obj.is_emblem
-                    && crate::game::filter::matches_target_filter(state, **id, target_filter, &ctx)
-            })
-            .map(|(id, _)| *id)
-            .collect();
-        let eligible: Vec<ObjectId> = if dest_zone == Zone::Exile {
-            eligible
-                .into_iter()
-                .filter(|id| {
-                    let acting_player = state
-                        .objects
-                        .get(id)
-                        .map(|obj| obj.controller)
-                        .unwrap_or(ability.controller);
-                    !crate::game::static_abilities::triggered_cause_sacrifice_or_exile_muzzled(
-                        state,
-                        ability,
-                        *id,
-                        acting_player,
-                    )
-                })
-                .collect()
-        } else {
-            eligible
-        };
 
         let (choice_count, min_count, choice_up_to) =
             resolution_choice_cardinality(state, ability, eligible.len(), up_to);
@@ -2360,6 +2443,160 @@ mod tests {
             ObjectId(100),
             PlayerId(0),
         )
+    }
+
+    fn exact_scoped_graveyard_exile_ability() -> ResolvedAbility {
+        let mut ability = ResolvedAbility::new(
+            Effect::ChangeZone {
+                origin: Some(Zone::Graveyard),
+                destination: Zone::Exile,
+                target: TargetFilter::Typed(TypedFilter::card().properties(vec![
+                    FilterProp::Owned {
+                        controller: ControllerRef::ScopedPlayer,
+                    },
+                    FilterProp::InZone {
+                        zone: Zone::Graveyard,
+                    },
+                ])),
+                owner_library: false,
+                enter_transformed: false,
+                enters_under: None,
+                enter_tapped: crate::types::zones::EtbTapState::Unspecified,
+                enters_attacking: false,
+                up_to: false,
+                enter_with_counters: vec![],
+                conditional_enter_with_counters: vec![],
+                face_down_profile: None,
+                enters_modified_if: None,
+            },
+            vec![],
+            ObjectId(100),
+            PlayerId(0),
+        );
+        ability.optional = true;
+        ability.optional_for = Some(OpponentMayScope::AnyPlayer);
+        ability.multi_target = Some(MultiTargetSpec::exact(QuantityExpr::Fixed { value: 3 }));
+        ability.target_choice_timing = TargetChoiceTiming::Resolution;
+        ability.set_scoped_player_recursive(PlayerId(1));
+        ability
+    }
+
+    #[test]
+    fn exact_scoped_graveyard_exile_feasibility_uses_legal_candidate_count() {
+        let mut state = GameState::new_two_player(42);
+        let ability = exact_scoped_graveyard_exile_ability();
+        for index in 0..2 {
+            create_object(
+                &mut state,
+                CardId(index + 1),
+                PlayerId(1),
+                format!("Eligible {index}"),
+                Zone::Graveyard,
+            );
+        }
+        create_object(
+            &mut state,
+            CardId(10),
+            PlayerId(0),
+            "Controller decoy".to_string(),
+            Zone::Graveyard,
+        );
+        assert_eq!(
+            exact_scoped_graveyard_exile_is_infeasible(&state, &ability),
+            Some(true)
+        );
+
+        create_object(
+            &mut state,
+            CardId(3),
+            PlayerId(1),
+            "Eligible 2".to_string(),
+            Zone::Graveyard,
+        );
+        assert_eq!(
+            exact_scoped_graveyard_exile_is_infeasible(&state, &ability),
+            Some(false)
+        );
+    }
+
+    #[test]
+    fn exact_scoped_graveyard_exile_feasibility_declines_adjacent_shapes() {
+        let state = GameState::new_two_player(42);
+        let baseline = exact_scoped_graveyard_exile_ability();
+
+        let mut ordinary_you_may = baseline.clone();
+        ordinary_you_may.optional_for = None;
+        assert_eq!(
+            exact_scoped_graveyard_exile_is_infeasible(&state, &ordinary_you_may),
+            None
+        );
+
+        let mut up_to = baseline.clone();
+        up_to.multi_target = Some(MultiTargetSpec::up_to(QuantityExpr::Fixed { value: 3 }));
+        assert_eq!(
+            exact_scoped_graveyard_exile_is_infeasible(&state, &up_to),
+            None
+        );
+
+        let mut unlimited = baseline.clone();
+        unlimited.multi_target = Some(MultiTargetSpec::unlimited(0));
+        assert_eq!(
+            exact_scoped_graveyard_exile_is_infeasible(&state, &unlimited),
+            None
+        );
+
+        let mut stack_choice = baseline.clone();
+        stack_choice.target_choice_timing = TargetChoiceTiming::Stack;
+        assert_eq!(
+            exact_scoped_graveyard_exile_is_infeasible(&state, &stack_choice),
+            None
+        );
+
+        let mut controller_relative = baseline.clone();
+        if let Effect::ChangeZone { target, .. } = &mut controller_relative.effect {
+            *target = TargetFilter::Typed(
+                TypedFilter::card()
+                    .controller(ControllerRef::You)
+                    .properties(vec![FilterProp::InZone {
+                        zone: Zone::Graveyard,
+                    }]),
+            );
+        }
+        assert_eq!(
+            exact_scoped_graveyard_exile_is_infeasible(&state, &controller_relative),
+            None
+        );
+
+        let mut extra_property = baseline.clone();
+        if let Effect::ChangeZone {
+            target: TargetFilter::Typed(target),
+            ..
+        } = &mut extra_property.effect
+        {
+            target.properties.push(FilterProp::Another);
+        }
+        assert_eq!(
+            exact_scoped_graveyard_exile_is_infeasible(&state, &extra_property),
+            None
+        );
+
+        let mut wrong_origin = baseline.clone();
+        if let Effect::ChangeZone { origin, .. } = &mut wrong_origin.effect {
+            *origin = Some(Zone::Hand);
+        }
+        assert_eq!(
+            exact_scoped_graveyard_exile_is_infeasible(&state, &wrong_origin),
+            None
+        );
+
+        let mut wrong_destination = baseline;
+        if let Effect::ChangeZone { destination, .. } = &mut wrong_destination.effect {
+            *destination = Zone::Hand;
+        }
+        assert_eq!(
+            exact_scoped_graveyard_exile_is_infeasible(&state, &wrong_destination),
+            None
+        );
     }
 
     /// V15 — CR 701.17c + CR 400.7 + CR 603.7c: `resolve` fills an absent

--- a/crates/engine/src/game/effects/change_zone.rs
+++ b/crates/engine/src/game/effects/change_zone.rs
@@ -480,12 +480,8 @@ pub(crate) fn exact_scoped_graveyard_exile_is_infeasible(
     else {
         return None;
     };
-    let Some(spec) = ability.multi_target.as_ref() else {
-        return None;
-    };
-    let Some(max) = spec.max.as_ref() else {
-        return None;
-    };
+    let spec = ability.multi_target.as_ref()?;
+    let max = spec.max.as_ref()?;
     let canonical_properties = [
         FilterProp::Owned {
             controller: ControllerRef::ScopedPlayer,

--- a/crates/engine/src/game/effects/change_zone.rs
+++ b/crates/engine/src/game/effects/change_zone.rs
@@ -497,7 +497,7 @@ pub(crate) fn exact_scoped_graveyard_exile_is_infeasible(
             .iter()
             .any(|target| matches!(target, TargetRef::Object(_)))
         || ability.target_choice_timing != TargetChoiceTiming::Resolution
-        || type_filters.as_slice() != [TypeFilter::Card]
+        || !type_filters.contains(&TypeFilter::Card)
         || properties.as_slice() != canonical_properties
         || max != &spec.min
     {
@@ -2545,6 +2545,32 @@ mod tests {
         stack_choice.target_choice_timing = TargetChoiceTiming::Stack;
         assert_eq!(
             exact_scoped_graveyard_exile_is_infeasible(&state, &stack_choice),
+            None
+        );
+
+        let mut restricted_card_type = baseline.clone();
+        if let Effect::ChangeZone {
+            target: TargetFilter::Typed(target),
+            ..
+        } = &mut restricted_card_type.effect
+        {
+            target.type_filters = vec![TypeFilter::Creature, TypeFilter::Card];
+        }
+        assert_eq!(
+            exact_scoped_graveyard_exile_is_infeasible(&state, &restricted_card_type),
+            Some(true)
+        );
+
+        let mut object_type_without_card = baseline.clone();
+        if let Effect::ChangeZone {
+            target: TargetFilter::Typed(target),
+            ..
+        } = &mut object_type_without_card.effect
+        {
+            target.type_filters = vec![TypeFilter::Creature];
+        }
+        assert_eq!(
+            exact_scoped_graveyard_exile_is_infeasible(&state, &object_type_without_card),
             None
         );
 

--- a/crates/engine/src/game/engine_payment_choices.rs
+++ b/crates/engine/src/game/engine_payment_choices.rs
@@ -371,11 +371,49 @@ fn handle_opponent_may_choice_inner(
     state.cost_payment_failed_flag = false;
 
     if accept {
-        if let Some(mut frame) = state.active_optional_effect_frame().cloned() {
-            let mut ability = frame.ability;
+        if let Some(frame) = state.active_optional_effect_frame().cloned() {
+            let mut ability = frame.ability.clone();
+            // CR 608.2c: "their" in an accepted any-player instruction binds
+            // to the player who accepted across the complete local chain.
+            // `controller` remains the controller of the resolving ability.
+            ability.set_scoped_player_recursive(promptee);
+            ability.context.accepting_player = Some(promptee);
+
+            // CR 608.2d: a player cannot accept an exact resolution-time
+            // selection they cannot make. This query deliberately recognizes
+            // only counted `their graveyard` exile instructions; every
+            // adjacent optional effect stays on the established path below.
+            if crate::game::effects::change_zone::exact_scoped_graveyard_exile_is_infeasible(
+                state, &ability,
+            ) == Some(true)
+            {
+                if let Some((&next, rest)) = remaining.split_first() {
+                    state.waiting_for = WaitingFor::OpponentMayChoice {
+                        player: next,
+                        source_id,
+                        description,
+                        remaining: rest.to_vec(),
+                    };
+                    return Ok(state.waiting_for.clone());
+                }
+
+                state
+                    .take_active_optional_effect_frame()
+                    .map_err(|error| EngineError::InvalidAction(error.to_string()))?
+                    .expect("cloned optional-effect frame remains active until final decision");
+                set_active_priority(state);
+                resolve_all_declined_opponent_may(state, &frame.ability, events)?;
+                resume_pending_continuation_if_priority(state, events)?;
+                super::triggers::collect_and_drain_observer_triggers_if_settled(
+                    state,
+                    events,
+                    events_before,
+                );
+                return Ok(state.waiting_for.clone());
+            }
+
             ability.optional = false;
             ability.optional_for = None;
-            ability.context.accepting_player = Some(promptee);
 
             let target_selection = match &ability.effect {
                 // CR 701.21a (sacrifice) / CR 701.26a (tap): an optional
@@ -458,10 +496,6 @@ fn handle_opponent_may_choice_inner(
                 if !remaining.is_empty() {
                     let next = remaining[0];
                     let rest = remaining[1..].to_vec();
-                    frame.ability = ability;
-                    state
-                        .replace_active_optional_effect_frame(frame)
-                        .map_err(|error| EngineError::InvalidAction(error.to_string()))?;
                     state.waiting_for = WaitingFor::OpponentMayChoice {
                         player: next,
                         source_id,

--- a/crates/engine/src/game/scenario.rs
+++ b/crates/engine/src/game/scenario.rs
@@ -4401,6 +4401,14 @@ impl GameSnapshot {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::game::combat::AttackTarget;
+    use crate::types::ability::{
+        AbilityCondition, ControllerRef, FilterProp, TargetChoiceTiming, TypedFilter,
+    };
+    use crate::types::replacements::ReplacementEvent;
+
+    const CARRION_RATS_ORACLE: &str = "Whenever this creature attacks or blocks, any player may exile a card from their graveyard. If a player does, this creature assigns no combat damage this turn.";
+    const CARRION_WURM_ORACLE: &str = "Whenever this creature attacks or blocks, any player may exile three cards from their graveyard. If a player does, this creature assigns no combat damage this turn.";
 
     #[test]
     fn scenario_new_creates_valid_game_state() {
@@ -4646,6 +4654,416 @@ mod tests {
             hand_after, hand_before,
             "no card should be drawn because no sacrifice happened"
         );
+    }
+
+    fn attack_until_optional_prompt(runner: &mut GameRunner, attacker: ObjectId) {
+        runner.advance_to_combat();
+        assert!(matches!(
+            runner.state().waiting_for,
+            WaitingFor::DeclareAttackers { .. }
+        ));
+        runner
+            .declare_attackers(&[(attacker, AttackTarget::Player(P1))])
+            .expect("declare Carrion attacker");
+        runner.advance_until_stack_empty();
+        assert!(matches!(
+            runner.state().waiting_for,
+            WaitingFor::OpponentMayChoice { .. }
+        ));
+    }
+
+    fn scoped_owned_card_in(zone: Zone) -> TargetFilter {
+        TargetFilter::Typed(TypedFilter::card().properties(vec![
+            FilterProp::Owned {
+                controller: ControllerRef::ScopedPlayer,
+            },
+            FilterProp::InZone { zone },
+        ]))
+    }
+
+    fn move_zone_effect(origin: Option<Zone>, destination: Zone, target: TargetFilter) -> Effect {
+        Effect::ChangeZone {
+            origin,
+            destination,
+            target,
+            owner_library: false,
+            enter_transformed: false,
+            enters_under: None,
+            enter_tapped: Default::default(),
+            enters_attacking: false,
+            up_to: false,
+            enter_with_counters: Vec::new(),
+            conditional_enter_with_counters: Vec::new(),
+            face_down_profile: None,
+            enters_modified_if: None,
+        }
+    }
+
+    /// CR 101.4 + CR 608.2d: an impossible exact-three acceptance is skipped
+    /// without recording acceptance, and the APNAP offer advances to the next
+    /// player whose selection is feasible.
+    #[test]
+    fn carrion_wurm_impossible_first_accept_advances_to_feasible_player() {
+        let mut scenario = GameScenario::new();
+        scenario.at_phase(Phase::PreCombatMain);
+        let wurm = scenario
+            .add_creature_from_oracle(P0, "Carrion Wurm", 6, 5, CARRION_WURM_ORACLE)
+            .id();
+        let p0_cards = [
+            scenario.add_spell_to_graveyard(P0, "P0 Card A", true).id(),
+            scenario.add_spell_to_graveyard(P0, "P0 Card B", true).id(),
+        ];
+        let p1_cards = [
+            scenario.add_spell_to_graveyard(P1, "P1 Card A", true).id(),
+            scenario.add_spell_to_graveyard(P1, "P1 Card B", true).id(),
+            scenario.add_spell_to_graveyard(P1, "P1 Card C", true).id(),
+        ];
+        let mut runner = scenario.build();
+
+        attack_until_optional_prompt(&mut runner, wurm);
+        runner
+            .act(GameAction::DecideOptionalEffect { accept: true })
+            .expect("infeasible first acceptance advances");
+        assert!(matches!(
+            &runner.state().waiting_for,
+            WaitingFor::OpponentMayChoice { player: P1, .. }
+        ));
+        assert!(!runner.state().player_actions_this_way.contains(&(
+            P0,
+            crate::types::events::PlayerActionKind::AcceptedOptionalEffect
+        )));
+        assert!(p0_cards
+            .iter()
+            .all(|card| runner.state().objects[card].zone == Zone::Graveyard));
+
+        runner
+            .act(GameAction::DecideOptionalEffect { accept: true })
+            .expect("feasible second acceptance opens exact choice");
+        match &runner.state().waiting_for {
+            WaitingFor::EffectZoneChoice {
+                player,
+                cards,
+                count,
+                min_count,
+                up_to,
+                zone: Zone::Graveyard,
+                destination: Some(Zone::Exile),
+                ..
+            } => {
+                assert_eq!(*player, P1);
+                assert_eq!((*count, *min_count, *up_to), (3, 3, false));
+                assert_eq!(cards.len(), 3);
+                assert!(p1_cards.iter().all(|card| cards.contains(card)));
+                assert!(p0_cards.iter().all(|card| !cards.contains(card)));
+            }
+            other => panic!("expected exact scoped graveyard choice, got {other:?}"),
+        }
+        assert!(
+            !runner.state().objects[&wurm].assigns_no_combat_damage,
+            "the dependent rider must wait for the selection"
+        );
+
+        runner
+            .act(GameAction::SelectCards {
+                cards: p1_cards.to_vec(),
+            })
+            .expect("exact-three selection resolves");
+        assert!(p1_cards
+            .iter()
+            .all(|card| runner.state().objects[card].zone == Zone::Exile));
+        assert!(runner.state().objects[&wurm].assigns_no_combat_damage);
+        assert!(matches!(
+            runner.state().waiting_for,
+            WaitingFor::Priority { .. }
+        ));
+        assert!(runner.state().active_ability_continuation().is_none());
+    }
+
+    /// CR 603.5 + CR 608.2c + CR 510.1a: the singular Carrion Rats path
+    /// completes synchronously, then applies its dependent combat-damage rider.
+    #[test]
+    fn carrion_rats_direct_acceptance_moves_one_card_then_applies_rider() {
+        let mut scenario = GameScenario::new();
+        scenario.at_phase(Phase::PreCombatMain);
+        let rats = scenario
+            .add_creature_from_oracle(P0, "Carrion Rats", 2, 1, CARRION_RATS_ORACLE)
+            .id();
+        let p1_card = scenario
+            .add_spell_to_graveyard(P1, "P1 Graveyard Card", true)
+            .id();
+        let p0_decoy = scenario
+            .add_spell_to_graveyard(P0, "P0 Graveyard Card", true)
+            .id();
+        let mut runner = scenario.build();
+
+        attack_until_optional_prompt(&mut runner, rats);
+        runner
+            .act(GameAction::DecideOptionalEffect { accept: false })
+            .expect("controller declines");
+        runner
+            .act(GameAction::DecideOptionalEffect { accept: true })
+            .expect("opponent accepts singular exile");
+
+        assert_eq!(runner.state().objects[&p1_card].zone, Zone::Exile);
+        assert_eq!(runner.state().objects[&p0_decoy].zone, Zone::Graveyard);
+        assert!(runner.state().objects[&rats].assigns_no_combat_damage);
+        assert!(matches!(
+            runner.state().waiting_for,
+            WaitingFor::Priority { .. }
+        ));
+    }
+
+    /// CR 608.2d: when every player lacks three eligible cards, exhausting the
+    /// APNAP offers with impossible acceptances is equivalent to no player
+    /// performing the instruction.
+    #[test]
+    fn carrion_wurm_all_infeasible_acceptances_leave_rider_false() {
+        let mut scenario = GameScenario::new();
+        scenario.at_phase(Phase::PreCombatMain);
+        let wurm = scenario
+            .add_creature_from_oracle(P0, "Carrion Wurm", 6, 5, CARRION_WURM_ORACLE)
+            .id();
+        scenario.add_spell_to_graveyard(P0, "P0 Only Card", true);
+        scenario.add_spell_to_graveyard(P1, "P1 Only Card", true);
+        let mut runner = scenario.build();
+
+        attack_until_optional_prompt(&mut runner, wurm);
+        runner
+            .act(GameAction::DecideOptionalEffect { accept: true })
+            .expect("controller cannot make exact selection");
+        assert!(matches!(
+            runner.state().waiting_for,
+            WaitingFor::OpponentMayChoice { player: P1, .. }
+        ));
+        runner
+            .act(GameAction::DecideOptionalEffect { accept: true })
+            .expect("last player also cannot make the exact selection");
+
+        assert!(!runner.state().objects[&wurm].assigns_no_combat_damage);
+        assert!(matches!(
+            runner.state().waiting_for,
+            WaitingFor::Priority { .. }
+        ));
+        assert!(runner.state().active_ability_continuation().is_none());
+    }
+
+    /// CR 608.2d + CR 101.4: explicit declines from every player exhaust the
+    /// APNAP offer without satisfying the dependent "if a player does" rider.
+    #[test]
+    fn carrion_wurm_all_players_decline_leaves_rider_false() {
+        let mut scenario = GameScenario::new();
+        scenario.at_phase(Phase::PreCombatMain);
+        let wurm = scenario
+            .add_creature_from_oracle(P0, "Carrion Wurm", 6, 5, CARRION_WURM_ORACLE)
+            .id();
+        for (player, name) in [
+            (P0, "P0 Grave A"),
+            (P0, "P0 Grave B"),
+            (P0, "P0 Grave C"),
+            (P1, "P1 Grave A"),
+            (P1, "P1 Grave B"),
+            (P1, "P1 Grave C"),
+        ] {
+            scenario.add_spell_to_graveyard(player, name, true);
+        }
+        let mut runner = scenario.build();
+
+        attack_until_optional_prompt(&mut runner, wurm);
+        runner
+            .act(GameAction::DecideOptionalEffect { accept: false })
+            .expect("controller declines");
+        assert!(matches!(
+            runner.state().waiting_for,
+            WaitingFor::OpponentMayChoice { player: P1, .. }
+        ));
+        runner
+            .act(GameAction::DecideOptionalEffect { accept: false })
+            .expect("opponent declines");
+
+        assert!(!runner.state().objects[&wurm].assigns_no_combat_damage);
+        assert!(matches!(
+            runner.state().waiting_for,
+            WaitingFor::Priority { .. }
+        ));
+        assert!(runner.state().active_ability_continuation().is_none());
+    }
+
+    /// CR 608.2c: the player bound by "their" remains the accepting player
+    /// throughout the dependent local ability chain. Controller-owned cards in
+    /// both relevant zones make a root-only scope assignment fail this test.
+    #[test]
+    fn carrion_wurm_accepting_player_scope_reaches_downstream_zone_move() {
+        let mut scenario = GameScenario::new();
+        scenario.at_phase(Phase::PreCombatMain);
+        let wurm = scenario
+            .add_creature_from_oracle(P0, "Carrion Wurm", 6, 5, CARRION_WURM_ORACLE)
+            .id();
+
+        let downstream = AbilityDefinition::new(
+            AbilityKind::Database,
+            move_zone_effect(
+                Some(Zone::Hand),
+                Zone::Exile,
+                scoped_owned_card_in(Zone::Hand),
+            ),
+        )
+        .target_choice_timing(TargetChoiceTiming::Resolution);
+        let object = scenario
+            .state
+            .objects
+            .get_mut(&wurm)
+            .expect("Carrion Wurm exists");
+        let triggers = Arc::make_mut(&mut object.base_trigger_definitions);
+        let root = triggers[0]
+            .execute
+            .as_mut()
+            .expect("parsed Carrion Wurm trigger has an effect");
+        let rider = root
+            .sub_ability
+            .as_mut()
+            .expect("parsed Carrion Wurm trigger has its dependent rider");
+        assert!(rider
+            .condition
+            .as_ref()
+            .is_some_and(AbilityCondition::is_optional_effect_performed));
+        rider.sub_ability = Some(Box::new(downstream));
+        object.materialize_base_trigger_definitions();
+
+        let p0_graveyard_decoys = [
+            scenario.add_spell_to_graveyard(P0, "P0 Grave A", true).id(),
+            scenario.add_spell_to_graveyard(P0, "P0 Grave B", true).id(),
+            scenario.add_spell_to_graveyard(P0, "P0 Grave C", true).id(),
+        ];
+        let p1_graveyard_cards = [
+            scenario.add_spell_to_graveyard(P1, "P1 Grave A", true).id(),
+            scenario.add_spell_to_graveyard(P1, "P1 Grave B", true).id(),
+            scenario.add_spell_to_graveyard(P1, "P1 Grave C", true).id(),
+        ];
+        let p0_hand_decoy = scenario.add_card_to_hand(P0, "P0 Hand Decoy");
+        let p1_hand_card = scenario.add_card_to_hand(P1, "P1 Hand Card");
+        let mut runner = scenario.build();
+
+        attack_until_optional_prompt(&mut runner, wurm);
+        runner
+            .act(GameAction::DecideOptionalEffect { accept: false })
+            .expect("controller declines");
+        runner
+            .act(GameAction::DecideOptionalEffect { accept: true })
+            .expect("opponent accepts");
+        let WaitingFor::EffectZoneChoice { player, cards, .. } = &runner.state().waiting_for else {
+            panic!(
+                "expected accepting-player graveyard choice, got {:?}",
+                runner.state().waiting_for
+            );
+        };
+        assert_eq!(*player, P1);
+        assert!(p1_graveyard_cards.iter().all(|card| cards.contains(card)));
+        assert!(p0_graveyard_decoys.iter().all(|card| !cards.contains(card)));
+
+        runner
+            .act(GameAction::SelectCards {
+                cards: p1_graveyard_cards.to_vec(),
+            })
+            .expect("opponent's exact selection resolves the complete chain");
+
+        assert!(p1_graveyard_cards
+            .iter()
+            .all(|card| runner.state().objects[card].zone == Zone::Exile));
+        assert_eq!(runner.state().objects[&p1_hand_card].zone, Zone::Exile);
+        assert_eq!(runner.state().objects[&p0_hand_decoy].zone, Zone::Hand);
+        assert!(p0_graveyard_decoys
+            .iter()
+            .all(|card| runner.state().objects[card].zone == Zone::Graveyard));
+        assert!(runner.state().objects[&wurm].assigns_no_combat_damage);
+        assert!(matches!(
+            runner.state().waiting_for,
+            WaitingFor::Priority { .. }
+        ));
+        assert!(runner.state().active_ability_continuation().is_none());
+    }
+
+    /// CR 608.2c + CR 616.1: accepting the exact exile parks the selected
+    /// ChangeZone iteration when two applicable redirects compete. The rider
+    /// waits for that iteration to settle, then runs even though a replacement
+    /// redirected the first selected card away from exile.
+    #[test]
+    fn carrion_wurm_replacement_pause_resumes_before_dependent_rider() {
+        let mut scenario = GameScenario::new();
+        scenario.at_phase(Phase::PreCombatMain);
+        let wurm = scenario
+            .add_creature_from_oracle(P0, "Carrion Wurm", 6, 5, CARRION_WURM_ORACLE)
+            .id();
+        let selected = [
+            scenario.add_spell_to_graveyard(P0, "Selected A", true).id(),
+            scenario.add_spell_to_graveyard(P0, "Selected B", true).id(),
+            scenario.add_spell_to_graveyard(P0, "Selected C", true).id(),
+        ];
+
+        for (name, destination) in [
+            ("Redirect Selected Move to Hand", Zone::Hand),
+            ("Redirect Selected Move to Library", Zone::Library),
+        ] {
+            let replacement = ReplacementDefinition::new(ReplacementEvent::Moved)
+                .execute(AbilityDefinition::new(
+                    AbilityKind::Database,
+                    move_zone_effect(None, destination, TargetFilter::SelfRef),
+                ))
+                .valid_card(TargetFilter::Any)
+                .destination_zone(Zone::Exile);
+            scenario
+                .add_creature(P1, name, 0, 1)
+                .with_replacement_definition(replacement);
+        }
+        let mut runner = scenario.build();
+
+        attack_until_optional_prompt(&mut runner, wurm);
+        runner
+            .act(GameAction::DecideOptionalEffect { accept: true })
+            .expect("feasible controller acceptance opens exact selection");
+        assert!(matches!(
+            runner.state().waiting_for,
+            WaitingFor::EffectZoneChoice { .. }
+        ));
+        assert!(!runner.state().objects[&wurm].assigns_no_combat_damage);
+
+        runner
+            .act(GameAction::SelectCards {
+                cards: selected.to_vec(),
+            })
+            .expect("selected move parks for replacement ordering");
+
+        assert!(matches!(
+            runner.state().waiting_for,
+            WaitingFor::ReplacementChoice { .. }
+        ));
+        assert!(runner.state().active_change_zone_frame().is_some());
+        assert!(runner.state().resolution_stack.iter().any(|frame| matches!(
+            frame,
+            crate::types::resolution::ResolutionFrame::AbilityContinuation(_)
+        )));
+        assert!(!runner.state().objects[&wurm].assigns_no_combat_damage);
+
+        for _ in 0..selected.len() {
+            if !matches!(
+                runner.state().waiting_for,
+                WaitingFor::ReplacementChoice { .. }
+            ) {
+                break;
+            }
+            assert!(!runner.state().objects[&wurm].assigns_no_combat_damage);
+            runner
+                .act(GameAction::ChooseReplacement { index: 0 })
+                .expect("chosen redirect advances the selected move");
+        }
+
+        assert_ne!(runner.state().objects[&selected[0]].zone, Zone::Exile);
+        assert!(runner.state().objects[&wurm].assigns_no_combat_damage);
+        assert!(matches!(
+            runner.state().waiting_for,
+            WaitingFor::Priority { .. }
+        ));
+        assert!(runner.state().active_change_zone_frame().is_none());
+        assert!(runner.state().active_ability_continuation().is_none());
     }
 
     /// CR 608.2d + CR 101.4 (issue #3236): Browbeat-class — when ALL players

--- a/crates/engine/src/parser/oracle_effect/imperative.rs
+++ b/crates/engine/src/parser/oracle_effect/imperative.rs
@@ -9029,30 +9029,37 @@ fn filter_targets_stack(filter: &TargetFilter) -> bool {
     }
 }
 
-/// CR 700.4 (#5649): match "&lt;quantity&gt; cards from your graveyard" and return the
-/// exile count. `"that many"` → the dynamic replacement amount
-/// (`QuantityRef::EventContextAmount`, Nefarious Lich); a number word → `Fixed`.
-/// Anchored on the possessive "your graveyard" so it never overlaps the
-/// top-of-library impulse idiom guarded by `parse_dynamic_count_phrase`.
-fn parse_exile_count_from_your_graveyard(lower: &str) -> Option<QuantityExpr> {
-    let trimmed = lower.trim().trim_end_matches('.').trim();
-    let (rest, qty) = alt((
-        value(
-            QuantityExpr::Ref {
-                qty: crate::types::ability::QuantityRef::EventContextAmount,
-            },
-            tag::<_, _, OracleError<'_>>("that many"),
-        ),
-        map(crate::parser::oracle_nom::primitives::parse_number, |n| {
-            QuantityExpr::Fixed { value: n as i32 }
-        }),
+/// CR 107.1 + CR 608.2c: parse the quantity prefix of
+/// "<quantity> cards from <possessive graveyard>". The complete noun,
+/// connective, possessor, and zone phrase remains for `parse_target_with_ctx`,
+/// the target grammar's single authority. `"that many"` preserves the dynamic
+/// event-context amount; a number word becomes `Fixed`.
+fn parse_exile_count_prefix<'a>(text: &'a str, lower: &str) -> Option<(QuantityExpr, &'a str)> {
+    nom_on_lower(text, lower, |input| {
+        let (input, quantity) = alt((
+            value(
+                QuantityExpr::Ref {
+                    qty: QuantityRef::EventContextAmount,
+                },
+                (tag("that"), space1, tag("many")),
+            ),
+            map(nom_primitives::parse_number, |number| QuantityExpr::Fixed {
+                value: number as i32,
+            }),
+        ))
+        .parse(input)?;
+        let (input, _) = space1.parse(input)?;
+        Ok((input, quantity))
+    })
+}
+
+fn terminal_punctuation_only(input: &str) -> bool {
+    all_consuming(value(
+        (),
+        (space0::<_, OracleError<'_>>, opt(one_of(".;")), space0),
     ))
-    .parse(trimmed)
-    .ok()?;
-    let (rest, _) = tag::<_, _, OracleError<'_>>(" cards from your graveyard")
-        .parse(rest)
-        .ok()?;
-    rest.trim().is_empty().then_some(qty)
+    .parse(input)
+    .is_ok()
 }
 
 /// CR 608.2c: Resolve the count expression of a dynamic-count top-of-library
@@ -9592,26 +9599,28 @@ pub(super) fn parse_exile_ast(
         }
     }
 
-    // CR 700.4 (#5649): "exile <N> cards from your graveyard" is a COUNTED
-    // graveyard exile — Nefarious Lich's damage substitution ("exile that many
-    // cards from your graveyard instead"). `Effect::ChangeZone` has no count
-    // slot, so capture the quantity here and thread it onto the clause's
-    // `MultiTargetSpec` at lowering (Forage precedent). The generic tail below
-    // would otherwise drop the count and bind a bare `ParentTarget`.
-    if let Some(count) = parse_exile_count_from_your_graveyard(&rest_text.to_ascii_lowercase()) {
-        let mut filter = crate::types::ability::TypedFilter::default()
-            .controller(ControllerRef::You)
-            .properties(vec![crate::types::ability::FilterProp::InZone {
-                zone: crate::types::zones::Zone::Graveyard,
-            }]);
-        filter.type_filters = vec![crate::types::ability::TypeFilter::Card];
-        return Some(ZoneCounterImperativeAst::Exile {
-            origin: Some(crate::types::zones::Zone::Graveyard),
-            target: TargetFilter::Typed(filter),
-            all: false,
-            enter_with_counters: vec![],
-            multi_target: Some(crate::types::ability::MultiTargetSpec::exact(count)),
-        });
+    // CR 107.1 + CR 608.2c + CR 608.2d + CR 701.13a: a counted graveyard
+    // exile preserves the exact quantity while the shared target grammar owns
+    // the possessive player and graveyard semantics. Full consumption keeps
+    // this branch from swallowing adjacent exile classes.
+    if let Some((count, target_text)) = parse_exile_count_prefix(rest_text, rest_lower) {
+        let (target, remainder) = parse_target_with_ctx(target_text, ctx);
+        let is_card_filter = matches!(
+            &target,
+            TargetFilter::Typed(filter) if filter.type_filters == vec![TypeFilter::Card]
+        );
+        if is_card_filter
+            && target.extract_in_zone() == Some(Zone::Graveyard)
+            && terminal_punctuation_only(remainder)
+        {
+            return Some(ZoneCounterImperativeAst::Exile {
+                origin: Some(Zone::Graveyard),
+                target,
+                all: false,
+                enter_with_counters: vec![],
+                multi_target: Some(MultiTargetSpec::exact(count)),
+            });
+        }
     }
 
     // CR 608.2k: thread `ctx` through so bare "it"/"them" anaphors in trigger
@@ -13391,7 +13400,7 @@ pub(super) fn lower_imperative_family_ast(ast: ImperativeFamilyAst) -> ParsedEff
             clause.multi_target = multi_target;
             clause
         }
-        // CR 115.1d + CR 601.2c + CR 700.4: sibling of the `Return` arm above
+        // CR 115.1d + CR 601.2c + CR 608.2c: sibling of the `Return` arm above
         // for the `origin.is_some()` shape ("return up to N cards from your
         // graveyard to your hand" lowers to a `ChangeZone`, not a `Bounce`,
         // when an explicit origin zone is present — Ill-Gotten Gains). Mirrors
@@ -13609,8 +13618,9 @@ pub(super) fn lower_imperative_family_ast(ast: ImperativeFamilyAst) -> ParsedEff
             )));
             clause
         }
-        // CR 700.4 (#5649): a COUNTED graveyard exile ("exile that many cards
-        // from your graveyard", Nefarious Lich) captured a `multi_target`; the
+        // CR 107.1 + CR 608.2c + CR 701.13a: a counted graveyard exile
+        // ("exile that many cards from your graveyard", Nefarious Lich)
+        // captured a `multi_target`; the
         // bare-Effect lowering below produces a `ChangeZone` that cannot carry
         // the count, so thread it onto the clause here (mirroring the Tap/Untap
         // arm). The runtime resolves the card selection via the shared
@@ -15094,7 +15104,7 @@ fn try_parse_bolster(lower: &str) -> Option<Effect> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::types::ability::{ParitySource, ZoneChoiceChooser};
+    use crate::types::ability::{ParitySource, TargetChoiceTiming, ZoneChoiceChooser};
 
     /// Matrix row 18 — the mana ROLE must survive the cost-resource AST
     /// round-trip byte-for-byte.
@@ -23764,64 +23774,167 @@ mod tests {
         }
     }
 
-    /// #5649 review (matthewevans): the `Fixed`-count arm of
-    /// `parse_exile_count_from_your_graveyard` fixes 8 of the 9 affected cards
-    /// (Aegis Sculptor / Bloodcurdler / Egon / Insatiable Frugivore / Kroxa /
-    /// Emeritus / Ultimecia — "exile <N> cards from your graveyard"), while the
-    /// "that many" arm covers Nefarious Lich. Pin both arms AND the negative that
-    /// the possessive "your graveyard" anchor keeps the top-of-library impulse
-    /// idiom (owned by `parse_dynamic_count_phrase`) untouched.
+    /// CR 107.1 + CR 608.2c: the quantity-prefix parser preserves fixed and
+    /// event-context counts while leaving the possessor-qualified zone phrase
+    /// for the shared target grammar.
     #[test]
-    fn exile_count_from_your_graveyard_binds_fixed_and_dynamic_counts() {
-        // Fixed-count arm — the eight numeric cards.
+    fn exile_count_prefix_binds_fixed_and_dynamic_counts() {
+        let parse = |text: &str| {
+            parse_exile_count_prefix(text, &text.to_ascii_lowercase())
+                .map(|(quantity, remainder)| (quantity, remainder.to_string()))
+        };
+
         assert_eq!(
-            parse_exile_count_from_your_graveyard("two cards from your graveyard"),
-            Some(QuantityExpr::Fixed { value: 2 })
+            parse("two cards from your graveyard"),
+            Some((
+                QuantityExpr::Fixed { value: 2 },
+                "cards from your graveyard".to_string()
+            ))
         );
         assert_eq!(
-            parse_exile_count_from_your_graveyard("eight cards from your graveyard"),
-            Some(QuantityExpr::Fixed { value: 8 })
-        );
-        // Dynamic arm — Nefarious Lich.
-        assert_eq!(
-            parse_exile_count_from_your_graveyard("that many cards from your graveyard"),
-            Some(QuantityExpr::Ref {
-                qty: QuantityRef::EventContextAmount
-            })
-        );
-        // Negatives: the possessive "your graveyard" anchor must never capture the
-        // top-of-library impulse idiom.
-        assert_eq!(
-            parse_exile_count_from_your_graveyard("the top two cards of your library"),
-            None
+            parse("eight cards from their graveyard"),
+            Some((
+                QuantityExpr::Fixed { value: 8 },
+                "cards from their graveyard".to_string()
+            ))
         );
         assert_eq!(
-            parse_exile_count_from_your_graveyard("two cards from the top of your library"),
-            None
+            parse("that many cards from your graveyard"),
+            Some((
+                QuantityExpr::Ref {
+                    qty: QuantityRef::EventContextAmount
+                },
+                "cards from your graveyard".to_string()
+            ))
         );
+        assert_eq!(parse("the top two cards of your library"), None);
 
         // End-to-end: a fixed graveyard exile rides the clause's `MultiTargetSpec`.
         let def = crate::parser::oracle_effect::parse_effect_chain(
             "exile two cards from your graveyard",
             AbilityKind::Spell,
         );
-        assert!(
-            matches!(
-                &*def.effect,
-                Effect::ChangeZone {
-                    origin: Some(crate::types::zones::Zone::Graveyard),
-                    destination: crate::types::zones::Zone::Exile,
-                    ..
-                }
-            ),
-            "expected a graveyard->exile ChangeZone, got {:?}",
-            def.effect
+        let Effect::ChangeZone {
+            origin: Some(Zone::Graveyard),
+            destination: Zone::Exile,
+            target: TargetFilter::Typed(target),
+            ..
+        } = def.effect.as_ref()
+        else {
+            panic!(
+                "expected a graveyard->exile ChangeZone, got {:?}",
+                def.effect
+            );
+        };
+        assert_eq!(
+            target,
+            &TypedFilter::card()
+                .controller(ControllerRef::You)
+                .properties(vec![FilterProp::InZone {
+                    zone: Zone::Graveyard,
+                }]),
+            "a fixed 'your graveyard' count must remain controller-relative"
         );
         assert_eq!(
             def.multi_target,
             Some(MultiTargetSpec::exact(QuantityExpr::Fixed { value: 2 })),
             "the count must ride the clause MultiTargetSpec as exact(Fixed {{ 2 }})"
         );
+
+        let dynamic = crate::parser::oracle_effect::parse_effect_chain(
+            "exile that many cards from your graveyard",
+            AbilityKind::Spell,
+        );
+        assert_eq!(
+            dynamic.multi_target,
+            Some(MultiTargetSpec::exact(QuantityExpr::Ref {
+                qty: QuantityRef::EventContextAmount,
+            })),
+            "Nefarious Lich's dynamic event count must remain exact"
+        );
+    }
+
+    /// SHAPE — Carrion Wurm's verbatim Oracle text must preserve both the exact
+    /// count and the accepting-player-relative graveyard filter.
+    #[test]
+    fn carrion_wurm_trigger_preserves_exact_scoped_graveyard_exile() {
+        let parsed = crate::parser::oracle::parse_oracle_text(
+            "Whenever this creature attacks or blocks, any player may exile three cards from their graveyard. If a player does, this creature assigns no combat damage this turn.",
+            "Carrion Wurm",
+            &[],
+            &["Creature".to_string()],
+            &["Zombie".to_string(), "Wurm".to_string()],
+        );
+        let trigger = parsed.triggers.first().expect("Carrion Wurm trigger");
+        let execute = trigger.execute.as_ref().expect("trigger execute");
+        assert!(
+            !crate::parser::oracle::has_unimplemented(execute),
+            "verbatim Carrion Wurm trigger must parse fully: {execute:?}"
+        );
+        let Effect::ChangeZone {
+            origin: Some(Zone::Graveyard),
+            destination: Zone::Exile,
+            target: TargetFilter::Typed(target),
+            ..
+        } = execute.effect.as_ref()
+        else {
+            panic!("expected graveyard-to-exile ChangeZone, got {execute:?}");
+        };
+        assert_eq!(
+            target,
+            &TypedFilter::card().properties(vec![
+                FilterProp::Owned {
+                    controller: ControllerRef::ScopedPlayer,
+                },
+                FilterProp::InZone {
+                    zone: Zone::Graveyard,
+                },
+            ])
+        );
+        assert_eq!(
+            execute.multi_target,
+            Some(MultiTargetSpec::exact(QuantityExpr::Fixed { value: 3 }))
+        );
+        assert_eq!(execute.target_choice_timing, TargetChoiceTiming::Resolution);
+    }
+
+    #[test]
+    fn singular_and_adjacent_exile_grammars_remain_on_existing_paths() {
+        let singular = crate::parser::oracle_effect::parse_effect_chain(
+            "exile a card from their graveyard",
+            AbilityKind::Spell,
+        );
+        assert_eq!(singular.multi_target, None);
+        assert!(matches!(
+            singular.effect.as_ref(),
+            Effect::ChangeZone {
+                target: TargetFilter::Typed(target),
+                ..
+            } if target.properties.contains(&FilterProp::Owned {
+                controller: ControllerRef::ScopedPlayer,
+            })
+        ));
+
+        let up_to = crate::parser::oracle_effect::parse_effect_chain(
+            "exile up to three cards from your graveyard",
+            AbilityKind::Spell,
+        );
+        assert_eq!(
+            up_to.multi_target,
+            Some(MultiTargetSpec::up_to(QuantityExpr::Fixed { value: 3 }))
+        );
+
+        let any_number = crate::parser::oracle_effect::parse_effect_chain(
+            "exile any number of cards from your graveyard",
+            AbilityKind::Spell,
+        );
+        assert_eq!(any_number.multi_target, Some(MultiTargetSpec::unlimited(0)));
+
+        let top = crate::parser::oracle_effect::parse_effect_chain(
+            "exile the top three cards of your library",
+            AbilityKind::Spell,
+        );
+        assert!(matches!(top.effect.as_ref(), Effect::ExileTop { .. }));
     }
 
     /// Ill-Gotten Gains class (issue filed alongside this fix): "return up to

--- a/crates/engine/src/parser/oracle_effect/imperative.rs
+++ b/crates/engine/src/parser/oracle_effect/imperative.rs
@@ -9049,6 +9049,7 @@ fn parse_exile_count_prefix<'a>(text: &'a str, lower: &str) -> Option<(QuantityE
         ))
         .parse(input)?;
         let (input, _) = space1.parse(input)?;
+        let (input, _) = peek(tag("cards")).parse(input)?;
         Ok((input, quantity))
     })
 }
@@ -23806,6 +23807,11 @@ mod tests {
                 },
                 "cards from your graveyard".to_string()
             ))
+        );
+        assert_eq!(parse("a card from their graveyard"), None);
+        assert_eq!(
+            parse("five target cards from an opponent's graveyard"),
+            None
         );
         assert_eq!(parse("the top two cards of your library"), None);
 

--- a/crates/engine/src/parser/oracle_ir/ast.rs
+++ b/crates/engine/src/parser/oracle_ir/ast.rs
@@ -1788,8 +1788,9 @@ pub(crate) enum ZoneCounterImperativeAst {
         /// ("exile a card … with N <type> counters on it"). Empty for the
         /// common no-counter case. Mirrors `Effect::ChangeZone.enter_with_counters`.
         enter_with_counters: Vec<(CounterType, QuantityExpr)>,
-        /// CR 700.4 (#5649): a counted graveyard exile — "exile <N> cards from
-        /// your graveyard" (Nefarious Lich: "exile that many cards … instead").
+        /// CR 107.1 + CR 608.2c + CR 701.13a: a counted graveyard exile —
+        /// "exile <N> cards from your graveyard" (Nefarious Lich: "exile that
+        /// many cards … instead").
         /// `Effect::ChangeZone` carries no count, so the quantity rides the
         /// clause's `MultiTargetSpec` (mirroring Forage), threaded at lowering by
         /// `lower_imperative_family_ast`. `None` for the ordinary single-object


### PR DESCRIPTION
Carrion Wurm’s “three cards from their graveyard” cost was lowered as a single-card exile, collapsing it with Carrion Rats. Preserve the parsed exact count and scoped graveyard owner through feasibility checks, APNAP choice handling, player binding, and replacement-effect continuations.

Validation:
- parser combinator and CR citation pre-commit gates
- 7 focused Carrion parser/runtime tests
- Terra high implementation review: clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected resolution of effects that exile an exact number of cards from a player’s graveyard.
  - “Any player may” choices now skip players who cannot legally fulfill the requested exile and continue to the next eligible player.
  - Improved handling of accepting-player references in follow-up effects.
  - Preserved correct behavior when all players decline or lack eligible cards.
- **Tests**
  - Added coverage for dependent effects, replacement prompts, declined offers, and downstream zone changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->