### PR TITLE
Preserve exploit victim filters across parsing and persistence

### DIFF
--- a/crates/engine/src/database/forge/cost.rs
+++ b/crates/engine/src/database/forge/cost.rs
@@ -1,4 +1,4 @@
-use crate::types::ability::{AbilityCost, QuantityExpr, TargetFilter};
+use crate::types::ability::{AbilityCost, QuantityExpr, SacrificeCost, TargetFilter};
 use crate::types::mana::{ManaCost, ManaCostShard};
 
 use super::filter::translate_filter;

--- a/crates/engine/src/database/forge/effect.rs
+++ b/crates/engine/src/database/forge/effect.rs
@@ -177,7 +177,10 @@ fn translate_draw(
     resolver: &mut SvarResolver,
 ) -> Result<Effect, ForgeTranslateError> {
     let count = resolve_quantity(params, "NumCards", resolver);
-    Ok(Effect::Draw { count })
+    Ok(Effect::Draw {
+        count,
+        target: TargetFilter::Controller,
+    })
 }
 
 // CR 119.1: Gain life.
@@ -605,8 +608,9 @@ mod tests {
         let mut resolver = make_resolver();
         let effect = translate_effect(&params, &mut resolver).unwrap();
         match effect {
-            Effect::Draw { count } => {
+            Effect::Draw { count, target } => {
                 assert_eq!(count, QuantityExpr::Fixed { value: 2 });
+                assert_eq!(target, TargetFilter::Controller);
             }
             other => panic!("expected Draw, got {other:?}"),
         }

--- a/crates/engine/src/database/forge/translate.rs
+++ b/crates/engine/src/database/forge/translate.rs
@@ -606,31 +606,73 @@ mod tests {
     }
 
     #[test]
-    fn rejected_exploited_forge_filter_does_not_replace_or_append() {
+    fn exploited_fallback_accepts_supported_filter_and_rejects_unsupported_filter() {
         let directory = tempfile::tempdir().expect("temporary Forge cards folder");
         fs::write(
             directory.path().join("card.txt"),
-            "Name:Test Card\nTypes:Creature\nT:Mode$ Exploited | ValidSource$ Creature.YouCtrl | ValidCard$ Creature.!token | Execute$ Payoff\nSVar:Payoff:DB$ Draw | NumCards$ 1\n",
+            "Name:Test Card\nTypes:Creature\nT:Mode$ Exploited | ValidSource$ Creature.YouCtrl | ValidCard$ Creature | Execute$ Payoff\nSVar:Payoff:DB$ Draw | NumCards$ 1\n",
         )
-        .expect("write Forge card script");
-        let index = ForgeIndex::scan(directory.path());
-        let mut face = CardFace {
+        .expect("write supported Forge card script");
+        let supported_index = ForgeIndex::scan(directory.path());
+        assert_eq!(
+            supported_index.len(),
+            1,
+            "the supported fixture reached a real Forge index"
+        );
+
+        let mut original_face = CardFace {
             name: "Test Card".to_string(),
             ..CardFace::default()
         };
-        let mut oracle = TriggerDefinition::new(crate::types::triggers::TriggerMode::Unknown(
-            "unsupported exploit clause".to_string(),
+        let mut oracle = TriggerDefinition::new(crate::types::triggers::TriggerMode::Exploited);
+        oracle.valid_source = Some(TargetFilter::Typed(
+            crate::types::ability::TypedFilter::creature()
+                .controller(crate::types::ability::ControllerRef::You),
+        ));
+        oracle.valid_card = Some(TargetFilter::Typed(
+            crate::types::ability::TypedFilter::creature()
+                .properties(vec![crate::types::ability::FilterProp::NonToken]),
         ));
         oracle.execute = Some(Box::new(AbilityDefinition::new(
             AbilityKind::Database,
             Effect::unimplemented("exploit", "unsupported exploit clause"),
         )));
-        face.triggers.push(oracle.clone());
+        original_face.triggers.push(oracle.clone());
 
-        apply_forge_fallback(&mut face, &index);
+        let mut supported_face = original_face.clone();
+        apply_forge_fallback(&mut supported_face, &supported_index);
 
-        assert_eq!(face.metadata.forge_triggers, 0);
-        assert_eq!(face.triggers, vec![oracle]);
+        assert_eq!(supported_face.metadata.forge_triggers, 1);
+        assert_eq!(supported_face.triggers[0].valid_source, oracle.valid_source);
+        assert_eq!(supported_face.triggers[0].valid_card, oracle.valid_card);
+        assert!(matches!(
+            supported_face.triggers[0]
+                .execute
+                .as_deref()
+                .map(|ability| ability.effect.as_ref()),
+            Some(Effect::Draw {
+                target: TargetFilter::Controller,
+                ..
+            })
+        ));
+
+        fs::write(
+            directory.path().join("card.txt"),
+            "Name:Test Card\nTypes:Creature\nT:Mode$ Exploited | ValidSource$ Creature.YouCtrl | ValidCard$ Creature.!token | Execute$ Payoff\nSVar:Payoff:DB$ Draw | NumCards$ 1\n",
+        )
+        .expect("write unsupported Forge card script");
+        let unsupported_index = ForgeIndex::scan(directory.path());
+        assert_eq!(
+            unsupported_index.len(),
+            1,
+            "the unsupported fixture reached a real Forge index"
+        );
+        let mut unsupported_face = original_face;
+
+        apply_forge_fallback(&mut unsupported_face, &unsupported_index);
+
+        assert_eq!(unsupported_face.metadata.forge_triggers, 0);
+        assert_eq!(unsupported_face.triggers, vec![oracle]);
     }
 
     #[test]

--- a/crates/engine/src/database/forge/translate.rs
+++ b/crates/engine/src/database/forge/translate.rs
@@ -409,6 +409,8 @@ fn replace_unimplemented_replacements(
 
 #[cfg(test)]
 mod tests {
+    use std::fs;
+
     use super::*;
 
     use crate::database::forge::loader::parse_params;
@@ -493,6 +495,7 @@ mod tests {
             AbilityKind::Spell,
             Effect::Draw {
                 count: crate::types::ability::QuantityExpr::Fixed { value: 1 },
+                target: TargetFilter::Controller,
             },
         );
 
@@ -505,5 +508,165 @@ mod tests {
         ));
         // Second ability (was Unimplemented) should now be Draw
         assert!(matches!(&*face.abilities[1].effect, Effect::Draw { .. }));
+    }
+
+    #[test]
+    fn exploited_fallback_replaces_only_execute_and_preserves_oracle_roles() {
+        let directory = tempfile::tempdir().expect("temporary Forge cardsfolder");
+        fs::write(
+            directory.path().join("card.txt"),
+            "Name:Test Card\nTypes:Creature\nT:Mode$ Exploited | ValidSource$ Creature.YouCtrl | ValidCard$ Creature | Execute$ Payoff\nSVar:Payoff:DB$ Draw | NumCards$ 1\n",
+        )
+        .expect("write Forge card script");
+        let index = ForgeIndex::scan(directory.path());
+        assert_eq!(
+            index.len(),
+            1,
+            "the fallback test reached a real Forge index"
+        );
+
+        let mut face = CardFace {
+            name: "Test Card".to_string(),
+            ..CardFace::default()
+        };
+        let mut oracle = TriggerDefinition::new(crate::types::triggers::TriggerMode::Exploited);
+        oracle.valid_source = Some(TargetFilter::Typed(
+            crate::types::ability::TypedFilter::creature()
+                .controller(crate::types::ability::ControllerRef::You),
+        ));
+        oracle.valid_card = Some(TargetFilter::Typed(
+            crate::types::ability::TypedFilter::creature()
+                .properties(vec![crate::types::ability::FilterProp::NonToken]),
+        ));
+        oracle.execute = Some(Box::new(AbilityDefinition::new(
+            AbilityKind::Database,
+            Effect::unimplemented("create", "create a Zombie token"),
+        )));
+        face.triggers.push(oracle.clone());
+
+        apply_forge_fallback(&mut face, &index);
+
+        assert_eq!(face.metadata.forge_triggers, 1);
+        assert_eq!(face.triggers[0].valid_source, oracle.valid_source);
+        assert_eq!(face.triggers[0].valid_card, oracle.valid_card);
+        assert!(matches!(
+            face.triggers[0]
+                .execute
+                .as_deref()
+                .map(|ability| ability.effect.as_ref()),
+            Some(Effect::Draw {
+                target: TargetFilter::Controller,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn exploited_fallback_appends_supported_translated_roles() {
+        let directory = tempfile::tempdir().expect("temporary Forge cards folder");
+        fs::write(
+            directory.path().join("card.txt"),
+            "Name:Test Card\nTypes:Creature\nT:Mode$ Exploited | ValidSource$ Creature.YouCtrl | ValidCard$ Creature.OppCtrl | Execute$ Payoff\nSVar:Payoff:DB$ Draw | NumCards$ 1\n",
+        )
+        .expect("write Forge card script");
+        let index = ForgeIndex::scan(directory.path());
+        let mut face = CardFace {
+            name: "Test Card".to_string(),
+            ..CardFace::default()
+        };
+
+        apply_forge_fallback(&mut face, &index);
+
+        assert_eq!(face.metadata.forge_triggers, 1);
+        assert_eq!(face.triggers.len(), 1);
+        assert_eq!(
+            face.triggers[0].valid_source,
+            Some(TargetFilter::Typed(
+                crate::types::ability::TypedFilter::creature()
+                    .controller(crate::types::ability::ControllerRef::You),
+            ))
+        );
+        assert_eq!(
+            face.triggers[0].valid_card,
+            Some(TargetFilter::Typed(
+                crate::types::ability::TypedFilter::creature()
+                    .controller(crate::types::ability::ControllerRef::Opponent),
+            ))
+        );
+        assert!(matches!(
+            face.triggers[0]
+                .execute
+                .as_deref()
+                .map(|ability| ability.effect.as_ref()),
+            Some(Effect::Draw {
+                target: TargetFilter::Controller,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn rejected_exploited_forge_filter_does_not_replace_or_append() {
+        let directory = tempfile::tempdir().expect("temporary Forge cards folder");
+        fs::write(
+            directory.path().join("card.txt"),
+            "Name:Test Card\nTypes:Creature\nT:Mode$ Exploited | ValidSource$ Creature.YouCtrl | ValidCard$ Creature.!token | Execute$ Payoff\nSVar:Payoff:DB$ Draw | NumCards$ 1\n",
+        )
+        .expect("write Forge card script");
+        let index = ForgeIndex::scan(directory.path());
+        let mut face = CardFace {
+            name: "Test Card".to_string(),
+            ..CardFace::default()
+        };
+        let mut oracle = TriggerDefinition::new(crate::types::triggers::TriggerMode::Unknown(
+            "unsupported exploit clause".to_string(),
+        ));
+        oracle.execute = Some(Box::new(AbilityDefinition::new(
+            AbilityKind::Database,
+            Effect::unimplemented("exploit", "unsupported exploit clause"),
+        )));
+        face.triggers.push(oracle.clone());
+
+        apply_forge_fallback(&mut face, &index);
+
+        assert_eq!(face.metadata.forge_triggers, 0);
+        assert_eq!(face.triggers, vec![oracle]);
+    }
+
+    #[test]
+    fn supported_oracle_exploit_filter_survives_rejected_forge_filter() {
+        let directory = tempfile::tempdir().expect("temporary Forge cards folder");
+        fs::write(
+            directory.path().join("card.txt"),
+            "Name:Test Card\nTypes:Creature\nT:Mode$ Exploited | ValidSource$ Creature.YouCtrl | ValidCard$ Creature.!token | Execute$ Payoff\nSVar:Payoff:DB$ Draw | NumCards$ 1\n",
+        )
+        .expect("write Forge card script");
+        let index = ForgeIndex::scan(directory.path());
+        let mut face = CardFace {
+            name: "Test Card".to_string(),
+            ..CardFace::default()
+        };
+        let mut oracle = TriggerDefinition::new(crate::types::triggers::TriggerMode::Exploited);
+        oracle.valid_source = Some(TargetFilter::Typed(
+            crate::types::ability::TypedFilter::creature()
+                .controller(crate::types::ability::ControllerRef::You),
+        ));
+        oracle.valid_card = Some(TargetFilter::Typed(
+            crate::types::ability::TypedFilter::creature()
+                .properties(vec![crate::types::ability::FilterProp::NonToken]),
+        ));
+        oracle.execute = Some(Box::new(AbilityDefinition::new(
+            AbilityKind::Database,
+            Effect::Draw {
+                count: crate::types::ability::QuantityExpr::Fixed { value: 1 },
+                target: TargetFilter::Controller,
+            },
+        )));
+        face.triggers.push(oracle.clone());
+
+        apply_forge_fallback(&mut face, &index);
+
+        assert_eq!(face.metadata.forge_triggers, 0);
+        assert_eq!(face.triggers, vec![oracle]);
     }
 }

--- a/crates/engine/src/database/forge/trigger.rs
+++ b/crates/engine/src/database/forge/trigger.rs
@@ -384,7 +384,14 @@ mod tests {
             "Victim".to_string(),
             Zone::Battlefield,
         );
-        for object_id in [actor, victim] {
+        let friendly_victim = create_object(
+            &mut state,
+            CardId(4),
+            PlayerId(0),
+            "Friendly Victim".to_string(),
+            Zone::Battlefield,
+        );
+        for object_id in [actor, victim, friendly_victim] {
             let object = state.objects.get_mut(&object_id).unwrap();
             object.card_types.core_types.push(CoreType::Creature);
             object.base_card_types = object.card_types.clone();
@@ -417,6 +424,33 @@ mod tests {
         state.objects.get_mut(&actor).unwrap().controller = PlayerId(1);
         assert!(!matcher(
             &event,
+            &trigger,
+            &test_trigger_source_context(&state, source),
+            &state,
+        ));
+
+        state.objects.get_mut(&actor).unwrap().controller = PlayerId(0);
+        let mut friendly_zone_events = Vec::new();
+        move_to_zone(
+            &mut state,
+            friendly_victim,
+            Zone::Graveyard,
+            &mut friendly_zone_events,
+        );
+        let friendly_record = friendly_zone_events
+            .iter()
+            .find_map(|event| match event {
+                GameEvent::ZoneChanged { record, .. } => Some(record.clone()),
+                _ => None,
+            })
+            .expect("the production move captured the friendly victim record");
+        let friendly_event = GameEvent::CreatureExploited {
+            exploiter: actor,
+            sacrificed: friendly_victim,
+            record: friendly_record,
+        };
+        assert!(!matcher(
+            &friendly_event,
             &trigger,
             &test_trigger_source_context(&state, source),
             &state,

--- a/crates/engine/src/database/forge/trigger.rs
+++ b/crates/engine/src/database/forge/trigger.rs
@@ -1,10 +1,32 @@
-use crate::types::ability::TriggerDefinition;
+use nom::branch::alt;
+use nom::bytes::complete::tag;
+use nom::combinator::{all_consuming, opt, recognize};
+use nom::sequence::preceded;
+use nom::Parser;
+
+use crate::types::ability::{TargetFilter, TriggerDefinition};
 use crate::types::triggers::TriggerMode;
 use crate::types::Zone;
 
 use super::filter::translate_filter;
 use super::svar::SvarResolver;
 use super::types::{ForgeAbilityLine, ForgeTranslateError};
+
+fn validate_exploited_filter(filter: &str) -> Result<&str, ForgeTranslateError> {
+    let filter = filter.trim();
+    let mut parser = all_consuming(alt((
+        tag::<_, _, nom::error::Error<&str>>("Any"),
+        tag("Card.Self"),
+        recognize((
+            tag("Creature"),
+            opt(preceded(tag("."), alt((tag("YouCtrl"), tag("OppCtrl"))))),
+        )),
+    )));
+    parser
+        .parse(filter)
+        .map(|(_, matched)| matched)
+        .map_err(|_| ForgeTranslateError::UnparsableFilter(filter.to_string()))
+}
 
 /// Translate a Forge `T:` line into a `TriggerDefinition`.
 ///
@@ -39,8 +61,25 @@ pub(crate) fn translate_trigger(
         }
     }
 
-    // ValidCard$ → valid_card filter
-    if let Some(filter_str) = params.get("ValidCard") {
+    if matches!(trigger.mode, TriggerMode::Exploited) {
+        if params.has("InvertValidSource") || params.has("InvertValidCard") {
+            return Err(ForgeTranslateError::Other(
+                "inverted Exploited filters are unsupported".to_string(),
+            ));
+        }
+
+        trigger.valid_source = Some(match params.get("ValidSource") {
+            Some(filter_str) => translate_filter(validate_exploited_filter(filter_str)?)?,
+            None => TargetFilter::Any,
+        });
+        trigger.valid_card = params
+            .get("ValidCard")
+            .map(validate_exploited_filter)
+            .transpose()?
+            .map(translate_filter)
+            .transpose()?;
+    } else if let Some(filter_str) = params.get("ValidCard") {
+        // ValidCard$ → valid_card filter for non-Exploited modes.
         if let Ok(filter) = translate_filter(filter_str) {
             trigger.valid_card = Some(filter);
         }
@@ -200,7 +239,14 @@ mod tests {
     use super::*;
     use crate::database::forge::loader::parse_params;
     use crate::database::forge::types::ForgeAbilityLine;
-    use crate::types::ability::TargetFilter;
+    use crate::game::trigger_matchers::{test_trigger_source_context, trigger_matcher};
+    use crate::game::zones::{create_object, move_to_zone};
+    use crate::types::ability::{ControllerRef, TargetFilter, TypedFilter};
+    use crate::types::card_type::CoreType;
+    use crate::types::events::GameEvent;
+    use crate::types::game_state::GameState;
+    use crate::types::identifiers::CardId;
+    use crate::types::player::PlayerId;
 
     fn make_resolver(svars: &[(&str, &str)]) -> SvarResolver<'static> {
         let map: HashMap<String, String> = svars
@@ -259,5 +305,121 @@ mod tests {
 
         assert_eq!(trigger.mode, TriggerMode::Drawn);
         assert_eq!(trigger.trigger_zones, vec![Zone::Battlefield]);
+    }
+
+    fn translate_exploited(raw: &str) -> Result<TriggerDefinition, ForgeTranslateError> {
+        let line = ForgeAbilityLine {
+            raw: raw.to_string(),
+            params: parse_params(raw),
+        };
+        let mut resolver = make_resolver(&[("TrigDraw", "DB$ Draw | NumCards$ 1")]);
+        translate_trigger(&line, &mut resolver)
+    }
+
+    #[test]
+    fn exploited_roles_are_strict_and_lossless() {
+        let trigger = translate_exploited(
+            "Mode$ Exploited | ValidSource$ Creature.YouCtrl | ValidCard$ Creature.OppCtrl | Execute$ TrigDraw",
+        )
+        .unwrap();
+        assert_eq!(
+            trigger.valid_source,
+            Some(TargetFilter::Typed(
+                TypedFilter::creature().controller(ControllerRef::You)
+            ))
+        );
+        assert_eq!(
+            trigger.valid_card,
+            Some(TargetFilter::Typed(
+                TypedFilter::creature().controller(ControllerRef::Opponent)
+            ))
+        );
+        assert!(trigger.execute.is_some());
+
+        let omitted = translate_exploited("Mode$ Exploited | Execute$ TrigDraw").unwrap();
+        assert_eq!(omitted.valid_source, Some(TargetFilter::Any));
+        assert_eq!(omitted.valid_card, None);
+
+        for invalid in [
+            "ValidSource$ ",
+            "ValidSource$ Creature.!token",
+            "ValidSource$ Creature.YouOwn",
+            "ValidSource$ Creature.YouCtrl.OppCtrl",
+            "ValidSource$ Creature,Card.Self",
+            "ValidCard$ Creature.nonHuman",
+            "ValidCard$ Creature.Unknown",
+            "InvertValidSource$ True",
+            "InvertValidCard$ True",
+        ] {
+            let raw = format!("Mode$ Exploited | {invalid} | Execute$ TrigDraw");
+            assert!(translate_exploited(&raw).is_err(), "accepted {raw}");
+        }
+    }
+
+    #[test]
+    fn translated_exploited_roles_reach_the_registered_matcher() {
+        let trigger = translate_exploited(
+            "Mode$ Exploited | ValidSource$ Creature.YouCtrl | ValidCard$ Creature.OppCtrl | Execute$ TrigDraw",
+        )
+        .unwrap();
+        let mut state = GameState::new_two_player(42);
+        let source = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Observer".to_string(),
+            Zone::Battlefield,
+        );
+        let actor = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(0),
+            "Exploiter".to_string(),
+            Zone::Battlefield,
+        );
+        let victim = create_object(
+            &mut state,
+            CardId(3),
+            PlayerId(1),
+            "Victim".to_string(),
+            Zone::Battlefield,
+        );
+        for object_id in [actor, victim] {
+            let object = state.objects.get_mut(&object_id).unwrap();
+            object.card_types.core_types.push(CoreType::Creature);
+            object.base_card_types = object.card_types.clone();
+        }
+
+        let mut zone_events = Vec::new();
+        move_to_zone(&mut state, victim, Zone::Graveyard, &mut zone_events);
+        let record = zone_events
+            .iter()
+            .find_map(|event| match event {
+                GameEvent::ZoneChanged { record, .. } => Some(record.clone()),
+                _ => None,
+            })
+            .expect("the production move captured the victim record");
+        let event = GameEvent::CreatureExploited {
+            exploiter: actor,
+            sacrificed: victim,
+            record,
+        };
+        let matcher = trigger_matcher(TriggerMode::Exploited)
+            .expect("Exploited has a registered runtime matcher");
+
+        assert!(matcher(
+            &event,
+            &trigger,
+            &test_trigger_source_context(&state, source),
+            &state,
+        ));
+
+        state.objects.get_mut(&actor).unwrap().controller = PlayerId(1);
+        assert!(!matcher(
+            &event,
+            &trigger,
+            &test_trigger_source_context(&state, source),
+            &state,
+        ));
     }
 }

--- a/crates/engine/src/game/effects/counters.rs
+++ b/crates/engine/src/game/effects/counters.rs
@@ -3135,7 +3135,9 @@ mod tests {
     use crate::types::identifiers::{CardId, ObjectId, ObjectIncarnationRef};
     use crate::types::player::PlayerId;
     use crate::types::replacements::ReplacementEvent;
-    use crate::types::resolution::{ResolutionFrame, ResolutionStateWire};
+    use crate::types::resolution::{
+        ResolutionFrame, ResolutionStateWire, RESOLUTION_STATE_WIRE_VERSION,
+    };
     use crate::types::zones::Zone;
 
     fn make_counter_ability(effect: Effect, target: ObjectId) -> ResolvedAbility {
@@ -5387,10 +5389,11 @@ mod tests {
 
     /// CR 616.1 + CR 122.5: a selected CounterMoves queue remains the sole
     /// runtime owner while each move's add stage chooses among noncommuting
-    /// counter replacements. The queue re-parks for every prompt and v2 restores
-    /// that real prompt boundary before production replacement actions resume it.
+    /// counter replacements. The queue re-parks for every prompt and the
+    /// current wire restores that real prompt boundary before production
+    /// replacement actions resume it.
     #[test]
-    fn counter_moves_queue_reparks_and_roundtrips_v2_at_replacement_choice() {
+    fn counter_moves_queue_reparks_and_roundtrips_current_wire_at_replacement_choice() {
         let mut state = GameState::new_two_player(42);
         let source_id = create_object(
             &mut state,
@@ -5455,11 +5458,14 @@ mod tests {
         );
 
         let saved = serde_json::to_value(ResolutionStateWire::from_game_state(state))
-            .expect("paused CounterMoves prompt serializes as v2");
-        assert_eq!(saved["resolution_state_version"], 2);
+            .expect("paused CounterMoves prompt serializes through the current wire");
+        assert_eq!(
+            saved["resolution_state_version"],
+            RESOLUTION_STATE_WIRE_VERSION
+        );
         assert!(saved.get("pending_counter_moves").is_none());
         let restored: ResolutionStateWire =
-            serde_json::from_value(saved).expect("v2 CounterMoves prompt restores");
+            serde_json::from_value(saved).expect("current CounterMoves prompt restores");
         let mut state = restored.into_game_state();
 
         for _ in 0..8 {
@@ -5499,10 +5505,11 @@ mod tests {
 
     /// CR 107.1c + CR 608.2h + CR 616.1: the production counter-removal choice
     /// parks its selected tail in CounterRemovals while each removal offers its
-    /// applicable optional replacement. v2 restores that real replacement prompt
-    /// before the production actions finish the queue and stamp its total.
+    /// applicable optional replacement. The current wire restores that real
+    /// replacement prompt before the production actions finish the queue and
+    /// stamp its total.
     #[test]
-    fn counter_removals_queue_reparks_and_roundtrips_v2_at_replacement_choice() {
+    fn counter_removals_queue_reparks_and_roundtrips_current_wire_at_replacement_choice() {
         let mut state = GameState::new_two_player(42);
         let source_id = create_object(
             &mut state,
@@ -5578,11 +5585,14 @@ mod tests {
         );
 
         let saved = serde_json::to_value(ResolutionStateWire::from_game_state(state))
-            .expect("paused CounterRemovals prompt serializes as v2");
-        assert_eq!(saved["resolution_state_version"], 2);
+            .expect("paused CounterRemovals prompt serializes through the current wire");
+        assert_eq!(
+            saved["resolution_state_version"],
+            RESOLUTION_STATE_WIRE_VERSION
+        );
         assert!(saved.get("pending_counter_removals").is_none());
         let restored: ResolutionStateWire =
-            serde_json::from_value(saved).expect("v2 CounterRemovals prompt restores");
+            serde_json::from_value(saved).expect("current CounterRemovals prompt restores");
         let mut state = restored.into_game_state();
 
         for replacement_index in 0..8 {
@@ -5817,10 +5827,10 @@ mod tests {
     /// CR 122.1 + CR 616.1: the production multi-target counter-addition
     /// resolver parks its remaining recipients and completion in CounterAdditions
     /// while each recipient's placement chooses among noncommuting replacements.
-    /// v2 restores that real prompt before production replacement actions finish
-    /// the queue.
+    /// The current wire restores that real prompt before production replacement
+    /// actions finish the queue.
     #[test]
-    fn counter_additions_queue_reparks_and_roundtrips_v2_at_replacement_choice() {
+    fn counter_additions_queue_reparks_and_roundtrips_current_wire_at_replacement_choice() {
         let mut state = GameState::new_two_player(42);
         install_noncommuting_counter_replacements(&mut state);
         let first = create_object(
@@ -5868,11 +5878,14 @@ mod tests {
         );
 
         let saved = serde_json::to_value(ResolutionStateWire::from_game_state(state))
-            .expect("paused CounterAdditions prompt serializes as v2");
-        assert_eq!(saved["resolution_state_version"], 2);
+            .expect("paused CounterAdditions prompt serializes through the current wire");
+        assert_eq!(
+            saved["resolution_state_version"],
+            RESOLUTION_STATE_WIRE_VERSION
+        );
         assert!(saved.get("pending_counter_additions").is_none());
         let restored: ResolutionStateWire =
-            serde_json::from_value(saved).expect("v2 CounterAdditions prompt restores");
+            serde_json::from_value(saved).expect("current CounterAdditions prompt restores");
         let mut state = restored.into_game_state();
 
         for _ in 0..8 {

--- a/crates/engine/src/game/effects/exploit.rs
+++ b/crates/engine/src/game/effects/exploit.rs
@@ -50,6 +50,7 @@ mod tests {
     use super::*;
     use crate::game::zones::create_object;
     use crate::types::ability::{Effect, TargetFilter};
+    use crate::types::card_type::CoreType;
     use crate::types::identifiers::{CardId, ObjectId};
     use crate::types::player::PlayerId;
     use crate::types::zones::Zone;
@@ -151,6 +152,11 @@ mod tests {
             "Sidisi's Faithful".to_string(),
             Zone::Battlefield,
         );
+        {
+            let object = state.objects.get_mut(&creature).unwrap();
+            object.card_types.core_types.push(CoreType::Creature);
+            object.base_card_types = object.card_types.clone();
+        }
 
         let mut trig_def = crate::parser::oracle_trigger::parse_trigger_line(
             "When Sidisi's Faithful exploits a creature, return target creature to its owner's hand.",

--- a/crates/engine/src/game/effects/exploit.rs
+++ b/crates/engine/src/game/effects/exploit.rs
@@ -90,13 +90,24 @@ mod tests {
         // Victim should be in graveyard
         assert!(state.players[0].graveyard.contains(&victim));
 
-        // Should have CreatureExploited event
-        assert!(events.iter().any(|e| matches!(
-            e,
+        let departure_record = events
+            .iter()
+            .find_map(|event| match event {
+                GameEvent::ZoneChanged {
+                    object_id, record, ..
+                } if *object_id == victim => Some(record),
+                _ => None,
+            })
+            .expect("the successful sacrifice emits a departure record");
+        assert!(events.iter().any(|event| matches!(
+            event,
             GameEvent::CreatureExploited {
-                exploiter: e_id,
-                sacrificed: s_id,
-            } if *e_id == exploiter && *s_id == victim
+                exploiter: event_exploiter,
+                sacrificed,
+                record,
+            } if *event_exploiter == exploiter
+                && *sacrificed == victim
+                && record == departure_record
         )));
     }
 

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -16772,7 +16772,9 @@ mod tests {
     use crate::types::mana::{ManaColor, ManaCost, ManaType, ManaUnit};
     use crate::types::phase::Phase;
     use crate::types::player::{PlayerCounterKind, PlayerId};
-    use crate::types::resolution::{OptionalEffectFrame, ResolutionStateWire};
+    use crate::types::resolution::{
+        OptionalEffectFrame, ResolutionStateWire, RESOLUTION_STATE_WIRE_VERSION,
+    };
     use crate::types::statics::CastFrequency;
     use crate::types::triggers::TriggerMode;
     use crate::types::zones::Zone;
@@ -18539,14 +18541,19 @@ mod tests {
         ));
         state.current_trigger_event = None;
 
-        let v2 = serde_json::to_value(ResolutionStateWire::from_game_state(state.clone()))
-            .expect("real optional-effect prompt serializes as v2");
-        assert_eq!(v2["resolution_state_version"], 2);
-        assert!(v2.get("pending_optional_effect").is_none());
-        assert!(v2.get("pending_optional_trigger_event").is_none());
-        assert!(v2.get("pending_optional_trigger_match_count").is_none());
-        state = serde_json::from_value::<ResolutionStateWire>(v2)
-            .expect("real optional-effect prompt round-trips through the v2 wire")
+        let current = serde_json::to_value(ResolutionStateWire::from_game_state(state.clone()))
+            .expect("real optional-effect prompt serializes through the current wire");
+        assert_eq!(
+            current["resolution_state_version"],
+            RESOLUTION_STATE_WIRE_VERSION
+        );
+        assert!(current.get("pending_optional_effect").is_none());
+        assert!(current.get("pending_optional_trigger_event").is_none());
+        assert!(current
+            .get("pending_optional_trigger_match_count")
+            .is_none());
+        state = serde_json::from_value::<ResolutionStateWire>(current)
+            .expect("real optional-effect prompt round-trips through the current wire")
             .into_game_state();
 
         crate::game::engine::apply(

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -10327,11 +10327,15 @@ fn record_announced_sacrifice(
 /// CR 701.21a: Derive terminal sacrifice bookkeeping from the actual events,
 /// not from attempts. This includes an event delivered by the replacement
 /// response immediately before the pending queue is drained.
+// The boxed records are cloned directly from `ZoneChanged` and moved into
+// `CreatureExploited`; retaining that allocation avoids an unbox/rebox copy at
+// this handoff.
+#[allow(clippy::vec_box)]
 fn record_sacrifice_batch_events(
     completion: &mut PendingPlayerScopeSacrificeCompletion,
     events: &[GameEvent],
-) -> Vec<ObjectId> {
-    let mut completed = Vec::new();
+) -> Vec<Box<ZoneChangeRecord>> {
+    let mut completed: Vec<Box<ZoneChangeRecord>> = Vec::new();
     for event in events {
         match event {
             GameEvent::PermanentSacrificed { object_id, .. }
@@ -10339,7 +10343,6 @@ fn record_sacrifice_batch_events(
                     && !completion.sacrificed.contains(object_id) =>
             {
                 completion.sacrificed.push(*object_id);
-                completed.push(*object_id);
                 if !completion.zone_changed.contains(object_id) {
                     completion.zone_changed.push(*object_id);
                 }
@@ -10357,7 +10360,6 @@ fn record_sacrifice_batch_events(
                 // announced sacrifice's terminal result.
                 if !completion.sacrificed.contains(object_id) {
                     completion.sacrificed.push(*object_id);
-                    completed.push(*object_id);
                 }
                 if !completion.zone_changed.contains(object_id) {
                     completion.zone_changed.push(*object_id);
@@ -10370,6 +10372,17 @@ fn record_sacrifice_batch_events(
                         .departed_zone_change_indices
                         .push(record.turn_zone_change_index);
                 }
+                // CR 603.2g + CR 702.110b: only the actual announced
+                // battlefield departure proves the creature was sacrificed as
+                // exploit resolved. `PermanentSacrificed` bookkeeping alone
+                // cannot fabricate the victim snapshot.
+                if !completion.followed_up_sacrifices.contains(object_id)
+                    && !completed
+                        .iter()
+                        .any(|completed_record| completed_record.object_id == *object_id)
+                {
+                    completed.push(record.clone());
+                }
             }
             _ => {}
         }
@@ -10381,16 +10394,18 @@ fn record_sacrifice_batch_events(
 /// follow-up only after the sacrifice event has completed. The completion ledger
 /// survives a replacement choice, so a resumed event is neither skipped nor
 /// emitted twice.
+#[allow(clippy::vec_box)]
 fn emit_sacrifice_batch_follow_ups(
     completion: &mut PendingPlayerScopeSacrificeCompletion,
-    completed: Vec<ObjectId>,
+    completed: Vec<Box<ZoneChangeRecord>>,
     events: &mut Vec<GameEvent>,
 ) {
     let Some(follow_up) = completion.follow_up.clone() else {
         return;
     };
 
-    for sacrificed in completed {
+    for record in completed {
+        let sacrificed = record.object_id;
         if completion.followed_up_sacrifices.contains(&sacrificed) {
             continue;
         }
@@ -10399,6 +10414,7 @@ fn emit_sacrifice_batch_follow_ups(
                 events.push(GameEvent::CreatureExploited {
                     exploiter,
                     sacrificed,
+                    record,
                 });
             }
         }
@@ -16470,6 +16486,128 @@ fn resolve_add_pending_enters_modifications(
 mod tests {
     use super::*;
     use crate::database::synthesis::synthesize_extort;
+
+    fn real_sacrifice_events() -> (ObjectId, ObjectId, Vec<GameEvent>, Box<ZoneChangeRecord>) {
+        let mut state = GameState::new_two_player(42);
+        let exploiter = create_object(
+            &mut state,
+            CardId(91),
+            PlayerId(0),
+            "Exploit source".to_string(),
+            Zone::Battlefield,
+        );
+        let victim = create_object(
+            &mut state,
+            CardId(92),
+            PlayerId(0),
+            "Exploit victim".to_string(),
+            Zone::Battlefield,
+        );
+        let victim_object = state.objects.get_mut(&victim).expect("victim exists");
+        victim_object.card_types.core_types.push(CoreType::Creature);
+        victim_object.base_card_types = victim_object.card_types.clone();
+        victim_object.is_token = true;
+        victim_object.controller = PlayerId(0);
+        victim_object.owner = PlayerId(1);
+
+        let mut events = Vec::new();
+        let outcome = crate::game::sacrifice::sacrifice_permanent(
+            &mut state,
+            victim,
+            PlayerId(0),
+            &mut events,
+        )
+        .expect("fixture sacrifice succeeds");
+        assert!(matches!(
+            outcome,
+            crate::game::sacrifice::SacrificeOutcome::Complete
+        ));
+        let record = events
+            .iter()
+            .find_map(|event| match event {
+                GameEvent::ZoneChanged {
+                    object_id, record, ..
+                } if *object_id == victim => Some(record.clone()),
+                _ => None,
+            })
+            .expect("successful sacrifice emits its departure record");
+        (exploiter, victim, events, record)
+    }
+
+    fn exploit_completion(
+        exploiter: ObjectId,
+        victim: ObjectId,
+    ) -> PendingPlayerScopeSacrificeCompletion {
+        PendingPlayerScopeSacrificeCompletion {
+            announced: vec![victim],
+            follow_up: Some(PendingPlayerScopeSacrificeFollowUp::Exploit { exploiter }),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn exploit_follow_up_uses_the_actual_departure_record_once_in_any_event_order() {
+        let (exploiter, victim, sacrifice_events, expected_record) = real_sacrifice_events();
+
+        for events in [sacrifice_events.clone(), {
+            let mut reversed = sacrifice_events.clone();
+            reversed.reverse();
+            reversed
+        }] {
+            let mut completion = exploit_completion(exploiter, victim);
+            let completed = record_sacrifice_batch_events(&mut completion, &events);
+            let mut emitted = Vec::new();
+            emit_sacrifice_batch_follow_ups(&mut completion, completed, &mut emitted);
+            assert_eq!(completion.sacrificed, vec![victim]);
+            assert_eq!(emitted.len(), 1);
+            assert!(matches!(
+                &emitted[0],
+                GameEvent::CreatureExploited {
+                    exploiter: event_exploiter,
+                    sacrificed,
+                    record,
+                } if *event_exploiter == exploiter
+                    && *sacrificed == victim
+                    && record == &expected_record
+            ));
+
+            let completed = record_sacrifice_batch_events(&mut completion, &events);
+            emit_sacrifice_batch_follow_ups(&mut completion, completed, &mut emitted);
+            assert_eq!(
+                emitted.len(),
+                1,
+                "repeated scans must not duplicate an exploit follow-up"
+            );
+        }
+    }
+
+    #[test]
+    fn exploit_follow_up_requires_an_announced_battlefield_departure_record() {
+        let (exploiter, victim, sacrifice_events, _) = real_sacrifice_events();
+        let permanent_sacrificed = sacrifice_events
+            .iter()
+            .find(|event| matches!(event, GameEvent::PermanentSacrificed { .. }))
+            .cloned()
+            .expect("successful sacrifice emits bookkeeping");
+
+        let mut completion = exploit_completion(exploiter, victim);
+        let completed = record_sacrifice_batch_events(
+            &mut completion,
+            std::slice::from_ref(&permanent_sacrificed),
+        );
+        let mut emitted = Vec::new();
+        emit_sacrifice_batch_follow_ups(&mut completion, completed, &mut emitted);
+        assert_eq!(completion.sacrificed, vec![victim]);
+        assert!(
+            emitted.is_empty(),
+            "bookkeeping without an actual departure cannot prove exploit"
+        );
+
+        let mut unannounced = exploit_completion(exploiter, ObjectId(victim.0 + 1));
+        let completed = record_sacrifice_batch_events(&mut unannounced, &sacrifice_events);
+        emit_sacrifice_batch_follow_ups(&mut unannounced, completed, &mut emitted);
+        assert!(emitted.is_empty());
+    }
 
     #[test]
     fn resolution_window_batch_reaches_a_chained_consumer() {

--- a/crates/engine/src/game/log.rs
+++ b/crates/engine/src/game/log.rs
@@ -1514,6 +1514,7 @@ fn format_segments(event: &GameEvent, state: &GameState) -> Vec<LogSegment> {
         GameEvent::CreatureExploited {
             exploiter,
             sacrificed,
+            ..
         } => vec![
             card_seg(state, *exploiter),
             text(" exploits "),

--- a/crates/engine/src/game/merge_tests.rs
+++ b/crates/engine/src/game/merge_tests.rs
@@ -1185,7 +1185,7 @@ mod cast_pipeline {
     use crate::types::mana::{ManaCost, ManaCostShard, ManaType, ManaUnit};
     use crate::types::phase::Phase;
     use crate::types::player::PlayerId;
-    use crate::types::resolution::ResolutionStateWire;
+    use crate::types::resolution::{ResolutionStateWire, RESOLUTION_STATE_WIRE_VERSION};
     use crate::types::zones::Zone;
 
     const P0: PlayerId = PlayerId(0);
@@ -1424,12 +1424,15 @@ mod cast_pipeline {
         );
         assert!(state.active_mutate_merge_frame().is_some());
 
-        let v2 = serde_json::to_value(ResolutionStateWire::from_game_state(state.clone()))
-            .expect("actual mutate-merge prompt serializes through the v2 wire boundary");
-        assert_eq!(v2["resolution_state_version"], 2);
-        assert!(v2.get("pending_mutate_merge").is_none());
+        let current = serde_json::to_value(ResolutionStateWire::from_game_state(state.clone()))
+            .expect("actual mutate-merge prompt serializes through the current wire boundary");
+        assert_eq!(
+            current["resolution_state_version"],
+            RESOLUTION_STATE_WIRE_VERSION
+        );
+        assert!(current.get("pending_mutate_merge").is_none());
         let restored: ResolutionStateWire =
-            serde_json::from_value(v2).expect("actual mutate-merge prompt restores from v2");
+            serde_json::from_value(current).expect("actual mutate-merge prompt restores");
         state = restored.into_game_state();
         assert!(state.active_mutate_merge_frame().is_some());
 

--- a/crates/engine/src/game/trigger_matchers.rs
+++ b/crates/engine/src/game/trigger_matchers.rs
@@ -17014,6 +17014,38 @@ mod tests {
     // CR 702.110b: `match_exploited` scopes the exploiter via `valid_card` /
     // `valid_source` rather than hard-coding `exploiter == source`.
 
+    fn exploit_event_from_real_departure(
+        state: &GameState,
+        exploiter: ObjectId,
+        sacrificed: ObjectId,
+    ) -> GameEvent {
+        let mut departure_state = state.clone();
+        let mut events = Vec::new();
+        crate::game::zones::move_to_zone(
+            &mut departure_state,
+            sacrificed,
+            Zone::Graveyard,
+            &mut events,
+        );
+        let record = events
+            .iter()
+            .find_map(|event| match event {
+                GameEvent::ZoneChanged {
+                    object_id,
+                    from: Some(Zone::Battlefield),
+                    record,
+                    ..
+                } if *object_id == sacrificed => Some(record.clone()),
+                _ => None,
+            })
+            .expect("the fixture's real battlefield departure emits a record");
+        GameEvent::CreatureExploited {
+            exploiter,
+            sacrificed,
+            record,
+        }
+    }
+
     #[test]
     fn exploited_self_ref_matches_self_exploit() {
         let mut state = setup();
@@ -17027,10 +17059,7 @@ mod tests {
         let mut trigger = make_trigger(TriggerMode::Exploited);
         trigger.valid_card = Some(TargetFilter::SelfRef);
 
-        let event = GameEvent::CreatureExploited {
-            exploiter: source,
-            sacrificed: source,
-        };
+        let event = exploit_event_from_real_departure(&state, source, source);
 
         assert!(match_exploited(
             &event,
@@ -17060,10 +17089,7 @@ mod tests {
         let mut trigger = make_trigger(TriggerMode::Exploited);
         trigger.valid_card = Some(TargetFilter::SelfRef);
 
-        let event = GameEvent::CreatureExploited {
-            exploiter: other,
-            sacrificed: other,
-        };
+        let event = exploit_event_from_real_departure(&state, other, other);
 
         assert!(!match_exploited(
             &event,
@@ -17105,10 +17131,7 @@ mod tests {
             TypedFilter::creature().controller(ControllerRef::You),
         ));
 
-        let event = GameEvent::CreatureExploited {
-            exploiter: other,
-            sacrificed: other,
-        };
+        let event = exploit_event_from_real_departure(&state, other, other);
 
         assert!(match_exploited(
             &event,
@@ -17132,10 +17155,7 @@ mod tests {
         assert!(trigger.valid_card.is_none());
         assert!(trigger.valid_source.is_none());
 
-        let event = GameEvent::CreatureExploited {
-            exploiter: source,
-            sacrificed: source,
-        };
+        let event = exploit_event_from_real_departure(&state, source, source);
 
         assert!(match_exploited(
             &event,
@@ -17184,12 +17204,26 @@ mod tests {
             .push(CoreType::Creature);
 
         // Real zone-change pipeline: snapshots LKI and strips the graveyard object.
-        crate::game::zones::move_to_zone(&mut state, source, Zone::Graveyard, &mut Vec::new());
+        let mut departure_events = Vec::new();
+        crate::game::zones::move_to_zone(
+            &mut state,
+            source,
+            Zone::Graveyard,
+            &mut departure_events,
+        );
         assert!(state.lki_cache.contains_key(&source));
 
+        let record = departure_events
+            .iter()
+            .find_map(|event| match event {
+                GameEvent::ZoneChanged { record, .. } => Some(record.clone()),
+                _ => None,
+            })
+            .expect("the self-sacrifice fixture emits a departure record");
         let event = GameEvent::CreatureExploited {
             exploiter: source,
             sacrificed: source,
+            record,
         };
 
         let mut you = make_trigger(TriggerMode::Exploited);
@@ -17251,7 +17285,8 @@ mod tests {
         }
 
         // Real zone-change pipeline: snapshots LKI on battlefield exit.
-        crate::game::zones::move_to_zone(&mut state, token, Zone::Graveyard, &mut Vec::new());
+        let mut departure_events = Vec::new();
+        crate::game::zones::move_to_zone(&mut state, token, Zone::Graveyard, &mut departure_events);
         assert!(state.lki_cache.contains_key(&token));
         // CR 111.7: the token ceases to exist — purged from `state.objects` before the
         // exploit trigger's filter is evaluated.
@@ -17264,9 +17299,17 @@ mod tests {
 
         // The token exploited ITSELF: it is both the exploiter (subject) and the trigger's
         // own source (context).
+        let record = departure_events
+            .iter()
+            .find_map(|event| match event {
+                GameEvent::ZoneChanged { record, .. } => Some(record.clone()),
+                _ => None,
+            })
+            .expect("the token self-sacrifice fixture emits a departure record");
         let event = GameEvent::CreatureExploited {
             exploiter: token,
             sacrificed: token,
+            record,
         };
 
         let mut you = make_trigger(TriggerMode::Exploited);

--- a/crates/engine/src/game/trigger_matchers.rs
+++ b/crates/engine/src/game/trigger_matchers.rs
@@ -3585,11 +3585,12 @@ pub(super) fn match_foretell(
     }
 }
 
-/// CR 702.110b: "exploits a creature" — fires when a creature matching the
-/// trigger's subject filter exploits. `valid_card`/`valid_source` scope the
-/// EXPLOITER: `SelfRef` ⇒ "this creature exploits", a typed/controller
-/// filter ⇒ "a creature you control exploits". With no filter, defaults to
-/// the source ("this creature exploits").
+/// CR 702.110b + CR 603.10a + CR 400.7 + CR 111.7: "exploits a creature"
+/// fires when the actor in `CreatureExploited.exploiter` matches `valid_source`
+/// and the sacrificed victim's captured battlefield appearance matches
+/// `valid_card`. The departure record remains authoritative after the victim
+/// changes zones or a token ceases to exist. With no actor filter, the actor
+/// defaults to the trigger source ("this creature exploits").
 pub(super) fn match_exploited(
     event: &GameEvent,
     trigger: &TriggerDefinition,
@@ -3597,19 +3598,25 @@ pub(super) fn match_exploited(
     state: &GameState,
 ) -> bool {
     let source_id = source_event_subject_id(source_context);
-    let GameEvent::CreatureExploited { exploiter, .. } = event else {
+    let GameEvent::CreatureExploited {
+        exploiter, record, ..
+    } = event
+    else {
         return false;
     };
-    // `valid_source`/`valid_card` scope the EXPLOITER's subject filter. With no
-    // filter, "this creature exploits" — match the source by identity.
-    match trigger
-        .valid_source
-        .as_ref()
-        .or(trigger.valid_card.as_ref())
-    {
+    let actor_matches = match trigger.valid_source.as_ref() {
         Some(filter) => exploiter_matches_subject_filter(state, *exploiter, filter, source_context),
         None => *exploiter == source_id,
-    }
+    };
+    actor_matches
+        && trigger.valid_card.as_ref().is_none_or(|filter| {
+            super::filter::matches_target_filter_on_zone_change_record(
+                state,
+                record,
+                filter,
+                &super::filter::FilterContext::from_trigger_source(source_context),
+            )
+        })
 }
 
 /// CR 603.10a + CR 400.7: Match an exploiter against the trigger's subject
@@ -17011,8 +17018,8 @@ mod tests {
         assert_eq!(count, None);
     }
 
-    // CR 702.110b: `match_exploited` scopes the exploiter via `valid_card` /
-    // `valid_source` rather than hard-coding `exploiter == source`.
+    // CR 702.110b: `match_exploited` scopes the actor via `valid_source` and
+    // the sacrificed victim via `valid_card`.
 
     fn exploit_event_from_real_departure(
         state: &GameState,
@@ -17057,7 +17064,7 @@ mod tests {
             Zone::Battlefield,
         );
         let mut trigger = make_trigger(TriggerMode::Exploited);
-        trigger.valid_card = Some(TargetFilter::SelfRef);
+        trigger.valid_source = Some(TargetFilter::SelfRef);
 
         let event = exploit_event_from_real_departure(&state, source, source);
 
@@ -17087,7 +17094,7 @@ mod tests {
             Zone::Battlefield,
         );
         let mut trigger = make_trigger(TriggerMode::Exploited);
-        trigger.valid_card = Some(TargetFilter::SelfRef);
+        trigger.valid_source = Some(TargetFilter::SelfRef);
 
         let event = exploit_event_from_real_departure(&state, other, other);
 
@@ -17127,7 +17134,7 @@ mod tests {
             .push(CoreType::Creature);
 
         let mut trigger = make_trigger(TriggerMode::Exploited);
-        trigger.valid_card = Some(TargetFilter::Typed(
+        trigger.valid_source = Some(TargetFilter::Typed(
             TypedFilter::creature().controller(ControllerRef::You),
         ));
 
@@ -17139,6 +17146,147 @@ mod tests {
             &test_trigger_source_context(&state, source),
             &state
         ));
+    }
+
+    #[test]
+    fn exploited_victim_filter_uses_departure_record_after_live_identity_changes() {
+        let mut state = setup();
+        let source = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Exploit Payoff".to_string(),
+            Zone::Battlefield,
+        );
+        let actor = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(0),
+            "Exploiter".to_string(),
+            Zone::Battlefield,
+        );
+        let victim = create_object(
+            &mut state,
+            CardId(3),
+            PlayerId(0),
+            "Victim Token".to_string(),
+            Zone::Battlefield,
+        );
+        for id in [actor, victim] {
+            let object = state.objects.get_mut(&id).unwrap();
+            object.card_types.core_types.push(CoreType::Creature);
+            object.base_card_types = object.card_types.clone();
+        }
+        state.objects.get_mut(&victim).unwrap().is_token = true;
+
+        let event = exploit_event_from_real_departure(&state, actor, victim);
+        let GameEvent::CreatureExploited { record, .. } = &event else {
+            unreachable!()
+        };
+        assert!(record.is_token);
+
+        let mut creature = make_trigger(TriggerMode::Exploited);
+        creature.valid_source = Some(TargetFilter::Typed(
+            TypedFilter::creature().controller(ControllerRef::You),
+        ));
+        creature.valid_card = Some(TargetFilter::Typed(TypedFilter::creature()));
+        let context = test_trigger_source_context(&state, source);
+        assert!(match_exploited(&event, &creature, &context, &state));
+
+        let mut nontoken = creature.clone();
+        nontoken.valid_card = Some(TargetFilter::Typed(
+            TypedFilter::creature().properties(vec![crate::types::ability::FilterProp::NonToken]),
+        ));
+        assert!(!match_exploited(&event, &nontoken, &context, &state));
+
+        state.objects.remove(&victim);
+        let replacement = create_object(
+            &mut state,
+            CardId(4),
+            PlayerId(0),
+            "Contradictory Live Object".to_string(),
+            Zone::Battlefield,
+        );
+        let mut replacement_object = state.objects.remove(&replacement).unwrap();
+        replacement_object.id = victim;
+        replacement_object
+            .card_types
+            .core_types
+            .push(CoreType::Creature);
+        replacement_object.is_token = false;
+        state.objects.insert(victim, replacement_object);
+
+        assert!(match_exploited(&event, &creature, &context, &state));
+        assert!(!match_exploited(&event, &nontoken, &context, &state));
+    }
+
+    #[test]
+    fn exploited_victim_filter_composes_subtype_negation_and_controller() {
+        let mut state = setup();
+        let source = create_object(
+            &mut state,
+            CardId(10),
+            PlayerId(0),
+            "Henry Wu".to_string(),
+            Zone::Battlefield,
+        );
+        let actor = create_object(
+            &mut state,
+            CardId(11),
+            PlayerId(0),
+            "Exploiter".to_string(),
+            Zone::Battlefield,
+        );
+        let human = create_object(
+            &mut state,
+            CardId(12),
+            PlayerId(1),
+            "Human Victim".to_string(),
+            Zone::Battlefield,
+        );
+        let zombie = create_object(
+            &mut state,
+            CardId(13),
+            PlayerId(1),
+            "Non-Human Victim".to_string(),
+            Zone::Battlefield,
+        );
+        for id in [actor, human, zombie] {
+            let object = state.objects.get_mut(&id).unwrap();
+            object.card_types.core_types.push(CoreType::Creature);
+            object.base_card_types = object.card_types.clone();
+        }
+        state
+            .objects
+            .get_mut(&human)
+            .unwrap()
+            .card_types
+            .subtypes
+            .push("Human".to_string());
+        state
+            .objects
+            .get_mut(&zombie)
+            .unwrap()
+            .card_types
+            .subtypes
+            .push("Zombie".to_string());
+
+        let mut trigger = make_trigger(TriggerMode::Exploited);
+        trigger.valid_source = Some(TargetFilter::Typed(
+            TypedFilter::creature().controller(ControllerRef::You),
+        ));
+        trigger.valid_card = Some(TargetFilter::Typed(
+            TypedFilter::creature()
+                .with_type(crate::types::ability::TypeFilter::Non(Box::new(
+                    crate::types::ability::TypeFilter::Subtype("Human".to_string()),
+                )))
+                .controller(ControllerRef::Opponent),
+        ));
+        let context = test_trigger_source_context(&state, source);
+        let nonhuman_event = exploit_event_from_real_departure(&state, actor, zombie);
+        let human_event = exploit_event_from_real_departure(&state, actor, human);
+        assert!(match_exploited(&nonhuman_event, &trigger, &context, &state));
+        assert!(!match_exploited(&human_event, &trigger, &context, &state));
     }
 
     #[test]
@@ -17227,7 +17375,7 @@ mod tests {
         };
 
         let mut you = make_trigger(TriggerMode::Exploited);
-        you.valid_card = Some(TargetFilter::Typed(
+        you.valid_source = Some(TargetFilter::Typed(
             TypedFilter::creature().controller(ControllerRef::You),
         ));
         assert!(
@@ -17241,7 +17389,7 @@ mod tests {
         );
 
         let mut opponent = make_trigger(TriggerMode::Exploited);
-        opponent.valid_card = Some(TargetFilter::Typed(
+        opponent.valid_source = Some(TargetFilter::Typed(
             TypedFilter::creature().controller(ControllerRef::Opponent),
         ));
         assert!(
@@ -17313,7 +17461,7 @@ mod tests {
         };
 
         let mut you = make_trigger(TriggerMode::Exploited);
-        you.valid_card = Some(TargetFilter::Typed(
+        you.valid_source = Some(TargetFilter::Typed(
             TypedFilter::creature().controller(ControllerRef::You),
         ));
         assert!(
@@ -17328,7 +17476,7 @@ mod tests {
         );
 
         let mut opponent = make_trigger(TriggerMode::Exploited);
-        opponent.valid_card = Some(TargetFilter::Typed(
+        opponent.valid_source = Some(TargetFilter::Typed(
             TypedFilter::creature().controller(ControllerRef::Opponent),
         ));
         assert!(

--- a/crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+++ b/crates/engine/src/parser/oracle_ir/snapshot_tests.rs
@@ -12,7 +12,8 @@ use crate::parser::oracle_ir::trigger::TriggerNodeIr;
 use crate::parser::{parse_oracle_text, parse_oracle_text_traced};
 use crate::types::ability::MultiTargetSpec;
 use crate::types::ability::{
-    AbilityCost, ActivationRestriction, Effect, TargetChoiceTiming, TriggerCondition,
+    AbilityCost, ActivationRestriction, ControllerRef, Effect, FilterProp, TargetChoiceTiming,
+    TargetFilter, TriggerCondition, TypedFilter,
 };
 use crate::types::game_state::DistributionUnit;
 
@@ -84,6 +85,24 @@ fn parser_trace_uses_production_output_and_records_real_item_routes() {
         traced.events.len(),
         "one outer event per emitted item"
     );
+    let exploit = ordinary
+        .triggers
+        .iter()
+        .find(|trigger| trigger.mode == crate::types::triggers::TriggerMode::Exploited)
+        .expect("Skull Skaab exploit payoff trigger");
+    assert_eq!(
+        exploit.valid_source,
+        Some(TargetFilter::Typed(
+            TypedFilter::creature().controller(ControllerRef::You)
+        ))
+    );
+    assert!(matches!(
+        exploit.valid_card.as_ref(),
+        Some(TargetFilter::Typed(filter)) if filter.properties.contains(&FilterProp::NonToken)
+    ));
+    assert!(!ability_has_unimplemented(
+        exploit.execute.as_deref().expect("Skull Skaab payoff")
+    ));
 }
 
 #[test]
@@ -95,6 +114,64 @@ fn parser_trace_skull_skaab_pair_preserves_input_difference_and_omits_trigger_ca
     let subtypes = vec!["Zombie".to_string()];
     let left = parse_oracle_text_traced(left_text, "Skull Skaab", &keywords, &types, &subtypes);
     let right = parse_oracle_text_traced(right_text, "A-Skull Skaab", &keywords, &types, &subtypes);
+    let (left_ir, left_lowered) = parse_two_layer_with_keywords(
+        left_text,
+        "Skull Skaab",
+        &["Exploit"],
+        &["Creature"],
+        &["Zombie"],
+    );
+    let (right_ir, right_lowered) = parse_two_layer_with_keywords(
+        right_text,
+        "A-Skull Skaab",
+        &["Exploit"],
+        &["Creature"],
+        &["Zombie"],
+    );
+
+    for (ir, expects_nontoken) in [(&left_ir, true), (&right_ir, false)] {
+        let parsed = ir
+            .items
+            .iter()
+            .find_map(|item| match &item.node {
+                OracleNodeIr::Trigger(TriggerNodeIr::Parsed(trigger))
+                    if trigger.partial_def.mode
+                        == crate::types::triggers::TriggerMode::Exploited =>
+                {
+                    Some(trigger)
+                }
+                _ => None,
+            })
+            .expect("typed Exploited TriggerIr");
+        assert_eq!(
+            parsed.partial_def.valid_source,
+            Some(TargetFilter::Typed(
+                TypedFilter::creature().controller(ControllerRef::You)
+            ))
+        );
+        assert_eq!(
+            matches!(
+                parsed.partial_def.valid_card.as_ref(),
+                Some(TargetFilter::Typed(filter))
+                    if filter.properties.contains(&FilterProp::NonToken)
+            ),
+            expects_nontoken
+        );
+    }
+
+    assert_eq!(
+        serde_json::to_value(&left.production_output).unwrap(),
+        serde_json::to_value(&left_lowered).unwrap()
+    );
+    assert_eq!(
+        serde_json::to_value(&right.production_output).unwrap(),
+        serde_json::to_value(&right_lowered).unwrap()
+    );
+    let mut left_projection = serde_json::to_value(&left_lowered).unwrap();
+    let mut right_projection = serde_json::to_value(&right_lowered).unwrap();
+    crate::parser::audit_projection::omit_definition_descriptions(&mut left_projection);
+    crate::parser::audit_projection::omit_definition_descriptions(&mut right_projection);
+    assert_ne!(left_projection, right_projection);
 
     assert_ne!(left.normalized_source, right.normalized_source);
     assert!(left

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -13126,8 +13126,9 @@ fn try_parse_event(
         BecomesMonstrous,
         BecomesRenowned,
         Mutates,
-        ExploitsCreature,
-        Exploits,
+        Exploits {
+            victim: Option<TargetFilter>,
+        },
         /// CR 701.44b: A permanent "explores" after the explore process completes.
         Explores,
         /// CR 701.50f: A permanent "connives" after the connive process completes.
@@ -13165,6 +13166,34 @@ fn try_parse_event(
             )));
         }
         Ok((rest, SimpleEvent::BecomesUnattached(Some(filter))))
+    }
+    fn parse_exploit_victim(input: &str) -> OracleResult<'_, TargetFilter> {
+        let (filter, remaining) = parse_type_phrase_folding(input);
+        if matches!(filter, TargetFilter::Any) || remaining.len() == input.len() {
+            return Err(nom::Err::Error(OracleError::new(
+                input,
+                nom::error::ErrorKind::Verify,
+            )));
+        }
+        Ok((remaining, filter))
+    }
+    /// CR 702.110b + CR 603.2: an exploit event distinguishes the creature
+    /// performing exploit from the creature sacrificed as the ability resolves.
+    fn parse_exploits_event(input: &str) -> OracleResult<'_, SimpleEvent> {
+        let (remaining, _) = tag("exploits").parse(input)?;
+        if remaining.is_empty() {
+            return Ok((remaining, SimpleEvent::Exploits { victim: None }));
+        }
+
+        let (victim_text, _) =
+            preceded(space1, terminated(alt((tag("a"), tag("an"))), space1)).parse(remaining)?;
+        let (_, victim) = all_consuming(parse_exploit_victim).parse(victim_text)?;
+        Ok((
+            "",
+            SimpleEvent::Exploits {
+                victim: Some(victim),
+            },
+        ))
     }
     /// CR 120.4 + CR 120.4b: the source-scoping tail on the received-damage
     /// grammar — `"…by a single source"` (Pain Magnification). It narrows the
@@ -13349,9 +13378,7 @@ fn try_parse_event(
                 (tag("becomes"), space1, tag("renowned")),
             ),
             value(SimpleEvent::Mutates, tag("mutates")),
-            // CR 702.110b: "exploits a creature" — exploit trigger
-            value(SimpleEvent::ExploitsCreature, tag("exploits a creature")),
-            value(SimpleEvent::Exploits, tag("exploits")),
+            parse_exploits_event,
             // CR 701.44b: "explores" / "explore" — explore trigger
             value(SimpleEvent::Explores, tag("explores")),
             value(SimpleEvent::Explores, tag("explore")),
@@ -13604,9 +13631,10 @@ fn try_parse_event(
                 def.mode = TriggerMode::Mutates;
                 def.valid_card = Some(subject.clone());
             }
-            SimpleEvent::ExploitsCreature | SimpleEvent::Exploits => {
+            SimpleEvent::Exploits { victim } => {
                 def.mode = TriggerMode::Exploited;
-                def.valid_card = Some(subject.clone());
+                def.valid_source = Some(subject.clone());
+                def.valid_card = victim;
             }
             SimpleEvent::Explores => {
                 if !remaining.trim().is_empty() {

--- a/crates/engine/src/parser/oracle_trigger_tests.rs
+++ b/crates/engine/src/parser/oracle_trigger_tests.rs
@@ -5054,11 +5054,153 @@ fn trigger_pack_tactics() {
 
 #[test]
 fn trigger_exploits_a_creature() {
-    let def = parse_trigger_line(
-        "When Sidisi's Faithful exploits a creature, return target creature to its owner's hand.",
-        "Sidisi's Faithful",
+    let controlled_creature =
+        TargetFilter::Typed(TypedFilter::creature().controller(ControllerRef::You));
+    let creature = TargetFilter::Typed(TypedFilter::creature());
+    let cases = [
+        (
+            "When Sidisi's Faithful exploits a creature, return target creature to its owner's hand.",
+            TargetFilter::SelfRef,
+            Some(creature.clone()),
+        ),
+        (
+            "Whenever a creature you control exploits a creature, draw a card.",
+            controlled_creature.clone(),
+            Some(creature),
+        ),
+        (
+            "Whenever a creature you control exploits a nontoken creature, draw a card.",
+            controlled_creature.clone(),
+            Some(TargetFilter::Typed(
+                TypedFilter::creature().properties(vec![FilterProp::NonToken]),
+            )),
+        ),
+        (
+            "Whenever a creature you control exploits a non-Human creature, draw a card.",
+            controlled_creature,
+            Some(TargetFilter::Typed(
+                TypedFilter::creature()
+                    .with_type(TypeFilter::Non(Box::new(TypeFilter::Subtype("Human".to_string())))),
+            )),
+        ),
+        (
+            "When Sidisi's Faithful exploits, draw a card.",
+            TargetFilter::SelfRef,
+            None,
+        ),
+    ];
+
+    for (oracle, actor, victim) in cases {
+        let def = parse_trigger_line(oracle, "Sidisi's Faithful");
+        assert_eq!(def.mode, TriggerMode::Exploited, "{oracle}");
+        assert_eq!(def.valid_source, Some(actor), "{oracle}");
+        assert_eq!(def.valid_card, victim, "{oracle}");
+    }
+
+    let supported = parse_trigger_line(
+        "Whenever a creature you control exploits a creature, draw a card.",
+        "Exploit Payoff",
     );
-    assert_eq!(def.mode, TriggerMode::Exploited);
+    assert_eq!(supported.mode, TriggerMode::Exploited);
+    assert_no_unimplemented(supported.execute.as_deref().expect("trigger body"));
+
+    let unsupported = parse_trigger_line(
+        "Whenever a creature you control exploits a creature with an unsupported quality, draw a card.",
+        "Exploit Payoff",
+    );
+    assert!(matches!(unsupported.mode, TriggerMode::Unknown(_)));
+}
+
+#[test]
+fn exploit_real_cards_preserve_actor_victim_and_payoff_target_roles() {
+    const SKULL: &str = "Exploit (When this creature enters, you may sacrifice a creature.)\nWhenever a creature you control exploits a nontoken creature, create a 2/2 black Zombie creature token.";
+    const A_SKULL: &str = "Exploit (When this creature enters, you may sacrifice a creature.)\nWhenever a creature you control exploits a creature, create a 2/2 black Zombie creature token.";
+    const HENRY: &str = "Henry Wu and other Human creatures you control have exploit. (When a creature with exploit enters, you may sacrifice a creature.)\nWhenever a creature you control exploits a non-Human creature, draw a card. If the exploited creature had power 3 or greater, create a Treasure token.";
+    const FELL: &str = "Deathtouch\nExploit (When this creature enters, you may sacrifice a creature.)\nWhen this creature exploits a creature, target player draws two cards and loses 2 life.";
+
+    let parse = |oracle: &str, name: &str, keywords: &[&str], subtypes: &[&str]| {
+        parse_oracle_text(
+            oracle,
+            name,
+            &keywords
+                .iter()
+                .map(|value| (*value).to_string())
+                .collect::<Vec<_>>(),
+            &["Creature".to_string()],
+            &subtypes
+                .iter()
+                .map(|value| (*value).to_string())
+                .collect::<Vec<_>>(),
+        )
+    };
+    let skull = parse(SKULL, "Skull Skaab", &["Exploit"], &["Zombie"]);
+    let a_skull = parse(A_SKULL, "A-Skull Skaab", &["Exploit"], &["Zombie"]);
+    let henry = parse(
+        HENRY,
+        "Henry Wu, InGen Geneticist",
+        &[],
+        &["Human", "Scientist"],
+    );
+    let fell = parse(
+        FELL,
+        "Fell Stinger",
+        &["Deathtouch", "Exploit"],
+        &["Zombie", "Scorpion"],
+    );
+
+    fn exploit_trigger(parsed: &crate::parser::oracle::ParsedAbilities) -> &TriggerDefinition {
+        parsed
+            .triggers
+            .iter()
+            .find(|trigger| trigger.mode == TriggerMode::Exploited)
+            .expect("Exploited trigger")
+    }
+    let skull_trigger = exploit_trigger(&skull);
+    let a_skull_trigger = exploit_trigger(&a_skull);
+    assert_eq!(skull_trigger.valid_source, a_skull_trigger.valid_source);
+    assert_eq!(
+        skull_trigger.valid_source,
+        Some(TargetFilter::Typed(
+            TypedFilter::creature().controller(ControllerRef::You)
+        ))
+    );
+    assert!(matches!(
+        skull_trigger.valid_card.as_ref(),
+        Some(TargetFilter::Typed(filter)) if filter.properties.contains(&FilterProp::NonToken)
+    ));
+    assert_eq!(
+        a_skull_trigger.valid_card,
+        Some(TargetFilter::Typed(TypedFilter::creature()))
+    );
+    for trigger in [skull_trigger, a_skull_trigger] {
+        assert_no_unimplemented(trigger.execute.as_deref().expect("payoff"));
+    }
+
+    let henry_trigger = exploit_trigger(&henry);
+    assert!(matches!(
+        henry_trigger.valid_card.as_ref(),
+        Some(TargetFilter::Typed(filter))
+            if filter.type_filters.contains(&TypeFilter::Non(Box::new(TypeFilter::Subtype("Human".to_string()))))
+    ));
+
+    let fell_trigger = exploit_trigger(&fell);
+    assert_eq!(fell_trigger.valid_source, Some(TargetFilter::SelfRef));
+    assert_eq!(
+        fell_trigger.valid_card,
+        Some(TargetFilter::Typed(TypedFilter::creature()))
+    );
+    let execute = fell_trigger
+        .execute
+        .as_deref()
+        .expect("Fell Stinger payoff");
+    assert_no_unimplemented(execute);
+    assert!(matches!(
+        execute.effect.as_ref(),
+        Effect::Draw {
+            target: TargetFilter::Player,
+            ..
+        }
+    ));
 }
 
 #[test]

--- a/crates/engine/src/types/events.rs
+++ b/crates/engine/src/types/events.rs
@@ -1670,10 +1670,14 @@ pub enum GameEvent {
         is_mana_ability: bool,
     },
 
-    /// CR 702.110: A creature exploited another creature (sacrificed via exploit ETB).
+    /// CR 702.110b + CR 603.10a + CR 400.7: A creature exploited another
+    /// creature. `exploiter` identifies the actor, while `record` preserves the
+    /// sacrificed victim's exact pre-departure characteristics for later
+    /// trigger matching after the victim has become a new object.
     CreatureExploited {
         exploiter: ObjectId,
         sacrificed: ObjectId,
+        record: Box<ZoneChangeRecord>,
     },
     /// CR 122.1: A player's energy counter total changed.
     EnergyChanged {

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -19797,6 +19797,78 @@ pub(crate) enum GameStateDecodeMode {
 /// restore caller from silently becoming a second compatibility boundary.
 pub(crate) struct GameStateDecode;
 
+const LEGACY_EXPLOIT_EVENT_EVIDENCE_ERROR: &str =
+    "CreatureExploited snapshot lacks authoritative victim record; restore a save that contains the exploit departure record";
+
+fn reject_legacy_exploit_event_evidence(value: &serde_json::Value) -> Result<(), String> {
+    fn reject(path: &str, reason: &str) -> Result<(), String> {
+        Err(format!(
+            "{LEGACY_EXPLOIT_EVENT_EVIDENCE_ERROR} at {path}: {reason}"
+        ))
+    }
+
+    fn validate_event_data(data: &serde_json::Value, path: &str) -> Result<(), String> {
+        let Some(data) = data.as_object() else {
+            return reject(path, "event data is not an object");
+        };
+        let Some(record) = data.get("record") else {
+            return reject(path, "record is missing");
+        };
+        let Some(record) = record.as_object() else {
+            return reject(path, "record must be an object");
+        };
+        match record.get("is_token") {
+            None => return reject(path, "record.is_token is missing"),
+            Some(value) if !value.is_boolean() => {
+                return reject(path, "record.is_token must be a boolean");
+            }
+            Some(_) => {}
+        }
+        if let (Some(sacrificed), Some(object_id)) = (
+            data.get("sacrificed").and_then(serde_json::Value::as_u64),
+            record.get("object_id").and_then(serde_json::Value::as_u64),
+        ) {
+            if sacrificed != object_id {
+                return reject(path, "record.object_id disagrees with event.sacrificed");
+            }
+        }
+        Ok(())
+    }
+
+    fn visit(value: &serde_json::Value, path: &str) -> Result<(), String> {
+        match value {
+            serde_json::Value::Array(values) => {
+                for (index, value) in values.iter().enumerate() {
+                    visit(value, &format!("{path}[{index}]"))?;
+                }
+            }
+            serde_json::Value::Object(object) => {
+                if object.get("type").and_then(serde_json::Value::as_str)
+                    == Some("CreatureExploited")
+                {
+                    let Some(data) = object.get("data") else {
+                        return reject(path, "event data is missing");
+                    };
+                    validate_event_data(data, &format!("{path}.data"))?;
+                }
+                if let Some(data) = object.get("CreatureExploited") {
+                    validate_event_data(data, &format!("{path}.CreatureExploited"))?;
+                }
+                for (key, value) in object {
+                    visit(value, &format!("{path}.{key}"))?;
+                }
+            }
+            serde_json::Value::Null
+            | serde_json::Value::Bool(_)
+            | serde_json::Value::Number(_)
+            | serde_json::Value::String(_) => {}
+        }
+        Ok(())
+    }
+
+    visit(value, "$")
+}
+
 impl GameStateDecode {
     pub(crate) fn decode_persisted_resolution_state(
         mut value: serde_json::Value,
@@ -19846,6 +19918,7 @@ impl GameStateDecode {
         mut value: serde_json::Value,
         mode: GameStateDecodeMode,
     ) -> Result<GameState, String> {
+        reject_legacy_exploit_event_evidence(&value)?;
         reject_legacy_raw_prompt_authority(&value)?;
         if !matches!(mode, GameStateDecodeMode::DirectCurrentRaw) {
             migrate_legacy_delayed_trigger_provenance(&mut value)?;
@@ -19891,6 +19964,7 @@ impl GameStateDecode {
             mode,
             GameStateDecodeMode::ResolutionWireV1 | GameStateDecodeMode::ResolutionWireV2
         ));
+        reject_legacy_exploit_event_evidence(value)?;
         reject_legacy_raw_prompt_authority(value)?;
         migrate_legacy_delayed_trigger_provenance(value)?;
         migrate_legacy_trigger_firing_carriers(
@@ -27730,6 +27804,162 @@ mod tests {
     };
     use crate::types::resolved_commands::ResolvedDelayedTriggerCommand;
     use crate::types::triggers::TriggerMode;
+
+    fn state_with_recorded_exploit() -> (GameState, GameEvent) {
+        let mut state = GameState::new_two_player(42);
+        let exploiter = create_object(
+            &mut state,
+            CardId(70),
+            PlayerId(0),
+            "Exploit source".to_string(),
+            Zone::Battlefield,
+        );
+        let victim = create_object(
+            &mut state,
+            CardId(71),
+            PlayerId(1),
+            "Exploit victim".to_string(),
+            Zone::Battlefield,
+        );
+        let victim_object = state.objects.get_mut(&victim).expect("victim exists");
+        victim_object.controller = PlayerId(0);
+        victim_object.card_types.core_types.push(CoreType::Creature);
+        victim_object.base_card_types = victim_object.card_types.clone();
+        victim_object.is_token = true;
+
+        let mut departure_events = Vec::new();
+        crate::game::zones::move_to_zone(
+            &mut state,
+            victim,
+            Zone::Graveyard,
+            &mut departure_events,
+        );
+        let record = departure_events
+            .iter()
+            .find_map(|event| match event {
+                GameEvent::ZoneChanged {
+                    object_id, record, ..
+                } if *object_id == victim => Some(record.clone()),
+                _ => None,
+            })
+            .expect("the fixture emits an authoritative departure record");
+        let exploit = GameEvent::CreatureExploited {
+            exploiter,
+            sacrificed: victim,
+            record,
+        };
+        state.deferred_entry_events = vec![exploit.clone()];
+        (state, exploit)
+    }
+
+    #[test]
+    fn recorded_exploit_round_trips_through_current_and_persisted_ingresses() {
+        let (state, expected) = state_with_recorded_exploit();
+
+        let direct: GameState =
+            serde_json::from_value(serde_json::to_value(&state).expect("current state serializes"))
+                .expect("current state with complete exploit evidence decodes");
+        assert_eq!(direct.deferred_entry_events, vec![expected.clone()]);
+
+        for persisted in [
+            PersistedGameState::Raw(Box::new(state.clone())),
+            PersistedGameState::capture(state),
+        ] {
+            let restored = serde_json::from_value::<PersistedGameState>(
+                serde_json::to_value(persisted).expect("persisted state serializes"),
+            )
+            .expect("persisted state with complete exploit evidence decodes")
+            .into_game_state_unchecked();
+            assert_eq!(restored.deferred_entry_events, vec![expected.clone()]);
+        }
+    }
+
+    #[test]
+    fn exploit_evidence_guard_rejects_obsolete_and_untrustworthy_snapshots() {
+        let (state, _) = state_with_recorded_exploit();
+        let base = serde_json::to_value(state).expect("fixture serializes");
+        let event_path = "$.deferred_entry_events[0].data";
+
+        let mut cases = Vec::new();
+        let mut missing_record = base.clone();
+        missing_record["deferred_entry_events"][0]["data"]
+            .as_object_mut()
+            .expect("event data is an object")
+            .remove("record");
+        cases.push((missing_record, "record is missing"));
+
+        let mut null_record = base.clone();
+        null_record["deferred_entry_events"][0]["data"]["record"] = serde_json::Value::Null;
+        cases.push((null_record, "record must be an object"));
+
+        let mut scalar_record = base.clone();
+        scalar_record["deferred_entry_events"][0]["data"]["record"] =
+            serde_json::Value::from("not a record");
+        cases.push((scalar_record, "record must be an object"));
+
+        let mut missing_token = base.clone();
+        missing_token["deferred_entry_events"][0]["data"]["record"]
+            .as_object_mut()
+            .expect("record is an object")
+            .remove("is_token");
+        cases.push((missing_token, "record.is_token is missing"));
+
+        let mut invalid_token = base.clone();
+        invalid_token["deferred_entry_events"][0]["data"]["record"]["is_token"] =
+            serde_json::Value::from("true");
+        cases.push((invalid_token, "record.is_token must be a boolean"));
+
+        let mut mismatched_id = base.clone();
+        mismatched_id["deferred_entry_events"][0]["data"]["record"]["object_id"] =
+            serde_json::Value::from(99_999_u64);
+        cases.push((
+            mismatched_id,
+            "record.object_id disagrees with event.sacrificed",
+        ));
+
+        for (value, reason) in cases {
+            let error = serde_json::from_value::<GameState>(value)
+                .expect_err("invalid exploit evidence must refuse the containing state")
+                .to_string();
+            assert!(
+                error.contains(LEGACY_EXPLOIT_EVENT_EVIDENCE_ERROR),
+                "{error}"
+            );
+            assert!(error.contains(event_path), "{error}");
+            assert!(error.contains(reason), "{error}");
+        }
+
+        let mut partial_record = base.clone();
+        partial_record["deferred_entry_events"][0]["data"]["record"]
+            .as_object_mut()
+            .expect("record is an object")
+            .remove("name");
+        let error = serde_json::from_value::<GameState>(partial_record)
+            .expect_err("ordinary incomplete record shape remains a serde schema error")
+            .to_string();
+        assert!(error.contains("missing field `name`"), "{error}");
+        assert!(
+            !error.contains(LEGACY_EXPLOIT_EVENT_EVIDENCE_ERROR),
+            "ordinary record schema errors must not be mislabeled as legacy exploit evidence: {error}"
+        );
+
+        let historical = serde_json::json!({
+            "journal": [{
+                "CreatureExploited": {
+                    "exploiter": 1,
+                    "sacrificed": 2
+                }
+            }]
+        });
+        let error = reject_legacy_exploit_event_evidence(&historical)
+            .expect_err("historical externally tagged evidence is diagnostic-only");
+        assert!(error.contains(LEGACY_EXPLOIT_EVENT_EVIDENCE_ERROR));
+        assert!(error.contains("$.journal[0].CreatureExploited"));
+
+        let benign = serde_json::json!({ "description": "CreatureExploited" });
+        reject_legacy_exploit_event_evidence(&benign)
+            .expect("a string mentioning the event is not an event envelope");
+    }
 
     #[test]
     fn persisted_legacy_tap_effects_migrate_only_effect_payloads() {

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -52,6 +52,8 @@ use super::proposed_event::{
 use super::replacements::ReplacementEvent;
 #[cfg(debug_assertions)]
 use super::resolution::debug_assert_runtime_resolution_invariants;
+#[cfg(test)]
+use super::resolution::RESOLUTION_STATE_WIRE_VERSION;
 use super::resolution::{
     AbilityContinuationFrame, ChangeZoneFrame, ChildStackDepth, FrameGate, MultiDrawFrame,
     OptionalEffectFrame, PendingCoinFlip, PendingDieRoll, PendingDieRollInstruction,
@@ -6564,13 +6566,13 @@ pub enum PendingCounterPostAction {
     ///
     /// Serialized surface: this enum reaches persisted state through
     /// `PendingEffectResolved::post_actions`, carried on the
-    /// `RESOLUTION_STATE_WIRE_VERSION` = 2 frame wire. A new externally-tagged
+    /// `RESOLUTION_STATE_WIRE_VERSION` = 3 frame wire. A new externally-tagged
     /// variant is backward compatible — no save written before it can contain
     /// one, so existing saves still decode — but NOT forward compatible: a build
     /// predating this variant cannot decode a save taken mid-paused-proliferate.
     /// That is the same one-way contract `MarkMonstrous`, `MarkRenowned` and
     /// `EmitCommittedCopyTokenEntry` shipped under, so the wire version is
-    /// deliberately not bumped.
+    /// did not itself require a bump.
     ContinueProliferateActions {
         pending: PendingProliferateActions,
     },
@@ -9829,8 +9831,9 @@ fn visit_persisted_journal_zone_change_trigger_records(
 /// omit either field and deserialize them as zero.
 ///
 /// This runs against serialized `ResolutionStateWire` input before either v1
-/// legacy fields or v2 frames materialize into runtime state. The caller passes
-/// any v1-only live roots; v2 frames are part of the canonical root set below.
+/// legacy fields or v2/v3 typed frames materialize into runtime state. The
+/// caller passes any v1-only live roots; typed frames are part of the canonical
+/// root set below.
 /// Raw and Trusted persistence are both fallible at that boundary, and rebinding
 /// after deserialization would be too late: callers could already observe an
 /// ambiguous trigger event.
@@ -19789,6 +19792,7 @@ pub(crate) enum GameStateDecodeMode {
     TrustedEnvelope,
     ResolutionWireV1,
     ResolutionWireV2,
+    ResolutionWireV3,
     DirectCurrentRaw,
 }
 
@@ -19799,6 +19803,87 @@ pub(crate) struct GameStateDecode;
 
 const LEGACY_EXPLOIT_EVENT_EVIDENCE_ERROR: &str =
     "CreatureExploited snapshot lacks authoritative victim record; restore a save that contains the exploit departure record";
+
+const SERIALIZED_TRIGGER_DEFINITION_CORE_FIELDS: &[&str] = &[
+    "execute",
+    "valid_card",
+    "origin",
+    "destination",
+    "trigger_zones",
+    "phase",
+    "optional",
+    "damage_kind",
+    "secondary",
+    "valid_target",
+    "valid_source",
+    "description",
+    "constraint",
+    "condition",
+];
+
+fn is_serialized_exploited_trigger_definition(
+    object: &serde_json::Map<String, serde_json::Value>,
+) -> bool {
+    object.get("mode").and_then(serde_json::Value::as_str) == Some("Exploited")
+        && SERIALIZED_TRIGGER_DEFINITION_CORE_FIELDS
+            .iter()
+            .all(|field| object.contains_key(*field))
+}
+
+pub(crate) fn contains_ambiguous_serialized_exploited_trigger_definition(
+    value: &serde_json::Value,
+) -> bool {
+    match value {
+        serde_json::Value::Array(values) => values
+            .iter()
+            .any(contains_ambiguous_serialized_exploited_trigger_definition),
+        serde_json::Value::Object(object) => {
+            (is_serialized_exploited_trigger_definition(object)
+                && object
+                    .get("valid_card")
+                    .is_some_and(|valid_card| !valid_card.is_null()))
+                || object
+                    .values()
+                    .any(contains_ambiguous_serialized_exploited_trigger_definition)
+        }
+        serde_json::Value::Null
+        | serde_json::Value::Bool(_)
+        | serde_json::Value::Number(_)
+        | serde_json::Value::String(_) => false,
+    }
+}
+
+fn migrate_legacy_exploited_trigger_roles(value: &mut serde_json::Value) {
+    match value {
+        serde_json::Value::Array(values) => {
+            for value in values {
+                migrate_legacy_exploited_trigger_roles(value);
+            }
+        }
+        serde_json::Value::Object(object) => {
+            if is_serialized_exploited_trigger_definition(object) {
+                if object
+                    .get("valid_source")
+                    .is_none_or(serde_json::Value::is_null)
+                {
+                    let legacy_actor = object
+                        .get("valid_card")
+                        .cloned()
+                        .unwrap_or(serde_json::Value::Null);
+                    object.insert("valid_source".to_string(), legacy_actor);
+                }
+                object.insert("valid_card".to_string(), serde_json::Value::Null);
+            }
+            for value in object.values_mut() {
+                migrate_legacy_exploited_trigger_roles(value);
+            }
+        }
+        serde_json::Value::Null
+        | serde_json::Value::Bool(_)
+        | serde_json::Value::Number(_)
+        | serde_json::Value::String(_) => {}
+    }
+}
 
 fn reject_legacy_exploit_event_evidence(value: &serde_json::Value) -> Result<(), String> {
     fn reject(path: &str, reason: &str) -> Result<(), String> {
@@ -19874,26 +19959,27 @@ impl GameStateDecode {
         mut value: serde_json::Value,
         mode: GameStateDecodeMode,
     ) -> Result<GameState, String> {
-        let object = value
-            .as_object_mut()
-            .ok_or_else(|| "persisted game state must be a JSON object".to_string())?;
+        if !value.is_object() {
+            return Err("persisted game state must be a JSON object".to_string());
+        }
         match mode {
             // An UNVERSIONED raw payload carries no resolution-wire
             // discriminator. Raw persistence in general does: the engine's own
             // raw writer, `PersistedGameState::Raw`'s `Serialize`, routes
             // through `ResolutionStateWire::to_value`, which always declares
-            // version 2. This is the only ingress allowed to infer a MISSING
+            // the current version. This is the only ingress allowed to infer a MISSING
             // discriminator, and `declare_raw_resolution_wire` is the single
             // authority that does. A payload that declares its own version
             // keeps it and is handled exactly as any declared payload is.
             GameStateDecodeMode::PersistedRaw => {
-                crate::types::resolution::declare_raw_resolution_wire(object)?;
+                crate::types::resolution::declare_raw_resolution_wire(&mut value)?;
             }
             // Trusted snapshots are written as versioned resolution-wire
             // envelopes and must retain their declared compatibility mode.
             GameStateDecodeMode::TrustedEnvelope => {}
             GameStateDecodeMode::ResolutionWireV1
             | GameStateDecodeMode::ResolutionWireV2
+            | GameStateDecodeMode::ResolutionWireV3
             | GameStateDecodeMode::DirectCurrentRaw => {
                 return Err("invalid persisted resolution-state decode mode".to_string());
             }
@@ -19962,10 +20048,18 @@ impl GameStateDecode {
     ) -> Result<(), String> {
         debug_assert!(matches!(
             mode,
-            GameStateDecodeMode::ResolutionWireV1 | GameStateDecodeMode::ResolutionWireV2
+            GameStateDecodeMode::ResolutionWireV1
+                | GameStateDecodeMode::ResolutionWireV2
+                | GameStateDecodeMode::ResolutionWireV3
         ));
         reject_legacy_exploit_event_evidence(value)?;
         reject_legacy_raw_prompt_authority(value)?;
+        if matches!(
+            mode,
+            GameStateDecodeMode::ResolutionWireV1 | GameStateDecodeMode::ResolutionWireV2
+        ) {
+            migrate_legacy_exploited_trigger_roles(value);
+        }
         migrate_legacy_delayed_trigger_provenance(value)?;
         migrate_legacy_trigger_firing_carriers(
             value,
@@ -27877,6 +27971,9 @@ mod tests {
     #[test]
     fn exploit_evidence_guard_rejects_obsolete_and_untrustworthy_snapshots() {
         let (state, _) = state_with_recorded_exploit();
+        let current_wire =
+            serde_json::to_value(ResolutionStateWire::from_game_state(state.clone()))
+                .expect("versioned fixture serializes");
         let base = serde_json::to_value(state).expect("fixture serializes");
         let event_path = "$.deferred_entry_events[0].data";
 
@@ -27959,6 +28056,327 @@ mod tests {
         let benign = serde_json::json!({ "description": "CreatureExploited" });
         reject_legacy_exploit_event_evidence(&benign)
             .expect("a string mentioning the event is not an event envelope");
+
+        for version in [1_u64, 2_u64] {
+            let mut historical_wire = current_wire.clone();
+            historical_wire["resolution_state_version"] = serde_json::Value::from(version);
+            if version == 1 {
+                historical_wire
+                    .as_object_mut()
+                    .expect("wire is an object")
+                    .remove("resolution_frames");
+            }
+            historical_wire["deferred_entry_events"][0]["data"]
+                .as_object_mut()
+                .expect("event data is an object")
+                .remove("record");
+            let error = serde_json::from_value::<ResolutionStateWire>(historical_wire)
+                .unwrap_err()
+                .to_string();
+            assert!(
+                error.contains(LEGACY_EXPLOIT_EVENT_EVIDENCE_ERROR),
+                "declared v{version}: {error}"
+            );
+        }
+    }
+
+    fn legacy_exploited_definition(marker: &str, actor_id: u64) -> serde_json::Value {
+        let mut definition = TriggerDefinition::new(TriggerMode::Exploited);
+        definition.description = Some(marker.to_string());
+        let mut value = serde_json::to_value(definition)
+            .expect("typed exploited trigger definition serializes");
+        value["valid_card"] = serde_json::to_value(TargetFilter::SpecificObject {
+            id: ObjectId(actor_id),
+        })
+        .expect("actor filter serializes");
+        value["valid_source"] = serde_json::Value::Null;
+        value
+    }
+
+    fn assert_migrated_exploited_definition(
+        tree: &serde_json::Value,
+        pointer: &str,
+        marker: &str,
+        actor_id: u64,
+    ) {
+        let definition = tree
+            .pointer(pointer)
+            .unwrap_or_else(|| panic!("fixture contains {pointer}"));
+        assert_eq!(definition["description"], marker);
+        assert_eq!(definition["valid_source"]["type"], "SpecificObject");
+        assert_eq!(definition["valid_source"]["id"], actor_id);
+        assert!(definition["valid_card"].is_null());
+    }
+
+    #[test]
+    fn legacy_exploited_role_migration_visits_every_persisted_definition_carrier() {
+        let mut decoy = legacy_exploited_definition("decoy", 99);
+        decoy
+            .as_object_mut()
+            .expect("definition is an object")
+            .remove("execute");
+        let expected_decoy = decoy.clone();
+
+        let mut tree = serde_json::json!({
+            "objects": {
+                "1": {
+                    "trigger_definitions": [{ "definition": legacy_exploited_definition("live", 1) }],
+                    "base_trigger_definitions": [legacy_exploited_definition("base", 2)]
+                }
+            },
+            "zone_change_record": {
+                "trigger_definitions": [{ "definition": legacy_exploited_definition("record", 3) }],
+                "trigger_source_context": {
+                    "trigger_entries": [{ "definition": legacy_exploited_definition("context", 4) }]
+                }
+            },
+            "logical_zone_change_group": {
+                "immediately_before_batched_triggers": [{ "definition": legacy_exploited_definition("latch-before", 5) }],
+                "immediately_after_batched_triggers": [{ "definition": legacy_exploited_definition("latch-after", 6) }]
+            },
+            "delayed_triggers": [
+                {
+                    "condition": {
+                        "type": "WheneverEvent",
+                        "trigger": legacy_exploited_definition("whenever", 7)
+                    }
+                },
+                {
+                    "condition": {
+                        "type": "WhenNextEvent",
+                        "trigger": legacy_exploited_definition("when-next", 8),
+                        "or_trigger": legacy_exploited_definition("when-next-or", 9)
+                    }
+                }
+            ],
+            "nested_effects": [
+                {
+                    "type": "CreateDelayedTrigger",
+                    "condition": {
+                        "type": "WheneverEvent",
+                        "trigger": legacy_exploited_definition("created-delayed", 10)
+                    }
+                },
+                {
+                    "type": "CreateEmblem",
+                    "triggers": [legacy_exploited_definition("emblem", 11)]
+                }
+            ],
+            "preexisting_source": {
+                "definition": legacy_exploited_definition("preexisting-source", 13)
+            },
+            "decoy": decoy
+        });
+        tree["preexisting_source"]["definition"]["valid_source"] =
+            serde_json::to_value(TargetFilter::SpecificObject { id: ObjectId(12) })
+                .expect("preexisting actor filter serializes");
+
+        migrate_legacy_exploited_trigger_roles(&mut tree);
+
+        for (pointer, marker, actor_id) in [
+            ("/objects/1/trigger_definitions/0/definition", "live", 1),
+            ("/objects/1/base_trigger_definitions/0", "base", 2),
+            (
+                "/zone_change_record/trigger_definitions/0/definition",
+                "record",
+                3,
+            ),
+            (
+                "/zone_change_record/trigger_source_context/trigger_entries/0/definition",
+                "context",
+                4,
+            ),
+            (
+                "/logical_zone_change_group/immediately_before_batched_triggers/0/definition",
+                "latch-before",
+                5,
+            ),
+            (
+                "/logical_zone_change_group/immediately_after_batched_triggers/0/definition",
+                "latch-after",
+                6,
+            ),
+            ("/delayed_triggers/0/condition/trigger", "whenever", 7),
+            ("/delayed_triggers/1/condition/trigger", "when-next", 8),
+            (
+                "/delayed_triggers/1/condition/or_trigger",
+                "when-next-or",
+                9,
+            ),
+            ("/nested_effects/0/condition/trigger", "created-delayed", 10),
+            ("/nested_effects/1/triggers/0", "emblem", 11),
+        ] {
+            assert_migrated_exploited_definition(&tree, pointer, marker, actor_id);
+        }
+        assert_migrated_exploited_definition(
+            &tree,
+            "/preexisting_source/definition",
+            "preexisting-source",
+            12,
+        );
+        assert_eq!(tree["decoy"], expected_decoy);
+    }
+
+    fn state_with_exploited_trigger_roles(
+        mut state: GameState,
+        actor: TargetFilter,
+        victim: Option<TargetFilter>,
+    ) -> (GameState, ObjectId) {
+        let object_id = ObjectId(9_170);
+        let mut definition = TriggerDefinition::new(TriggerMode::Exploited);
+        definition.valid_source = Some(actor);
+        definition.valid_card = victim;
+        let mut object = GameObject::new(
+            object_id,
+            CardId(9_170),
+            PlayerId(0),
+            "Exploit observer".to_string(),
+            Zone::Battlefield,
+        );
+        object.push_printed_trigger(definition);
+        state.objects.insert(object_id, object);
+        (state, object_id)
+    }
+
+    fn downgrade_exploited_roles(value: &mut serde_json::Value) {
+        match value {
+            serde_json::Value::Array(values) => {
+                for value in values {
+                    downgrade_exploited_roles(value);
+                }
+            }
+            serde_json::Value::Object(object) => {
+                if is_serialized_exploited_trigger_definition(object) {
+                    let actor = object
+                        .get("valid_source")
+                        .cloned()
+                        .expect("complete trigger definition has valid_source");
+                    object.insert("valid_card".to_string(), actor);
+                    object.insert("valid_source".to_string(), serde_json::Value::Null);
+                }
+                for value in object.values_mut() {
+                    downgrade_exploited_roles(value);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn assert_restored_exploit_roles(
+        restored: &GameState,
+        object_id: ObjectId,
+        actor: &TargetFilter,
+        victim: Option<&TargetFilter>,
+    ) {
+        let definition = &restored.objects[&object_id].trigger_definitions[0].definition;
+        assert_eq!(definition.valid_source.as_ref(), Some(actor));
+        assert_eq!(definition.valid_card.as_ref(), victim);
+    }
+
+    #[test]
+    fn declared_resolution_wires_migrate_only_legacy_exploited_roles() {
+        let actor = TargetFilter::SpecificObject {
+            id: ObjectId(9_171),
+        };
+        let victim = TargetFilter::SpecificObject {
+            id: ObjectId(9_172),
+        };
+        let (state, object_id) = state_with_exploited_trigger_roles(
+            GameState::new_two_player(42),
+            actor.clone(),
+            Some(victim.clone()),
+        );
+        let current = serde_json::to_value(ResolutionStateWire::from_game_state(state))
+            .expect("current resolution wire serializes");
+
+        assert_eq!(
+            current["resolution_state_version"],
+            serde_json::Value::from(RESOLUTION_STATE_WIRE_VERSION)
+        );
+        let restored_current = serde_json::from_value::<ResolutionStateWire>(current.clone())
+            .expect("declared v3 payload restores")
+            .into_game_state();
+        assert_restored_exploit_roles(&restored_current, object_id, &actor, Some(&victim));
+
+        for version in [1_u64, 2_u64] {
+            let mut legacy = current.clone();
+            legacy["resolution_state_version"] = serde_json::Value::from(version);
+            if version == 1 {
+                legacy
+                    .as_object_mut()
+                    .expect("wire is an object")
+                    .remove("resolution_frames");
+            }
+            downgrade_exploited_roles(&mut legacy);
+            let restored = serde_json::from_value::<ResolutionStateWire>(legacy)
+                .unwrap_or_else(|error| panic!("declared v{version} payload restores: {error}"))
+                .into_game_state();
+            assert_restored_exploit_roles(&restored, object_id, &actor, None);
+        }
+    }
+
+    #[test]
+    fn unversioned_ambiguous_exploited_roles_fail_closed_before_carrier_inference() {
+        let actor = TargetFilter::SpecificObject {
+            id: ObjectId(9_173),
+        };
+        let victim = TargetFilter::SpecificObject {
+            id: ObjectId(9_174),
+        };
+        let (state, _) =
+            state_with_exploited_trigger_roles(GameState::new_two_player(42), actor, Some(victim));
+        let bare_current = serde_json::to_value(state).expect("bare state serializes");
+        assert!(bare_current.get("resolution_state_version").is_none());
+        assert!(bare_current.get("resolution_stack").is_none());
+        assert!(contains_ambiguous_serialized_exploited_trigger_definition(
+            &bare_current
+        ));
+
+        let error = serde_json::from_value::<PersistedGameState>(bare_current.clone())
+            .expect_err("unversioned v3 role layout is ambiguous")
+            .to_string();
+        assert!(error.contains(
+            "unversioned raw resolution state contains an Exploited trigger with ambiguous role layout"
+        ));
+
+        let mut old_layout = bare_current;
+        downgrade_exploited_roles(&mut old_layout);
+        assert!(contains_ambiguous_serialized_exploited_trigger_definition(
+            &old_layout
+        ));
+        let error = serde_json::from_value::<PersistedGameState>(old_layout)
+            .expect_err("unversioned legacy role layout is equally ambiguous")
+            .to_string();
+        assert!(error.contains(
+            "unversioned raw resolution state contains an Exploited trigger with ambiguous role layout"
+        ));
+    }
+
+    #[test]
+    fn unversioned_safe_exploited_roles_restore_with_or_without_a_live_stack() {
+        let actor = TargetFilter::SpecificObject {
+            id: ObjectId(9_175),
+        };
+        for (label, state) in [
+            ("empty stack", GameState::new_two_player(42)),
+            ("live stack", parked_spell_resolution_fixture()),
+        ] {
+            let (state, object_id) = state_with_exploited_trigger_roles(state, actor.clone(), None);
+            let bare = serde_json::to_value(state).expect("bare state serializes");
+            assert!(bare.get("resolution_state_version").is_none(), "{label}");
+            assert_eq!(
+                bare.get("resolution_stack").is_some(),
+                label == "live stack"
+            );
+            assert!(
+                !contains_ambiguous_serialized_exploited_trigger_definition(&bare),
+                "{label}"
+            );
+            let restored = serde_json::from_value::<PersistedGameState>(bare)
+                .unwrap_or_else(|error| panic!("{label} safe role layout restores: {error}"))
+                .into_game_state_unchecked();
+            assert_restored_exploit_roles(&restored, object_id, &actor, None);
+        }
     }
 
     #[test]
@@ -30119,7 +30537,7 @@ mod tests {
         // `GameState`'s derived `Serialize` — the unversioned raw writer whose
         // shape `declare_raw_resolution_wire` infers from. NOT
         // `to_value(PersistedGameState::Raw(..))`, which routes through
-        // `ResolutionStateWire::to_value` and emits a DECLARED v2 wire that would
+        // `ResolutionStateWire::to_value` and emits a DECLARED current wire that would
         // take the inference's early return and make this test vacuous.
         let wire = serde_json::to_value(&state).expect("the bare GameState serializes");
         assert!(
@@ -30133,7 +30551,7 @@ mod tests {
         );
         assert!(
             wire.get("resolution_frames").is_none(),
-            "the raw writer must not emit the v2 frame carrier"
+            "the raw writer must not emit the typed-frame carrier"
         );
 
         let restored = serde_json::from_value::<PersistedGameState>(wire)
@@ -30180,9 +30598,10 @@ mod tests {
     }
 
     /// V6 + V7. The unlabeled-carrier allowance is **not** widened to the raw
-    /// ingress by the inference. A raw payload that now classifies as v2 and
-    /// carries a triggered `resolving_stack_entry` with no firing carrier is
-    /// refused, at BOTH a Priority rest and a non-Priority prompt rest.
+    /// ingress by the inference. A raw payload that now classifies as the
+    /// current wire and carries a triggered `resolving_stack_entry` with no
+    /// firing carrier is refused, at BOTH a Priority rest and a non-Priority
+    /// prompt rest.
     ///
     /// What this prevents: `migrate_legacy_trigger_firing_carriers` fabricates
     /// `TriggerFiring::LegacyDelayed` for an unlabeled triggered carrier when
@@ -30194,7 +30613,7 @@ mod tests {
     /// for an ordinary trigger is a rules error, so the inference must leave the
     /// allowance exactly where it was.
     #[test]
-    fn raw_inferred_v2_refuses_an_unlabeled_triggered_carrier() {
+    fn raw_inferred_current_wire_refuses_an_unlabeled_triggered_carrier() {
         let priority_rest = parked_frame_on_triggered_carrier_fixture();
 
         // The non-Priority sibling. `SpellResolution` is an `AfterChild` frame,
@@ -30216,7 +30635,7 @@ mod tests {
             let labeled = serde_json::to_value(&state).expect("the bare GameState serializes");
             assert!(
                 labeled.get("resolution_stack").is_some(),
-                "{label}: the fixture must reach the inferred-v2 classification"
+                "{label}: the fixture must reach the inferred-current-wire classification"
             );
 
             // Paired positive reach-guard, asserted FIRST: the identical payload
@@ -30275,7 +30694,14 @@ mod tests {
                 1_u64,
                 "v1 resolution state must not contain resolution_stack",
             ),
-            (2_u64, "v2 resolution state is missing resolution_frames"),
+            (
+                2_u64,
+                "typed-frame resolution state is missing resolution_frames",
+            ),
+            (
+                RESOLUTION_STATE_WIRE_VERSION,
+                "typed-frame resolution state is missing resolution_frames",
+            ),
         ] {
             let declared = declare(version);
             let raw_error = serde_json::from_value::<PersistedGameState>(declared.clone())
@@ -30470,7 +30896,7 @@ mod tests {
     /// that fixture sets a triggered `resolving_stack_entry` AND a live firing,
     /// so extending it yields the coherent shape, which the client wire already
     /// refuses without any of this — see
-    /// `raw_inferred_v2_refuses_an_unlabeled_triggered_carrier`.
+    /// `raw_inferred_current_wire_refuses_an_unlabeled_triggered_carrier`.
     fn parked_continuation_fixture(stashed: Option<TriggerFiring>) -> GameState {
         let mut state = GameState::new_two_player(42);
         let source = create_object(
@@ -31091,7 +31517,7 @@ mod tests {
     }
 
     #[test]
-    fn v2_continuation_zone_change_event_reconciles_in_serialized_frame() {
+    fn current_continuation_zone_change_event_reconciles_in_serialized_frame() {
         let mut state = trigger_continuation_fixture();
         state.turn_number = 19;
         let record = persisted_zone_change_record(ObjectId(9_172), state.turn_number, 0);
@@ -31112,14 +31538,14 @@ mod tests {
         state.park_ability_continuation(continuation);
 
         let mut persisted = serde_json::to_value(PersistedGameState::Raw(Box::new(state)))
-            .expect("v2 frame fixture serializes");
+            .expect("current frame fixture serializes");
         erase_persisted_event_occurrence_fields(persisted_state_payload_mut(&mut persisted));
         let restored = serde_json::from_value::<PersistedGameState>(persisted)
-            .expect("v2 frame event reconciles before materialization")
+            .expect("current frame event reconciles before materialization")
             .into_game_state_unchecked();
         let GameEvent::ZoneChanged { record, .. } = &restored
             .active_ability_continuation()
-            .expect("v2 frame restores as an active continuation")
+            .expect("current frame restores as an active continuation")
             .trigger_context
             .as_ref()
             .expect("continuation retains its trigger context")
@@ -31132,7 +31558,7 @@ mod tests {
         assert_eq!(
             (record.recorded_turn_number, record.turn_zone_change_index),
             (19, 0),
-            "serialized v2 frame event is reconciled to its current ledger occurrence"
+            "serialized current frame event is reconciled to its ledger occurrence"
         );
     }
 
@@ -31140,7 +31566,7 @@ mod tests {
     fn direct_resolution_wire_rejects_unlabeled_active_trigger_carriers() {
         let state = normal_trigger_firing_fixture();
         let wire = serde_json::to_value(ResolutionStateWire::from_game_state(state))
-            .expect("coherent trigger fixture serializes as v2 wire");
+            .expect("coherent trigger fixture serializes through the current wire");
 
         let mut missing_pending = wire.clone();
         missing_pending
@@ -31186,7 +31612,7 @@ mod tests {
         continuation_state.park_ability_continuation(continuation);
         let continuation_wire =
             serde_json::to_value(ResolutionStateWire::from_game_state(continuation_state))
-                .expect("continuation fixture serializes as v2 wire");
+                .expect("continuation fixture serializes through the current wire");
         let continuation_error = serde_json::from_value::<ResolutionStateWire>(continuation_wire)
             .expect_err("direct wire must reject an unlabeled active continuation");
         assert!(
@@ -31473,7 +31899,8 @@ mod tests {
     fn direct_v2_resolution_wire_rejects_orphaned_trigger_continuation() {
         let state = trigger_continuation_fixture();
         let mut wire = serde_json::to_value(ResolutionStateWire::from_game_state(state))
-            .expect("v2 fixture serializes");
+            .expect("current fixture serializes before v2 downgrade");
+        wire["resolution_state_version"] = serde_json::Value::from(2_u64);
         remove_resolving_trigger_carrier(&mut wire);
 
         let error = serde_json::from_value::<ResolutionStateWire>(wire)
@@ -31508,7 +31935,7 @@ mod tests {
     }
 
     #[test]
-    fn direct_v2_resolution_wire_preserves_normal_continuations() {
+    fn direct_current_resolution_wire_preserves_normal_continuations() {
         let mut state = normal_trigger_firing_fixture();
         let continuation = PendingContinuation::new(
             state
@@ -36330,7 +36757,7 @@ mod tests {
     }
 
     #[test]
-    fn persisted_state_decodes_v1_at_the_boundary_and_rewrites_v2_only() {
+    fn persisted_state_decodes_v1_at_the_boundary_and_rewrites_current_only() {
         let mut v1 =
             serde_json::to_value(GameState::new_two_player(43)).expect("serialize v1 baseline");
         v1["pending_multi_draw"] = serde_json::to_value(PendingMultiDraw {
@@ -36353,20 +36780,20 @@ mod tests {
             Some(2)
         );
 
-        let raw_v2 = serde_json::to_value(restored).expect("restored raw state serializes");
+        let raw_current = serde_json::to_value(restored).expect("restored raw state serializes");
         assert_eq!(
-            raw_v2["resolution_state_version"],
-            serde_json::Value::from(2)
+            raw_current["resolution_state_version"],
+            serde_json::Value::from(RESOLUTION_STATE_WIRE_VERSION)
         );
-        assert!(raw_v2.get("resolution_frames").is_some());
-        assert!(raw_v2.get("pending_multi_draw").is_none());
+        assert!(raw_current.get("resolution_frames").is_some());
+        assert!(raw_current.get("pending_multi_draw").is_none());
 
-        let trusted_v2 = serde_json::to_value(PersistedGameState::capture(resumed))
+        let trusted_current = serde_json::to_value(PersistedGameState::capture(resumed))
             .expect("trusted state serializes");
-        let trusted_state = &trusted_v2["state"];
+        let trusted_state = &trusted_current["state"];
         assert_eq!(
             trusted_state["resolution_state_version"],
-            serde_json::Value::from(2)
+            serde_json::Value::from(RESOLUTION_STATE_WIRE_VERSION)
         );
         assert!(trusted_state.get("resolution_frames").is_some());
         assert!(trusted_state.get("pending_multi_draw").is_none());

--- a/crates/engine/src/types/resolution.rs
+++ b/crates/engine/src/types/resolution.rs
@@ -375,8 +375,8 @@ pub struct ChangeZoneFrame {
 ///
 /// `ChooseFromZone` stores its narrow trigger-context sidecar beside the
 /// continuation it will drain, not beside the independent per-category
-/// iterator. Keeping it here prevents a v1→v2 conversion from dropping that
-/// sidecar at a save boundary.
+/// iterator. Keeping it here prevents a legacy-to-typed-frame conversion from
+/// dropping that sidecar at a save boundary.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct AbilityContinuationFrame {
     pub pending: PendingContinuation,
@@ -496,7 +496,7 @@ impl ResolutionFrame {
 
     /// Whether this frame resides in `GameState::resolution_stack` at runtime.
     ///
-    /// The v2 wire also carries the remaining legacy resolution authorities as
+    /// The typed-frame wire also carries the remaining legacy resolution authorities as
     /// frames. Those are projected back into their dedicated state fields on
     /// decode, so they may follow an active stack-resident child in wire order.
     const fn is_runtime_stack_resident(&self) -> bool {
@@ -3650,15 +3650,18 @@ impl ResolutionStack {
 
 /// The full-state resolution wire version for typed [`ResolutionStack`] frames.
 ///
-/// Version 2 is the compatibility boundary for protocol-19 clients. Phase 4
-/// hardening changes neither this serialized shape nor the version.
-pub const RESOLUTION_STATE_WIRE_VERSION: u64 = 2;
+/// Version 3 distinguishes the current exploited-trigger source/victim roles
+/// from the legacy actor fallback stored in `valid_card`.
+pub const RESOLUTION_STATE_WIRE_VERSION: u64 = 3;
 
 /// Historical full-state resolution wire version accepted only for migration.
 ///
-/// The reader accepts v1 saves and converts them to v2 frames; the writer
+/// The reader accepts v1 saves and converts them to typed frames; the writer
 /// never emits v1 resolution fields.
 const LEGACY_RESOLUTION_STATE_WIRE_VERSION: u64 = 1;
+
+/// Historical typed-frame wire version accepted only for migration.
+const LEGACY_TYPED_FRAME_RESOLUTION_STATE_WIRE_VERSION: u64 = 2;
 
 /// The `GameState` fields whose serialized form is UNCONDITIONAL: each carries
 /// `#[serde(default …)]` but NO `skip_serializing_if`, so the derived
@@ -3775,17 +3778,18 @@ fn is_redacted_client_wire_projection(object: &Map<String, Value>) -> bool {
 /// changes. Do not delete it.
 ///
 /// The version stamped below is the same kind of mutable premise: the mapping
-/// is to the shape **v2** defines — v2's carrier is `resolution_frames`, and it
-/// deserializes the same `ResolutionStack` that `resolution_stack` does — not to
-/// "whatever the current version is", so it must be RE-DERIVED, not merely
-/// recompiled, if `RESOLUTION_STATE_WIRE_VERSION` moves.
+/// is to the current typed-frame shape, whose carrier is `resolution_frames`
+/// and which deserializes the same `ResolutionStack` that `resolution_stack`
+/// does. It must be RE-DERIVED, not merely recompiled, if the current wire
+/// changes shape.
 ///
 /// An undeclared payload carrying BOTH carriers is refused rather than
 /// inferred: choosing one would discard the other with no error, at an ingress
 /// that takes untrusted uploaded saves.
 ///
 /// `PersistedGameState::Raw` does NOT write this shape: its `Serialize` routes
-/// through `ResolutionStateWire::to_value`, which always declares version 2.
+/// through `ResolutionStateWire::to_value`, which always declares the current
+/// version.
 ///
 /// The mapping is exact, not heuristic. #6269 (`f4a6f32b85`, 2026-07-21) added
 /// `resolution_stack` and removed all 29 legacy `pending_*` /
@@ -3804,9 +3808,13 @@ fn is_redacted_client_wire_projection(object: &Map<String, Value>) -> bool {
 /// `resolution_stack` and `resolution_frames` carry the same serialized
 /// `ResolutionStack`, allocators included: `to_value` builds its frames by
 /// copying `state.resolution_stack` (see `canonicalize_legacy_resolution_state`),
-/// and the v2 branch deserializes the field straight back into `ResolutionStack`.
+/// and the typed-frame branch deserializes the field straight back into
+/// `ResolutionStack`.
 /// The move below is a rename, not a reinterpretation.
-pub(crate) fn declare_raw_resolution_wire(object: &mut Map<String, Value>) -> Result<(), String> {
+pub(crate) fn declare_raw_resolution_wire(value: &mut Value) -> Result<(), String> {
+    let object = value
+        .as_object_mut()
+        .ok_or_else(|| "persisted game state must be a JSON object".to_string())?;
     if object.contains_key("resolution_state_version") {
         return Ok(());
     }
@@ -3850,12 +3858,12 @@ pub(crate) fn declare_raw_resolution_wire(object: &mut Map<String, Value>) -> Re
     // row carrying a payload that bears both carriers AND the fingerprint.
     //
     // SCOPED TO THIS ARM ON PURPOSE. A payload WITHOUT `resolution_stack` keeps
-    // the legacy v1 treatment untouched even when it bears the fingerprint:
-    // those payloads decode today, their exposure predates the wire inference,
-    // and refusing them would be a genuine availability regression for a defect
-    // this ingress did not introduce. Within this arm nothing regresses,
-    // because every `resolution_stack`-bearing unversioned payload was refused
-    // outright before the inference existed.
+    // the legacy v1 resolution-wire treatment even when it bears the
+    // fingerprint. The independent exploited-role ambiguity check below can
+    // still refuse it because no wire version exists to disambiguate that
+    // semantic layout. Those payloads otherwise decode today, their exposure
+    // predates the wire inference, and refusing them would be a genuine
+    // availability regression for a defect this ingress did not introduce.
     if object.contains_key("resolution_stack") && is_redacted_client_wire_projection(object) {
         return Err(
             // Written to be TRUE of both populations that reach here, not just
@@ -3872,6 +3880,15 @@ pub(crate) fn declare_raw_resolution_wire(object: &mut Map<String, Value>) -> Re
                 .to_string(),
         );
     }
+    if crate::types::game_state::contains_ambiguous_serialized_exploited_trigger_definition(value) {
+        return Err(
+            "unversioned raw resolution state contains an Exploited trigger with ambiguous role layout; restore a versioned save"
+                .to_string(),
+        );
+    }
+    let object = value
+        .as_object_mut()
+        .expect("the checked raw resolution state remains an object");
     match object.remove("resolution_stack") {
         Some(frames) => {
             object.insert("resolution_frames".to_string(), frames);
@@ -3892,7 +3909,7 @@ pub(crate) fn declare_raw_resolution_wire(object: &mut Map<String, Value>) -> Re
 
 /// V1 suspension carriers that may retain an active `GameEvent::ZoneChanged`.
 /// Both provenance materialization and occurrence-key reconciliation must visit
-/// this exact legacy surface before it projects into the v2 frame stack.
+/// this exact legacy surface before it projects into the typed frame stack.
 const LEGACY_LIVE_ZONE_CHANGED_EVENT_ROOTS: &[&str] = &[
     "pending_continuation",
     "pending_choose_zone_trigger_context",
@@ -3906,8 +3923,8 @@ const LEGACY_LIVE_ZONE_CHANGED_EVENT_ROOTS: &[&str] = &[
 /// Versioned wire adapter for full game-state persistence and transport.
 ///
 /// This adapter is the persistence seam between v1's legacy-only payloads and
-/// v2's typed frames. v1 decoding converts migrated family payloads into the
-/// runtime stack; v2 decoding restores those frames directly while retaining
+/// typed frames. v1 decoding converts migrated family payloads into the
+/// runtime stack; v2/v3 decoding restores those frames directly while retaining
 /// legacy slots solely for unmigrated families. Both supported versions refuse
 /// `CreatureExploited` events that predate authoritative victim records; the
 /// version distinguishes frame layouts and cannot safely synthesize event facts.
@@ -3954,8 +3971,8 @@ impl ResolutionStateWire {
 
     /// Decodes persisted full-game state at the resolution compatibility boundary.
     ///
-    /// Version 1 is read only through the legacy migration path below. Version
-    /// 2 is the only shape this adapter writes for protocol-19 clients.
+    /// Version 1 is read only through the legacy migration path below. Versions
+    /// 2 and 3 share the typed-frame reader; only version 3 is written.
     fn from_value(mut value: Value) -> Result<Self, String> {
         let version = {
             let object = value
@@ -3972,10 +3989,13 @@ impl ResolutionStateWire {
 
         let decode_mode = match version {
             LEGACY_RESOLUTION_STATE_WIRE_VERSION => GameStateDecodeMode::ResolutionWireV1,
-            RESOLUTION_STATE_WIRE_VERSION => GameStateDecodeMode::ResolutionWireV2,
+            LEGACY_TYPED_FRAME_RESOLUTION_STATE_WIRE_VERSION => {
+                GameStateDecodeMode::ResolutionWireV2
+            }
+            RESOLUTION_STATE_WIRE_VERSION => GameStateDecodeMode::ResolutionWireV3,
             _ => {
                 return Err(format!(
-                    "unsupported resolution_state_version {version}; expected 1 or {RESOLUTION_STATE_WIRE_VERSION}"
+                    "unsupported resolution_state_version {version}; expected 1, 2, or {RESOLUTION_STATE_WIRE_VERSION}"
                 ));
             }
         };
@@ -3988,7 +4008,7 @@ impl ResolutionStateWire {
         GameStateDecode::prepare_resolution_wire(&mut value, decode_mode)?;
         let additional_live_event_roots = match decode_mode {
             GameStateDecodeMode::ResolutionWireV1 => LEGACY_LIVE_ZONE_CHANGED_EVENT_ROOTS,
-            GameStateDecodeMode::ResolutionWireV2 => &[],
+            GameStateDecodeMode::ResolutionWireV2 | GameStateDecodeMode::ResolutionWireV3 => &[],
             GameStateDecodeMode::PersistedRaw
             | GameStateDecodeMode::TrustedEnvelope
             | GameStateDecodeMode::DirectCurrentRaw => {
@@ -4174,7 +4194,7 @@ impl ResolutionStateWire {
                 debug_assert_runtime_resolution_invariants(&legacy);
                 Ok(Self { state: legacy })
             }
-            GameStateDecodeMode::ResolutionWireV2 => {
+            GameStateDecodeMode::ResolutionWireV2 | GameStateDecodeMode::ResolutionWireV3 => {
                 crate::types::game_state::reconcile_persisted_zone_change_occurrences(
                     &mut value,
                     &[],
@@ -4184,12 +4204,12 @@ impl ResolutionStateWire {
                     .expect("the checked resolution state wire remains an object");
                 if legacy_resolution_wire_field(object).is_some() {
                     return Err(
-                        "v2 resolution state must not contain a legacy resolution field"
+                        "typed-frame resolution state must not contain a legacy resolution field"
                             .to_string(),
                     );
                 }
                 let frames_value = object.get("resolution_frames").ok_or_else(|| {
-                    "v2 resolution state is missing resolution_frames".to_string()
+                    "typed-frame resolution state is missing resolution_frames".to_string()
                 })?;
                 if has_removed_batched_repeated_optional_payment(frames_value) {
                     return Err(
@@ -4209,7 +4229,8 @@ impl ResolutionStateWire {
                 state_object.remove("resolution_frames");
                 if state_object.remove("resolution_stack").is_some() {
                     return Err(
-                        "v2 resolution state must not contain runtime resolution_stack".to_string(),
+                        "typed-frame resolution state must not contain runtime resolution_stack"
+                            .to_string(),
                     );
                 }
                 let state = GameStateDecode::materialize_prepared(state_value)?;
@@ -4220,7 +4241,7 @@ impl ResolutionStateWire {
                 let canonical = canonicalize_legacy_resolution_state(&projected)?;
                 if canonical != frames {
                     return Err(
-                        "v2 resolution frames cannot be represented by the legacy runtime slots"
+                        "typed-frame resolution frames cannot be represented by the legacy runtime slots"
                             .to_string(),
                     );
                 }
@@ -4256,7 +4277,7 @@ impl ResolutionStateWire {
 /// belongs to the next priority window; it cannot keep the prior resolution
 /// carrier alive.
 ///
-/// This is intentionally limited to the v1 projection above. Current v2
+/// This is intentionally limited to the v1 projection above. Current
 /// snapshots must preserve their exact active carrier and are validated rather
 /// than normalized during decode.
 fn normalize_legacy_completed_resolution_carrier(state: &mut GameState) {
@@ -4421,7 +4442,7 @@ fn has_removed_batched_repeated_optional_payment(value: &Value) -> bool {
 /// Checks the Phase-3 runtime invariants after a restore and after every
 /// public action. Migrated families are authoritative in `ResolutionStack`;
 /// canonicalization combines those with unmigrated legacy families for the
-/// v2 wire boundary. Valid in-flight trigger occurrences may intentionally be
+/// typed-frame wire boundary. Valid in-flight trigger occurrences may intentionally be
 /// non-serializable and are checked only structurally at this boundary.
 #[cfg(debug_assertions)]
 pub(crate) fn debug_assert_runtime_resolution_invariants(state: &GameState) {
@@ -4439,14 +4460,14 @@ pub(crate) fn debug_assert_runtime_resolution_invariants(state: &GameState) {
         "the active inline-mana override must not survive a public boundary"
     );
 
-    if let Ok(v2) = ResolutionStateWire::from_game_state(state.clone()).to_value() {
-        let object = v2
+    if let Ok(current) = ResolutionStateWire::from_game_state(state.clone()).to_value() {
+        let object = current
             .as_object()
             .expect("resolution wire serialization is always an object");
         for field in legacy_resolution_wire_fields() {
             assert!(
                 !object.contains_key(*field),
-                "v2 resolution frames must not co-reside with legacy runtime field {field}"
+                "current resolution frames must not co-reside with legacy runtime field {field}"
             );
         }
     }
@@ -4997,7 +5018,7 @@ pub(crate) fn canonicalize_legacy_resolution_state(
     frames.restore_next_discard_frame_id(state.resolution_stack.next_discard_frame_id());
     // Threaded for the same reason as the two above: this function is both the
     // WRITER's canonicalization (`ResolutionStateWire::to_value`) and the
-    // right-hand side of the v2 identity gate, and `ResolutionStack` derives
+    // right-hand side of the typed-frame identity gate, and `ResolutionStack` derives
     // `PartialEq`. Without this, every save in which a post-replacement dispatch
     // ever occurred fails that gate on load.
     frames.restore_last_post_replacement_frame_id(
@@ -5028,7 +5049,7 @@ fn project_frames_into_legacy_state(
     projected
         .resolution_stack
         .restore_next_discard_frame_id(frames.next_discard_frame_id());
-    // The left-hand side of the v2 identity gate. `state` is materialized from a
+    // The left-hand side of the typed-frame identity gate. `state` is materialized from a
     // value with `resolution_frames` removed and `resolution_stack` forbidden,
     // so its allocator is `Default` (0); without this restore the projection's
     // allocator stays 0 while `frames` carries N, and the derived `PartialEq`
@@ -5313,15 +5334,19 @@ mod tests {
         value
     }
 
+    fn v2_wire_value(state: GameState) -> Value {
+        let mut value = ResolutionStateWire::from_game_state(state)
+            .to_value()
+            .expect("current wire serializes before fixture downgrade");
+        value["resolution_state_version"] =
+            Value::from(LEGACY_TYPED_FRAME_RESOLUTION_STATE_WIRE_VERSION);
+        value
+    }
+
     #[test]
     fn exploit_victim_record_survives_v1_and_v2_resolution_wires() {
         let (state, expected) = state_with_recorded_exploit_event();
-        let wires = [
-            v1_wire_value(state.clone()),
-            ResolutionStateWire::from_game_state(state)
-                .to_value()
-                .expect("v2 wire serializes"),
-        ];
+        let wires = [v1_wire_value(state.clone()), v2_wire_value(state)];
 
         for wire in wires {
             let restored: ResolutionStateWire =
@@ -5336,12 +5361,7 @@ mod tests {
     #[test]
     fn v1_and_v2_resolution_wires_reject_recordless_exploit_events() {
         let (state, _) = state_with_recorded_exploit_event();
-        let mut wires = [
-            v1_wire_value(state.clone()),
-            ResolutionStateWire::from_game_state(state)
-                .to_value()
-                .expect("v2 wire serializes"),
-        ];
+        let mut wires = [v1_wire_value(state.clone()), v2_wire_value(state)];
 
         for wire in &mut wires {
             wire["deferred_entry_events"][0]["data"]
@@ -5639,21 +5659,21 @@ mod tests {
 
         let wire: ResolutionStateWire = serde_json::from_value(v1)
             .expect("v1 optional-effect fixture converts through the wire");
-        let v2 = serde_json::to_value(&wire).expect("converted fixture serializes as v2");
+        let current = serde_json::to_value(&wire).expect("converted fixture serializes");
         assert_eq!(
-            v2["resolution_state_version"],
+            current["resolution_state_version"],
             Value::from(RESOLUTION_STATE_WIRE_VERSION)
         );
-        assert!(v2.get("resolution_frames").is_some());
+        assert!(current.get("resolution_frames").is_some());
         for field in legacy_resolution_wire_fields() {
             assert!(
-                v2.get(*field).is_none(),
-                "v2 fixture must not write legacy field {field}"
+                current.get(*field).is_none(),
+                "current fixture must not write legacy field {field}"
             );
         }
 
-        serde_json::from_value::<ResolutionStateWire>(v2)
-            .expect("v2 optional-effect fixture restores for the runtime action path")
+        serde_json::from_value::<ResolutionStateWire>(current)
+            .expect("current optional-effect fixture restores for the runtime action path")
             .into_game_state()
     }
 
@@ -5671,21 +5691,21 @@ mod tests {
 
         let wire: ResolutionStateWire = serde_json::from_value(v1)
             .expect("v1 repeated-payment fixture converts through the wire");
-        let v2 = serde_json::to_value(&wire).expect("converted fixture serializes as v2");
+        let current = serde_json::to_value(&wire).expect("converted fixture serializes");
         assert_eq!(
-            v2["resolution_state_version"],
+            current["resolution_state_version"],
             Value::from(RESOLUTION_STATE_WIRE_VERSION)
         );
-        assert!(v2.get("resolution_frames").is_some());
+        assert!(current.get("resolution_frames").is_some());
         for field in legacy_resolution_wire_fields() {
             assert!(
-                v2.get(*field).is_none(),
-                "v2 fixture must not write legacy field {field}"
+                current.get(*field).is_none(),
+                "current fixture must not write legacy field {field}"
             );
         }
 
-        serde_json::from_value::<ResolutionStateWire>(v2)
-            .expect("v2 repeated-payment fixture restores for the runtime action path")
+        serde_json::from_value::<ResolutionStateWire>(current)
+            .expect("current repeated-payment fixture restores for the runtime action path")
             .into_game_state()
     }
 
@@ -5698,21 +5718,21 @@ mod tests {
 
         let wire: ResolutionStateWire =
             serde_json::from_value(v1).expect("v1 coin-flip fixture converts through the wire");
-        let v2 = serde_json::to_value(&wire).expect("converted fixture serializes as v2");
+        let current = serde_json::to_value(&wire).expect("converted fixture serializes");
         assert_eq!(
-            v2["resolution_state_version"],
+            current["resolution_state_version"],
             Value::from(RESOLUTION_STATE_WIRE_VERSION)
         );
-        assert!(v2.get("resolution_frames").is_some());
+        assert!(current.get("resolution_frames").is_some());
         for field in legacy_resolution_wire_fields() {
             assert!(
-                v2.get(*field).is_none(),
-                "v2 fixture must not write legacy field {field}"
+                current.get(*field).is_none(),
+                "current fixture must not write legacy field {field}"
             );
         }
 
-        serde_json::from_value::<ResolutionStateWire>(v2)
-            .expect("v2 coin-flip fixture restores for the runtime action path")
+        serde_json::from_value::<ResolutionStateWire>(current)
+            .expect("current coin-flip fixture restores for the runtime action path")
             .into_game_state()
     }
 
@@ -5728,21 +5748,21 @@ mod tests {
 
         let wire: ResolutionStateWire =
             serde_json::from_value(v1).expect("v1 proliferate fixture converts through the wire");
-        let v2 = serde_json::to_value(&wire).expect("converted fixture serializes as v2");
+        let current = serde_json::to_value(&wire).expect("converted fixture serializes");
         assert_eq!(
-            v2["resolution_state_version"],
+            current["resolution_state_version"],
             Value::from(RESOLUTION_STATE_WIRE_VERSION)
         );
-        assert!(v2.get("resolution_frames").is_some());
+        assert!(current.get("resolution_frames").is_some());
         for field in legacy_resolution_wire_fields() {
             assert!(
-                v2.get(*field).is_none(),
-                "v2 fixture must not write legacy field {field}"
+                current.get(*field).is_none(),
+                "current fixture must not write legacy field {field}"
             );
         }
 
-        serde_json::from_value::<ResolutionStateWire>(v2)
-            .expect("v2 proliferate fixture restores for the runtime action path")
+        serde_json::from_value::<ResolutionStateWire>(current)
+            .expect("current proliferate fixture restores for the runtime action path")
             .into_game_state()
     }
 
@@ -5755,21 +5775,21 @@ mod tests {
 
         let wire: ResolutionStateWire =
             serde_json::from_value(v1).expect("v1 mutate-merge fixture converts through the wire");
-        let v2 = serde_json::to_value(&wire).expect("converted fixture serializes as v2");
+        let current = serde_json::to_value(&wire).expect("converted fixture serializes");
         assert_eq!(
-            v2["resolution_state_version"],
+            current["resolution_state_version"],
             Value::from(RESOLUTION_STATE_WIRE_VERSION)
         );
-        assert!(v2.get("resolution_frames").is_some());
+        assert!(current.get("resolution_frames").is_some());
         for field in legacy_resolution_wire_fields() {
             assert!(
-                v2.get(*field).is_none(),
-                "v2 fixture must not write legacy field {field}"
+                current.get(*field).is_none(),
+                "current fixture must not write legacy field {field}"
             );
         }
 
-        serde_json::from_value::<ResolutionStateWire>(v2)
-            .expect("v2 mutate-merge fixture restores for the runtime action path")
+        serde_json::from_value::<ResolutionStateWire>(current)
+            .expect("current mutate-merge fixture restores for the runtime action path")
             .into_game_state()
     }
 
@@ -5987,25 +6007,27 @@ mod tests {
             .into_game_state()
     }
 
-    fn assert_reserializes_v2_only(state: GameState) {
-        let v2 = serde_json::to_value(ResolutionStateWire::from_game_state(state))
-            .expect("resumed fixture serializes as v2");
+    fn assert_reserializes_current_only(state: GameState) {
+        let current = serde_json::to_value(ResolutionStateWire::from_game_state(state))
+            .expect("resumed fixture serializes through the current resolution wire");
         assert_eq!(
-            v2["resolution_state_version"],
+            current["resolution_state_version"],
             Value::from(RESOLUTION_STATE_WIRE_VERSION)
         );
-        assert!(v2.get("resolution_frames").is_some());
+        assert!(current.get("resolution_frames").is_some());
         for field in legacy_resolution_wire_fields() {
             assert!(
-                v2.get(*field).is_none(),
-                "resumed v2 fixture must not write legacy field {field}"
+                current.get(*field).is_none(),
+                "resumed current fixture must not write legacy field {field}"
             );
         }
     }
 
     fn v2_fixture_with_frames(state: GameState, frames: ResolutionStack) -> Value {
         let mut v2 = serde_json::to_value(ResolutionStateWire::from_game_state(state))
-            .expect("empty v2 fixture serializes");
+            .expect("empty current fixture serializes");
+        v2["resolution_state_version"] =
+            Value::from(LEGACY_TYPED_FRAME_RESOLUTION_STATE_WIRE_VERSION);
         v2["resolution_frames"] = serde_json::to_value(frames).expect("fixture frames serialize");
         v2
     }
@@ -6491,7 +6513,7 @@ mod tests {
     }
 
     #[test]
-    fn resolution_state_wire_converts_v1_to_v2_without_legacy_projection() {
+    fn resolution_state_wire_converts_v1_to_current_without_legacy_projection() {
         let mut state = GameState::new_two_player(42);
         state.waiting_for = WaitingFor::CoinFlipKeepChoice {
             player: PlayerId(0),
@@ -6516,16 +6538,16 @@ mod tests {
             serde_json::from_value(v1).expect("v1 legacy state converts through frames");
         assert_eq!(wire.game_state().active_coin_flip_frame(), Some(&pending));
 
-        let v2 = serde_json::to_value(&wire).expect("v2 wire serializes");
+        let current = serde_json::to_value(&wire).expect("current wire serializes");
         assert_eq!(
-            v2["resolution_state_version"],
+            current["resolution_state_version"],
             Value::from(RESOLUTION_STATE_WIRE_VERSION)
         );
-        assert!(v2.get("resolution_frames").is_some());
-        assert!(v2.get("pending_coin_flip").is_none());
+        assert!(current.get("resolution_frames").is_some());
+        assert!(current.get("pending_coin_flip").is_none());
 
-        let restored: ResolutionStateWire =
-            serde_json::from_value(v2).expect("v2 frame state restores for the runtime action");
+        let restored: ResolutionStateWire = serde_json::from_value(current)
+            .expect("current frame state restores for the runtime action");
         assert_eq!(
             restored.into_game_state().active_coin_flip_frame(),
             Some(&pending)
@@ -6533,9 +6555,10 @@ mod tests {
     }
 
     #[test]
-    fn resolution_wire_contract_pins_v2_and_the_v1_reader() {
-        assert_eq!(RESOLUTION_STATE_WIRE_VERSION, 2);
+    fn resolution_wire_contract_pins_v3_and_the_legacy_readers() {
+        assert_eq!(RESOLUTION_STATE_WIRE_VERSION, 3);
         assert_eq!(LEGACY_RESOLUTION_STATE_WIRE_VERSION, 1);
+        assert_eq!(LEGACY_TYPED_FRAME_RESOLUTION_STATE_WIRE_VERSION, 2);
 
         let mut v1 =
             serde_json::to_value(GameState::new_two_player(57)).expect("legacy state serializes");
@@ -6564,11 +6587,11 @@ mod tests {
             },
         );
         let wire = ResolutionStateWire::from_game_state(restored);
-        let v2 = serde_json::to_value(&wire).expect("v2 wire serializes");
-        assert!(v2.get("pending_choose_zone_trigger_context").is_none());
+        let current = serde_json::to_value(&wire).expect("current wire serializes");
+        assert!(current.get("pending_choose_zone_trigger_context").is_none());
 
-        let restored: ResolutionStateWire =
-            serde_json::from_value(v2).expect("v2 continuation sidecar projects for runtime");
+        let restored: ResolutionStateWire = serde_json::from_value(current)
+            .expect("current continuation sidecar projects for runtime");
         assert_eq!(
             restored
                 .into_game_state()
@@ -6638,11 +6661,11 @@ mod tests {
         let snapshot = HashSet::from([ObjectId(7), ObjectId(8)]);
         let restored = restore_v1_change_zone_fixture(state, None, Some(snapshot.clone()));
         let wire = ResolutionStateWire::from_game_state(restored);
-        let v2 = serde_json::to_value(&wire).expect("v2 wire serializes");
-        assert!(v2.get("devour_eligible_snapshot").is_none());
+        let current = serde_json::to_value(&wire).expect("current wire serializes");
+        assert!(current.get("devour_eligible_snapshot").is_none());
 
         let restored: ResolutionStateWire =
-            serde_json::from_value(v2).expect("v2 devour sidecar projects for runtime");
+            serde_json::from_value(current).expect("current devour sidecar projects for runtime");
         assert_eq!(
             restored.into_game_state().active_devour_eligible_snapshot(),
             Some(&snapshot)
@@ -6658,11 +6681,13 @@ mod tests {
         v1["resolution_state_version"] = Value::from(LEGACY_RESOLUTION_STATE_WIRE_VERSION);
         let wire: ResolutionStateWire =
             serde_json::from_value(v1).expect("v1 payment count converts through frames");
-        let v2 = serde_json::to_value(&wire).expect("v2 wire serializes");
-        assert!(v2.get("optional_cost_payments_this_resolution").is_none());
+        let current = serde_json::to_value(&wire).expect("current wire serializes");
+        assert!(current
+            .get("optional_cost_payments_this_resolution")
+            .is_none());
 
         let restored: ResolutionStateWire =
-            serde_json::from_value(v2).expect("v2 payment count projects for runtime");
+            serde_json::from_value(current).expect("current payment count projects for runtime");
         assert_eq!(
             restored
                 .into_game_state()
@@ -6690,9 +6715,9 @@ mod tests {
 
         let wire: ResolutionStateWire =
             serde_json::from_value(v1).expect("paused drain and draw become one adjacent pair");
-        let v2 = serde_json::to_value(&wire).expect("converted pair serializes");
-        let frames: ResolutionStack =
-            serde_json::from_value(v2["resolution_frames"].clone()).expect("frame payload parses");
+        let current = serde_json::to_value(&wire).expect("converted pair serializes");
+        let frames: ResolutionStack = serde_json::from_value(current["resolution_frames"].clone())
+            .expect("frame payload parses");
         assert_eq!(
             frames.iter().map(ResolutionFrame::kind).collect::<Vec<_>>(),
             vec![FrameKind::PostReplacement, FrameKind::MultiDraw]
@@ -6703,20 +6728,20 @@ mod tests {
     fn resolution_state_wire_rejects_missing_unknown_and_mixed_versions() {
         let state = GameState::new_two_player(42);
         let wire = ResolutionStateWire::from_game_state(state);
-        let v2 = serde_json::to_value(wire).expect("v2 wire serializes");
+        let current = serde_json::to_value(wire).expect("current wire serializes");
 
-        let mut missing = v2.clone();
+        let mut missing = current.clone();
         missing
             .as_object_mut()
             .expect("wire is an object")
             .remove("resolution_state_version");
         assert!(serde_json::from_value::<ResolutionStateWire>(missing).is_err());
 
-        let mut unknown = v2.clone();
+        let mut unknown = current.clone();
         unknown["resolution_state_version"] = Value::from(99);
         assert!(serde_json::from_value::<ResolutionStateWire>(unknown).is_err());
 
-        let mut mixed = v2;
+        let mut mixed = current;
         mixed["pending_coin_flip"] = Value::Null;
         assert!(serde_json::from_value::<ResolutionStateWire>(mixed).is_err());
     }
@@ -6870,7 +6895,7 @@ mod tests {
         )
         .expect("repeated-payment fixture resumes through the real optional-choice action");
         assert!(repeated.active_repeated_optional_payment_frame().is_none());
-        assert_reserializes_v2_only(repeated);
+        assert_reserializes_current_only(repeated);
 
         let mut optional = GameState::new_two_player(102);
         optional.waiting_for = WaitingFor::OptionalEffectChoice {
@@ -6895,7 +6920,7 @@ mod tests {
         )
         .expect("optional-effect fixture resumes through the real optional-choice action");
         assert!(optional.active_optional_effect_frame().is_none());
-        assert_reserializes_v2_only(optional);
+        assert_reserializes_current_only(optional);
 
         let mut coin = GameState::new_two_player(103);
         coin.waiting_for = WaitingFor::CoinFlipKeepChoice {
@@ -6923,7 +6948,7 @@ mod tests {
         )
         .expect("coin-flip fixture resumes through the real keep-choice action");
         assert!(coin.active_coin_flip_frame().is_none());
-        assert_reserializes_v2_only(coin);
+        assert_reserializes_current_only(coin);
 
         let mut proliferate = GameState::new_two_player(104);
         proliferate.waiting_for = WaitingFor::ProliferateChoice {
@@ -6946,7 +6971,7 @@ mod tests {
         )
         .expect("proliferate fixture resumes through the real target-choice action");
         assert!(proliferate.active_proliferate_frame().is_none());
-        assert_reserializes_v2_only(proliferate);
+        assert_reserializes_current_only(proliferate);
 
         let mut scenario = GameScenario::new();
         let merging_id = scenario.add_creature(PlayerId(0), "Rider", 4, 4).id();
@@ -6981,7 +7006,7 @@ mod tests {
                 .merged_components,
             vec![merging_id, target_id]
         );
-        assert_reserializes_v2_only(mutate);
+        assert_reserializes_current_only(mutate);
     }
 
     #[test]
@@ -6996,7 +7021,7 @@ mod tests {
             },
         ));
         assert!(continuation.active_ability_continuation().is_none());
-        assert_reserializes_v2_only(continuation);
+        assert_reserializes_current_only(continuation);
 
         let repeat_for = GameState::new_two_player(111);
         let repeat_for = resume_priority_fixture(restore_v1_repeat_for_fixture(
@@ -7010,7 +7035,7 @@ mod tests {
             },
         ));
         assert!(repeat_for.active_repeat_for().is_none());
-        assert_reserializes_v2_only(repeat_for);
+        assert_reserializes_current_only(repeat_for);
 
         let repeat_until = GameState::new_two_player(112);
         let mut repeat_ability = resolved_draw(112);
@@ -7031,7 +7056,7 @@ mod tests {
         )
         .expect("repeat-until fixture resumes through the real repeat decision");
         assert!(repeat_until.active_repeat_until().is_none());
-        assert_reserializes_v2_only(repeat_until);
+        assert_reserializes_current_only(repeat_until);
 
         let ResolutionFrame::ChangeZone(change_zone_frame) = change_zone_frame(113) else {
             unreachable!("helper constructs a change-zone frame")
@@ -7043,7 +7068,7 @@ mod tests {
             Some(HashSet::from([ObjectId(113)])),
         ));
         assert!(change_zone.active_change_zone_frame().is_none());
-        assert_reserializes_v2_only(change_zone);
+        assert_reserializes_current_only(change_zone);
 
         let counter_moves = GameState::new_two_player(114);
         let counter_moves = resume_priority_fixture(restore_v1_counter_moves_fixture(
@@ -7055,7 +7080,7 @@ mod tests {
             },
         ));
         assert!(counter_moves.active_counter_moves().is_none());
-        assert_reserializes_v2_only(counter_moves);
+        assert_reserializes_current_only(counter_moves);
 
         let counter_removals = GameState::new_two_player(115);
         let counter_removals = resume_priority_fixture(restore_v1_counter_removals_fixture(
@@ -7070,7 +7095,7 @@ mod tests {
             },
         ));
         assert!(counter_removals.active_counter_removals().is_none());
-        assert_reserializes_v2_only(counter_removals);
+        assert_reserializes_current_only(counter_removals);
 
         let counter_additions = GameState::new_two_player(116);
         let counter_additions = resume_priority_fixture(restore_v1_counter_additions_fixture(
@@ -7081,7 +7106,7 @@ mod tests {
             },
         ));
         assert!(counter_additions.active_counter_additions().is_none());
-        assert_reserializes_v2_only(counter_additions);
+        assert_reserializes_current_only(counter_additions);
     }
 
     #[test]
@@ -7110,7 +7135,7 @@ mod tests {
         let mut batch = restore_v1_batch_delivery_fixture(batch, pending.clone());
         crate::game::zone_pipeline::drain_pending_batch_deliveries(&mut batch, &mut Vec::new());
         assert!(batch.active_batch_delivery().is_none());
-        assert_reserializes_v2_only(batch);
+        assert_reserializes_current_only(batch);
 
         let alias_state = GameState::new_two_player(120);
         let mut v1 = serde_json::to_value(alias_state).expect("legacy alias fixture serializes");
@@ -7121,7 +7146,7 @@ mod tests {
             .expect("v1 pending_mill_deliveries alias restores")
             .into_game_state();
         assert!(alias.active_batch_delivery().is_some());
-        assert_reserializes_v2_only(alias);
+        assert_reserializes_current_only(alias);
 
         let mut copy_token = restore_v1_copy_token_fixture(
             GameState::new_two_player(121),
@@ -7137,7 +7162,7 @@ mod tests {
             &mut Vec::new(),
         );
         assert!(copy_token.active_copy_token().is_none());
-        assert_reserializes_v2_only(copy_token);
+        assert_reserializes_current_only(copy_token);
     }
 
     #[test]
@@ -7181,11 +7206,12 @@ mod tests {
 
         let wire: ResolutionStateWire =
             serde_json::from_value(v1).expect("v1 nested pause converts through the wire");
-        let v2 = serde_json::to_value(&wire).expect("nested pause serializes as v2 frames");
+        let current =
+            serde_json::to_value(&wire).expect("nested pause serializes as current frames");
         for field in legacy_resolution_wire_fields() {
             assert!(
-                v2.get(*field).is_none(),
-                "nested v2 fixture must not write legacy field {field}"
+                current.get(*field).is_none(),
+                "nested current fixture must not write legacy field {field}"
             );
         }
 
@@ -7211,7 +7237,7 @@ mod tests {
         assert!(state.active_each_player_copy_chosen().is_none());
         assert!(state.active_copy_token().is_none());
         assert!(state.active_counter_additions().is_none());
-        assert_reserializes_v2_only(state);
+        assert_reserializes_current_only(state);
     }
 
     #[test]
@@ -7240,7 +7266,7 @@ mod tests {
             &mut Vec::new(),
         );
         assert!(each_player_copy.active_each_player_copy_chosen().is_none());
-        assert_reserializes_v2_only(each_player_copy);
+        assert_reserializes_current_only(each_player_copy);
 
         let choose_one_of = GameState::new_two_player(131);
         let mut choose_one_of = restore_v1_choose_one_of_fixture(
@@ -7258,7 +7284,7 @@ mod tests {
         );
         crate::game::effects::choose_one_of::resume_pending(&mut choose_one_of, &mut Vec::new());
         assert!(choose_one_of.active_choose_one_of().is_none());
-        assert_reserializes_v2_only(choose_one_of);
+        assert_reserializes_current_only(choose_one_of);
 
         let vote = GameState::new_two_player(132);
         let mut vote = restore_v1_vote_ballot_fixture(
@@ -7275,7 +7301,7 @@ mod tests {
         );
         crate::game::effects::vote::drain_active_vote_ballot(&mut vote, &mut Vec::new());
         assert!(vote.active_vote_ballot().is_none());
-        assert_reserializes_v2_only(vote);
+        assert_reserializes_current_only(vote);
 
         let choose_from_zone = resolved_effect(
             133,
@@ -7308,7 +7334,7 @@ mod tests {
             &mut Vec::new(),
         );
         assert!(per_player.active_per_player_zone_choice().is_none());
-        assert_reserializes_v2_only(per_player);
+        assert_reserializes_current_only(per_player);
 
         let for_each_category = resolved_effect(
             134,
@@ -7336,7 +7362,7 @@ mod tests {
             &mut Vec::new(),
         );
         assert!(per_category.active_per_category_zone_choice().is_none());
-        assert_reserializes_v2_only(per_category);
+        assert_reserializes_current_only(per_category);
     }
 
     #[test]
@@ -7348,8 +7374,10 @@ mod tests {
             HashSet::new(),
             DrawSequenceOrigin::Plain,
         );
-        let v2 = serde_json::to_value(ResolutionStateWire::from_game_state(state))
+        let mut v2 = serde_json::to_value(ResolutionStateWire::from_game_state(state))
             .expect("v2 active draw fixture serializes");
+        v2["resolution_state_version"] =
+            Value::from(LEGACY_TYPED_FRAME_RESOLUTION_STATE_WIRE_VERSION);
         let mut with_outer_allocator = v2.clone();
         with_outer_allocator["resolution_frames"]["next_draw_sequence_frame_id"] = Value::from(99);
         let restored_with_outer =
@@ -7449,8 +7477,10 @@ mod tests {
     fn v2_reader_recovers_discard_allocator_and_rejects_duplicate_frame_ids() {
         let mut state = GameState::new_two_player(140);
         let captured = state.resolution_stack.begin_discard(None);
-        let v2 = serde_json::to_value(ResolutionStateWire::from_game_state(state))
+        let mut v2 = serde_json::to_value(ResolutionStateWire::from_game_state(state))
             .expect("v2 active discard fixture serializes");
+        v2["resolution_state_version"] =
+            Value::from(LEGACY_TYPED_FRAME_RESOLUTION_STATE_WIRE_VERSION);
 
         let mut stale_outer_allocator = v2.clone();
         stale_outer_allocator["resolution_frames"]["next_discard_frame_id"] = Value::from(0);
@@ -7849,7 +7879,7 @@ mod tests {
         // payload can present this shape. `validate` is still called with no
         // such recovery in front of it by the runtime invariant check
         // (`debug_assert_runtime_resolution_invariants`, after a restore and
-        // after every public action) and by the v2 WRITE side
+        // after every public action) and by the current WRITE side
         // (`ResolutionStateWire::to_value`), which is what this exercises.
         //
         // Constructed identically to `at_the_allocator` above except that the
@@ -7875,14 +7905,14 @@ mod tests {
         );
     }
 
-    /// **H6(d) — round-trip half.** The allocator survives the real v2 write →
-    /// read → identity-gate round trip.
+    /// **H6(d) — round-trip half.** The allocator survives the real current
+    /// write followed by the v2 compatibility read and identity gate.
     ///
     /// Deliberately goes through the WRITE side (`to_value` → `canonicalize` →
     /// `validate`) rather than through `v2_fixture_with_frames`, because the
     /// writer is half of what the round-trip threading breaks.
     #[test]
-    fn h6d_the_post_replacement_allocator_survives_the_v2_round_trip() {
+    fn h6d_the_post_replacement_allocator_survives_current_write_and_v2_read() {
         let mut state = GameState::new_two_player(147);
         state
             .resolution_stack
@@ -7911,8 +7941,10 @@ mod tests {
             "non-vacuity: the frame must be stamped before serializing"
         );
 
-        let v2 = serde_json::to_value(ResolutionStateWire::from_game_state(state))
-            .expect("stamped v2 fixture serializes");
+        let mut v2 = serde_json::to_value(ResolutionStateWire::from_game_state(state))
+            .expect("current writer serializes the fixture before its v2 downgrade");
+        v2["resolution_state_version"] =
+            Value::from(LEGACY_TYPED_FRAME_RESOLUTION_STATE_WIRE_VERSION);
         let restored = serde_json::from_value::<ResolutionStateWire>(v2)
             .expect("stamped v2 payload decodes")
             .into_game_state();
@@ -7953,7 +7985,7 @@ mod tests {
             &mut Vec::new(),
         );
         assert!(multi_draw.active_draw_sequence().is_none());
-        assert_reserializes_v2_only(multi_draw);
+        assert_reserializes_current_only(multi_draw);
 
         let mut connive = GameScenario::new();
         let conniver = connive.add_creature(PlayerId(0), "Conniver", 1, 1).id();
@@ -7984,7 +8016,7 @@ mod tests {
         )
         .expect("connive fixture re-enters through the production proposer");
         assert!(connive.active_connive_reentry().is_none());
-        assert_reserializes_v2_only(connive);
+        assert_reserializes_current_only(connive);
 
         let life = GameState::new_two_player(141);
         let pending_life_total_assignment = PendingLifeTotalAssignment {
@@ -8001,7 +8033,7 @@ mod tests {
             .into_game_state();
         crate::game::effects::life::drain_pending_life_total_assignment(&mut life, &mut Vec::new());
         assert!(life.active_life_total_assignment().is_none());
-        assert_reserializes_v2_only(life);
+        assert_reserializes_current_only(life);
 
         let mut spell = GameState::new_two_player(142);
         let spell_id = crate::game::zones::create_object(
@@ -8076,7 +8108,7 @@ mod tests {
         apply_as_current(&mut spell, GameAction::ChooseReplacement { index: 0 })
             .expect("spell fixture resumes through the real replacement action");
         assert!(spell.active_spell_resolution().is_none());
-        assert_reserializes_v2_only(spell);
+        assert_reserializes_current_only(spell);
 
         let mut drains = PostReplacementDrainStack::default();
         assert!(drains.install(
@@ -8105,7 +8137,7 @@ mod tests {
             .is_none()
         );
         assert!(post_replacement.active_post_replacement_drains().is_none());
-        assert_reserializes_v2_only(post_replacement);
+        assert_reserializes_current_only(post_replacement);
     }
 
     #[test]
@@ -8138,25 +8170,25 @@ mod tests {
         );
         assert!(paired.active_draw_sequence().is_none());
         assert!(paired.active_post_replacement_drains().is_none());
-        assert_reserializes_v2_only(paired);
+        assert_reserializes_current_only(paired);
     }
 
     #[test]
     fn resolution_state_wire_rejects_translated_ambiguous_and_invalid_frame_shapes() {
         let base = GameState::new_two_player(150);
-        let v2 = serde_json::to_value(ResolutionStateWire::from_game_state(base.clone()))
-            .expect("base v2 fixture serializes");
+        let current = serde_json::to_value(ResolutionStateWire::from_game_state(base.clone()))
+            .expect("base current fixture serializes");
 
-        let mut v2_missing_frames = v2.clone();
-        v2_missing_frames
+        let mut current_missing_frames = current.clone();
+        current_missing_frames
             .as_object_mut()
-            .expect("v2 fixture is an object")
+            .expect("current fixture is an object")
             .remove("resolution_frames");
-        assert!(serde_json::from_value::<ResolutionStateWire>(v2_missing_frames).is_err());
+        assert!(serde_json::from_value::<ResolutionStateWire>(current_missing_frames).is_err());
 
-        let mut v2_with_legacy = v2.clone();
-        v2_with_legacy["pending_coin_flip"] = Value::Null;
-        assert!(serde_json::from_value::<ResolutionStateWire>(v2_with_legacy).is_err());
+        let mut current_with_legacy = current.clone();
+        current_with_legacy["pending_coin_flip"] = Value::Null;
+        assert!(serde_json::from_value::<ResolutionStateWire>(current_with_legacy).is_err());
 
         let mut v1_with_frames = serde_json::to_value(base.clone()).expect("v1 serializes");
         v1_with_frames["resolution_state_version"] =
@@ -8164,7 +8196,7 @@ mod tests {
         v1_with_frames["resolution_frames"] = Value::Array(Vec::new());
         assert!(serde_json::from_value::<ResolutionStateWire>(v1_with_frames).is_err());
 
-        let mut invalid_version_type = v2.clone();
+        let mut invalid_version_type = current.clone();
         invalid_version_type["resolution_state_version"] = Value::from("two");
         assert!(serde_json::from_value::<ResolutionStateWire>(invalid_version_type).is_err());
 

--- a/crates/engine/src/types/resolution.rs
+++ b/crates/engine/src/types/resolution.rs
@@ -3908,7 +3908,9 @@ const LEGACY_LIVE_ZONE_CHANGED_EVENT_ROOTS: &[&str] = &[
 /// This adapter is the persistence seam between v1's legacy-only payloads and
 /// v2's typed frames. v1 decoding converts migrated family payloads into the
 /// runtime stack; v2 decoding restores those frames directly while retaining
-/// legacy slots solely for unmigrated families.
+/// legacy slots solely for unmigrated families. Both supported versions refuse
+/// `CreatureExploited` events that predate authoritative victim records; the
+/// version distinguishes frame layouts and cannot safely synthesize event facts.
 #[derive(Debug, Clone)]
 pub struct ResolutionStateWire {
     state: GameState,
@@ -3980,7 +3982,9 @@ impl ResolutionStateWire {
         // `ResolutionStateWire` is a public persistence boundary in its own
         // right. Its historic-shape preparation and raw-state materialization
         // both belong to `GameStateDecode`; no wire branch gets a private
-        // `GameState` serde shortcut.
+        // `GameState` serde shortcut. Historical externally tagged exploit
+        // events are recognized there only to produce the same incompatibility
+        // diagnostic; this adapter does not add support for that event codec.
         GameStateDecode::prepare_resolution_wire(&mut value, decode_mode)?;
         let additional_live_event_roots = match decode_mode {
             GameStateDecodeMode::ResolutionWireV1 => LEGACY_LIVE_ZONE_CHANGED_EVENT_ROOTS,
@@ -5251,6 +5255,111 @@ mod tests {
     use crate::types::replacements::ReplacementEvent;
     use crate::types::zones::{EtbTapState, Zone};
     use std::collections::VecDeque;
+
+    fn state_with_recorded_exploit_event() -> (GameState, GameEvent) {
+        let mut state = GameState::new_two_player(42);
+        let exploiter = crate::game::zones::create_object(
+            &mut state,
+            CardId(80),
+            PlayerId(0),
+            "Exploit source".to_string(),
+            Zone::Battlefield,
+        );
+        let victim = crate::game::zones::create_object(
+            &mut state,
+            CardId(81),
+            PlayerId(0),
+            "Exploit victim".to_string(),
+            Zone::Battlefield,
+        );
+        state
+            .objects
+            .get_mut(&victim)
+            .expect("victim exists")
+            .is_token = true;
+        let mut departure_events = Vec::new();
+        crate::game::zones::move_to_zone(
+            &mut state,
+            victim,
+            Zone::Graveyard,
+            &mut departure_events,
+        );
+        let record = departure_events
+            .iter()
+            .find_map(|event| match event {
+                GameEvent::ZoneChanged {
+                    object_id, record, ..
+                } if *object_id == victim => Some(record.clone()),
+                _ => None,
+            })
+            .expect("the fixture emits an authoritative departure record");
+        let exploit = GameEvent::CreatureExploited {
+            exploiter,
+            sacrificed: victim,
+            record,
+        };
+        state.deferred_entry_events = vec![exploit.clone()];
+        (state, exploit)
+    }
+
+    fn v1_wire_value(state: GameState) -> Value {
+        let mut value = serde_json::to_value(state).expect("state serializes");
+        let object = value.as_object_mut().expect("state is an object");
+        object.remove("resolution_stack");
+        object.insert(
+            "resolution_state_version".to_string(),
+            Value::from(LEGACY_RESOLUTION_STATE_WIRE_VERSION),
+        );
+        value
+    }
+
+    #[test]
+    fn exploit_victim_record_survives_v1_and_v2_resolution_wires() {
+        let (state, expected) = state_with_recorded_exploit_event();
+        let wires = [
+            v1_wire_value(state.clone()),
+            ResolutionStateWire::from_game_state(state)
+                .to_value()
+                .expect("v2 wire serializes"),
+        ];
+
+        for wire in wires {
+            let restored: ResolutionStateWire =
+                serde_json::from_value(wire).expect("complete exploit evidence restores");
+            assert_eq!(
+                restored.game_state().deferred_entry_events,
+                vec![expected.clone()]
+            );
+        }
+    }
+
+    #[test]
+    fn v1_and_v2_resolution_wires_reject_recordless_exploit_events() {
+        let (state, _) = state_with_recorded_exploit_event();
+        let mut wires = [
+            v1_wire_value(state.clone()),
+            ResolutionStateWire::from_game_state(state)
+                .to_value()
+                .expect("v2 wire serializes"),
+        ];
+
+        for wire in &mut wires {
+            wire["deferred_entry_events"][0]["data"]
+                .as_object_mut()
+                .expect("event data is an object")
+                .remove("record");
+            let error = serde_json::from_value::<ResolutionStateWire>(wire.clone())
+                .expect_err("recordless exploit evidence must refuse the full wire")
+                .to_string();
+            assert!(
+                error.contains(
+                    "CreatureExploited snapshot lacks authoritative victim record; restore a save that contains the exploit departure record"
+                ),
+                "{error}"
+            );
+            assert!(error.contains("$.deferred_entry_events[0].data"), "{error}");
+        }
+    }
 
     #[test]
     fn removed_batched_repeated_payment_snapshot_is_detected() {

--- a/crates/engine/tests/integration/cost_zone_pipeline.rs
+++ b/crates/engine/tests/integration/cost_zone_pipeline.rs
@@ -25,8 +25,8 @@ use engine::types::events::{GameEvent, PlayerActionKind};
 use engine::types::game_state::{
     BatchCompletion, CastPaymentMode, CollectEvidenceResume, ExileLinkKind, GameState,
     ManaAbilityCostParentLifecycle, ManaAbilityCostResolutionMode, ManaAbilityResume, ManaChoice,
-    PayCostKind, PendingCast, PendingCostMoveResume, PendingReplacement, StackEntryKind,
-    WaitingFor, ZoneDeliveryExileTracking,
+    PayCostKind, PendingCast, PendingCostMoveResume, PendingReplacement, PersistedGameState,
+    StackEntryKind, WaitingFor, ZoneDeliveryExileTracking,
 };
 use engine::types::identifiers::ObjectId;
 use engine::types::keywords::Keyword;
@@ -34,6 +34,7 @@ use engine::types::mana::{ManaColor, ManaCost, ManaCostShard, ManaType};
 use engine::types::phase::Phase;
 use engine::types::proposed_event::{ProposedEvent, ReplacementId};
 use engine::types::replacements::ReplacementEvent;
+use engine::types::resolution::ResolutionStateWire;
 use engine::types::triggers::TriggerMode;
 use engine::types::zones::{EtbTapState, Zone};
 use std::sync::Arc;
@@ -12684,52 +12685,125 @@ fn effect_zone_sacrifice_replacement_preserves_tracked_set_and_tail() {
 
 /// W-163-D: Exploit emits its per-creature event and terminal event only after
 /// the replacement-delivered sacrifice has actually completed.
-#[test]
-fn exploit_replacement_preserves_creature_exploited_follow_up() {
+fn run_exploit_replacement_restore_case(
+    replacement_index: usize,
+    restore_through_persisted_raw: bool,
+    victim_is_token: bool,
+) {
+    const GURMAG_DROWNER: &str = "Exploit (When this creature enters, you may sacrifice a creature.)\nWhen this creature exploits a creature, look at the top four cards of your library. Put one of them into your hand and the rest into your graveyard.";
+
     let mut scenario = GameScenario::new();
     scenario.at_phase(Phase::PreCombatMain);
-    let exploiter = scenario
-        .add_creature(P0, "Exploit Replacement Source", 1, 1)
-        .id();
+    let exploiter = {
+        let mut card = scenario.add_creature_to_hand(P0, "Gurmag Drowner", 2, 4);
+        card.from_oracle_text_with_keywords(&["Exploit"], GURMAG_DROWNER)
+            .id()
+    };
     let victim = scenario
         .add_creature(P0, "Exploit Replacement Victim", 1, 1)
         .with_replacement_definition(redirect_self_moved_to(Zone::Graveyard, Zone::Exile))
         .with_replacement_definition(redirect_self_moved_to(Zone::Graveyard, Zone::Hand))
         .id();
-    let ability = ResolvedAbility::new(
-        Effect::Exploit {
-            target: TargetFilter::Any,
-        },
-        vec![TargetRef::Object(victim)],
-        exploiter,
-        P0,
-    );
     let mut runner = scenario.build();
-    let mut initial_events = Vec::new();
+    runner
+        .state_mut()
+        .objects
+        .get_mut(&victim)
+        .expect("fixture victim exists")
+        .is_token = victim_is_token;
+    let paused = runner
+        .cast(exploiter)
+        .target_object(victim)
+        .accept_optional()
+        .effect_zone(&[victim])
+        .resolve();
+    assert!(matches!(
+        paused.final_waiting_for(),
+        WaitingFor::ReplacementChoice { .. }
+    ));
+    assert!(!paused
+        .events()
+        .iter()
+        .any(|event| matches!(event, GameEvent::CreatureExploited { .. })));
 
-    resolve_ability_chain(runner.state_mut(), &ability, &mut initial_events, 0)
-        .expect("exploit reaches the replacement choice");
+    let restored = if restore_through_persisted_raw {
+        let encoded =
+            serde_json::to_value(PersistedGameState::Raw(Box::new(paused.state().clone())))
+                .expect("paused raw state serializes");
+        serde_json::from_value::<PersistedGameState>(encoded)
+            .expect("paused raw state decodes")
+            .into_game_state()
+            .expect("paused raw state satisfies restore finalization")
+    } else {
+        let encoded =
+            serde_json::to_value(ResolutionStateWire::from_game_state(paused.state().clone()))
+                .expect("paused resolution wire serializes");
+        serde_json::from_value::<ResolutionStateWire>(encoded)
+            .expect("paused resolution wire decodes")
+            .into_game_state()
+    };
+    let mut runner = GameRunner::from_state(restored);
     assert!(matches!(
         runner.state().waiting_for,
         WaitingFor::ReplacementChoice { .. }
     ));
-    assert!(!initial_events
-        .iter()
-        .any(|event| matches!(event, GameEvent::CreatureExploited { .. })));
 
     let completed = runner
-        .act(GameAction::ChooseReplacement { index: 0 })
+        .act(GameAction::ChooseReplacement {
+            index: replacement_index,
+        })
         .expect("replacement delivery completes exploit");
     assert!(matches!(completed.waiting_for, WaitingFor::Priority { .. }));
+    let expected_destination = if replacement_index == 0 {
+        Zone::Exile
+    } else {
+        Zone::Hand
+    };
+    let departure_record = completed
+        .events
+        .iter()
+        .find_map(|event| match event {
+            GameEvent::ZoneChanged {
+                object_id,
+                from: Some(Zone::Battlefield),
+                to,
+                record,
+            } if *object_id == victim && *to == expected_destination => Some(record),
+            _ => None,
+        })
+        .expect("replacement completion exposes the victim's actual departure record");
+    let exploited_event = completed
+        .events
+        .iter()
+        .find(|event| {
+            matches!(
+                event,
+                GameEvent::CreatureExploited {
+                    exploiter: event_exploiter,
+                    sacrificed,
+                    ..
+                } if *event_exploiter == exploiter && *sacrificed == victim
+            )
+        })
+        .expect("completed sacrifice emits the exploit event");
+    let GameEvent::CreatureExploited { record, .. } = exploited_event else {
+        unreachable!("the event was matched as CreatureExploited")
+    };
+    assert_eq!(record, departure_record);
     assert_eq!(
-        initial_events
+        serde_json::to_value(exploited_event).expect("event serializes")["data"]["record"],
+        serde_json::to_value(departure_record).expect("departure record serializes")
+    );
+    assert_eq!(
+        completed
+            .events
             .iter()
-            .chain(completed.events.iter())
             .filter(|event| matches!(
                 event,
                 GameEvent::CreatureExploited {
                     exploiter: event_exploiter,
                     sacrificed,
+                    ..
                 } if *event_exploiter == exploiter && *sacrificed == victim
             ))
             .count(),
@@ -12737,9 +12811,9 @@ fn exploit_replacement_preserves_creature_exploited_follow_up() {
         "the exploit follow-up is emitted once after delivery"
     );
     assert_eq!(
-        initial_events
+        completed
+            .events
             .iter()
-            .chain(completed.events.iter())
             .filter(|event| matches!(
                 event,
                 GameEvent::EffectResolved {
@@ -12751,6 +12825,25 @@ fn exploit_replacement_preserves_creature_exploited_follow_up() {
             .count(),
         1
     );
+    assert!(runner
+        .state()
+        .pending_player_scope_sacrifice_choice
+        .is_none());
+}
+
+#[test]
+fn exploit_replacement_preserves_creature_exploited_follow_up() {
+    for replacement_index in [0, 1] {
+        for restore_through_persisted_raw in [false, true] {
+            for victim_is_token in [false, true] {
+                run_exploit_replacement_restore_case(
+                    replacement_index,
+                    restore_through_persisted_raw,
+                    victim_is_token,
+                );
+            }
+        }
+    }
 }
 
 /// W-163-E: the terminal sweep of choose-and-sacrifice-rest keeps its complete

--- a/crates/engine/tests/integration/cr733_resolved_frame_transition.rs
+++ b/crates/engine/tests/integration/cr733_resolved_frame_transition.rs
@@ -13,7 +13,7 @@ use engine::types::player::PlayerId;
 use engine::types::resolution::{
     CipherEncodeStage, FrameKind, MultiDrawFrame, OptionalEffectFrame, PendingCipherEncode,
     PendingCoinFlip, PendingCoinFlipKind, ResolutionFrame, ResolutionStackError,
-    ResolutionStateWire,
+    ResolutionStateWire, RESOLUTION_STATE_WIRE_VERSION,
 };
 use engine::types::resolved_commands::{
     ResolvedCommandOrdinal, ResolvedFrameTransition, ResolvedFrameTransitionCommand,
@@ -414,10 +414,10 @@ fn production_parent_insertions_preserve_adjacency_and_journal_the_transition() 
         )));
 }
 
-/// Frame-transition commands use the existing v2 resolution-state wire and
+/// Frame-transition commands use the current resolution-state wire and
 /// preserve both their journal evidence and their structural stack exactly.
 #[test]
-fn resolution_state_wire_v2_round_trip_preserves_frame_transition_journal_and_stack() {
+fn current_resolution_wire_round_trip_preserves_frame_transition_journal_and_stack() {
     let mut state = GameState::new_two_player(102);
     state
         .resolve_and_apply_frame_transition(ResolvedFrameTransition::Push {
@@ -428,10 +428,13 @@ fn resolution_state_wire_v2_round_trip_preserves_frame_transition_journal_and_st
     let expected_stack = frames(&state);
 
     let wire = serde_json::to_value(ResolutionStateWire::from_game_state(state))
-        .expect("v2 resolution state serializes");
-    assert_eq!(wire["resolution_state_version"], 2);
+        .expect("current resolution state serializes");
+    assert_eq!(
+        wire["resolution_state_version"],
+        RESOLUTION_STATE_WIRE_VERSION
+    );
     let restored = serde_json::from_value::<ResolutionStateWire>(wire)
-        .expect("v2 resolution state restores")
+        .expect("current resolution state restores")
         .into_game_state();
 
     assert_eq!(restored.resolved_rules_journal, expected_journal);

--- a/crates/engine/tests/integration/exploit_ceased_exploiter_lki.rs
+++ b/crates/engine/tests/integration/exploit_ceased_exploiter_lki.rs
@@ -596,14 +596,26 @@ fn replay_exploited_over_ledger(strip_source_context: bool) -> i64 {
         .damage_marked = 99;
     commit.resolve();
 
-    let row = runner
+    let exploiter_row = runner
         .state()
         .zone_changes_this_turn
         .iter()
         .rposition(|change| change.object_id == aven && change.from_zone == Some(Zone::Battlefield))
         .expect("reach guard: the ceased exploiter must own a battlefield-origin ledger row");
+    let victim_record = runner
+        .state()
+        .zone_changes_this_turn
+        .iter()
+        .rfind(|change| {
+            change.object_id == victim
+                && change.from_zone == Some(Zone::Battlefield)
+                && change.to_zone == Zone::Graveyard
+        })
+        .cloned()
+        .expect("reach guard: exploit must record the sacrificed victim's departure");
+    assert_eq!(victim_record.object_id, victim);
     assert!(
-        runner.state().zone_changes_this_turn[row]
+        runner.state().zone_changes_this_turn[exploiter_row]
             .trigger_source_context
             .is_some(),
         "reach guard: a real producer must have stamped the row's source context (CR 608.2h)"
@@ -614,14 +626,14 @@ fn replay_exploited_over_ledger(strip_source_context: bool) -> i64 {
     );
 
     if strip_source_context {
-        runner.state_mut().zone_changes_this_turn[row].trigger_source_context = None;
+        runner.state_mut().zone_changes_this_turn[exploiter_row].trigger_source_context = None;
     }
 
     let hand_before = hand_size(runner.state(), P0);
     let replay = vec![GameEvent::CreatureExploited {
         exploiter: aven,
         sacrificed: victim,
-        record: Box::new(runner.state().zone_changes_this_turn[row].clone()),
+        record: Box::new(victim_record),
     }];
     triggers::process_triggers(runner.state_mut(), &replay);
     runner.advance_until_stack_empty();

--- a/crates/engine/tests/integration/exploit_ceased_exploiter_lki.rs
+++ b/crates/engine/tests/integration/exploit_ceased_exploiter_lki.rs
@@ -621,6 +621,7 @@ fn replay_exploited_over_ledger(strip_source_context: bool) -> i64 {
     let replay = vec![GameEvent::CreatureExploited {
         exploiter: aven,
         sacrificed: victim,
+        record: Box::new(runner.state().zone_changes_this_turn[row].clone()),
     }];
     triggers::process_triggers(runner.state_mut(), &replay);
     runner.advance_until_stack_empty();

--- a/crates/engine/tests/integration/exploit_object_filter.rs
+++ b/crates/engine/tests/integration/exploit_object_filter.rs
@@ -16,7 +16,6 @@ const SKULL_SKAAB: &str = "Exploit (When this creature enters, you may sacrifice
 const A_SKULL_SKAAB: &str = "Exploit (When this creature enters, you may sacrifice a creature.)\nWhenever a creature you control exploits a creature, create a 2/2 black Zombie creature token.";
 const FELL_STINGER: &str = "Deathtouch\nExploit (When this creature enters, you may sacrifice a creature.)\nWhen this creature exploits a creature, target player draws two cards and loses 2 life.";
 const EXPLOIT_ONLY: &str = "Exploit (When this creature enters, you may sacrifice a creature.)";
-const GURMAG_DROWNER: &str = "Exploit (When this creature enters, you may sacrifice a creature.)\nWhen this creature exploits a creature, look at the top four cards of your library. Put one of them into your hand and the rest into your graveyard.";
 const GURMAG_DROWNER_WITH_TRAILING_EFFECT: &str = "Exploit (When this creature enters, you may sacrifice a creature.)\nWhen this creature exploits a creature, look at the top four cards of your library. Put one of them into your hand and the rest into your graveyard. Then you gain 1 life.";
 
 fn zombie_tokens(state: &engine::types::game_state::GameState) -> usize {

--- a/crates/engine/tests/integration/exploit_object_filter.rs
+++ b/crates/engine/tests/integration/exploit_object_filter.rs
@@ -1,0 +1,116 @@
+use engine::game::scenario::{GameScenario, P0, P1};
+use engine::types::events::GameEvent;
+use engine::types::phase::Phase;
+use engine::types::zones::Zone;
+
+const SKULL_SKAAB: &str = "Exploit (When this creature enters, you may sacrifice a creature.)\nWhenever a creature you control exploits a nontoken creature, create a 2/2 black Zombie creature token.";
+const A_SKULL_SKAAB: &str = "Exploit (When this creature enters, you may sacrifice a creature.)\nWhenever a creature you control exploits a creature, create a 2/2 black Zombie creature token.";
+const FELL_STINGER: &str = "Deathtouch\nExploit (When this creature enters, you may sacrifice a creature.)\nWhen this creature exploits a creature, target player draws two cards and loses 2 life.";
+const EXPLOIT_ONLY: &str = "Exploit (When this creature enters, you may sacrifice a creature.)";
+
+fn zombie_tokens(state: &engine::types::game_state::GameState) -> usize {
+    state
+        .objects
+        .values()
+        .filter(|object| {
+            object.zone == Zone::Battlefield
+                && object.is_token
+                && object
+                    .card_types
+                    .subtypes
+                    .iter()
+                    .any(|subtype| subtype == "Zombie")
+        })
+        .count()
+}
+
+fn run_skaab_case(oracle: &str, victim_is_token: bool) -> (usize, usize) {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario
+        .add_creature(P0, "Exploit Observer", 2, 2)
+        .from_oracle_text_with_keywords(&["Exploit"], oracle);
+    let actor = scenario
+        .add_creature_to_hand(P0, "Exploit Actor", 1, 1)
+        .from_oracle_text_with_keywords(&["Exploit"], EXPLOIT_ONLY)
+        .id();
+    let victim = scenario.add_creature(P0, "Exploit Victim", 1, 1).id();
+    let mut runner = scenario.build();
+    runner
+        .state_mut()
+        .objects
+        .get_mut(&victim)
+        .unwrap()
+        .is_token = victim_is_token;
+    let before = zombie_tokens(runner.state());
+
+    let outcome = runner
+        .cast(actor)
+        .target_object(victim)
+        .accept_optional()
+        .effect_zone(&[victim])
+        .resolve();
+
+    if victim_is_token {
+        assert!(
+            !outcome.state().objects.contains_key(&victim),
+            "CR 111.7: the sacrificed token has ceased to exist"
+        );
+    } else {
+        assert_eq!(outcome.zone_of(victim), Zone::Graveyard);
+    }
+    assert_eq!(
+        outcome
+            .events()
+            .iter()
+            .filter(|event| matches!(event, GameEvent::CreatureExploited { sacrificed, .. } if *sacrificed == victim))
+            .count(),
+        1
+    );
+    (before, zombie_tokens(outcome.state()))
+}
+
+#[test]
+fn skull_skaab_filters_the_sacrificed_victim_record() {
+    let (before, after) = run_skaab_case(A_SKULL_SKAAB, true);
+    assert_eq!(
+        after,
+        before + 1,
+        "unqualified A-Skull accepts a token victim"
+    );
+
+    let (before, after) = run_skaab_case(SKULL_SKAAB, true);
+    assert_eq!(after, before, "Skull Skaab rejects a token victim");
+
+    for oracle in [SKULL_SKAAB, A_SKULL_SKAAB] {
+        let (before, after) = run_skaab_case(oracle, false);
+        assert_eq!(after, before + 1, "both Skaabs accept nontoken victims");
+    }
+}
+
+#[test]
+fn fell_stinger_payoff_target_remains_independent_of_exploit_roles() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let stinger = scenario
+        .add_creature_to_hand(P0, "Fell Stinger", 3, 2)
+        .from_oracle_text_with_keywords(&["Deathtouch", "Exploit"], FELL_STINGER)
+        .id();
+    let victim = scenario.add_creature(P0, "Exploit Victim", 1, 1).id();
+    for index in 0..3 {
+        scenario.add_card_to_library_top(P1, &format!("Draw {index}"));
+    }
+    let mut runner = scenario.build();
+
+    let outcome = runner
+        .cast(stinger)
+        .target_object(victim)
+        .target_player(P1)
+        .accept_optional()
+        .effect_zone(&[victim])
+        .resolve();
+
+    assert_eq!(outcome.zone_of(victim), Zone::Graveyard);
+    outcome.assert_hand_drawn(P1, 2);
+    outcome.assert_life_delta(P1, -2);
+}

--- a/crates/engine/tests/integration/exploit_object_filter.rs
+++ b/crates/engine/tests/integration/exploit_object_filter.rs
@@ -8,7 +8,7 @@ use engine::types::card_type::CoreType;
 use engine::types::events::GameEvent;
 use engine::types::game_state::{PersistedGameState, WaitingFor};
 use engine::types::phase::Phase;
-use engine::types::resolution::ResolutionStateWire;
+use engine::types::resolution::{ResolutionStateWire, RESOLUTION_STATE_WIRE_VERSION};
 use engine::types::triggers::TriggerMode;
 use engine::types::zones::Zone;
 
@@ -80,6 +80,47 @@ fn run_skaab_case(oracle: &str, victim_is_token: bool) -> (usize, usize) {
     (before, zombie_tokens(outcome.state()))
 }
 
+fn visit_exploited_definitions_mut(
+    value: &mut serde_json::Value,
+    visit: &mut impl FnMut(&mut serde_json::Map<String, serde_json::Value>),
+) {
+    match value {
+        serde_json::Value::Array(values) => {
+            for value in values {
+                visit_exploited_definitions_mut(value, visit);
+            }
+        }
+        serde_json::Value::Object(object) => {
+            if object.get("mode").and_then(serde_json::Value::as_str) == Some("Exploited")
+                && [
+                    "execute",
+                    "valid_card",
+                    "origin",
+                    "destination",
+                    "trigger_zones",
+                    "phase",
+                    "optional",
+                    "damage_kind",
+                    "secondary",
+                    "valid_target",
+                    "valid_source",
+                    "description",
+                    "constraint",
+                    "condition",
+                ]
+                .iter()
+                .all(|field| object.contains_key(*field))
+            {
+                visit(object);
+            }
+            for value in object.values_mut() {
+                visit_exploited_definitions_mut(value, visit);
+            }
+        }
+        _ => {}
+    }
+}
+
 #[test]
 fn skull_skaab_filters_the_sacrificed_victim_record() {
     let (before, after) = run_skaab_case(A_SKULL_SKAAB, true);
@@ -96,6 +137,100 @@ fn skull_skaab_filters_the_sacrificed_victim_record() {
         let (before, after) = run_skaab_case(oracle, false);
         assert_eq!(after, before + 1, "both Skaabs accept nontoken victims");
     }
+}
+
+#[test]
+fn declared_v2_exploited_actor_filter_migrates_through_the_real_persistence_boundary() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let observer = scenario
+        .add_creature(P0, "Exploit Observer", 2, 2)
+        .from_oracle_text_with_keywords(&["Exploit"], SKULL_SKAAB)
+        .id();
+    let actor = scenario
+        .add_creature_to_hand(P0, "Exploit Actor", 1, 1)
+        .from_oracle_text_with_keywords(&["Exploit"], EXPLOIT_ONLY)
+        .id();
+    let victim = scenario.add_creature(P0, "Exploit Victim", 1, 1).id();
+    let runner = scenario.build();
+    let before = zombie_tokens(runner.state());
+
+    let mut current =
+        serde_json::to_value(ResolutionStateWire::from_game_state(runner.state().clone()))
+            .expect("canonical current resolution snapshot serializes");
+    assert_eq!(
+        current["resolution_state_version"],
+        RESOLUTION_STATE_WIRE_VERSION
+    );
+    assert_eq!(RESOLUTION_STATE_WIRE_VERSION, 3);
+    assert!(
+        !current.to_string().contains("CreatureExploited"),
+        "the snapshot must predate the exploit event"
+    );
+
+    let mut current_layouts = Vec::new();
+    visit_exploited_definitions_mut(&mut current, &mut |definition| {
+        current_layouts.push((
+            definition["valid_source"].clone(),
+            definition["valid_card"].clone(),
+        ));
+    });
+    assert!(
+        !current_layouts.is_empty(),
+        "the canonical snapshot contains the observer's exploited trigger"
+    );
+    assert!(current_layouts
+        .iter()
+        .all(|(actor, victim)| { !actor.is_null() && !victim.is_null() && actor != victim }));
+
+    let mut v2_definition_count = 0;
+    visit_exploited_definitions_mut(&mut current, &mut |definition| {
+        let actor = definition["valid_source"].clone();
+        definition.insert("valid_card".to_string(), actor);
+        definition.insert("valid_source".to_string(), serde_json::Value::Null);
+        v2_definition_count += 1;
+    });
+    current["resolution_state_version"] = serde_json::Value::from(2_u64);
+    assert_eq!(current["resolution_state_version"], 2);
+    assert!(v2_definition_count > 0);
+    let mut old_layouts = Vec::new();
+    visit_exploited_definitions_mut(&mut current, &mut |definition| {
+        old_layouts.push((
+            definition["valid_source"].clone(),
+            definition["valid_card"].clone(),
+        ));
+    });
+    assert!(
+        old_layouts
+            .iter()
+            .all(|(source, card)| source.is_null() && !card.is_null()),
+        "the fixture must carry exactly the v2 actor-in-valid_card layout"
+    );
+
+    let restored = serde_json::from_value::<ResolutionStateWire>(current)
+        .expect("declared v2 observer snapshot restores")
+        .into_game_state();
+    let restored_definition = restored.objects[&observer]
+        .trigger_definitions
+        .iter_unchecked()
+        .find(|entry| entry.definition.mode == TriggerMode::Exploited)
+        .expect("restored observer keeps its exploited payoff definition");
+    assert!(restored_definition.definition.valid_source.is_some());
+    assert!(restored_definition.definition.valid_card.is_none());
+
+    let mut restored_runner = GameRunner::from_state(restored);
+    let outcome = restored_runner
+        .cast(actor)
+        .target_object(victim)
+        .accept_optional()
+        .effect_zone(&[victim])
+        .resolve();
+    assert_eq!(outcome.zone_of(victim), Zone::Graveyard);
+    assert_eq!(
+        zombie_tokens(outcome.state()),
+        before + 1,
+        "the migrated observer matches the different exploiting creature"
+    );
 }
 
 #[test]

--- a/crates/engine/tests/integration/exploit_object_filter.rs
+++ b/crates/engine/tests/integration/exploit_object_filter.rs
@@ -1,12 +1,22 @@
-use engine::game::scenario::{GameScenario, P0, P1};
+use engine::game::scenario::{GameRunner, GameScenario, P0, P1};
+use engine::game::triggers::trigger_matcher;
+use engine::types::ability::{
+    EffectKind, FilterProp, TargetFilter, TriggerDefinition, TypedFilter,
+};
+use engine::types::actions::GameAction;
+use engine::types::card_type::CoreType;
 use engine::types::events::GameEvent;
+use engine::types::game_state::{PersistedGameState, WaitingFor};
 use engine::types::phase::Phase;
+use engine::types::resolution::ResolutionStateWire;
+use engine::types::triggers::TriggerMode;
 use engine::types::zones::Zone;
 
 const SKULL_SKAAB: &str = "Exploit (When this creature enters, you may sacrifice a creature.)\nWhenever a creature you control exploits a nontoken creature, create a 2/2 black Zombie creature token.";
 const A_SKULL_SKAAB: &str = "Exploit (When this creature enters, you may sacrifice a creature.)\nWhenever a creature you control exploits a creature, create a 2/2 black Zombie creature token.";
 const FELL_STINGER: &str = "Deathtouch\nExploit (When this creature enters, you may sacrifice a creature.)\nWhen this creature exploits a creature, target player draws two cards and loses 2 life.";
 const EXPLOIT_ONLY: &str = "Exploit (When this creature enters, you may sacrifice a creature.)";
+const GURMAG_DROWNER: &str = "Exploit (When this creature enters, you may sacrifice a creature.)\nWhen this creature exploits a creature, look at the top four cards of your library. Put one of them into your hand and the rest into your graveyard.";
 
 fn zombie_tokens(state: &engine::types::game_state::GameState) -> usize {
     state
@@ -113,4 +123,216 @@ fn fell_stinger_payoff_target_remains_independent_of_exploit_roles() {
     assert_eq!(outcome.zone_of(victim), Zone::Graveyard);
     outcome.assert_hand_drawn(P1, 2);
     outcome.assert_life_delta(P1, -2);
+}
+
+#[test]
+fn exploited_event_record_survives_payoff_pause_and_restore() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let exploiter = scenario
+        .add_creature_to_hand(P0, "Gurmag Drowner", 2, 4)
+        .from_oracle_text_with_keywords(&["Exploit"], GURMAG_DROWNER)
+        .id();
+    let victim = scenario.add_creature(P0, "Exploit Token", 1, 1).id();
+    let rest_three = scenario.add_card_to_library_top(P0, "Dig Rest Three");
+    let rest_two = scenario.add_card_to_library_top(P0, "Dig Rest Two");
+    let rest_one = scenario.add_card_to_library_top(P0, "Dig Rest One");
+    let chosen = scenario.add_card_to_library_top(P0, "Dig Chosen");
+    let dig_cards = vec![chosen, rest_one, rest_two, rest_three];
+    let mut runner = scenario.build();
+    runner
+        .state_mut()
+        .objects
+        .get_mut(&victim)
+        .expect("fixture token exists")
+        .is_token = true;
+
+    let paused = runner
+        .cast(exploiter)
+        .target_object(victim)
+        .accept_optional()
+        .effect_zone(&[victim])
+        .resolve();
+    let WaitingFor::DigChoice { cards, .. } = paused.final_waiting_for() else {
+        panic!("Gurmag Drowner must pause at its DigChoice payoff")
+    };
+    assert_eq!(cards, &dig_cards);
+    // CR 702.110b + CR 111.7: a successful exploit records the sacrificed
+    // creature even after that token has ceased to exist.
+    assert!(
+        !paused.state().objects.contains_key(&victim),
+        "CR 111.7: the sacrificed token has ceased to exist"
+    );
+
+    let mut exploited_events = paused.events().iter().filter(|event| {
+        matches!(
+            event,
+            GameEvent::CreatureExploited {
+                exploiter: event_exploiter,
+                sacrificed,
+                ..
+            } if *event_exploiter == exploiter && *sacrificed == victim
+        )
+    });
+    let exploited_event = exploited_events
+        .next()
+        .expect("the completed exploit emits its follow-up event")
+        .clone();
+    assert!(
+        exploited_events.next().is_none(),
+        "the exploit follow-up is emitted once before the payoff pause"
+    );
+    let GameEvent::CreatureExploited { record, .. } = &exploited_event else {
+        unreachable!("the event was selected as CreatureExploited")
+    };
+    assert_eq!(record.object_id, victim);
+    assert!(record.is_token);
+    assert!(record.core_types.contains(&CoreType::Creature));
+
+    let paused_frame = paused
+        .state()
+        .active_ability_continuation_frame()
+        .expect("the DigChoice owns a parked continuation");
+    let paused_context = paused_frame
+        .pending
+        .trigger_context
+        .as_ref()
+        .expect("the parked continuation retains its trigger context");
+    assert_eq!(paused_context.event.as_ref(), Some(&exploited_event));
+    assert!(paused_context.events.contains(&exploited_event));
+    assert!(paused.state().current_trigger_event.is_none());
+    assert!(paused.state().current_trigger_events.is_empty());
+
+    let mut nontoken_trigger = TriggerDefinition::new(TriggerMode::Exploited);
+    nontoken_trigger.valid_card = Some(TargetFilter::Typed(
+        TypedFilter::creature().properties(vec![FilterProp::NonToken]),
+    ));
+    let matcher = trigger_matcher(TriggerMode::Exploited)
+        .expect("Exploited has a registered production matcher");
+
+    for restore_through_raw in [true, false] {
+        let restored = if restore_through_raw {
+            let encoded =
+                serde_json::to_value(PersistedGameState::Raw(Box::new(paused.state().clone())))
+                    .expect("paused raw state serializes");
+            serde_json::from_value::<PersistedGameState>(encoded)
+                .expect("paused raw state decodes")
+                .into_game_state()
+                .expect("paused raw state satisfies restore finalization")
+        } else {
+            let encoded =
+                serde_json::to_value(ResolutionStateWire::from_game_state(paused.state().clone()))
+                    .expect("paused resolution wire serializes");
+            serde_json::from_value::<ResolutionStateWire>(encoded)
+                .expect("paused resolution wire decodes")
+                .into_game_state()
+        };
+
+        let WaitingFor::DigChoice { cards, .. } = &restored.waiting_for else {
+            panic!("restored Gurmag Drowner must remain at DigChoice")
+        };
+        assert_eq!(cards, &dig_cards);
+        assert!(!restored.objects.contains_key(&victim));
+        {
+            let restored_frame = restored
+                .active_ability_continuation_frame()
+                .expect("restored DigChoice retains its continuation");
+            let restored_context = restored_frame
+                .pending
+                .trigger_context
+                .as_ref()
+                .expect("restored continuation retains its trigger context");
+            let restored_event = restored_context
+                .event
+                .as_ref()
+                .expect("restored trigger context retains the exploit event");
+            assert_eq!(restored_event, &exploited_event);
+            assert!(restored_context.events.contains(&exploited_event));
+            let trigger_source = restored_frame
+                .pending
+                .chain
+                .trigger_source
+                .as_ref()
+                .expect("restored continuation retains the trigger source");
+            assert!(!matcher(
+                restored_event,
+                &nontoken_trigger,
+                trigger_source,
+                &restored,
+            ));
+
+            let mut nontoken_event = restored_event.clone();
+            let GameEvent::CreatureExploited { record, .. } = &mut nontoken_event else {
+                unreachable!("the restored event is CreatureExploited")
+            };
+            record.is_token = false;
+            assert!(matcher(
+                &nontoken_event,
+                &nontoken_trigger,
+                trigger_source,
+                &restored,
+            ));
+        }
+
+        let mut restored_runner = GameRunner::from_state(restored);
+        // CR 608.2c: resume Gurmag Drowner's paused instructions exactly once,
+        // putting the selected card in hand and the rest in the graveyard.
+        let completed = restored_runner
+            .act(GameAction::SelectCards {
+                cards: vec![chosen],
+            })
+            .expect("selecting Gurmag Drowner's kept card completes the payoff");
+        assert!(matches!(completed.waiting_for, WaitingFor::Priority { .. }));
+        assert_eq!(restored_runner.state().objects[&chosen].zone, Zone::Hand);
+        for rest in [rest_one, rest_two, rest_three] {
+            assert_eq!(restored_runner.state().objects[&rest].zone, Zone::Graveyard);
+        }
+        assert!(restored_runner
+            .state()
+            .active_ability_continuation_frame()
+            .is_none());
+        assert!(restored_runner.state().current_trigger_event.is_none());
+        assert!(restored_runner.state().current_trigger_events.is_empty());
+        assert_eq!(
+            paused
+                .events()
+                .iter()
+                .chain(completed.events.iter())
+                .filter(|event| matches!(event, GameEvent::CreatureExploited { .. }))
+                .count(),
+            1
+        );
+        assert_eq!(
+            paused
+                .events()
+                .iter()
+                .chain(completed.events.iter())
+                .filter(|event| matches!(
+                    event,
+                    GameEvent::ZoneChanged {
+                        object_id,
+                        from: Some(Zone::Battlefield),
+                        ..
+                    } if *object_id == victim
+                ))
+                .count(),
+            1
+        );
+        assert_eq!(
+            paused
+                .events()
+                .iter()
+                .chain(completed.events.iter())
+                .filter(|event| matches!(
+                    event,
+                    GameEvent::EffectResolved {
+                        kind: EffectKind::Dig,
+                        source_id,
+                        ..
+                    } if *source_id == exploiter
+                ))
+                .count(),
+            1
+        );
+    }
 }

--- a/crates/engine/tests/integration/exploit_object_filter.rs
+++ b/crates/engine/tests/integration/exploit_object_filter.rs
@@ -17,6 +17,7 @@ const A_SKULL_SKAAB: &str = "Exploit (When this creature enters, you may sacrifi
 const FELL_STINGER: &str = "Deathtouch\nExploit (When this creature enters, you may sacrifice a creature.)\nWhen this creature exploits a creature, target player draws two cards and loses 2 life.";
 const EXPLOIT_ONLY: &str = "Exploit (When this creature enters, you may sacrifice a creature.)";
 const GURMAG_DROWNER: &str = "Exploit (When this creature enters, you may sacrifice a creature.)\nWhen this creature exploits a creature, look at the top four cards of your library. Put one of them into your hand and the rest into your graveyard.";
+const GURMAG_DROWNER_WITH_TRAILING_EFFECT: &str = "Exploit (When this creature enters, you may sacrifice a creature.)\nWhen this creature exploits a creature, look at the top four cards of your library. Put one of them into your hand and the rest into your graveyard. Then you gain 1 life.";
 
 fn zombie_tokens(state: &engine::types::game_state::GameState) -> usize {
     state
@@ -266,7 +267,7 @@ fn exploited_event_record_survives_payoff_pause_and_restore() {
     scenario.at_phase(Phase::PreCombatMain);
     let exploiter = scenario
         .add_creature_to_hand(P0, "Gurmag Drowner", 2, 4)
-        .from_oracle_text_with_keywords(&["Exploit"], GURMAG_DROWNER)
+        .from_oracle_text_with_keywords(&["Exploit"], GURMAG_DROWNER_WITH_TRAILING_EFFECT)
         .id();
     let victim = scenario.add_creature(P0, "Exploit Token", 1, 1).id();
     let rest_three = scenario.add_card_to_library_top(P0, "Dig Rest Three");

--- a/crates/engine/tests/integration/issue_1337_tekuthal_proliferate_twice.rs
+++ b/crates/engine/tests/integration/issue_1337_tekuthal_proliferate_twice.rs
@@ -18,7 +18,7 @@ use engine::types::game_state::WaitingFor;
 use engine::types::phase::Phase;
 use engine::types::proposed_event::ProposedEvent;
 use engine::types::replacements::ReplacementEvent;
-use engine::types::resolution::ResolutionStateWire;
+use engine::types::resolution::{ResolutionStateWire, RESOLUTION_STATE_WIRE_VERSION};
 
 const TEKUTHAL: &str = "If you would proliferate, proliferate twice instead.";
 const TEKUTHAL_FULL: &str = "Flying\nIf you would proliferate, proliferate twice instead.\n{1}{U/P}{U/P}, Remove three counters from among other artifacts, creatures, and planeswalkers you control: Put an indestructible counter on Tekuthal. ({U/P} can be paid with either {U} or 2 life.)";
@@ -120,16 +120,20 @@ fn tekuthal_proliferate_opens_two_choices_and_adds_two_counters() {
         runner.state().active_proliferate_frame().is_some(),
         "the typed proliferate frame owns the first real target-choice prompt"
     );
-    let v2 = serde_json::to_value(ResolutionStateWire::from_game_state(runner.state().clone()))
-        .expect("real proliferate prompt serializes as v2");
-    assert_eq!(v2["resolution_state_version"], 2);
-    assert!(v2.get("pending_proliferate_actions").is_none());
+    let current =
+        serde_json::to_value(ResolutionStateWire::from_game_state(runner.state().clone()))
+            .expect("real proliferate prompt serializes through the current wire");
+    assert_eq!(
+        current["resolution_state_version"],
+        RESOLUTION_STATE_WIRE_VERSION
+    );
+    assert!(current.get("pending_proliferate_actions").is_none());
     let restored: ResolutionStateWire =
-        serde_json::from_value(v2).expect("v2 proliferate prompt round-trips");
+        serde_json::from_value(current).expect("current proliferate prompt round-trips");
     *runner.state_mut() = restored.into_game_state();
     assert!(
         runner.state().active_proliferate_frame().is_some(),
-        "the v2 round-trip preserves the prompt-owning proliferate frame"
+        "the current round-trip preserves the prompt-owning proliferate frame"
     );
 
     let first = runner

--- a/crates/engine/tests/integration/krark_thumb_coin_flip.rs
+++ b/crates/engine/tests/integration/krark_thumb_coin_flip.rs
@@ -28,7 +28,7 @@ use engine::types::phase::Phase;
 use engine::types::player::PlayerId;
 use engine::types::proposed_event::ProposedEvent;
 use engine::types::replacements::ReplacementEvent;
-use engine::types::resolution::ResolutionStateWire;
+use engine::types::resolution::{ResolutionStateWire, RESOLUTION_STATE_WIRE_VERSION};
 use rand::SeedableRng;
 use rand_chacha::ChaCha20Rng;
 use std::collections::HashSet;
@@ -262,16 +262,20 @@ fn keeping_a_flip_emits_exactly_one_coin_flipped_and_returns_to_priority() {
         runner.state().active_coin_flip_frame().is_some(),
         "the typed coin-flip frame owns the real keep prompt"
     );
-    let v2 = serde_json::to_value(ResolutionStateWire::from_game_state(runner.state().clone()))
-        .expect("real coin-flip prompt serializes as v2");
-    assert_eq!(v2["resolution_state_version"], 2);
-    assert!(v2.get("pending_coin_flip").is_none());
+    let current =
+        serde_json::to_value(ResolutionStateWire::from_game_state(runner.state().clone()))
+            .expect("real coin-flip prompt serializes through the current wire");
+    assert_eq!(
+        current["resolution_state_version"],
+        RESOLUTION_STATE_WIRE_VERSION
+    );
+    assert!(current.get("pending_coin_flip").is_none());
     let restored: ResolutionStateWire =
-        serde_json::from_value(v2).expect("v2 coin-flip prompt round-trips");
+        serde_json::from_value(current).expect("current coin-flip prompt round-trips");
     *runner.state_mut() = restored.into_game_state();
     assert!(
         runner.state().active_coin_flip_frame().is_some(),
-        "the v2 round-trip preserves the prompt-owning coin-flip frame"
+        "the current round-trip preserves the prompt-owning coin-flip frame"
     );
 
     // Keep the first flip. (`act` dispatches as the current acting player, P0.)

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -1339,6 +1339,7 @@ mod etching_of_kumano_die_exile;
 mod everything_comes_to_dust_convoke_exile;
 mod exhaust_keyword_once_per_permanent;
 mod expensive_taste_look_and_play;
+mod exploit_object_filter;
 mod explore_all_doubler_ordering;
 mod explore_all_sub_runs_once;
 mod explore_spell_3315;

--- a/crates/engine/tests/integration/mill_double_redirect_choice_continuation.rs
+++ b/crates/engine/tests/integration/mill_double_redirect_choice_continuation.rs
@@ -28,7 +28,9 @@ use engine::types::ability::{
 use engine::types::actions::GameAction;
 use engine::types::game_state::WaitingFor;
 use engine::types::replacements::ReplacementEvent;
-use engine::types::resolution::{ResolutionFrame, ResolutionStateWire};
+use engine::types::resolution::{
+    ResolutionFrame, ResolutionStateWire, RESOLUTION_STATE_WIRE_VERSION,
+};
 use engine::types::zones::{EtbTapState, Zone};
 
 /// CR 614.6: "If a card would be put into a graveyard from anywhere, exile it
@@ -103,12 +105,15 @@ fn mill_under_two_graveyard_redirects_delivers_every_card_through_ordering_choic
         Some(ResolutionFrame::BatchDelivery(_))
     ));
     let saved = serde_json::to_value(ResolutionStateWire::from_game_state(runner.state().clone()))
-        .expect("paused BatchDelivery prompt serializes as v2");
-    assert_eq!(saved["resolution_state_version"], 2);
+        .expect("paused BatchDelivery prompt serializes through the current wire");
+    assert_eq!(
+        saved["resolution_state_version"],
+        RESOLUTION_STATE_WIRE_VERSION
+    );
     assert!(saved.get("pending_batch_deliveries").is_none());
     assert!(saved.get("resolution_frames").is_some());
     let restored: ResolutionStateWire =
-        serde_json::from_value(saved).expect("v2 BatchDelivery prompt restores");
+        serde_json::from_value(saved).expect("current BatchDelivery prompt restores");
     *runner.state_mut() = restored.into_game_state();
 
     // CR 616.1: each milled card surfaces an ordering prompt between the two


### PR DESCRIPTION
Skull Skaab-style exploit triggers lost victim qualifiers such as nontoken, so actor and sacrificed-creature constraints could be applied to the wrong object. This change preserves the completed sacrifice record, models exploiter and victim filters separately through Oracle/Forge parsing and trigger matching, and migrates persisted v1/v2 trigger definitions while keeping v3 semantics unchanged.

Validation: targeted exploit parser/matcher/runtime and persistence migration suites passed during implementation; cargo fmt and parser/CR pre-commit gates passed; independent Terra high implementation review is CLEAN.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for more precise exploit-trigger filtering, including the exploiting creature and sacrificed creature’s characteristics.
  - Exploit events now retain the sacrificed creature’s departure details for accurate trigger resolution and resumed games.
  - Draw effects now explicitly target the appropriate player.

- **Bug Fixes**
  - Improved exploit handling across pauses, persistence, migrations, and restored game states.
  - Prevented unsupported or ambiguous exploit conditions from being incorrectly applied.

- **Compatibility**
  - Updated resolution-state persistence to version 3 while preserving compatibility with earlier saved states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->