### PR TITLE
Preserve extra turn quantities

### DIFF
--- a/client/src/adapter/__tests__/p2p-adapter-multiplayer.test.ts
+++ b/client/src/adapter/__tests__/p2p-adapter-multiplayer.test.ts
@@ -4407,14 +4407,14 @@ describe("P2P wire-protocol version gate", () => {
   // Both halves stamp LITERALS. A frame built from WIRE_PROTOCOL_VERSION
   // cannot tell a bumped client from an unbumped one, which is why every
   // other handshake fixture in the suite is useless as an instrument for a
-  // bump. Revert 51 → 50 and BOTH halves red: the v50 frame stops being
-  // refused, and the v51 frame stops being admitted. The admitting half is
-  // the reach-guard — without it "refuses v50" is also satisfied by a client
+  // bump. Revert 52 → 51 and BOTH halves red: the v51 frame stops being
+  // refused, and the v52 frame stops being admitted. The admitting half is
+  // the reach-guard — without it "refuses v51" is also satisfied by a client
   // that refuses everything.
-  it("refuses the previous wire protocol (v50) and admits its own (v51)", async () => {
+  it("refuses the previous wire protocol (v51) and admits its own (v52)", async () => {
     const refusing = makeGuest();
     await refusing.adapter.initialize();
-    await refusing.conn.simulateData(setupFrameAt(50));
+    await refusing.conn.simulateData(setupFrameAt(51));
 
     await expect(refusing.adapter.initializeGame()).rejects.toMatchObject({
       code: "P2P_REJECTED",
@@ -4426,7 +4426,7 @@ describe("P2P wire-protocol version gate", () => {
 
     const admitting = makeGuest();
     await admitting.adapter.initialize();
-    await admitting.conn.simulateData(setupFrameAt(51));
+    await admitting.conn.simulateData(setupFrameAt(52));
 
     await expect(admitting.adapter.initializeGame()).resolves.toBeDefined();
     expect(admitting.emitted).not.toHaveBeenCalledWith(

--- a/client/src/adapter/types.ts
+++ b/client/src/adapter/types.ts
@@ -2928,6 +2928,7 @@ export type GameEvent =
       data: { searcher: PlayerId; cards: LibrarySearchCardView[]; audience: PlayerId[] };
     }
   | { type: "TurnStarted"; data: { player_id: PlayerId; turn_number: number } }
+  | { type: "ExtraTurnCreated"; data: { player_id: PlayerId; anchor: PlayerId } }
   | { type: "PhaseChanged"; data: { phase: Phase } }
   | { type: "PriorityPassed"; data: { player_id: PlayerId } }
   | { type: "SpellCast"; data: { card_id: CardId; controller: PlayerId; object_id: ObjectId; cast_mana_value?: number } }

--- a/client/src/adapter/ws-adapter.ts
+++ b/client/src/adapter/ws-adapter.ts
@@ -208,6 +208,10 @@ export class NativeEngineVersionMismatchError extends Error {
  * `crates/server-core/src/protocol.rs`. Bump in lockstep when either side
  * adds, removes, renames, or changes the type of a protocol variant field.
  *
+ * 69 — GameEvent gained the tagged variant ExtraTurnCreated { player_id,
+ *      anchor }. Event-bearing full-server frames can now carry that tag, so
+ *      the exact handshake must refuse v68 peers that do not share the variant
+ *      contract. P2P moves in lockstep; lobby messages are unchanged.
  * 68 — PendingManaAbility.chosen_tappers changed from Vec<ObjectId> to
  *      Option<Vec<ObjectId>> (#8698), so an ANSWERED zero-tapper selection of
  *      the CR 107.3a X-sentinel form (X=0) is distinguishable from a selection
@@ -459,7 +463,7 @@ export class NativeEngineVersionMismatchError extends Error {
  *      into a MulliganDecisionPhase::BottomCards sub-phase on
  *      WaitingFor::MulliganDecision.
  */
-export const PROTOCOL_VERSION = 68;
+export const PROTOCOL_VERSION = 69;
 
 /**
  * Lowest server protocol version this client will accept in the handshake.

--- a/client/src/animation/__tests__/eventNormalizer.test.ts
+++ b/client/src/animation/__tests__/eventNormalizer.test.ts
@@ -204,6 +204,22 @@ describe("normalizeEvents", () => {
     expect(steps[0].effects[0].event.type).toBe("TurnStarted");
   });
 
+  it("ExtraTurnCreated is non-visual while TurnStarted remains visual", () => {
+    const creation: GameEvent = {
+      type: "ExtraTurnCreated",
+      data: { player_id: 1, anchor: 0 },
+    };
+    const turnStarted: GameEvent = {
+      type: "TurnStarted",
+      data: { player_id: 1, turn_number: 2 },
+    };
+
+    expect(normalizeEvents([creation])).toEqual([]);
+    const steps = normalizeEvents([creation, turnStarted]);
+    expect(steps).toHaveLength(1);
+    expect(steps[0].effects[0].event.type).toBe("TurnStarted");
+  });
+
   it("BlockersDeclared is non-visual (no animation step)", () => {
     const events: GameEvent[] = [
       { type: "BlockersDeclared", data: { assignments: [[3, 1]] } },

--- a/client/src/animation/eventNormalizer.ts
+++ b/client/src/animation/eventNormalizer.ts
@@ -21,6 +21,7 @@ const NON_VISUAL_EVENTS = new Set([
   "PriorityPassed",
   "MulliganStarted",
   "GameStarted",
+  "ExtraTurnCreated",
   "ManaAdded",
   "DamageCleared",
   "PowerToughnessChanged",

--- a/client/src/network/__tests__/protocol.test.ts
+++ b/client/src/network/__tests__/protocol.test.ts
@@ -71,8 +71,8 @@ const PREVIEW_ANSWER = {
 } as never;
 
 describe("encodeWireMessage / decodeWireMessage", () => {
-  it("pins the P2P wire protocol to v51", () => {
-    expect(WIRE_PROTOCOL_VERSION).toBe(51);
+  it("pins the P2P wire protocol to v52", () => {
+    expect(WIRE_PROTOCOL_VERSION).toBe(52);
   });
 
   it("defaults shortcut actions for a legacy payload created before the additive field", () => {

--- a/client/src/network/protocol.ts
+++ b/client/src/network/protocol.ts
@@ -106,6 +106,10 @@ export function legalActionsFromWire(wire: LegalActionsWire): LegalActionsResult
  * seat or adopts reconnect state.
  *
  * Bumps to date:
+ *  52 — game_setup and state_update carry GameEvent[] and can now carry the
+ *       tagged ExtraTurnCreated event. First contact therefore rejects a v51
+ *       peer before state delivery. Bumped in lockstep with full-game protocol
+ *       69.
  *  51 — PendingManaAbility.chosen_tappers changed from Vec<ObjectId> to
  *       Option<Vec<ObjectId>> (#8698), separating an ANSWERED zero-tapper
  *       CR 107.3a X-sentinel selection (X=0) from an unanswered one. A PARSE
@@ -369,7 +373,7 @@ export type P2PInteractionPreviewAnswer =
   | { type: "preview"; preview: InteractionPreview }
   | { type: "failed"; message: string };
 
-export const WIRE_PROTOCOL_VERSION = 51 as const;
+export const WIRE_PROTOCOL_VERSION = 52 as const;
 
 export type P2PMessage = P2PAuthorityWire & (
   | {

--- a/crates/engine/src/analysis/ability_graph.rs
+++ b/crates/engine/src/analysis/ability_graph.rs
@@ -812,8 +812,9 @@ fn effect_projection(effect: &Effect) -> Projection {
             }
         }
         // ----- EXTRA TURNS / PHASES (CR 500.7 / CR 500.8) -----
-        Effect::ExtraTurn { .. } => {
-            b.add_extra_turn(1, AxisMagnitude::Fixed(1));
+        Effect::ExtraTurn { count, .. } => {
+            let (a, mag) = count_seed(count);
+            b.add_extra_turn(a, mag);
         }
         // CR 500.8: only an additional *combat* phase pumps a modeled axis; any
         // other extra phase carries no countable resource ⇒ Unmodeled (M2).
@@ -2150,7 +2151,7 @@ pub(crate) fn candidate_cycles_from_nodes(nodes: Vec<AbilityNode>) -> Vec<Candid
 mod tests {
     use super::*;
     use crate::types::ability::{
-        default_target_filter_any, EffectScope, PlayerFilter, PtValue, SacrificeCost,
+        default_target_filter_any, EffectScope, PlayerFilter, PtValue, QuantityRef, SacrificeCost,
         TriggerDefinition, TypedFilter,
     };
     use crate::types::counter::CounterType;
@@ -2968,11 +2969,34 @@ mod tests {
             "TimeWalk",
             &activated(Effect::ExtraTurn {
                 target: TargetFilter::Controller,
+                count: fixed(1),
             }),
             None,
         );
         assert_eq!(et.net.extra_turns, 1);
         assert!(et.produces.contains(&AxisKey::ExtraTurn));
+
+        let two = build_node(
+            "TimeStretch",
+            &activated(Effect::ExtraTurn {
+                target: TargetFilter::Controller,
+                count: fixed(2),
+            }),
+            None,
+        );
+        assert_eq!(two.net.extra_turns, 2);
+
+        let dynamic = effect_projection(&Effect::ExtraTurn {
+            target: TargetFilter::Controller,
+            count: QuantityExpr::Ref {
+                qty: QuantityRef::Variable { name: "X".into() },
+            },
+        });
+        assert!(matches!(
+            dynamic,
+            Projection::Modeled { ref magnitudes, .. }
+                if magnitudes.get(&AxisKey::ExtraTurn) == Some(&AxisMagnitude::Unbounded)
+        ));
 
         // CR 500.8: an additional combat phase pumps the Combat axis.
         let combat = build_node(

--- a/crates/engine/src/analysis/sim.rs
+++ b/crates/engine/src/analysis/sim.rs
@@ -23,7 +23,7 @@
 use crate::analysis::resource::{ResourceVector, TriggerKind};
 use crate::game::engine::EngineError;
 use crate::game::scenario::GameRunner;
-use crate::types::ability::{EffectKind, TargetRef};
+use crate::types::ability::TargetRef;
 use crate::types::actions::GameAction;
 use crate::types::card_type::CoreType;
 use crate::types::events::{GameEvent, PlayerActionKind};
@@ -86,14 +86,11 @@ pub fn accumulate_events(acc: &mut ResourceVector, events: &[GameEvent]) {
             // counted here.
             GameEvent::SpellCast { .. } => acc.casts_this_step += 1,
 
-            // CR 500.7: an EXTRA turn is created when `Effect::ExtraTurn` resolves
-            // and pushes onto `state.extra_turns` (one resolve == one turn). The
-            // creation event — not `TurnStarted`, which also fires on every natural
-            // turn — is what keeps ordinary turn progression off this axis.
-            GameEvent::EffectResolved {
-                kind: EffectKind::ExtraTurn,
-                ..
-            } => acc.extra_turns += 1,
+            // CR 500.7: emitted once per successful extra-turn queue insertion.
+            // `TurnStarted` also covers natural turns, while `EffectResolved`
+            // counts completed instructions and therefore cannot represent
+            // insertion cardinality.
+            GameEvent::ExtraTurnCreated { .. } => acc.extra_turns += 1,
 
             // CR 603.6a / CR 603.6c: battlefield zone changes drive the ETB / LTB /
             // dies / landfall trigger axes. The `ZoneChangeRecord` carries the
@@ -258,6 +255,7 @@ fn splice_event_fed(target: &mut ResourceVector, events: &ResourceVector) {
 mod tests {
     use super::*;
     use crate::game::scenario::{GameScenario, P0, P1};
+    use crate::types::ability::EffectKind;
     use crate::types::game_state::{CastPaymentMode, WaitingFor, ZoneChangeRecord};
     use crate::types::identifiers::{CardId, ObjectId};
     use crate::types::phase::Phase;
@@ -318,10 +316,9 @@ mod tests {
             GameEvent::PhaseChanged {
                 phase: Phase::BeginCombat,
             },
-            GameEvent::EffectResolved {
-                kind: EffectKind::ExtraTurn,
-                source_id: ObjectId(9),
-                subject: None,
+            GameEvent::ExtraTurnCreated {
+                player_id: PlayerId(0),
+                anchor: PlayerId(1),
             },
             // ETB of a land == landfall + etb.
             zone_change(Some(Zone::Hand), Zone::Battlefield, vec![CoreType::Land]),
@@ -641,8 +638,8 @@ mod tests {
     /// Drive a probe through a natural turn rollover via `PassPriority`. The raw
     /// runner event stream MUST contain a natural `TurnStarted` (asserted below) —
     /// the OLD arm counted that, so against the deleted code `delta.extra_turns`
-    /// would be >= 1. With the fix it is 0, because no `EffectResolved{ExtraTurn}`
-    /// (a creation signal) ever fired — only a natural turn began.
+    /// would be >= 1. With the fix it is 0, because no `ExtraTurnCreated` event
+    /// fired — only a natural turn began.
     #[test]
     fn natural_next_turn_is_not_extra_turn() {
         let mut scenario = GameScenario::new();
@@ -682,14 +679,32 @@ mod tests {
         );
     }
 
-    /// P1 — the extra-turn axis is fed by the `EffectResolved{ExtraTurn}`
-    /// CREATION event, and ONLY that kind. Discriminates the `kind` match: a
-    /// different `EffectKind` (here `DealDamage`) must not touch `extra_turns`.
+    /// P1 — the extra-turn axis is fed once per committed queue insertion, not
+    /// once per instruction completion.
     #[test]
     fn extra_turn_creation_feeds_axis() {
         let mut acc = ResourceVector::default();
         accumulate_events(
             &mut acc,
+            &[
+                GameEvent::ExtraTurnCreated {
+                    player_id: PlayerId(0),
+                    anchor: PlayerId(0),
+                },
+                GameEvent::ExtraTurnCreated {
+                    player_id: PlayerId(1),
+                    anchor: PlayerId(0),
+                },
+            ],
+        );
+        assert_eq!(
+            acc.extra_turns, 2,
+            "each ExtraTurnCreated event feeds the extra-turns axis"
+        );
+
+        let mut completed_instruction = ResourceVector::default();
+        accumulate_events(
+            &mut completed_instruction,
             &[GameEvent::EffectResolved {
                 kind: EffectKind::ExtraTurn,
                 source_id: ObjectId(7),
@@ -697,14 +712,13 @@ mod tests {
             }],
         );
         assert_eq!(
-            acc.extra_turns, 1,
-            "an ExtraTurn creation event feeds the extra-turns axis"
+            completed_instruction.extra_turns, 0,
+            "an ExtraTurn instruction completion without an insertion must not feed the axis"
         );
 
-        // A different EffectKind must NOT increment the axis (kind discrimination).
-        let mut other = ResourceVector::default();
+        let mut unrelated = ResourceVector::default();
         accumulate_events(
-            &mut other,
+            &mut unrelated,
             &[GameEvent::EffectResolved {
                 kind: EffectKind::DealDamage,
                 source_id: ObjectId(7),
@@ -712,8 +726,8 @@ mod tests {
             }],
         );
         assert_eq!(
-            other.extra_turns, 0,
-            "a non-ExtraTurn EffectResolved must not feed the extra-turns axis"
+            unrelated.extra_turns, 0,
+            "an unrelated event must not feed the extra-turns axis"
         );
     }
 

--- a/crates/engine/src/game/ability_rw.rs
+++ b/crates/engine/src/game/ability_rw.rs
@@ -3011,7 +3011,6 @@ fn legacy_effect(x: &Effect) -> bool {
         | Effect::ApplyPerpetual { target, .. }
         | Effect::TurnFaceUp { target }
         | Effect::TurnFaceDown { target, .. }
-        | Effect::ExtraTurn { target }
         | Effect::Double { target, .. }
         | Effect::CrankContraptions { target }
         | Effect::ReassembleContraption { target, .. }
@@ -3080,6 +3079,7 @@ fn legacy_effect(x: &Effect) -> bool {
         | Effect::Connive { target, count }
         | Effect::GivePlayerCounter { count, target, .. }
         | Effect::PutAtLibraryPosition { target, count, .. }
+        | Effect::ExtraTurn { target, count }
         | Effect::SkipNextTurn { target, count }
         | Effect::SkipNextStep { target, count, .. }
         | Effect::AdditionalPhase { target, count, .. }
@@ -5832,8 +5832,9 @@ fn rw_effect(
         // profiled read observes, NOT the `Other` catch-all (which falsely
         // conflicted with a co-occurring source counter/life read on Lighthouse
         // Chronologist / Second Chance / Regenerations Restored / Time Bends).
-        Effect::ExtraTurn { target } => {
+        Effect::ExtraTurn { target, count } => {
             let mut p = ext_write(StateKind::TurnStructure);
+            p.merge(rw_quantity_expr(count));
             flag_legacy_write_target(&mut p, target);
             (p, None)
         }
@@ -8917,6 +8918,14 @@ mod tests {
             ap.writes_external.turn_structure,
             "AdditionalPhase is a TurnStructure write"
         );
+
+        let dynamic = ability_rw_profile(&ra(Effect::ExtraTurn {
+            target: TargetFilter::Controller,
+            count: QuantityExpr::Ref {
+                qty: QuantityRef::EventContextAmount,
+            },
+        }));
+        assert!(dynamic.reads_event_live);
         assert!(
             !ap.writes_external.other,
             "AdditionalPhase is not the `Other` catch-all"
@@ -8927,6 +8936,7 @@ mod tests {
             cond(
                 ra(Effect::ExtraTurn {
                     target: TargetFilter::Controller,
+                    count: qfix(1),
                 }),
                 qcheck(counters_src(), 3),
             )

--- a/crates/engine/src/game/ability_scan.rs
+++ b/crates/engine/src/game/ability_scan.rs
@@ -1837,9 +1837,10 @@ fn scan_effect(x: &Effect, mode: ScanMode) -> Axes {
             acc = acc.or(scan_target_filter(target, target_ctx, mode));
             acc
         }
-        Effect::ExtraTurn { target } => {
+        Effect::ExtraTurn { target, count } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_target_filter(target, target_ctx, mode));
+            acc = acc.or(scan_quantity_expr(count, mode));
             acc
         }
         Effect::GrantExtraLoyaltyActivations { amount, target } => {
@@ -6979,6 +6980,20 @@ mod tests {
     use crate::types::statics::StaticMode;
     use crate::types::triggers::TriggerMode;
     use crate::types::zones::Zone;
+
+    #[test]
+    fn extra_turn_scan_reaches_dynamic_count() {
+        let axes = scan_effect(
+            &Effect::ExtraTurn {
+                target: TargetFilter::Controller,
+                count: QuantityExpr::Ref {
+                    qty: QuantityRef::EventContextAmount,
+                },
+            },
+            ScanMode::LoopFirewall,
+        );
+        assert!(axes.event);
+    }
 
     fn zone_choice_for_scan(
         zone: Zone,

--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -3921,8 +3921,11 @@ fn effect_details(effect: &Effect) -> Vec<(String, String)> {
             ));
             d.push(("target".into(), fmt_target(target)));
         }
-        Effect::ExtraTurn { target } => {
+        Effect::ExtraTurn { target, count } => {
             d.push(("player".into(), fmt_target(target)));
+            if !matches!(count, QuantityExpr::Fixed { value: 1 }) {
+                d.push(("count".into(), fmt_quantity(count)));
+            }
         }
         Effect::GrantExtraLoyaltyActivations { amount, target } => {
             d.push(("amount".into(), fmt_quantity(amount)));
@@ -14584,6 +14587,44 @@ mod tests {
             rarities: Default::default(),
             attraction_lights: vec![],
         }
+    }
+
+    #[test]
+    fn extra_turn_coverage_distinguishes_default_one_from_fixed_two() {
+        fn parsed_card(name: &str, oracle: &str) -> CardCoverageResult {
+            let parsed =
+                crate::parser::parse_oracle_text(oracle, name, &[], &["Sorcery".to_string()], &[]);
+            let mut face = make_face();
+            face.name = name.to_string();
+            face.oracle_text = Some(oracle.to_string());
+            face.abilities = parsed.abilities;
+            coverage_result_for_face(face)
+        }
+
+        let warp = parsed_card(
+            "Time Warp",
+            "Target player takes an extra turn after this one.",
+        );
+        let stretch = parsed_card(
+            "Time Stretch",
+            "Target player takes two extra turns after this one.",
+        );
+        let warp_effect = warp
+            .parse_details
+            .iter()
+            .find(|item| item.label == "ExtraTurn")
+            .expect("Time Warp coverage contains ExtraTurn");
+        let stretch_effect = stretch
+            .parse_details
+            .iter()
+            .find(|item| item.label == "ExtraTurn")
+            .expect("Time Stretch coverage contains ExtraTurn");
+        assert!(!warp_effect.details.iter().any(|(key, _)| key == "count"));
+        assert!(stretch_effect
+            .details
+            .iter()
+            .any(|(key, value)| key == "count" && value == "2"));
+        assert_ne!(warp_effect.details, stretch_effect.details);
     }
 
     fn build_test_ability_item(def: &AbilityDefinition) -> ParsedItem {

--- a/crates/engine/src/game/effects/extra_turn.rs
+++ b/crates/engine/src/game/effects/extra_turn.rs
@@ -32,12 +32,8 @@ pub fn resolve(
         }
     };
 
-    // CR 805.8: With shared team turns, an extra turn for a player is taken by
-    // that player's team; store the team's seat-order representative as anchor.
-    let player = crate::game::topology::normalize_shared_turn_recipient(state, player);
-
     // CR 500.7: Queue after the *specified* turn (current active player), LIFO.
-    crate::game::turns::enqueue_extra_turn(state, player, state.active_player);
+    crate::game::turns::enqueue_extra_turn(state, player, state.active_player, events);
 
     events.push(GameEvent::EffectResolved {
         kind: EffectKind::ExtraTurn,
@@ -137,13 +133,27 @@ mod tests {
         resolve(&mut state, &ability, &mut events).unwrap();
 
         assert_eq!(state.extra_turns, vec![et(0, 0)]);
-        assert!(events.iter().any(|e| matches!(
-            e,
-            GameEvent::EffectResolved {
-                kind: EffectKind::ExtraTurn,
-                ..
-            }
-        )));
+        assert_eq!(
+            events,
+            vec![
+                GameEvent::ExtraTurnCreated {
+                    player_id: PlayerId(0),
+                    anchor: PlayerId(0),
+                },
+                GameEvent::EffectResolved {
+                    kind: EffectKind::ExtraTurn,
+                    source_id: ObjectId(1),
+                    subject: None,
+                },
+            ]
+        );
+        let GameEvent::ExtraTurnCreated { player_id, anchor } = &events[0] else {
+            unreachable!();
+        };
+        assert_eq!(
+            (*player_id, *anchor),
+            (state.extra_turns[0].player, state.extra_turns[0].anchor)
+        );
     }
 
     #[test]

--- a/crates/engine/src/game/effects/extra_turn.rs
+++ b/crates/engine/src/game/effects/extra_turn.rs
@@ -1,3 +1,4 @@
+use crate::game::quantity::resolve_quantity_with_targets;
 use crate::types::ability::{
     Effect, EffectError, EffectKind, ResolvedAbility, TargetFilter, TargetRef,
 };
@@ -12,7 +13,7 @@ pub fn resolve(
     ability: &ResolvedAbility,
     events: &mut Vec<GameEvent>,
 ) -> Result<(), EffectError> {
-    let Effect::ExtraTurn { target } = &ability.effect else {
+    let Effect::ExtraTurn { target, count } = &ability.effect else {
         return Err(EffectError::MissingParam(
             "expected ExtraTurn effect".into(),
         ));
@@ -32,8 +33,13 @@ pub fn resolve(
         }
     };
 
-    // CR 500.7: Queue after the *specified* turn (current active player), LIFO.
-    crate::game::turns::enqueue_extra_turn(state, player, state.active_player, events);
+    // CR 107.1b: a negative calculated effect result is treated as zero.
+    let count = resolve_quantity_with_targets(state, count, ability).max(0);
+    // CR 500.7: add multiple extra turns one at a time after the same specified turn.
+    let anchor = state.active_player;
+    for _ in 0..count {
+        crate::game::turns::enqueue_extra_turn(state, player, anchor, events);
+    }
 
     events.push(GameEvent::EffectResolved {
         kind: EffectKind::ExtraTurn,
@@ -47,7 +53,7 @@ pub fn resolve(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::types::ability::{AbilityKind, SpellContext, TargetRef};
+    use crate::types::ability::{AbilityKind, QuantityExpr, SpellContext, TargetRef};
     use crate::types::format::FormatConfig;
     use crate::types::game_state::ExtraTurn;
     use crate::types::identifiers::ObjectId;
@@ -60,10 +66,14 @@ mod tests {
         }
     }
 
-    fn make_ability(target: TargetFilter, controller: PlayerId) -> ResolvedAbility {
+    fn make_ability_with_count(
+        target: TargetFilter,
+        count: QuantityExpr,
+        controller: PlayerId,
+    ) -> ResolvedAbility {
         ResolvedAbility {
             detached_remainder: crate::types::ability::DetachedRemainder::NoProducer,
-            effect: Effect::ExtraTurn { target },
+            effect: Effect::ExtraTurn { target, count },
             controller,
             original_controller: None,
             scoped_player: None,
@@ -122,6 +132,10 @@ mod tests {
             mode_abilities: vec![],
             parent_target_missing_reason: None,
         }
+    }
+
+    fn make_ability(target: TargetFilter, controller: PlayerId) -> ResolvedAbility {
+        make_ability_with_count(target, QuantityExpr::Fixed { value: 1 }, controller)
     }
 
     #[test]
@@ -210,12 +224,119 @@ mod tests {
     fn two_hg_extra_turn_normalizes_to_team_representative() {
         let mut state = GameState::new(FormatConfig::two_headed_giant(), 4, 0);
         let mut events = Vec::new();
-        let mut ability = make_ability(TargetFilter::Any, PlayerId(2));
+        let mut ability = make_ability_with_count(
+            TargetFilter::Any,
+            QuantityExpr::Fixed { value: 2 },
+            PlayerId(2),
+        );
         ability.targets = vec![TargetRef::Player(PlayerId(1))];
 
         resolve(&mut state, &ability, &mut events).unwrap();
 
-        assert_eq!(state.extra_turns, vec![et(0, 0)]);
+        assert_eq!(state.extra_turns, vec![et(0, 0), et(0, 0)]);
+        assert_eq!(
+            events
+                .iter()
+                .filter(|event| matches!(event, GameEvent::ExtraTurnCreated { .. }))
+                .count(),
+            2
+        );
+    }
+
+    #[test]
+    fn counted_extra_turns_enqueue_each_unit_and_complete_once() {
+        let mut state = GameState::new(FormatConfig::standard(), 3, 0);
+        state.active_player = PlayerId(2);
+        state.extra_turns.push(et(0, 1));
+        let mut events = Vec::new();
+        let mut ability = make_ability_with_count(
+            TargetFilter::Player,
+            QuantityExpr::Fixed { value: 2 },
+            PlayerId(0),
+        );
+        ability.targets = vec![TargetRef::Player(PlayerId(1))];
+
+        resolve(&mut state, &ability, &mut events).unwrap();
+
+        assert_eq!(state.extra_turns, vec![et(0, 1), et(1, 2), et(1, 2)]);
+        assert_eq!(
+            events,
+            vec![
+                GameEvent::ExtraTurnCreated {
+                    player_id: PlayerId(1),
+                    anchor: PlayerId(2),
+                },
+                GameEvent::ExtraTurnCreated {
+                    player_id: PlayerId(1),
+                    anchor: PlayerId(2),
+                },
+                GameEvent::EffectResolved {
+                    kind: EffectKind::ExtraTurn,
+                    source_id: ObjectId(1),
+                    subject: None,
+                },
+            ]
+        );
+        assert_eq!(
+            state.extra_turns.pop().map(|turn| turn.player),
+            Some(PlayerId(1))
+        );
+        assert_eq!(
+            state.extra_turns.pop().map(|turn| turn.player),
+            Some(PlayerId(1))
+        );
+        assert_eq!(
+            state.extra_turns.pop().map(|turn| turn.player),
+            Some(PlayerId(0))
+        );
+    }
+
+    #[test]
+    fn zero_extra_turns_still_complete_the_effect_once() {
+        let mut state = GameState::default();
+        let mut events = Vec::new();
+        let ability = make_ability_with_count(
+            TargetFilter::Controller,
+            QuantityExpr::Fixed { value: 0 },
+            PlayerId(0),
+        );
+
+        resolve(&mut state, &ability, &mut events).unwrap();
+
+        assert!(state.extra_turns.is_empty());
+        assert_eq!(
+            events,
+            vec![GameEvent::EffectResolved {
+                kind: EffectKind::ExtraTurn,
+                source_id: ObjectId(1),
+                subject: None,
+            }]
+        );
+    }
+
+    #[test]
+    fn dynamic_extra_turn_count_uses_the_resolving_ability_context() {
+        let mut state = GameState::default();
+        let mut events = Vec::new();
+        let mut ability = make_ability_with_count(
+            TargetFilter::Controller,
+            QuantityExpr::Ref {
+                qty: crate::types::ability::QuantityRef::Variable { name: "X".into() },
+            },
+            PlayerId(0),
+        );
+        ability.chosen_x = Some(2);
+
+        resolve(&mut state, &ability, &mut events).unwrap();
+
+        assert_eq!(state.extra_turns, vec![et(0, 0), et(0, 0)]);
+        assert_eq!(
+            events
+                .iter()
+                .filter(|event| matches!(event, GameEvent::ExtraTurnCreated { .. }))
+                .count(),
+            2
+        );
     }
 
     #[test]

--- a/crates/engine/src/game/effects/extra_turn.rs
+++ b/crates/engine/src/game/effects/extra_turn.rs
@@ -5,6 +5,11 @@ use crate::types::ability::{
 use crate::types::events::GameEvent;
 use crate::types::game_state::GameState;
 
+// IMPLEMENTATION BUDGET BOUND: resolving one effect must not allocate an
+// attacker-controlled number of queued turns and events. This is an engine
+// resource ceiling, not a restriction imposed by the Comprehensive Rules.
+pub(crate) const MAX_EXTRA_TURNS_PER_RESOLUTION: i32 = 1_000;
+
 /// CR 500.7: Grant an extra turn to the resolved target player.
 /// Extra turns are stored as a LIFO stack — push to end, pop from end.
 /// The most recently created extra turn is taken first.
@@ -35,6 +40,17 @@ pub fn resolve(
 
     // CR 107.1b: a negative calculated effect result is treated as zero.
     let count = resolve_quantity_with_targets(state, count, ability).max(0);
+    if count > MAX_EXTRA_TURNS_PER_RESOLUTION {
+        tracing::warn!(
+            source_id = ?ability.source_id,
+            count,
+            limit = MAX_EXTRA_TURNS_PER_RESOLUTION,
+            "rejecting oversized extra-turn resolution"
+        );
+        return Err(EffectError::InvalidParam(format!(
+            "extra turn count {count} exceeds the per-resolution limit of {MAX_EXTRA_TURNS_PER_RESOLUTION}"
+        )));
+    }
     // CR 500.7: add multiple extra turns one at a time after the same specified turn.
     let anchor = state.active_player;
     for _ in 0..count {
@@ -337,6 +353,72 @@ mod tests {
                 .count(),
             2
         );
+    }
+
+    #[test]
+    fn extra_turn_resolution_accepts_the_resource_limit() {
+        let mut state = GameState::default();
+        let mut events = Vec::new();
+        let ability = make_ability_with_count(
+            TargetFilter::Controller,
+            QuantityExpr::Fixed {
+                value: MAX_EXTRA_TURNS_PER_RESOLUTION,
+            },
+            PlayerId(0),
+        );
+
+        resolve(&mut state, &ability, &mut events).unwrap();
+
+        assert_eq!(
+            state.extra_turns.len(),
+            MAX_EXTRA_TURNS_PER_RESOLUTION as usize
+        );
+        assert_eq!(events.len(), MAX_EXTRA_TURNS_PER_RESOLUTION as usize + 1);
+        assert!(matches!(
+            events.last(),
+            Some(GameEvent::EffectResolved { .. })
+        ));
+    }
+
+    #[test]
+    fn extra_turn_resolution_rejects_oversized_fixed_and_dynamic_counts_atomically() {
+        let mut state = GameState::default();
+        state.extra_turns.push(et(1, 0));
+        let original_turns = state.extra_turns.clone();
+        let mut events = vec![GameEvent::EffectResolved {
+            kind: EffectKind::Draw,
+            source_id: ObjectId(2),
+            subject: None,
+        }];
+        let original_events = events.clone();
+        let fixed = make_ability_with_count(
+            TargetFilter::Controller,
+            QuantityExpr::Fixed {
+                value: MAX_EXTRA_TURNS_PER_RESOLUTION + 1,
+            },
+            PlayerId(0),
+        );
+
+        let error = resolve(&mut state, &fixed, &mut events).unwrap_err();
+
+        assert!(matches!(error, EffectError::InvalidParam(_)));
+        assert_eq!(state.extra_turns, original_turns);
+        assert_eq!(events, original_events);
+
+        let mut dynamic = make_ability_with_count(
+            TargetFilter::Controller,
+            QuantityExpr::Ref {
+                qty: crate::types::ability::QuantityRef::Variable { name: "X".into() },
+            },
+            PlayerId(0),
+        );
+        dynamic.chosen_x = Some(u32::MAX);
+
+        let error = resolve(&mut state, &dynamic, &mut events).unwrap_err();
+
+        assert!(matches!(error, EffectError::InvalidParam(_)));
+        assert_eq!(state.extra_turns, original_turns);
+        assert_eq!(events, original_events);
     }
 
     #[test]

--- a/crates/engine/src/game/effects/gift_delivery.rs
+++ b/crates/engine/src/game/effects/gift_delivery.rs
@@ -92,13 +92,10 @@ pub fn resolve(
         //
         // "After this one" is the ANCHOR: the extra turn follows the turn during
         // which the gift resolved, which is `state.active_player`'s — not the
-        // recipient's next turn. `enqueue_extra_turn` takes that anchor as its
-        // third argument, exactly as the effect resolver passes it.
+        // recipient's next turn. `enqueue_extra_turn` takes that anchor exactly
+        // as the effect resolver passes it.
         GiftKind::ExtraTurn => {
-            // CR 805.8: with shared team turns the extra turn is taken by the
-            // recipient's team; the same normalization the effect resolver does.
-            let recipient = crate::game::topology::normalize_shared_turn_recipient(state, opponent);
-            crate::game::turns::enqueue_extra_turn(state, recipient, state.active_player);
+            crate::game::turns::enqueue_extra_turn(state, opponent, state.active_player, events);
         }
     }
 
@@ -253,6 +250,25 @@ mod tests {
             vec![(PlayerId(1), state.active_player)],
             "CR 702.174g: the CHOSEN player takes the extra turn, after this one"
         );
+        assert_eq!(
+            events,
+            vec![
+                GameEvent::ExtraTurnCreated {
+                    player_id: PlayerId(1),
+                    anchor: state.active_player,
+                },
+                GameEvent::EffectResolved {
+                    kind: EffectKind::GiftDelivery,
+                    source_id: ObjectId(100),
+                    subject: None,
+                },
+            ]
+        );
+        let turn = &state.extra_turns[0];
+        let GameEvent::ExtraTurnCreated { player_id, anchor } = &events[0] else {
+            unreachable!();
+        };
+        assert_eq!((*player_id, *anchor), (turn.player, turn.anchor));
     }
 
     /// The negative that keeps the row above honest: an unpromised gift queues
@@ -267,6 +283,10 @@ mod tests {
         resolve(&mut state, &ability, &mut events).unwrap();
 
         assert!(state.extra_turns.is_empty());
+        assert!(events.is_empty());
+        assert!(!events
+            .iter()
+            .any(|event| matches!(event, GameEvent::ExtraTurnCreated { .. })));
     }
 
     #[test]

--- a/crates/engine/src/game/log.rs
+++ b/crates/engine/src/game/log.rs
@@ -144,6 +144,7 @@ fn importance(event: &GameEvent) -> LogImportance {
         // never narrated (`should_exclude_event` drops it).
         GameEvent::Milled { .. }
         | GameEvent::HiddenSearchViewed { .. }
+        | GameEvent::ExtraTurnCreated { .. }
         | GameEvent::PriorityPassed { .. }
         | GameEvent::Mutated { .. }
         | GameEvent::Augmented { .. }
@@ -294,6 +295,7 @@ fn tone(event: &GameEvent) -> LogTone {
         | GameEvent::HiddenSearchViewed { .. }
         | GameEvent::CreatureExploited { .. }
         | GameEvent::TurnStarted { .. }
+        | GameEvent::ExtraTurnCreated { .. }
         | GameEvent::PhaseChanged { .. }
         | GameEvent::PriorityPassed { .. }
         | GameEvent::Mutated { .. }
@@ -453,6 +455,9 @@ fn should_exclude_event(event: &GameEvent, state: &GameState) -> bool {
         // can observe it; the player already saw the chapter ability itself
         // resolve. Same low-signal bookkeeping class as StackResolved.
         GameEvent::SagaChapterAbilityResolved { .. } => true,
+        // CR 500.7: queue insertion is low-signal bookkeeping. The resolving
+        // instruction and eventual `TurnStarted` event carry the narrative.
+        GameEvent::ExtraTurnCreated { .. } => true,
         // `handle_empty_attackers` emits this bookkeeping event so the combat
         // pipeline can advance uniformly, but no creature attacked. It must
         // not be narrated as an attack against the default defender.
@@ -535,6 +540,7 @@ fn categorize(event: &GameEvent) -> LogCategory {
         | GameEvent::MulliganStarted => LogCategory::Game,
 
         GameEvent::TurnStarted { .. }
+        | GameEvent::ExtraTurnCreated { .. }
         | GameEvent::PhaseChanged { .. }
         | GameEvent::PriorityPassed { .. } => LogCategory::Turn,
 
@@ -694,6 +700,7 @@ fn format_segments(event: &GameEvent, state: &GameState) -> Vec<LogSegment> {
     match event {
         GameEvent::GameStarted => vec![text("Game started")],
         GameEvent::HiddenSearchViewed { .. } => vec![],
+        GameEvent::ExtraTurnCreated { .. } => vec![],
         // CR 701.17a + CR 400.2: never narrated — the library departure it
         // reports is hidden information (`should_exclude_event` drops it).
         GameEvent::Milled { .. } => vec![],
@@ -1896,6 +1903,30 @@ mod tests {
             cast_mana_value: None,
         };
         assert!(!should_exclude_event(&cast, &state));
+    }
+
+    #[test]
+    fn extra_turn_creation_is_excluded_but_turn_start_is_visible() {
+        let state = GameState::new_two_player(42);
+        let creation = GameEvent::ExtraTurnCreated {
+            player_id: PlayerId(1),
+            anchor: PlayerId(0),
+        };
+        let turn_started = GameEvent::TurnStarted {
+            player_id: PlayerId(1),
+            turn_number: 2,
+        };
+
+        assert_eq!(importance(&creation), LogImportance::Detail);
+        assert_eq!(tone(&creation), LogTone::Neutral);
+        assert_eq!(categorize(&creation), LogCategory::Turn);
+        assert!(should_exclude_event(&creation, &state));
+        assert!(format_segments(&creation, &state).is_empty());
+        assert!(resolve_log_entries(&[creation], &state, &state).is_empty());
+        assert_eq!(
+            resolve_log_entries(&[turn_started], &state, &state).len(),
+            1
+        );
     }
 
     #[test]

--- a/crates/engine/src/game/public_state.rs
+++ b/crates/engine/src/game/public_state.rs
@@ -484,6 +484,7 @@ pub fn mark_public_state_from_events(state: &mut GameState, events: &[GameEvent]
             // `_ => {}`) so a new event variant must be classified to compile.
             GameEvent::GameStarted
             | GameEvent::HiddenSearchViewed { .. }
+            | GameEvent::ExtraTurnCreated { .. }
             // CR 701.17a: the milled object's display is already marked dirty by
             // the paired `ZoneChanged` in the same batch, and no player-level
             // display field depends on the mill itself.

--- a/crates/engine/src/game/stack.rs
+++ b/crates/engine/src/game/stack.rs
@@ -5205,6 +5205,64 @@ mod tests {
     }
 
     #[test]
+    fn oversized_extra_turn_effect_settles_without_allocating_turns_or_events() {
+        let mut state = setup();
+        let source_id = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Oversized extra turns".to_string(),
+            Zone::Stack,
+        );
+        let ability = ResolvedAbility::new(
+            Effect::ExtraTurn {
+                target: TargetFilter::Controller,
+                count: QuantityExpr::Fixed {
+                    value: crate::game::effects::extra_turn::MAX_EXTRA_TURNS_PER_RESOLUTION + 1,
+                },
+            },
+            Vec::new(),
+            source_id,
+            PlayerId(0),
+        );
+        state.stack.push_back(StackEntry {
+            id: source_id,
+            source_id,
+            controller: PlayerId(0),
+            kind: StackEntryKind::Spell {
+                card_id: CardId(1),
+                ability: Some(Box::new(ability)),
+                casting_variant: CastingVariant::Normal,
+                actual_mana_spent: 0,
+            },
+        });
+        let mut events = Vec::new();
+
+        resolve_top(&mut state, &mut events);
+
+        assert!(state.extra_turns.is_empty());
+        assert!(state.stack.is_empty());
+        assert_eq!(state.objects[&source_id].zone, Zone::Graveyard);
+        assert!(!events
+            .iter()
+            .any(|event| matches!(event, GameEvent::ExtraTurnCreated { .. })));
+        assert!(!events.iter().any(|event| matches!(
+            event,
+            GameEvent::EffectResolved {
+                kind: crate::types::ability::EffectKind::ExtraTurn,
+                ..
+            }
+        )));
+        assert_eq!(
+            events
+                .iter()
+                .filter(|event| matches!(event, GameEvent::StackResolved { object_id } if *object_id == source_id))
+                .count(),
+            1
+        );
+    }
+
+    #[test]
     fn stack_spell_copy_has_no_cast_occurrence_and_writes_no_cast_record() {
         let mut state = setup();
         let source_id = ObjectId(70);

--- a/crates/engine/src/game/targeting.rs
+++ b/crates/engine/src/game/targeting.rs
@@ -1905,6 +1905,7 @@ pub(crate) fn extract_target_object_from_event(
         | GameEvent::Evolved { .. }
         | GameEvent::CounterRemoved { .. }
         | GameEvent::TokenCreated { .. }
+        | GameEvent::ExtraTurnCreated { .. }
         | GameEvent::ObjectConjured { .. }
         | GameEvent::CreatureDestroyed { .. }
         | GameEvent::PermanentSacrificed { .. }

--- a/crates/engine/src/game/trigger_index.rs
+++ b/crates/engine/src/game/trigger_index.rs
@@ -1174,6 +1174,12 @@ pub fn ensure_ready(state: &mut GameState) {
 /// keys hit, plus the `unclassified` bucket. Caller dedups against the
 /// per-event `registered_this_event` set as usual.
 pub fn candidates_for_event(state: &GameState, event: &GameEvent) -> SmallVec<[ObjectId; 16]> {
+    // CR 500.7: creating an extra turn adds it directly after the specified
+    // turn. `ExtraTurnCreated` is internal accounting for that insertion, not
+    // a triggerable game event, so it must not reach catch-all definitions.
+    if matches!(event, GameEvent::ExtraTurnCreated { .. }) {
+        return SmallVec::new();
+    }
     let mut out: SmallVec<[ObjectId; 16]> = SmallVec::new();
     out.extend(state.trigger_index.unclassified.iter().copied());
     let keys = keys_from_event(event, state);
@@ -1357,6 +1363,37 @@ mod tests {
         let (keys, route) = keys_from_trigger_def(&def);
         assert!(keys.is_empty());
         assert!(route);
+    }
+
+    #[test]
+    fn extra_turn_creation_does_not_route_unclassified_candidates() {
+        let mut state = GameState::new_two_player(42);
+        let watcher = ObjectId(99);
+        state.objects.insert(
+            watcher,
+            GameObject::new(
+                watcher,
+                CardId(99),
+                PlayerId(0),
+                "Always Watcher".to_string(),
+                Zone::Battlefield,
+            ),
+        );
+        state.trigger_index.add(
+            watcher,
+            &[TriggerDefinition::new(TriggerMode::Always)],
+            false,
+        );
+        assert!(state.trigger_index.unclassified.contains(&watcher));
+
+        let candidates = candidates_for_event(
+            &state,
+            &GameEvent::ExtraTurnCreated {
+                player_id: PlayerId(0),
+                anchor: PlayerId(1),
+            },
+        );
+        assert!(candidates.is_empty());
     }
 
     #[test]

--- a/crates/engine/src/game/trigger_index.rs
+++ b/crates/engine/src/game/trigger_index.rs
@@ -494,6 +494,7 @@ pub(crate) fn keys_from_event(event: &GameEvent, state: &GameState) -> Keys {
         // CR 732.2: a halted-resolution notification produces no trigger keys.
         GameEvent::GameStarted
         | GameEvent::HiddenSearchViewed { .. }
+        | GameEvent::ExtraTurnCreated { .. }
         | GameEvent::ResolutionHalted { .. } => {}
         GameEvent::TurnStarted { .. } => push(TriggerEventKey::TurnStarted),
         GameEvent::PhaseChanged { phase } => push(TriggerEventKey::BeginningOfPhase(*phase)),
@@ -1382,6 +1383,28 @@ mod tests {
             &state,
         );
         assert!(event_keys.contains(&TriggerEventKey::PhaseIn));
+    }
+
+    #[test]
+    fn extra_turn_creation_is_trigger_inert() {
+        let state = GameState::new_two_player(42);
+        let creation_keys = keys_from_event(
+            &GameEvent::ExtraTurnCreated {
+                player_id: PlayerId(0),
+                anchor: PlayerId(1),
+            },
+            &state,
+        );
+        assert!(creation_keys.is_empty());
+
+        let turn_started_keys = keys_from_event(
+            &GameEvent::TurnStarted {
+                player_id: PlayerId(0),
+                turn_number: 2,
+            },
+            &state,
+        );
+        assert!(turn_started_keys.contains(&TriggerEventKey::TurnStarted));
     }
 
     #[test]

--- a/crates/engine/src/game/trigger_matchers.rs
+++ b/crates/engine/src/game/trigger_matchers.rs
@@ -1033,6 +1033,7 @@ fn count_matching_trigger_event_subjects(
         | GameEvent::SpellCountered { .. }
         | GameEvent::ObjectIntensified { .. }
         | GameEvent::CounterRemoved { .. }
+        | GameEvent::ExtraTurnCreated { .. }
         | GameEvent::ObjectConjured { .. }
         | GameEvent::EffectResolved { .. }
         | GameEvent::Unattached { .. }

--- a/crates/engine/src/game/turns.rs
+++ b/crates/engine/src/game/turns.rs
@@ -932,10 +932,18 @@ fn finish_enter_phase(state: &mut GameState, next: Phase, events: &mut Vec<GameE
 
 /// CR 500.7: Enqueue an extra turn for `player` after the specified turn
 /// represented by `anchor`. Both ids are team-normalized (CR 805.8).
-pub(crate) fn enqueue_extra_turn(state: &mut GameState, player: PlayerId, anchor: PlayerId) {
-    state.extra_turns.push(ExtraTurn {
-        player: super::topology::normalize_shared_turn_recipient(state, player),
-        anchor: super::topology::normalize_shared_turn_recipient(state, anchor),
+pub(crate) fn enqueue_extra_turn(
+    state: &mut GameState,
+    player: PlayerId,
+    anchor: PlayerId,
+    events: &mut Vec<GameEvent>,
+) {
+    let player = super::topology::normalize_shared_turn_recipient(state, player);
+    let anchor = super::topology::normalize_shared_turn_recipient(state, anchor);
+    state.extra_turns.push(ExtraTurn { player, anchor });
+    events.push(GameEvent::ExtraTurnCreated {
+        player_id: player,
+        anchor,
     });
 }
 
@@ -1055,7 +1063,13 @@ pub fn projected_turn_order(state: &GameState, max_slots: usize) -> Vec<PlayerId
             .map(|idx| turn_control::release_control_at(&mut scratch, idx).grant_extra_turn_after)
             .unwrap_or(false);
             if grant_extra_turn_after {
-                enqueue_extra_turn(&mut scratch, completed_player, completed_turn_key);
+                let mut preview_events = Vec::new();
+                enqueue_extra_turn(
+                    &mut scratch,
+                    completed_player,
+                    completed_turn_key,
+                    &mut preview_events,
+                );
             }
             scratch.active_full_turn_control = None;
             scratch.active_combat_phase_control = None;
@@ -1160,7 +1174,7 @@ pub fn start_next_turn(state: &mut GameState, events: &mut Vec<GameEvent>) {
         .map(|idx| turn_control::release_control_at(state, idx).grant_extra_turn_after)
         .unwrap_or(false);
         if grant_extra_turn_after {
-            enqueue_extra_turn(state, completed_player, completed_turn_key);
+            enqueue_extra_turn(state, completed_player, completed_turn_key, events);
         }
         // CR 723.1 + CR 723.2: every active window on the completed turn is done.
         // This also covers an effect that ended the turn during combat; an
@@ -5225,7 +5239,7 @@ mod tests {
     fn extra_turns_field_is_independent_of_extra_phases() {
         let mut state = setup();
         state.active_player = PlayerId(0);
-        enqueue_extra_turn(&mut state, PlayerId(0), PlayerId(0));
+        enqueue_extra_turn(&mut state, PlayerId(0), PlayerId(0), &mut Vec::new());
         // No extra_phases pushed — make sure normal phase advance is unaffected.
         state.phase = Phase::Cleanup;
 
@@ -9010,12 +9024,60 @@ mod tests {
     }
 
     #[test]
+    fn enqueue_extra_turn_publishes_the_stored_standard_record() {
+        let mut state = GameState::new(crate::types::format::FormatConfig::standard(), 2, 42);
+        let mut events = Vec::new();
+
+        enqueue_extra_turn(&mut state, PlayerId(1), PlayerId(0), &mut events);
+
+        assert_eq!(
+            state.extra_turns,
+            vec![ExtraTurn {
+                player: PlayerId(1),
+                anchor: PlayerId(0),
+            }]
+        );
+        assert_eq!(
+            events,
+            vec![GameEvent::ExtraTurnCreated {
+                player_id: PlayerId(1),
+                anchor: PlayerId(0),
+            }]
+        );
+    }
+
+    #[test]
+    fn enqueue_extra_turn_publishes_the_normalized_shared_turn_record() {
+        let mut state = GameState::new(
+            crate::types::format::FormatConfig::two_headed_giant(),
+            4,
+            42,
+        );
+        let mut events = Vec::new();
+
+        enqueue_extra_turn(&mut state, PlayerId(1), PlayerId(3), &mut events);
+
+        assert_eq!(state.extra_turns.len(), 1);
+        assert_eq!(events.len(), 1);
+        let ExtraTurn { player, anchor } = &state.extra_turns[0];
+        let GameEvent::ExtraTurnCreated {
+            player_id,
+            anchor: event_anchor,
+        } = &events[0]
+        else {
+            panic!("expected ExtraTurnCreated, got {:?}", events[0]);
+        };
+        assert_eq!((*player, *anchor), (PlayerId(0), PlayerId(2)));
+        assert_eq!((*player_id, *event_anchor), (*player, *anchor));
+    }
+
+    #[test]
     fn extra_turn_takes_precedence_over_seat_order() {
         let mut state = setup();
         state.active_player = PlayerId(0);
         state.turn_number = 1;
         // CR 500.7: Push extra turn for player 0 (in-sequence: anchor = player)
-        enqueue_extra_turn(&mut state, PlayerId(0), PlayerId(0));
+        enqueue_extra_turn(&mut state, PlayerId(0), PlayerId(0), &mut Vec::new());
 
         let mut events = Vec::new();
         start_next_turn(&mut state, &mut events);
@@ -9031,8 +9093,8 @@ mod tests {
         state.active_player = PlayerId(0);
         state.turn_number = 1;
         // CR 500.7: Push two extra turns — player 0 first, then player 1
-        enqueue_extra_turn(&mut state, PlayerId(0), PlayerId(0));
-        enqueue_extra_turn(&mut state, PlayerId(1), PlayerId(0));
+        enqueue_extra_turn(&mut state, PlayerId(0), PlayerId(0), &mut Vec::new());
+        enqueue_extra_turn(&mut state, PlayerId(1), PlayerId(0), &mut Vec::new());
 
         let mut events = Vec::new();
 
@@ -9053,8 +9115,8 @@ mod tests {
         let mut state = GameState::new(crate::types::format::FormatConfig::free_for_all(), 4, 42);
         state.active_player = PlayerId(2); // C
                                            // During C: grant A then B (LIFO → B first)
-        enqueue_extra_turn(&mut state, PlayerId(0), PlayerId(2));
-        enqueue_extra_turn(&mut state, PlayerId(1), PlayerId(2));
+        enqueue_extra_turn(&mut state, PlayerId(0), PlayerId(2), &mut Vec::new());
+        enqueue_extra_turn(&mut state, PlayerId(1), PlayerId(2), &mut Vec::new());
 
         let mut events = Vec::new();
         start_next_turn(&mut state, &mut events);
@@ -9076,7 +9138,7 @@ mod tests {
     fn extra_turn_nested_extra_preserves_outer_anchor() {
         let mut state = GameState::new(crate::types::format::FormatConfig::free_for_all(), 4, 42);
         state.active_player = PlayerId(2); // C
-        enqueue_extra_turn(&mut state, PlayerId(0), PlayerId(2));
+        enqueue_extra_turn(&mut state, PlayerId(0), PlayerId(2), &mut Vec::new());
 
         let mut events = Vec::new();
         start_next_turn(&mut state, &mut events);
@@ -9087,7 +9149,7 @@ mod tests {
             "first pop must latch specified turn C"
         );
 
-        enqueue_extra_turn(&mut state, PlayerId(1), PlayerId(0));
+        enqueue_extra_turn(&mut state, PlayerId(1), PlayerId(0), &mut Vec::new());
 
         start_next_turn(&mut state, &mut events);
         assert_eq!(
@@ -9199,6 +9261,7 @@ mod tests {
         assert_eq!(state.priority_player, PlayerId(0));
         assert_eq!(state.scheduled_turn_controls.len(), 1);
 
+        events.clear();
         start_next_turn(&mut state, &mut events);
 
         assert_eq!(state.active_player, PlayerId(1));
@@ -9206,6 +9269,56 @@ mod tests {
         assert_eq!(state.turn_decision_control_timestamp, None);
         assert_eq!(state.priority_player, PlayerId(1));
         assert!(state.scheduled_turn_controls.is_empty());
+        assert!(state.extra_turns.is_empty());
+        assert_eq!(state.extra_turn_sequence_anchor, Some(PlayerId(1)));
+
+        let creations = events
+            .iter()
+            .filter_map(|event| match event {
+                GameEvent::ExtraTurnCreated { player_id, anchor } => Some((*player_id, *anchor)),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(creations, vec![(PlayerId(1), PlayerId(1))]);
+        let creation_index = events
+            .iter()
+            .position(|event| matches!(event, GameEvent::ExtraTurnCreated { .. }))
+            .expect("controlled-turn release must publish its follow-up extra turn");
+        let turn_started_index = events
+            .iter()
+            .position(|event| matches!(event, GameEvent::TurnStarted { .. }))
+            .expect("the immediately selected extra turn must start");
+        assert!(creation_index < turn_started_index);
+    }
+
+    #[test]
+    fn controlled_turn_without_grant_publishes_no_extra_turn() {
+        let mut state = setup();
+        state.active_player = PlayerId(0);
+        state.turn_number = 1;
+        state
+            .scheduled_turn_controls
+            .push(crate::types::game_state::ScheduledTurnControl {
+                target_player: PlayerId(1),
+                controller: PlayerId(0),
+                timestamp: 0,
+                grant_extra_turn_after: false,
+                window: crate::types::ability::ControlWindow::NextTurn,
+            });
+
+        let mut events = Vec::new();
+        start_next_turn(&mut state, &mut events);
+        assert_eq!(state.active_player, PlayerId(1));
+        assert_eq!(state.turn_decision_controller, Some(PlayerId(0)));
+
+        events.clear();
+        start_next_turn(&mut state, &mut events);
+
+        assert_eq!(state.active_player, PlayerId(0));
+        assert!(state.scheduled_turn_controls.is_empty());
+        assert!(!events
+            .iter()
+            .any(|event| matches!(event, GameEvent::ExtraTurnCreated { .. })));
     }
 
     #[test]
@@ -9253,7 +9366,7 @@ mod tests {
         let mut state = GameState::new(crate::types::format::FormatConfig::free_for_all(), 4, 42);
         state.active_player = PlayerId(0);
         // Extra for P2 granted during P0's turn — anchor is the specified turn.
-        enqueue_extra_turn(&mut state, PlayerId(2), PlayerId(0));
+        enqueue_extra_turn(&mut state, PlayerId(2), PlayerId(0), &mut Vec::new());
         install_begin_turn_skip_permanent(
             &mut state,
             ObjectId(100),
@@ -9297,7 +9410,9 @@ mod tests {
                 window: ControlWindow::NextTurn,
             });
 
+        let before = serde_json::to_value(&state).unwrap();
         let projected = projected_turn_order(&state, 2);
+        let after = serde_json::to_value(&state).unwrap();
 
         assert_eq!(
             projected,
@@ -9307,6 +9422,7 @@ mod tests {
         assert!(state.extra_turns.is_empty());
         assert_eq!(state.scheduled_turn_controls.len(), 1);
         assert_eq!(state.turn_decision_controller, Some(PlayerId(2)));
+        assert_eq!(after, before, "projection must not mutate its source state");
     }
 
     #[test]
@@ -9323,7 +9439,9 @@ mod tests {
                 window: ControlWindow::NextTurn,
             });
 
+        let before = serde_json::to_value(&state).unwrap();
         let projected = projected_turn_order(&state, 3);
+        let after = serde_json::to_value(&state).unwrap();
 
         assert_eq!(
             projected,
@@ -9333,6 +9451,7 @@ mod tests {
         assert!(state.extra_turns.is_empty());
         assert_eq!(state.scheduled_turn_controls.len(), 1);
         assert_eq!(state.turn_decision_controller, None);
+        assert_eq!(after, before, "projection must not mutate its source state");
     }
 
     #[test]
@@ -9766,7 +9885,7 @@ mod tests {
 
         // Push an extra turn for player 0 (in-sequence). With no further extras,
         // the next natural turn after the skip should go to player 1.
-        enqueue_extra_turn(&mut state, PlayerId(0), PlayerId(0));
+        enqueue_extra_turn(&mut state, PlayerId(0), PlayerId(0), &mut Vec::new());
 
         let mut events = Vec::new();
         start_next_turn(&mut state, &mut events);

--- a/crates/engine/src/parser/oracle_effect/imperative.rs
+++ b/crates/engine/src/parser/oracle_effect/imperative.rs
@@ -68,6 +68,32 @@ use super::super::oracle_util::{
     split_around, starts_with_possessive, TextPair,
 };
 
+fn parse_extra_turn(input: &str) -> OracleResult<'_, QuantityExpr> {
+    all_consuming(terminated(
+        preceded(
+            (alt((tag("takes"), tag("take"))), space1),
+            terminated(
+                alt((
+                    value(QuantityExpr::Fixed { value: 1 }, tag("an extra turn")),
+                    map(
+                        (
+                            nom_primitives::parse_number,
+                            space1,
+                            alt((tag("extra turns"), tag("extra turn"))),
+                        ),
+                        |(value, _, _)| QuantityExpr::Fixed {
+                            value: value as i32,
+                        },
+                    ),
+                )),
+                (space1, tag("after this one")),
+            ),
+        ),
+        opt(tag(".")),
+    ))
+    .parse(input)
+}
+
 /// CR 611.2 + CR 601.2f + CR 118.7: Parse the transient (this-turn)
 /// activated-ability cost-reduction effect — "activated abilities of <subject>
 /// cost {N} less to activate [this turn]" (The Dining Car's chaos ability).
@@ -11719,17 +11745,21 @@ pub(super) fn parse_imperative_family_ast(
         // CR 500.7: "take an extra turn after this one"
         // CR 726.1: "take the initiative"
         "take" | "takes" => {
-            if alt((
-                value((), tag::<_, _, OracleError<'_>>("take the initiative")),
-                value((), tag("takes the initiative")),
+            if all_consuming(terminated(
+                alt((
+                    value((), tag::<_, _, OracleError<'_>>("take the initiative")),
+                    value((), tag("takes the initiative")),
+                )),
+                opt(tag(".")),
             ))
-            .parse(lower)
+            .parse(lower.trim())
             .is_ok()
             {
                 Some(ImperativeFamilyAst::TakeTheInitiative)
-            } else if nom_primitives::scan_contains(lower, "extra turn") {
+            } else if let Some(count) = nom_parse_lower(lower.trim(), parse_extra_turn) {
                 Some(ImperativeFamilyAst::GainKeyword(Effect::ExtraTurn {
                     target: TargetFilter::Controller,
+                    count,
                 }))
             } else {
                 None

--- a/crates/engine/src/parser/oracle_effect/imperative.rs
+++ b/crates/engine/src/parser/oracle_effect/imperative.rs
@@ -11756,13 +11756,13 @@ pub(super) fn parse_imperative_family_ast(
             .is_ok()
             {
                 Some(ImperativeFamilyAst::TakeTheInitiative)
-            } else if let Some(count) = nom_parse_lower(lower.trim(), parse_extra_turn) {
-                Some(ImperativeFamilyAst::GainKeyword(Effect::ExtraTurn {
+            } else {
+                nom_parse_lower(lower.trim(), parse_extra_turn).map(|count| {
+                    ImperativeFamilyAst::GainKeyword(Effect::ExtraTurn {
                     target: TargetFilter::Controller,
                     count,
-                }))
-            } else {
-                None
+                    })
+                })
             }
         }
         // CR 702.26a + CR 702.26c: "phase out" / "phases out" / "phase in" /

--- a/crates/engine/src/parser/oracle_effect/imperative.rs
+++ b/crates/engine/src/parser/oracle_effect/imperative.rs
@@ -2,7 +2,7 @@ use crate::parser::oracle_nom::error::{oracle_err, OracleError, OracleResult};
 use nom::branch::alt;
 use nom::bytes::complete::{tag, take_till, take_until};
 use nom::character::complete::{one_of, space0, space1, u8 as parse_u8};
-use nom::combinator::{all_consuming, eof, map, not, opt, peek, rest, value};
+use nom::combinator::{all_consuming, eof, map, map_res, not, opt, peek, rest, value};
 use nom::error::ParseError;
 use nom::sequence::{pair, preceded, terminated};
 use nom::Parser;
@@ -75,14 +75,14 @@ fn parse_extra_turn(input: &str) -> OracleResult<'_, QuantityExpr> {
             terminated(
                 alt((
                     value(QuantityExpr::Fixed { value: 1 }, tag("an extra turn")),
-                    map(
+                    map_res(
                         (
                             nom_primitives::parse_number,
                             space1,
                             alt((tag("extra turns"), tag("extra turn"))),
                         ),
-                        |(value, _, _)| QuantityExpr::Fixed {
-                            value: value as i32,
+                        |(value, _, _)| {
+                            i32::try_from(value).map(|value| QuantityExpr::Fixed { value })
                         },
                     ),
                 )),

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -24477,7 +24477,7 @@ fn inject_subject_target(effect: &mut Effect, subject: &SubjectPhraseAst) {
             *target = subject_filter;
         }
         // CR 500.7: "target player takes an extra turn" — inject subject target
-        Effect::ExtraTurn { target } if *target == TargetFilter::Controller => {
+        Effect::ExtraTurn { target, count: _ } if *target == TargetFilter::Controller => {
             *target = subject_filter;
         }
         // CR 104.3e: "that player loses the game" / "target player
@@ -34015,6 +34015,33 @@ fn parse_reciprocal_graveyard_choice_ir(text: &str, kind: AbilityKind) -> Option
     })
 }
 
+/// CR 705.2: Strip a trailing per-head quantifier when a preceding `FlipCoins`
+/// instruction already supplies the per-head iteration. The chain consolidator
+/// installs the stripped instruction as `FlipCoins::win_effect`, so retaining a
+/// second quantity here would apply it twice.
+fn strip_trailing_coin_heads_quantifier(text: &str) -> Option<&str> {
+    let lower = text.to_ascii_lowercase();
+    let (_, base) = all_consuming(terminated(
+        take_until(" for each "),
+        (
+            tag::<_, _, OracleError<'_>>(" for each "),
+            alt((tag("coins"), tag("coin"))),
+            space1,
+            tag("that"),
+            space1,
+            alt((tag("comes"), tag("come"), tag("came"))),
+            space1,
+            tag("up"),
+            space1,
+            tag("heads"),
+            opt(tag(".")),
+        ),
+    ))
+    .parse(lower.as_str())
+    .ok()?;
+    Some(text[..base.len()].trim_end())
+}
+
 pub(crate) fn parse_effect_chain_ir(
     text: &str,
     kind: AbilityKind,
@@ -34293,6 +34320,17 @@ pub(crate) fn parse_effect_chain_ir(
         if normalized_text.is_empty() {
             continue;
         }
+        let previous_is_multi_coin_flip = builder
+            .clauses()
+            .iter()
+            .rev()
+            .find(|clause| !matches!(clause.disposition, ClauseDisposition::Continue { .. }))
+            .is_some_and(|clause| matches!(clause.parsed.effect, Effect::FlipCoins { .. }));
+        let normalized_text = if previous_is_multi_coin_flip {
+            strip_trailing_coin_heads_quantifier(normalized_text).unwrap_or(normalized_text)
+        } else {
+            normalized_text
+        };
         let has_bare_recipient_counter_gate =
             crate::parser::oracle_nom::condition::is_leading_if_bare_recipient_counter_condition(
                 normalized_text,

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -34019,10 +34019,9 @@ fn parse_reciprocal_graveyard_choice_ir(text: &str, kind: AbilityKind) -> Option
 /// instruction already supplies the per-head iteration. The chain consolidator
 /// installs the stripped instruction as `FlipCoins::win_effect`, so retaining a
 /// second quantity here would apply it twice.
-fn strip_trailing_coin_heads_quantifier(text: &str) -> Option<&str> {
-    let lower = text.to_ascii_lowercase();
-    let (_, base) = all_consuming(terminated(
-        take_until(" for each "),
+fn parse_coin_heads_quantifier(input: &str) -> OracleResult<'_, ()> {
+    value(
+        (),
         (
             tag::<_, _, OracleError<'_>>(" for each "),
             alt((tag("coins"), tag("coin"))),
@@ -34036,6 +34035,18 @@ fn strip_trailing_coin_heads_quantifier(text: &str) -> Option<&str> {
             tag("heads"),
             opt(tag(".")),
         ),
+    )
+    .parse(input)
+}
+
+fn strip_trailing_coin_heads_quantifier(text: &str) -> Option<&str> {
+    let lower = text.to_ascii_lowercase();
+    let (_, base) = all_consuming(terminated(
+        recognize(many_till(
+            anychar,
+            peek(terminated(parse_coin_heads_quantifier, eof)),
+        )),
+        parse_coin_heads_quantifier,
     ))
     .parse(lower.as_str())
     .ok()?;

--- a/crates/engine/src/parser/oracle_effect/tests.rs
+++ b/crates/engine/src/parser/oracle_effect/tests.rs
@@ -31908,6 +31908,17 @@ fn extra_turn_fixed_cardinal_and_subject_are_preserved() {
 #[test]
 fn extra_turn_grammar_is_all_consuming_and_does_not_shadow_initiative() {
     assert!(matches!(
+        parse_imperative_effect(
+            "take two extra turns after this one",
+            &mut ParseContext::default(),
+        )
+        .effect,
+        Effect::ExtraTurn {
+            target: TargetFilter::Controller,
+            count: QuantityExpr::Fixed { value: 2 },
+        }
+    ));
+    assert!(matches!(
         parse_effect("Take the initiative."),
         Effect::TakeTheInitiative
     ));

--- a/crates/engine/src/parser/oracle_effect/tests.rs
+++ b/crates/engine/src/parser/oracle_effect/tests.rs
@@ -31922,6 +31922,25 @@ fn extra_turn_grammar_is_all_consuming_and_does_not_shadow_initiative() {
 }
 
 #[test]
+fn extra_turn_count_rejects_values_above_i32_max() {
+    assert!(matches!(
+        parse_effect("Target player takes 2147483647 extra turns after this one."),
+        Effect::ExtraTurn {
+            count: QuantityExpr::Fixed { value: i32::MAX },
+            ..
+        }
+    ));
+    assert!(matches!(
+        parse_imperative_effect(
+            "take 2147483648 extra turns after this one",
+            &mut ParseContext::default(),
+        )
+        .effect,
+        Effect::Unimplemented { .. }
+    ));
+}
+
+#[test]
 fn ral_zarek_coin_result_shell_preserves_singular_extra_turn_count() {
     let def = parse_effect_chain(
         "Flip five coins. Take an extra turn after this one for each coin that comes up heads.",
@@ -31944,6 +31963,16 @@ fn ral_zarek_coin_result_shell_preserves_singular_extra_turn_count() {
             count: QuantityExpr::Fixed { value: 1 },
         }
     ));
+}
+
+#[test]
+fn coin_heads_quantifier_uses_the_final_for_each_clause() {
+    assert_eq!(
+        strip_trailing_coin_heads_quantifier(
+            "For each player, draw a card for each coin that comes up heads."
+        ),
+        Some("For each player, draw a card")
+    );
 }
 
 #[test]

--- a/crates/engine/src/parser/oracle_effect/tests.rs
+++ b/crates/engine/src/parser/oracle_effect/tests.rs
@@ -31862,7 +31862,8 @@ fn extra_turn_controller() {
     assert!(matches!(
         e,
         Effect::ExtraTurn {
-            target: TargetFilter::Controller
+            target: TargetFilter::Controller,
+            count: QuantityExpr::Fixed { value: 1 },
         }
     ));
 }
@@ -31877,7 +31878,70 @@ fn extra_turn_imperative() {
     assert!(matches!(
         clause.effect,
         Effect::ExtraTurn {
-            target: TargetFilter::Controller
+            target: TargetFilter::Controller,
+            count: QuantityExpr::Fixed { value: 1 },
+        }
+    ));
+}
+
+#[test]
+fn extra_turn_fixed_cardinal_and_subject_are_preserved() {
+    let one = parse_effect("Target player takes an extra turn after this one.");
+    assert!(matches!(
+        one,
+        Effect::ExtraTurn {
+            target: TargetFilter::Player,
+            count: QuantityExpr::Fixed { value: 1 },
+        }
+    ));
+
+    let two = parse_effect("Target player takes two extra turns after this one.");
+    assert!(matches!(
+        two,
+        Effect::ExtraTurn {
+            target: TargetFilter::Player,
+            count: QuantityExpr::Fixed { value: 2 },
+        }
+    ));
+}
+
+#[test]
+fn extra_turn_grammar_is_all_consuming_and_does_not_shadow_initiative() {
+    assert!(matches!(
+        parse_effect("Take the initiative."),
+        Effect::TakeTheInitiative
+    ));
+    assert!(matches!(
+        parse_imperative_effect(
+            "take two extra turns after this one and draw a card",
+            &mut ParseContext::default(),
+        )
+        .effect,
+        Effect::Unimplemented { .. }
+    ));
+}
+
+#[test]
+fn ral_zarek_coin_result_shell_preserves_singular_extra_turn_count() {
+    let def = parse_effect_chain(
+        "Flip five coins. Take an extra turn after this one for each coin that comes up heads.",
+        AbilityKind::Activated,
+    );
+    let Effect::FlipCoins {
+        count,
+        win_effect: Some(win_effect),
+        lose_effect: None,
+        ..
+    } = def.effect.as_ref()
+    else {
+        panic!("expected FlipCoins, got {:?}", def.effect);
+    };
+    assert_eq!(count, &QuantityExpr::Fixed { value: 5 });
+    assert!(matches!(
+        win_effect.effect.as_ref(),
+        Effect::ExtraTurn {
+            target: TargetFilter::Controller,
+            count: QuantityExpr::Fixed { value: 1 },
         }
     ));
 }

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -30613,7 +30613,13 @@ fn ichormoon_gauntlet_grants_loyalty_abilities_to_planeswalkers() {
         grants[1].cost
     );
     assert!(
-        matches!(*grants[1].effect, Effect::ExtraTurn { .. }),
+        matches!(
+            *grants[1].effect,
+            Effect::ExtraTurn {
+                target: TargetFilter::Controller,
+                count: QuantityExpr::Fixed { value: 1 },
+            }
+        ),
         "second grant effect should be ExtraTurn, got {:?}",
         grants[1].effect
     );

--- a/crates/engine/src/parser/oracle_tests.rs
+++ b/crates/engine/src/parser/oracle_tests.rs
@@ -13,6 +13,37 @@ use crate::types::ability::{
 use crate::types::counter::{CounterMatch, CounterType};
 use crate::types::triggers::AttackTargetFilter;
 
+#[test]
+fn teferi_master_of_time_minus_ten_preserves_two_extra_turns() {
+    let oracle = "You may activate loyalty abilities of Teferi on any player's turn any time you could cast an instant.\n\
+[+1]: Draw a card, then discard a card.\n\
+[−3]: Target creature you don't control phases out. (Treat it and anything attached to it as though they don't exist until its controller's next turn.)\n\
+[−10]: Take two extra turns after this one.";
+    let parsed = parse_oracle_text(
+        oracle,
+        "Teferi, Master of Time",
+        &[],
+        &["Planeswalker".into()],
+        &["Teferi".into()],
+    );
+    let minus_ten = parsed
+        .abilities
+        .iter()
+        .find(|ability| matches!(&ability.cost, Some(AbilityCost::Loyalty { amount: -10 })))
+        .expect("Teferi's -10 loyalty ability parses");
+    assert!(matches!(
+        minus_ten.effect.as_ref(),
+        Effect::ExtraTurn {
+            target: TargetFilter::Controller,
+            count: QuantityExpr::Fixed { value: 2 },
+        }
+    ));
+    assert!(!matches!(
+        minus_ten.effect.as_ref(),
+        Effect::Unimplemented { .. }
+    ));
+}
+
 /// CR 607.2d + CR 614.1c: only an as-enters replacement whose separate static
 /// reads `IsChosenCardType` is promoted from its locally-labeled list.
 #[test]

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -17672,11 +17672,17 @@ pub enum Effect {
         profile: Option<FaceDownProfile>,
     },
     /// CR 500.7: Take an extra turn after this one. The target determines who
-    /// takes the extra turn (usually Controller for "take an extra turn").
-    /// Extra turns are stored as a LIFO stack — most recently created taken first.
+    /// takes the extra turn (usually Controller for "take an extra turn"). `count`
+    /// defaults to one for legacy serialized effects. Extra turns are stored as a
+    /// LIFO stack — most recently created taken first.
     ExtraTurn {
         #[serde(default = "default_target_filter_controller")]
         target: TargetFilter,
+        #[serde(
+            default = "default_quantity_one",
+            skip_serializing_if = "is_default_quantity_one"
+        )]
+        count: QuantityExpr,
     },
     /// CR 606.3: Grant the resolved target player the right to activate each of
     /// their planeswalkers' loyalty abilities `amount` additional times this
@@ -18151,6 +18157,10 @@ fn default_player_filter_controller() -> PlayerFilter {
 
 fn default_quantity_one() -> QuantityExpr {
     QuantityExpr::Fixed { value: 1 }
+}
+
+fn is_default_quantity_one(quantity: &QuantityExpr) -> bool {
+    matches!(quantity, QuantityExpr::Fixed { value: 1 })
 }
 
 fn default_duration_until_end_of_turn() -> Duration {
@@ -21228,6 +21238,9 @@ impl Effect {
             Effect::GrantExtraLoyaltyActivations { amount, .. } => {
                 f(amount);
             }
+            Effect::ExtraTurn { count, .. } => {
+                f(count);
+            }
             Effect::SkipNextTurn { count, .. } => {
                 f(count);
             }
@@ -21410,7 +21423,6 @@ impl Effect {
             | Effect::ManifestDread
             | Effect::TurnFaceUp { .. }
             | Effect::TurnFaceDown { .. }
-            | Effect::ExtraTurn { .. }
             | Effect::Double { .. }
             | Effect::RuntimeHandled { .. }
             | Effect::Specialize
@@ -21480,6 +21492,7 @@ impl Effect {
             | Effect::ChooseDrawnThisTurnPayOrTopdeck { count, .. }
             | Effect::Manifest { count, .. }
             | Effect::Cloak { count, .. }
+            | Effect::ExtraTurn { count, .. }
             | Effect::SkipNextTurn { count, .. }
             | Effect::SkipNextStep { count, .. }
             | Effect::AdditionalPhase { count, .. }
@@ -21589,7 +21602,6 @@ impl Effect {
             | Effect::Goad { .. }
             | Effect::Detain { .. }
             | Effect::SetRoomDoorLock { .. }
-            | Effect::ExtraTurn { .. }
             | Effect::Transform { .. }
             | Effect::FlipPermanent { .. }
             | Effect::RevealTop { .. }
@@ -21744,6 +21756,7 @@ impl Effect {
             | Effect::ChooseDrawnThisTurnPayOrTopdeck { count, .. }
             | Effect::Manifest { count, .. }
             | Effect::Cloak { count, .. }
+            | Effect::ExtraTurn { count, .. }
             | Effect::SkipNextTurn { count, .. }
             | Effect::SkipNextStep { count, .. }
             | Effect::AdditionalPhase { count, .. }
@@ -21853,7 +21866,6 @@ impl Effect {
             | Effect::Goad { .. }
             | Effect::Detain { .. }
             | Effect::SetRoomDoorLock { .. }
-            | Effect::ExtraTurn { .. }
             | Effect::Transform { .. }
             | Effect::FlipPermanent { .. }
             | Effect::RevealTop { .. }
@@ -34620,6 +34632,61 @@ mod tests {
                 scope: ObjectScope::Target,
             }
         );
+    }
+
+    #[test]
+    fn extra_turn_quantity_serde_is_backward_compatible() {
+        let legacy: Effect = serde_json::from_str(r#"{"type":"ExtraTurn"}"#).unwrap();
+        assert!(matches!(
+            &legacy,
+            Effect::ExtraTurn {
+                target: TargetFilter::Controller,
+                count: QuantityExpr::Fixed { value: 1 },
+            }
+        ));
+        let legacy_json = serde_json::to_value(&legacy).unwrap();
+        assert!(legacy_json.get("count").is_none());
+
+        let two = Effect::ExtraTurn {
+            target: TargetFilter::Player,
+            count: QuantityExpr::Fixed { value: 2 },
+        };
+        let json = serde_json::to_value(&two).unwrap();
+        assert_eq!(json["count"]["value"], serde_json::json!(2));
+        assert_eq!(serde_json::from_value::<Effect>(json).unwrap(), two);
+
+        let dynamic = Effect::ExtraTurn {
+            target: TargetFilter::Controller,
+            count: QuantityExpr::Ref {
+                qty: QuantityRef::Variable { name: "X".into() },
+            },
+        };
+        let dynamic_json = serde_json::to_value(&dynamic).unwrap();
+        assert!(dynamic_json.get("count").is_some());
+        assert_eq!(
+            serde_json::from_value::<Effect>(dynamic_json).unwrap(),
+            dynamic
+        );
+    }
+
+    #[test]
+    fn extra_turn_quantity_is_reached_by_all_generic_authorities() {
+        let mut effect = Effect::ExtraTurn {
+            target: TargetFilter::Controller,
+            count: QuantityExpr::Ref {
+                qty: QuantityRef::Variable { name: "X".into() },
+            },
+        };
+        let dynamic = effect.count_expr().cloned().unwrap();
+        let mut visited = Vec::new();
+        effect.for_each_quantity_expr(&mut |quantity| visited.push(quantity.clone()));
+        assert_eq!(visited, vec![dynamic]);
+
+        *effect.count_expr_mut().unwrap() = QuantityExpr::Fixed { value: 2 };
+        assert_eq!(effect.count_expr(), Some(&QuantityExpr::Fixed { value: 2 }));
+        visited.clear();
+        effect.for_each_quantity_expr(&mut |quantity| visited.push(quantity.clone()));
+        assert_eq!(visited, vec![QuantityExpr::Fixed { value: 2 }]);
     }
 
     #[test]

--- a/crates/engine/src/types/events.rs
+++ b/crates/engine/src/types/events.rs
@@ -766,6 +766,13 @@ pub enum GameEvent {
         player_id: PlayerId,
         turn_number: u32,
     },
+    /// CR 500.7: One extra turn was created after the turn identified by
+    /// `anchor`; `player_id` is the beneficiary. CR 805.8: In a shared-team-turn
+    /// game, both ids are the corresponding shared-turn representatives.
+    ExtraTurnCreated {
+        player_id: PlayerId,
+        anchor: PlayerId,
+    },
     PhaseChanged {
         phase: Phase,
     },
@@ -1803,6 +1810,22 @@ mod tests {
         let json = serde_json::to_value(&event).unwrap();
         assert_eq!(json["type"], "TurnStarted");
         assert_eq!(json["data"]["turn_number"], 1);
+    }
+
+    #[test]
+    fn extra_turn_created_serializes_with_normalized_record_identity() {
+        let event = GameEvent::ExtraTurnCreated {
+            player_id: PlayerId(2),
+            anchor: PlayerId(5),
+        };
+
+        let json = serde_json::to_value(&event).unwrap();
+        assert_eq!(json["type"], "ExtraTurnCreated");
+        assert_eq!(json["data"]["player_id"], 2);
+        assert_eq!(json["data"]["anchor"], 5);
+
+        let round_tripped: GameEvent = serde_json::from_value(json).unwrap();
+        assert_eq!(round_tripped, event);
     }
 
     #[test]

--- a/crates/engine/tests/integration/extra_turn_quantity.rs
+++ b/crates/engine/tests/integration/extra_turn_quantity.rs
@@ -1,0 +1,64 @@
+use engine::game::scenario::{GameScenario, P0, P1};
+use engine::types::ability::EffectKind;
+use engine::types::events::GameEvent;
+use engine::types::game_state::ExtraTurn;
+use engine::types::phase::Phase;
+
+const TIME_WARP: &str = "Target player takes an extra turn after this one.";
+const TIME_STRETCH: &str = "Target player takes two extra turns after this one.";
+
+fn cast_extra_turn_spell(name: &str, oracle: &str) -> engine::game::scenario::CastOutcome {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let spell = scenario
+        .add_spell_to_hand_from_oracle(P0, name, false, oracle)
+        .id();
+    let mut runner = scenario.build();
+    runner.cast(spell).target_player(P1).resolve()
+}
+
+fn assert_extra_turn_result(name: &str, oracle: &str, expected: usize) {
+    let outcome = cast_extra_turn_spell(name, oracle);
+    assert_eq!(
+        outcome.state().extra_turns,
+        vec![
+            ExtraTurn {
+                player: P1,
+                anchor: P0,
+            };
+            expected
+        ]
+    );
+    assert_eq!(
+        outcome
+            .events()
+            .iter()
+            .filter(|event| matches!(event, GameEvent::ExtraTurnCreated { player_id, anchor } if *player_id == P1 && *anchor == P0))
+            .count(),
+        expected
+    );
+    assert_eq!(
+        outcome
+            .events()
+            .iter()
+            .filter(|event| matches!(
+                event,
+                GameEvent::EffectResolved {
+                    kind: EffectKind::ExtraTurn,
+                    ..
+                }
+            ))
+            .count(),
+        1
+    );
+}
+
+#[test]
+fn time_warp_creates_one_extra_turn() {
+    assert_extra_turn_result("Time Warp", TIME_WARP, 1);
+}
+
+#[test]
+fn time_stretch_creates_two_extra_turns() {
+    assert_extra_turn_result("Time Stretch", TIME_STRETCH, 2);
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -1576,4 +1576,5 @@ mod zhulodok_double_cascade;
 mod context_ref_slot_hygiene;
 mod exchange_control_of_a_spell;
 mod exploit_ceased_exploiter_lki;
+mod extra_turn_quantity;
 mod ripple_reveal_choice_interaction;

--- a/crates/lobby-broker/src/protocol.rs
+++ b/crates/lobby-broker/src/protocol.rs
@@ -56,6 +56,10 @@ pub struct TournamentRequestId(pub u64);
 /// rather than a parse error, and the handshake is the only place that pairing
 /// can be refused. See 24.
 ///
+/// 69 — `GameEvent` gained the tagged variant `ExtraTurnCreated { player_id,
+///      anchor }`. Event-bearing full-game frames can now carry that tag, so
+///      the full-game handshake must reject v68 peers that do not share the
+///      variant contract. P2P moves in lockstep; lobby messages are unchanged.
 /// 68 — `PendingManaAbility::chosen_tappers` changed from `Vec<ObjectId>` to
 ///      `Option<Vec<ObjectId>>` (#8698) — a `GameState` payload field type
 ///      change, so an ANSWERED zero-tapper selection of the CR 107.3a
@@ -422,7 +426,7 @@ pub struct TournamentRequestId(pub u64);
 ///      payload; mulligan bottoming folded into a
 ///      `MulliganDecisionPhase::BottomCards` sub-phase on
 ///      `WaitingFor::MulliganDecision`.
-pub const PROTOCOL_VERSION: u32 = 68;
+pub const PROTOCOL_VERSION: u32 = 69;
 
 /// Minimum protocol version accepted by lobby-only brokers at the hello
 /// handshake **from clients that predate [`LOBBY_PROTOCOL_VERSION`]** — the
@@ -1467,12 +1471,12 @@ mod tests {
 
     #[test]
     fn protocol_version_tracks_full_game_wire_additions() {
-        assert_eq!(PROTOCOL_VERSION, 68);
+        assert_eq!(PROTOCOL_VERSION, 69);
         // Lobby keeps its one-version rollout window; full-game servers stay
         // current-only (`server_core::MIN_SUPPORTED_PROTOCOL == PROTOCOL_VERSION`),
         // which refuses an older full-game peer that cannot preserve the exact
         // Full-session identity across draft match attachment and follow-ups.
-        assert_eq!(MIN_SUPPORTED_PROTOCOL, 67);
+        assert_eq!(MIN_SUPPORTED_PROTOCOL, 68);
     }
 
     #[test]

--- a/crates/phase-ai/src/policies/anti_self_harm.rs
+++ b/crates/phase-ai/src/policies/anti_self_harm.rs
@@ -265,7 +265,8 @@ fn effect_grants_ai_extra_turn(effect: &Effect) -> bool {
     matches!(
         effect,
         Effect::ExtraTurn {
-            target: TargetFilter::Controller
+            target: TargetFilter::Controller,
+            count: _,
         }
     )
 }
@@ -5807,6 +5808,7 @@ mod tests {
             AbilityKind::Spell,
             Effect::ExtraTurn {
                 target: TargetFilter::Controller,
+                count: QuantityExpr::Fixed { value: 1 },
             },
         );
         if let Some(condition) = self_loss_condition {

--- a/crates/phase-ai/src/policies/context.rs
+++ b/crates/phase-ai/src/policies/context.rs
@@ -303,18 +303,28 @@ impl<'a> PolicyContext<'a> {
 /// `cast_facts::collect_definition_effects`, which does the same walk one level
 /// up on `AbilityDefinition`.
 pub(crate) fn collect_ability_effects(ability: &ResolvedAbility) -> Vec<&Effect> {
-    let mut effects = Vec::new();
-    push_resolved_effects(&mut effects, ability);
-    effects
+    collect_resolved_abilities(ability)
+        .into_iter()
+        .map(|node| &node.effect)
+        .collect()
 }
 
-fn push_resolved_effects<'a>(effects: &mut Vec<&'a Effect>, ability: &'a ResolvedAbility) {
-    effects.push(&ability.effect);
+pub(crate) fn collect_resolved_abilities(ability: &ResolvedAbility) -> Vec<&ResolvedAbility> {
+    let mut abilities = Vec::new();
+    push_resolved_abilities(&mut abilities, ability);
+    abilities
+}
+
+fn push_resolved_abilities<'a>(
+    abilities: &mut Vec<&'a ResolvedAbility>,
+    ability: &'a ResolvedAbility,
+) {
+    abilities.push(ability);
     if let Some(sub_ability) = &ability.sub_ability {
-        push_resolved_effects(effects, sub_ability);
+        push_resolved_abilities(abilities, sub_ability);
     }
     if let Some(else_ability) = &ability.else_ability {
-        push_resolved_effects(effects, else_ability);
+        push_resolved_abilities(abilities, else_ability);
     }
 }
 
@@ -398,6 +408,49 @@ mod tests {
             target: TargetFilter::Any,
             cant_regenerate: false,
         }
+    }
+
+    #[test]
+    fn resolved_ability_collection_preserves_node_context_and_order() {
+        let mut root = ResolvedAbility::new(Effect::NoOp, vec![], ObjectId(1), PlayerId(0));
+        root.chosen_x = Some(1);
+        let mut sub = ResolvedAbility::new(
+            Effect::NoOp,
+            vec![TargetRef::Player(PlayerId(2))],
+            ObjectId(2),
+            PlayerId(1),
+        );
+        sub.chosen_x = Some(2);
+        let mut otherwise = ResolvedAbility::new(
+            Effect::NoOp,
+            vec![TargetRef::Player(PlayerId(0))],
+            ObjectId(3),
+            PlayerId(2),
+        );
+        otherwise.chosen_x = Some(3);
+        root.sub_ability = Some(Box::new(sub));
+        root.else_ability = Some(Box::new(otherwise));
+
+        let nodes = collect_resolved_abilities(&root);
+        assert_eq!(nodes.len(), 3);
+        assert_eq!(
+            (nodes[0].chosen_x, nodes[0].controller),
+            (Some(1), PlayerId(0))
+        );
+        assert_eq!(
+            (nodes[1].chosen_x, nodes[1].controller),
+            (Some(2), PlayerId(1))
+        );
+        assert_eq!(nodes[1].targets, vec![TargetRef::Player(PlayerId(2))]);
+        assert_eq!(
+            (nodes[2].chosen_x, nodes[2].controller),
+            (Some(3), PlayerId(2))
+        );
+        assert_eq!(
+            collect_ability_effects(&root).len(),
+            nodes.len(),
+            "the compatibility projection walks the same nodes"
+        );
     }
 
     /// A modal spell on the stack whose printed modes are its spell-kind

--- a/crates/phase-ai/src/policies/self_cost_value.rs
+++ b/crates/phase-ai/src/policies/self_cost_value.rs
@@ -2612,6 +2612,7 @@ mod tests {
                 vec![
                     Effect::ExtraTurn {
                         target: TargetFilter::Player,
+                        count: QuantityExpr::Fixed { value: 1 },
                     },
                     Effect::LoseLife {
                         amount: QuantityExpr::Fixed { value: 20 },

--- a/crates/phase-ai/src/policies/stack_awareness.rs
+++ b/crates/phase-ai/src/policies/stack_awareness.rs
@@ -10,7 +10,7 @@ use crate::eval::evaluate_creature;
 use crate::features::DeckFeatures;
 
 use super::activation::turn_only;
-use super::context::{collect_ability_effects, PolicyContext};
+use super::context::{collect_ability_effects, collect_resolved_abilities, PolicyContext};
 use super::effect_classify::{effect_polarity, is_spell_beneficial, EffectPolarity};
 use super::registry::{DecisionKind, PolicyId, PolicyReason, PolicyVerdict, TacticalPolicy};
 
@@ -250,13 +250,17 @@ pub(crate) fn assess_spell_impact(state: &GameState, entry: &StackEntry) -> f64 
 
             let mut score = mv * 0.3;
 
-            let effects = entry
+            let abilities = entry
                 .ability()
-                .map(|a| collect_ability_effects(a))
+                .map(collect_resolved_abilities)
                 .unwrap_or_default();
-            for effect in effects {
-                score += match effect {
-                    Effect::ExtraTurn { .. } => 5.0,
+            for ability in abilities {
+                score += match &ability.effect {
+                    Effect::ExtraTurn { count, .. } => {
+                        engine::game::quantity::resolve_quantity_with_targets(state, count, ability)
+                            .max(0) as f64
+                            * 5.0
+                    }
                     Effect::DestroyAll { .. }
                     | Effect::DamageAll { .. }
                     | Effect::ChangeZoneAll { .. } => 4.0,
@@ -375,7 +379,9 @@ mod tests {
     use crate::config::AiConfig;
     use engine::ai_support::{ActionMetadata, AiDecisionContext, CandidateAction, TacticalClass};
     use engine::game::zones::create_object;
-    use engine::types::ability::{BounceSelection, EffectKind, ResolvedAbility, TargetFilter};
+    use engine::types::ability::{
+        BounceSelection, EffectKind, QuantityRef, ResolvedAbility, TargetFilter,
+    };
     use engine::types::card_type::CoreType;
     use engine::types::game_state::{
         GameState, PendingCast, StackEntry, StackEntryKind, TargetEffectDetail,
@@ -434,6 +440,96 @@ mod tests {
             source_rider: None,
             countered_spell_zone: None,
         }
+    }
+
+    fn extra_turn(count: QuantityExpr) -> Effect {
+        Effect::ExtraTurn {
+            target: TargetFilter::Controller,
+            count,
+        }
+    }
+
+    #[test]
+    fn spell_impact_values_each_extra_turn_and_uses_the_owning_node_context() {
+        let mut state = make_state();
+        let unrelated_id = push_spell(&mut state, PlayerId(1), 0, Effect::NoOp, vec![]);
+        let unrelated = state
+            .stack
+            .iter()
+            .find(|entry| entry.id == unrelated_id)
+            .unwrap();
+        assert_eq!(assess_spell_impact(&state, unrelated), 0.0);
+
+        let one_id = push_spell(
+            &mut state,
+            PlayerId(1),
+            0,
+            extra_turn(QuantityExpr::Fixed { value: 1 }),
+            vec![],
+        );
+        let one = state.stack.iter().find(|entry| entry.id == one_id).unwrap();
+        assert_eq!(assess_spell_impact(&state, one), 5.0);
+
+        let two_id = push_spell(
+            &mut state,
+            PlayerId(1),
+            0,
+            extra_turn(QuantityExpr::Fixed { value: 2 }),
+            vec![],
+        );
+        let two = state.stack.iter().find(|entry| entry.id == two_id).unwrap();
+        assert_eq!(assess_spell_impact(&state, two), 8.0);
+
+        let source_card_id = CardId(state.next_object_id);
+        let source_id = create_object(
+            &mut state,
+            source_card_id,
+            PlayerId(1),
+            "Context Spell".into(),
+            Zone::Stack,
+        );
+        let mut root = ResolvedAbility::new(Effect::NoOp, vec![], source_id, PlayerId(1));
+        root.chosen_x = Some(1);
+        let mut child = ResolvedAbility::new(
+            extra_turn(QuantityExpr::Ref {
+                qty: QuantityRef::Variable { name: "X".into() },
+            }),
+            vec![],
+            source_id,
+            PlayerId(1),
+        );
+        child.chosen_x = Some(2);
+        root.sub_ability = Some(Box::new(child));
+        let mut root_one = root.clone();
+        root_one
+            .sub_ability
+            .as_mut()
+            .expect("dynamic child")
+            .chosen_x = Some(1);
+        let entry = StackEntry {
+            id: ObjectId(state.next_object_id),
+            source_id,
+            controller: PlayerId(1),
+            kind: StackEntryKind::Spell {
+                ability: Some(Box::new(root)),
+                card_id: CardId(state.next_object_id),
+                casting_variant: Default::default(),
+                actual_mana_spent: 0,
+            },
+        };
+        assert_eq!(assess_spell_impact(&state, &entry), 8.0);
+        let one_entry = StackEntry {
+            id: ObjectId(state.next_object_id + 1),
+            source_id,
+            controller: PlayerId(1),
+            kind: StackEntryKind::Spell {
+                ability: Some(Box::new(root_one)),
+                card_id: CardId(state.next_object_id + 1),
+                casting_variant: Default::default(),
+                actual_mana_spent: 0,
+            },
+        };
+        assert_eq!(assess_spell_impact(&state, &one_entry), 5.0);
     }
 
     /// Sibling of [`push_stack_entry`] for multiplayer counter fixtures: the entry

--- a/crates/server-core/src/protocol.rs
+++ b/crates/server-core/src/protocol.rs
@@ -3204,21 +3204,18 @@ mod tests {
         }
     }
 
-    /// The bump this number is at: `PendingManaAbility::chosen_tappers` moved
-    /// from `Vec<ObjectId>` to `Option<Vec<ObjectId>>` (#8698), so an ANSWERED
-    /// zero-tapper selection of the CR 107.3a X-sentinel form stops decoding
-    /// as an unanswered one. The field carries no `#[serde(default)]`, so the
-    /// pre-68 shape fails deserialization instead of inverting silently — see
-    /// `engine::types::game_state`'s
-    /// `chosen_tappers_pre_option_wire_shape_is_rejected`.
+    /// The bump this number is at: `GameEvent` gained the tagged variant
+    /// `ExtraTurnCreated { player_id, anchor }`. `StateUpdate.events` and
+    /// `GameStarted.events` can now carry that tag, so a v68 peer must be
+    /// refused before it receives an event it cannot deserialize.
     ///
     /// The name embeds the numeral deliberately: `assert_eq!(PROTOCOL_VERSION,
     /// <n>)` under a function named for `<n-1>` is green, so
     /// `check-protocol-version.mjs` requires the current numeral in this name
     /// and refuses the superseded one.
     #[test]
-    fn protocol_version_is_68_for_pending_mana_ability_chosen_tappers() {
-        assert_eq!(PROTOCOL_VERSION, 68);
+    fn protocol_version_is_69_for_extra_turn_created_event() {
+        assert_eq!(PROTOCOL_VERSION, 69);
     }
 
     /// The bump alone is inert — a version number nobody enforces prevents no
@@ -3229,7 +3226,7 @@ mod tests {
     ///
     /// REVERT-PROBE: relax to `PROTOCOL_VERSION - 1` — the exact regression
     /// this guards — and this test reds while
-    /// `protocol_version_is_68_for_pending_mana_ability_chosen_tappers` stays
+    /// `protocol_version_is_69_for_extra_turn_created_event` stays
     /// green, which is why the two are separate assertions.
     #[test]
     fn full_game_floor_is_current_only_not_a_rollout_window() {

--- a/scripts/check-protocol-version.mjs
+++ b/scripts/check-protocol-version.mjs
@@ -3,7 +3,7 @@ import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
-const EXPECTED_PROTOCOL_VERSION = 68;
+const EXPECTED_PROTOCOL_VERSION = 69;
 // The LOBBY message-set version, not derived from the full-game number above.
 // The classifier below refuses an expression only on the SOURCE constants; this
 // script never reads itself, so its own EXPECTED_* must stay literals.
@@ -30,7 +30,7 @@ const EXPECTED_MIN_LOBBY_PROTOCOL_FOR_DEFAULT_SCORING = 6;
 // here, so a full-game bump could ship with an unbumped P2P version and CI
 // stayed green — a v(n-1) host and a v(n) guest would then complete a
 // handshake and only fail when the incompatible payload arrived.
-const EXPECTED_WIRE_PROTOCOL_VERSION = 51;
+const EXPECTED_WIRE_PROTOCOL_VERSION = 52;
 
 function extractVersion(source, pattern, label) {
   const match = source.match(pattern);


### PR DESCRIPTION
Extra-turn effects dropped numeric quantities during parsing and emitted no authoritative creation event, so Time Stretch behaved like Time Warp and downstream accounting could not observe created turns. This preserves the quantity from Oracle text through resolution, emits one typed event per created turn, updates protocol consumers and analysis/AI traversal, and retains default-one save compatibility.

Validation:
- focused engine extra-turn suite: 50 passed
- cast integration: Time Warp and Time Stretch, 2 passed
- focused phase-ai extra-turn suite: 7 passed
- protocol tests: lobby 27 passed, server-core 90 passed, frontend/P2P 168 passed
- all-target clippy for affected Rust crates passed on the cumulative candidate
- independent Terra high final review: clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Extra-turn effects now support explicit and dynamic quantities, including instructions such as “take two extra turns.”
  - Extra-turn creation is tracked consistently across game state and event consumers.
  - AI evaluation now accounts for the number of extra turns granted.

- **Bug Fixes**
  - Improved parsing prevents unrelated “extra turn” wording from being misinterpreted.
  - Fixed duplicate application of coin-based quantity modifiers.
  - Invalid or excessively large extra-turn counts are rejected safely.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->