### PR TITLE
Suppress impossible optional counter moves

### DIFF
--- a/crates/engine/src/game/effects/counters.rs
+++ b/crates/engine/src/game/effects/counters.rs
@@ -2756,6 +2756,67 @@ fn counter_transfer_source_counters(
         .collect()
 }
 
+/// CR 122.5 + CR 608.2d: an optional fixed stack-target counter move is
+/// impossible only when the resolver's own source/destination/counter census
+/// cannot produce a positive valid commit. This deliberately does not predict
+/// replacement effects or interactive move-selection modes; those remain
+/// offerable rather than being incorrectly suppressed.
+pub(crate) fn move_counters_optional_is_infeasible(
+    state: &GameState,
+    ability: &ResolvedAbility,
+) -> bool {
+    let Effect::MoveCounters {
+        source,
+        counter_type,
+        count,
+        mode: CounterTransferMode::Move,
+        selection: CounterMoveSelection::StackTarget,
+        target,
+    } = &ability.effect
+    else {
+        return false;
+    };
+
+    let transfer_limit = count
+        .as_ref()
+        .map(|expr| crate::game::quantity::resolve_quantity_with_targets(state, expr, ability))
+        .map(|value| value.max(0) as u32);
+    if transfer_limit == Some(0) {
+        return true;
+    }
+
+    let source_ids = resolve_counter_transfer_sources(state, ability, source);
+    let destination_ids = resolve_counter_transfer_destinations(state, ability, source, target);
+    let Some(destination_id) = destination_ids.first().copied() else {
+        return true;
+    };
+    let has_committable_move = source_ids.into_iter().any(|source_id| {
+        counter_transfer_source_counters(
+            state,
+            source_id,
+            CounterTransferMode::Move,
+            counter_type.as_ref(),
+        )
+        .into_iter()
+        .any(|(counter_type, available)| {
+            let count = transfer_limit.map_or(available, |limit| limit.min(available));
+            counter_move_commit_is_valid(
+                state,
+                &PendingCounterMove {
+                    actor: ability.controller,
+                    source_id,
+                    destination_id,
+                    counter_type,
+                    remove_count: count,
+                    add_count: count,
+                },
+            )
+        })
+    });
+
+    !has_committable_move
+}
+
 fn counter_count(state: &GameState, object_id: ObjectId, counter_type: &CounterType) -> u32 {
     state
         .objects
@@ -3147,6 +3208,121 @@ mod tests {
             ObjectId(100),
             PlayerId(0),
         )
+    }
+
+    /// CR 122.5 + CR 608.2d: only a fixed stack-target move with no positive
+    /// commit is impossible. Interactive and non-move shapes stay fail-open.
+    #[test]
+    fn optional_stack_target_move_infeasibility_requires_no_committable_pair() {
+        let mut state = GameState::new_two_player(42);
+        let ability_source = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Ability Source".to_string(),
+            Zone::Battlefield,
+        );
+        let source = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(0),
+            "Counter Source".to_string(),
+            Zone::Battlefield,
+        );
+        let destination = create_object(
+            &mut state,
+            CardId(3),
+            PlayerId(0),
+            "Counter Destination".to_string(),
+            Zone::Battlefield,
+        );
+        let move_ability = |targets, count, mode, selection| {
+            ResolvedAbility::new(
+                Effect::MoveCounters {
+                    source: TargetFilter::Any,
+                    counter_type: Some(CounterType::Plus1Plus1),
+                    count,
+                    mode,
+                    selection,
+                    target: TargetFilter::Any,
+                },
+                targets,
+                ability_source,
+                PlayerId(0),
+            )
+        };
+
+        let targets = vec![TargetRef::Object(source), TargetRef::Object(destination)];
+        assert!(move_counters_optional_is_infeasible(
+            &state,
+            &move_ability(
+                targets.clone(),
+                Some(QuantityExpr::Fixed { value: 1 }),
+                CounterTransferMode::Move,
+                CounterMoveSelection::StackTarget,
+            ),
+        ));
+
+        state
+            .objects
+            .get_mut(&source)
+            .unwrap()
+            .counters
+            .insert(CounterType::Plus1Plus1, 1);
+        assert!(!move_counters_optional_is_infeasible(
+            &state,
+            &move_ability(
+                targets.clone(),
+                Some(QuantityExpr::Fixed { value: 1 }),
+                CounterTransferMode::Move,
+                CounterMoveSelection::StackTarget,
+            ),
+        ));
+        assert!(move_counters_optional_is_infeasible(
+            &state,
+            &move_ability(
+                vec![TargetRef::Object(source), TargetRef::Object(source)],
+                Some(QuantityExpr::Fixed { value: 1 }),
+                CounterTransferMode::Move,
+                CounterMoveSelection::StackTarget,
+            ),
+        ));
+        assert!(move_counters_optional_is_infeasible(
+            &state,
+            &move_ability(
+                targets.clone(),
+                Some(QuantityExpr::Fixed { value: 0 }),
+                CounterTransferMode::Move,
+                CounterMoveSelection::StackTarget,
+            ),
+        ));
+        assert!(move_counters_optional_is_infeasible(
+            &state,
+            &move_ability(
+                vec![TargetRef::Object(source), TargetRef::Object(ObjectId(999))],
+                Some(QuantityExpr::Fixed { value: 1 }),
+                CounterTransferMode::Move,
+                CounterMoveSelection::StackTarget,
+            ),
+        ));
+        assert!(!move_counters_optional_is_infeasible(
+            &state,
+            &move_ability(
+                targets.clone(),
+                Some(QuantityExpr::Fixed { value: 1 }),
+                CounterTransferMode::Put,
+                CounterMoveSelection::StackTarget,
+            ),
+        ));
+        assert!(!move_counters_optional_is_infeasible(
+            &state,
+            &move_ability(
+                targets,
+                Some(QuantityExpr::Fixed { value: 1 }),
+                CounterTransferMode::Move,
+                CounterMoveSelection::ResolutionDistributionAnyNumber,
+            ),
+        ));
     }
 
     /// Kinetic Ooze's full verbatim Oracle text, used only as the branch-identity

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -7891,6 +7891,17 @@ pub(crate) fn has_member_driven_repeat_after_hydration(
     has_member_driven_repeat(&ability_with_event_context_targets(state, ability))
 }
 
+/// CR 608.2c + CR 608.2d + CR 603.12a: these repeat shapes apply an
+/// optional instruction independently to every iteration, rather than once to
+/// the whole ability. Keep this as the single structural exclusion for both
+/// the up-front prompt and the early infeasibility auto-decline: the latter
+/// must not decide the root from only its first bound member.
+fn optionality_is_per_iteration(state: &GameState, ability: &ResolvedAbility) -> bool {
+    has_kind_driven_repeat(ability)
+        || has_member_driven_repeat_after_hydration(state, ability)
+        || is_repeated_optional_payment(ability)
+}
+
 /// CR 608.2d: "A player can't choose an impossible option." An optional effect
 /// whose only reachable outcome is a no-op must not be offered as a "you may"
 /// prompt at all. Each arm below proves infeasibility through its authoritative
@@ -7918,6 +7929,12 @@ fn optional_effect_is_infeasible(state: &GameState, ability: &ResolvedAbility) -
         // `OptionalEffectPerformed` rider) must be suppressed (Sun Droplet #4776).
         Effect::RemoveCounter { .. } => {
             counters::remove_counter_optional_is_infeasible(state, ability)
+        }
+        // CR 122.5 + CR 608.2d: hydrate event-context targets before asking the
+        // move resolver's feasibility authority, exactly as resolution does.
+        Effect::MoveCounters { .. } => {
+            let effective = hydrate_event_context_targets(state, ability);
+            counters::move_counters_optional_is_infeasible(state, effective.as_ref())
         }
         // CR 608.2d + CR 122.1: an optional exact counter-removal selection
         // cannot be accepted unless every required permanent is selectable.
@@ -8145,10 +8162,7 @@ pub(crate) fn upfront_optional_gate(
     }
     // CR 608.2c + CR 608.2d + CR 603.12a: the three shapes that SUPPRESS the single up-front
     // gate and fire optionality per iteration instead.
-    if has_kind_driven_repeat(ability)
-        || has_member_driven_repeat_after_hydration(state, ability)
-        || is_repeated_optional_payment(ability)
-    {
+    if optionality_is_per_iteration(state, ability) {
         return None;
     }
     let infeasible = match feasibility {
@@ -12335,7 +12349,12 @@ fn resolve_chain_body(
         }
     }
 
-    let optional_is_infeasible = ability.optional && optional_effect_is_infeasible(state, ability);
+    // Per-iteration optionality must reach the rebound singleton ability before
+    // feasibility is decided. In particular, the root's first member can have
+    // no committable counter move while a later member remains offerable.
+    let optional_is_infeasible = ability.optional
+        && !optionality_is_per_iteration(state, ability)
+        && optional_effect_is_infeasible(state, ability);
 
     // CR 608.2c + CR 608.2d: An infeasible optional cast/play instruction or
     // exact object selection does not happen. Route either outcome through the existing
@@ -12352,6 +12371,7 @@ fn resolve_chain_body(
     let auto_decline_infeasible_optional = matches!(
         &ability.effect,
         Effect::CastFromZone { .. }
+            | Effect::MoveCounters { .. }
             | Effect::ChooseObjectsIntoTrackedSet {
                 cardinality: Some(ObjectSelectionCardinality::Exactly { .. }),
                 ..
@@ -16749,8 +16769,9 @@ mod tests {
         CardPredicateChoice, CastingPermission, ChoiceType, ChoiceValue, Chooser, ChosenAttribute,
         ChosenCounterCountCondition, Comparator, ContinuousModification, ControllerRef,
         DamageChannel, DelayedTriggerCondition, Duration, EffectKind, EffectScope, FilterProp,
-        ManaSpendPermission, ObjectProperty, PermissionGrantee, PlayerFilter, PlayerScope, PtValue,
-        QuantityExpr, QuantityRef, SpellContext, StaticDefinition, SubAbilityLink, TapStateChange,
+        ManaSpendPermission, ObjectProperty, ObjectScope, PermissionGrantee, PlayerFilter,
+        PlayerScope, PtValue, QuantityExpr, QuantityModification, QuantityRef,
+        ReplacementDefinition, SpellContext, StaticDefinition, SubAbilityLink, TapStateChange,
         TargetFilter, TargetRef, TargetSelectionMode, TriggerDefinition, TypeFilter, TypedFilter,
         UnlessPayModifier, UntilCondition, ZoneOwner,
     };
@@ -16773,6 +16794,7 @@ mod tests {
     use crate::types::mana::{ManaColor, ManaCost, ManaType, ManaUnit};
     use crate::types::phase::Phase;
     use crate::types::player::{PlayerCounterKind, PlayerId};
+    use crate::types::replacements::ReplacementEvent;
     use crate::types::resolution::{
         OptionalEffectFrame, ResolutionStateWire, RESOLUTION_STATE_WIRE_VERSION,
     };
@@ -18054,6 +18076,382 @@ mod tests {
         );
         ability.optional = true;
         ability
+    }
+
+    fn optional_stack_target_counter_move(
+        source_id: ObjectId,
+        targets: Vec<TargetRef>,
+    ) -> ResolvedAbility {
+        let mut ability = ResolvedAbility::new(
+            Effect::MoveCounters {
+                source: TargetFilter::Any,
+                counter_type: Some(CounterType::Plus1Plus1),
+                count: Some(QuantityExpr::Fixed { value: 1 }),
+                mode: crate::types::ability::CounterTransferMode::Move,
+                selection: crate::types::ability::CounterMoveSelection::StackTarget,
+                target: TargetFilter::Any,
+            },
+            targets,
+            source_id,
+            PlayerId(0),
+        );
+        ability.optional = true;
+        ability
+    }
+
+    /// CR 603.5 + CR 608.2d + CR 122.5: Tidus's two target slots may legally
+    /// name the same creature, but that makes the optional counter move
+    /// impossible. The resolver must therefore auto-decline it without a
+    /// prompt while retaining the normal prompt for a distinct, counter-bearing
+    /// sibling and routing the impossible branch through its printed else tail.
+    #[test]
+    fn optional_tidus_move_suppresses_only_impossible_prompt_and_runs_else() {
+        let mut state = GameState::new_two_player(42);
+        let tidus = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Tidus, Yuna's Guardian".to_string(),
+            Zone::Battlefield,
+        );
+        let sibling = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(0),
+            "Tidus's Ally".to_string(),
+            Zone::Battlefield,
+        );
+        let start_life = state.players[0].life;
+
+        let mut impossible = optional_stack_target_counter_move(
+            tidus,
+            vec![TargetRef::Object(tidus), TargetRef::Object(tidus)],
+        );
+        let mut else_ability =
+            optional_gain_life(tidus, PlayerId(0), 1).condition(AbilityCondition::Not {
+                condition: Box::new(AbilityCondition::EffectOutcome {
+                    signal: EffectOutcomeSignal::OptionalEffectPerformed,
+                }),
+            });
+        else_ability.optional = false;
+        impossible.else_ability = Some(Box::new(else_ability));
+        let mut events = Vec::new();
+        resolve_ability_chain(&mut state, &impossible, &mut events, 0)
+            .expect("an impossible optional move auto-declines");
+        assert!(
+            !matches!(state.waiting_for, WaitingFor::OptionalEffectChoice { .. }),
+            "same-object Tidus move must not offer an accept prompt"
+        );
+        assert_eq!(
+            state.players[0].life,
+            start_life + 1,
+            "the auto-decline must preserve the explicit else continuation"
+        );
+
+        state
+            .objects
+            .get_mut(&tidus)
+            .unwrap()
+            .counters
+            .insert(CounterType::Plus1Plus1, 1);
+        let feasible = optional_stack_target_counter_move(
+            tidus,
+            vec![TargetRef::Object(tidus), TargetRef::Object(sibling)],
+        );
+        resolve_ability_chain(&mut state, &feasible, &mut events, 0)
+            .expect("a feasible Tidus move resolves to the may gate");
+        assert!(
+            matches!(state.waiting_for, WaitingFor::OptionalEffectChoice { .. }),
+            "a distinct destination with a counter source must remain offerable"
+        );
+    }
+
+    /// CR 608.2b + CR 608.2d: target legality remains owned by the existing
+    /// validation seam. Once a target changes controller or incarnation, the
+    /// feasibility probe sees only the validated slots and suppresses a move
+    /// that can no longer commit.
+    #[test]
+    fn optional_move_counter_feasibility_uses_validated_target_slots() {
+        let mut state = GameState::new_two_player(42);
+        let source = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Counter Source".to_string(),
+            Zone::Battlefield,
+        );
+        let destination = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(0),
+            "Counter Destination".to_string(),
+            Zone::Battlefield,
+        );
+        for id in [source, destination] {
+            state
+                .objects
+                .get_mut(&id)
+                .unwrap()
+                .card_types
+                .core_types
+                .push(CoreType::Creature);
+        }
+        state
+            .objects
+            .get_mut(&source)
+            .unwrap()
+            .counters
+            .insert(CounterType::Plus1Plus1, 1);
+        let controlled_creature = TargetFilter::Typed(TypedFilter {
+            type_filters: vec![TypeFilter::Creature],
+            controller: Some(ControllerRef::You),
+            properties: vec![],
+        });
+        let mut ability = optional_stack_target_counter_move(
+            source,
+            vec![TargetRef::Object(source), TargetRef::Object(destination)],
+        );
+        let Effect::MoveCounters { target, .. } = &mut ability.effect else {
+            unreachable!("test constructs MoveCounters");
+        };
+        *target = controlled_creature;
+        ability.selected_target_incarnations = vec![
+            ObjectIncarnationRef::from_object(&state.objects[&source]),
+            ObjectIncarnationRef::from_object(&state.objects[&destination]),
+        ];
+
+        assert!(!optional_effect_is_infeasible(&state, &ability));
+        state.objects.get_mut(&destination).unwrap().controller = PlayerId(1);
+        let controller_changed =
+            crate::game::ability_utils::validate_targets_in_chain(&state, &ability);
+        assert_eq!(controller_changed.targets, vec![TargetRef::Object(source)]);
+        assert!(optional_effect_is_infeasible(&state, &controller_changed));
+
+        state.objects.get_mut(&destination).unwrap().controller = PlayerId(0);
+        state.objects.get_mut(&destination).unwrap().incarnation += 1;
+        let stale_incarnation =
+            crate::game::ability_utils::validate_targets_in_chain(&state, &ability);
+        assert_eq!(stale_incarnation.targets, vec![TargetRef::Object(source)]);
+        assert!(optional_effect_is_infeasible(&state, &stale_incarnation));
+    }
+
+    /// CR 603.2 + CR 608.2d: feasibility must hydrate the same event-context
+    /// target carrier as production resolution before resolving a quantity that
+    /// reads that target. Without the explicit hydration in
+    /// `optional_effect_is_infeasible`, the count reads zero from empty targets,
+    /// auto-declines, and runs the else branch instead of reaching this prompt.
+    #[test]
+    fn optional_move_counter_feasibility_hydrates_target_dependent_quantity() {
+        let mut state = GameState::new_two_player(42);
+        let source = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Counter Source".to_string(),
+            Zone::Battlefield,
+        );
+        let destination = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(0),
+            "Triggered Destination".to_string(),
+            Zone::Battlefield,
+        );
+        state
+            .objects
+            .get_mut(&source)
+            .unwrap()
+            .counters
+            .insert(CounterType::Plus1Plus1, 2);
+        state
+            .objects
+            .get_mut(&destination)
+            .unwrap()
+            .counters
+            .insert(CounterType::Plus1Plus1, 1);
+        state.current_trigger_event = Some(GameEvent::CounterAdded {
+            object_id: destination,
+            counter_type: CounterType::Plus1Plus1,
+            count: 1,
+            actor: PlayerId(0),
+        });
+        let mut ability = ResolvedAbility::new(
+            Effect::MoveCounters {
+                source: TargetFilter::SelfRef,
+                counter_type: Some(CounterType::Plus1Plus1),
+                count: Some(QuantityExpr::Ref {
+                    qty: QuantityRef::CountersOn {
+                        scope: ObjectScope::Target,
+                        counter_type: Some(CounterType::Plus1Plus1),
+                    },
+                }),
+                mode: crate::types::ability::CounterTransferMode::Move,
+                selection: crate::types::ability::CounterMoveSelection::StackTarget,
+                target: TargetFilter::TriggeringSource,
+            },
+            vec![],
+            source,
+            PlayerId(0),
+        );
+        ability.optional = true;
+        let start_life = state.players[0].life;
+        let mut else_ability = optional_gain_life(source, PlayerId(0), 1);
+        else_ability.optional = false;
+        else_ability.condition = Some(AbilityCondition::Not {
+            condition: Box::new(AbilityCondition::effect_performed()),
+        });
+        ability.else_ability = Some(Box::new(else_ability));
+
+        let mut events = Vec::new();
+        resolve_ability_chain(&mut state, &ability, &mut events, 0)
+            .expect("hydrated target-dependent counter move reaches its may gate");
+        assert!(
+            matches!(state.waiting_for, WaitingFor::OptionalEffectChoice { .. }),
+            "the hydrated event target makes the dynamic move offerable"
+        );
+        assert_eq!(
+            state.players[0].life, start_life,
+            "the else branch must not run while the hydrated move is offered"
+        );
+    }
+
+    /// CR 608.2c + CR 608.2d + CR 122.5: an optional member-driven move must
+    /// decide feasibility after each member is rebound. The first member is the
+    /// source itself (an impossible same-object move), but the second is a
+    /// distinct counter-bearing source/destination pair and remains offerable.
+    #[test]
+    fn optional_member_move_declines_only_impossible_member_and_reaches_later_prompt() {
+        let mut state = GameState::new_two_player(42);
+        let source = reflexive_test_creature(&mut state, PlayerId(0), "Counter Source");
+        let destination = reflexive_test_creature(&mut state, PlayerId(0), "Later Destination");
+        state
+            .objects
+            .get_mut(&source)
+            .unwrap()
+            .counters
+            .insert(CounterType::Plus1Plus1, 1);
+
+        let mut ability = ResolvedAbility::new(
+            Effect::MoveCounters {
+                source: TargetFilter::SelfRef,
+                counter_type: Some(CounterType::Plus1Plus1),
+                count: Some(QuantityExpr::Fixed { value: 1 }),
+                mode: crate::types::ability::CounterTransferMode::Move,
+                selection: crate::types::ability::CounterMoveSelection::StackTarget,
+                target: TargetFilter::ParentTarget,
+            },
+            vec![TargetRef::Object(source)],
+            source,
+            PlayerId(0),
+        );
+        ability.optional = true;
+        ability.repeat_for = Some(QuantityExpr::Ref {
+            qty: QuantityRef::ObjectCount {
+                filter: TargetFilter::Typed(TypedFilter::creature().controller(ControllerRef::You)),
+            },
+        });
+        let start_life = state.players[0].life;
+        let mut tail = optional_gain_life(source, PlayerId(0), 1);
+        tail.optional = false;
+        tail.sub_link = SubAbilityLink::SequentialSibling;
+        ability.sub_ability = Some(Box::new(tail));
+
+        let mut events = Vec::new();
+        resolve_ability_chain(&mut state, &ability, &mut events, 0)
+            .expect("member-driven move resolves its first member");
+        assert!(
+            matches!(state.waiting_for, WaitingFor::OptionalEffectChoice { .. }),
+            "the later distinct member must still receive its own may prompt"
+        );
+        assert_eq!(
+            state.players[0].life,
+            start_life + 1,
+            "the impossible first member must retain its sequential continuation"
+        );
+
+        crate::game::engine_payment_choices::handle_optional_effect_choice(
+            &mut state,
+            true,
+            &mut events,
+        )
+        .expect("accepting the later member resolves its move");
+        assert!(
+            !state.objects[&source]
+                .counters
+                .contains_key(&CounterType::Plus1Plus1),
+            "the later feasible member must move the source counter"
+        );
+        assert_eq!(
+            state.objects[&destination]
+                .counters
+                .get(&CounterType::Plus1Plus1)
+                .copied(),
+            Some(1),
+            "the later distinct destination must receive the moved counter"
+        );
+        assert_eq!(
+            state.players[0].life,
+            start_life + 2,
+            "the later accepted member must preserve its own sequential continuation"
+        );
+    }
+
+    /// CR 614.6 + CR 608.2d + CR 122.5: counter replacement legality is not
+    /// predicted by the structural optional probe. A destination that prevents
+    /// counters still receives the production-shaped may prompt; replacement
+    /// handling remains the counter resolver's responsibility after acceptance.
+    #[test]
+    fn optional_move_with_counter_prevention_remains_offerable() {
+        let mut state = GameState::new_two_player(42);
+        let source = reflexive_test_creature(&mut state, PlayerId(0), "Counter Source");
+        let destination = reflexive_test_creature(&mut state, PlayerId(0), "No Counters");
+        state
+            .objects
+            .get_mut(&source)
+            .unwrap()
+            .counters
+            .insert(CounterType::Plus1Plus1, 1);
+        let mut prevention = ReplacementDefinition::new(ReplacementEvent::AddCounter);
+        prevention.valid_card = Some(TargetFilter::SelfRef);
+        prevention.quantity_modification = Some(QuantityModification::Prevent);
+        state
+            .objects
+            .get_mut(&destination)
+            .unwrap()
+            .replacement_definitions
+            .push(prevention);
+
+        let ability = optional_stack_target_counter_move(
+            source,
+            vec![TargetRef::Object(source), TargetRef::Object(destination)],
+        );
+        let mut events = Vec::new();
+        resolve_ability_chain(&mut state, &ability, &mut events, 0)
+            .expect("replacement-sensitive counter move reaches its may gate");
+        assert!(
+            matches!(state.waiting_for, WaitingFor::OptionalEffectChoice { .. }),
+            "counter-placement prevention must fail open instead of suppressing the may"
+        );
+        crate::game::engine_payment_choices::handle_optional_effect_choice(
+            &mut state,
+            true,
+            &mut events,
+        )
+        .expect("accepting the replacement-sensitive move resolves through its pipeline");
+        assert_eq!(
+            state.objects[&source]
+                .counters
+                .get(&CounterType::Plus1Plus1)
+                .copied(),
+            Some(1),
+            "the blocked move must leave the source counter in place"
+        );
+        assert!(
+            !state.objects[&destination]
+                .counters
+                .contains_key(&CounterType::Plus1Plus1),
+            "the replacement must prevent the destination counter placement"
+        );
     }
 
     #[test]

--- a/crates/engine/tests/integration/issue_7386_ozolith_combat_counter_move.rs
+++ b/crates/engine/tests/integration/issue_7386_ozolith_combat_counter_move.rs
@@ -60,18 +60,16 @@
 //!     effect is applied; a player can't choose an impossible option.
 
 use super::rules::{GameScenario, Phase, WaitingFor, Zone, P0, P1};
-use engine::types::ability::TargetRef;
+use engine::types::ability::{
+    Effect, QuantityExpr, ResolvedAbility, SubAbilityLink, TargetFilter, TargetRef,
+};
 use engine::types::actions::GameAction;
 use engine::types::counter::CounterType;
+use engine::types::game_state::StackEntryKind;
 use engine::types::identifiers::ObjectId;
 use engine::types::mana::ManaCost;
 
 const OZOLITH_ORACLE: &str = "Whenever a creature you control leaves the battlefield, if it had counters on it, put those counters on The Ozolith.\nAt the beginning of combat on your turn, if The Ozolith has counters on it, you may move all counters from The Ozolith onto target creature.";
-
-/// Same `MoveCounters` shape as The Ozolith's second ability but with NO
-/// intervening-if, so the trigger still resolves when the source holds nothing.
-/// Used to pin the counterfactual the negative tests depend on.
-const NO_GATE_ORACLE: &str = "At the beginning of combat on your turn, you may move all counters from Counter Shuttle onto target creature.";
 
 /// Removal used to take a creature off the battlefield through the production
 /// pipeline. Casting this and letting it resolve drives the departure through
@@ -90,13 +88,50 @@ fn counters(runner: &super::rules::GameRunner, id: ObjectId, ct: &CounterType) -
         .unwrap_or(0)
 }
 
+/// Append a test-only independent instruction to the live Ozolith trigger.
+///
+/// The life-gain probe is a `SequentialSibling`, the engine's existing model
+/// of an independent following instruction under CR 608.2c. It therefore
+/// survives the optional move being auto-declined, but cannot run if the
+/// trigger is removed before normal resolution by CR 603.4 or CR 608.2b.
+fn append_resolution_entry_probe(runner: &mut super::rules::GameRunner) {
+    let entry = runner
+        .state_mut()
+        .stack
+        .back_mut()
+        .expect("the begin-combat trigger must be on the stack");
+    let StackEntryKind::TriggeredAbility { ability, .. } = &mut entry.kind else {
+        panic!("the probe must extend The Ozolith's triggered ability");
+    };
+    assert!(
+        ability.optional,
+        "the production Ozolith trigger must retain its printed 'you may'"
+    );
+    assert!(
+        ability.sub_ability.is_none(),
+        "the production Ozolith trigger has no existing continuation"
+    );
+
+    let mut probe = ResolvedAbility::new(
+        Effect::GainLife {
+            amount: QuantityExpr::Fixed { value: 1 },
+            player: TargetFilter::Controller,
+        },
+        vec![],
+        ability.source_id,
+        ability.controller,
+    );
+    probe.sub_link = SubAbilityLink::SequentialSibling;
+    ability.sub_ability = Some(Box::new(probe));
+}
+
 /// Which decisions the engine actually presented while the trigger resolved.
 ///
-/// These counts are the load-bearing discriminator for the negative tests. A
-/// "removed from the stack" path (CR 603.3d / 603.4 / 608.2b) asks NOTHING,
-/// whereas an ability that resolves and merely moves zero counters DOES present
-/// its "you may" window first (CR 608.2d). Without observing `optional`, a
-/// negative test that only checks counter totals passes either way.
+/// These counts distinguish the targeting and optional-decision surfaces that
+/// the engine actually presented. The negative tests separately record their
+/// expected stack departure under CR 603.3d / CR 603.4 / CR 608.2b; an absent
+/// optional prompt alone is not a stack-departure discriminator because
+/// CR 608.2d forbids choosing an impossible counter move.
 ///
 /// `trigger_target` and `target` are tracked separately so an assertion can pin
 /// which selection surface was used rather than conflating the two.
@@ -301,67 +336,6 @@ fn issue_7386_ozolith_moves_counters_it_collected_from_a_dead_creature() {
     );
 }
 
-/// COUNTERFACTUAL CONTROL for the two "no prompt" tests below.
-///
-/// Those tests prove a rule fired by observing that NO "you may" window was
-/// presented. That inference is only valid while a `MoveCounters` that resolves
-/// with nothing to move DOES present one. `optional_effect_is_infeasible`
-/// (effects/mod.rs) has CR 608.2d suppression arms for `PutChosenCounter`,
-/// `RemoveCounter`, `Forage` and `CastFromZone` but none for `MoveCounters`;
-/// adding the natural `MoveCounters` arm would silently turn both tests into
-/// tautologies that pass even with their rule deleted.
-///
-/// This test pins that assumption directly, using the same effect shape without
-/// an intervening-if so the ability actually resolves while empty. If someone
-/// adds the suppression arm, THIS test fails loudly and points at the two tests
-/// whose discriminator it just disarmed.
-#[test]
-fn issue_7386_resolved_but_empty_move_still_offers_its_optional_window() {
-    let mut scenario = GameScenario::new();
-    scenario.at_phase(Phase::PreCombatMain);
-
-    // No counters at all, and no intervening-if to stop the trigger.
-    let shuttle = scenario
-        .add_creature_from_oracle(P0, "Counter Shuttle", 0, 0, NO_GATE_ORACLE)
-        .as_artifact()
-        .id();
-
-    let receiver = scenario
-        .add_creature(P0, "Counter Receiver", 2, 2)
-        .with_plus_counters(12)
-        .id();
-
-    let mut runner = scenario.build();
-    runner.advance_to_phase(Phase::BeginCombat);
-
-    assert_eq!(
-        runner.state().stack.len(),
-        1,
-        "reach-guard: an ungated begin-combat trigger reaches the stack even \
-         with nothing to move"
-    );
-
-    let prompts = drive_trigger(&mut runner, receiver, true);
-
-    assert_eq!(
-        prompts.optional, 1,
-        "CR 608.2d: a MoveCounters that resolves with nothing to move STILL \
-         offers its 'you may' window. The CR 603.4 and CR 608.2b tests below \
-         infer 'the ability left the stack' from the ABSENCE of this window — \
-         if this assertion ever fails, those two tests are no longer valid."
-    );
-    assert_eq!(
-        counters(&runner, shuttle, &CounterType::Plus1Plus1),
-        0,
-        "control: nothing was on the source to move"
-    );
-    assert_eq!(
-        counters(&runner, receiver, &CounterType::Plus1Plus1),
-        12,
-        "control: accepting an empty move changes nothing"
-    );
-}
-
 /// CR 608.2b: the declared target is illegal by resolution, so the ability is
 /// removed from the stack and does nothing — the counters stay on The Ozolith
 /// rather than being destroyed or half-moved.
@@ -409,6 +383,8 @@ fn issue_7386_illegal_target_at_resolution_leaves_counters_untouched() {
         1,
         "reach-guard: the begin-combat trigger is on the stack awaiting resolution"
     );
+    append_resolution_entry_probe(&mut runner);
+    let life_before = runner.life(P0);
 
     // Kill the bound target IN RESPONSE, exactly as a real game would: an
     // instant cast while the trigger sits on the stack. `commit()` + a single
@@ -438,14 +414,19 @@ fn issue_7386_illegal_target_at_resolution_leaves_counters_untouched() {
         prompts,
         Prompts::default(),
         "CR 608.2b: the ability is removed from the stack, so NO decision is \
-         presented — not the target walk and not the 'you may' window. A \
-         resolved-but-empty move WOULD have asked (pinned by \
-         issue_7386_resolved_but_empty_move_still_offers_its_optional_window)."
+         presented — not the target walk and not the 'you may' window."
     );
     assert_eq!(
         runner.state().stack.len(),
         0,
         "CR 608.2b: the ability actually left the stack rather than stalling on it"
+    );
+    assert_eq!(
+        runner.life(P0),
+        life_before,
+        "CR 608.2b: removing the ability before normal resolution also skips its \
+         independent continuation. If the resolver instead reached the optional \
+         move and auto-declined it, this SequentialSibling probe would gain life."
     );
     assert_eq!(
         counters(&runner, ozolith, &CounterType::Plus1Plus1),
@@ -459,9 +440,10 @@ fn issue_7386_illegal_target_at_resolution_leaves_counters_untouched() {
 /// counters gone by then, the ability is removed from the stack and the target
 /// receives nothing.
 ///
-/// The discriminator is `prompts.optional == 0`. Were the recheck skipped, the
-/// ability would resolve normally, present its "you may" window, and then move
-/// zero counters — leaving counter totals byte-identical to this test's.
+/// The reach guards establish that the trigger was on the stack, and the final
+/// stack assertion records its expected departure. Counter totals and prompt
+/// absence alone cannot distinguish that from an impossible optional move,
+/// because CR 608.2d suppresses an unchoosable move.
 #[test]
 fn issue_7386_intervening_if_rechecked_at_resolution() {
     let mut scenario = GameScenario::new();
@@ -491,6 +473,8 @@ fn issue_7386_intervening_if_rechecked_at_resolution() {
         1,
         "reach-guard: the begin-combat trigger is on the stack awaiting resolution"
     );
+    append_resolution_entry_probe(&mut runner);
+    let life_before = runner.life(P0);
 
     // Stand in for an opponent's removal effect emptying The Ozolith while the
     // trigger is on the stack. Injected directly because no counter-removal
@@ -509,14 +493,19 @@ fn issue_7386_intervening_if_rechecked_at_resolution() {
     assert_eq!(
         prompts.optional, 0,
         "CR 603.4: the intervening-if is false on resolution, so the ability \
-         leaves the stack WITHOUT presenting its 'you may' window. A \
-         resolved-but-empty move WOULD have prompted (pinned by \
-         issue_7386_resolved_but_empty_move_still_offers_its_optional_window)."
+         leaves the stack WITHOUT presenting its 'you may' window."
     );
     assert_eq!(
         runner.state().stack.len(),
         0,
         "CR 603.4: the ability actually left the stack rather than stalling on it"
+    );
+    assert_eq!(
+        runner.life(P0),
+        life_before,
+        "CR 603.4: the false intervening-if prevents normal resolution and its \
+         independent continuation. If the resolver instead reached the optional \
+         move and auto-declined it, this SequentialSibling probe would gain life."
     );
     assert_eq!(
         counters(&runner, receiver, &CounterType::Plus1Plus1),


### PR DESCRIPTION
Fixes the Tidus optional counter-move report by declining only when the hydrated MoveCounters ability has no committable source/destination pair.

Preserves per-iteration prompts, replacement-aware fail-open behavior, else branches, and independent continuations. Updates Ozolith regression coverage to distinguish true CR 603.4/608.2b exits from normal-resolution auto-decline.

Verification:
- Sol implementation and current-main integration reviews: clean, Maintainer PASS
- cargo fmt --check
- phase-engine clippy --all-targets -D warnings
- focused Tidus and Ozolith tests
- full engine library/integration suites (known base stack-overflow test skipped; unrelated base doctest reproduced)
- phase-ai --all-features
- paired-seed ai-gate: exit 0, 0 FAIL / 2 WARN / 1 PASS, no baseline refresh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed optional counter-moving abilities that could incorrectly decline, fail to move counters, or offer invalid choices.
  - Improved handling of repeated abilities so optional decisions are evaluated at the correct iteration.
  - Corrected target validation and resolution for The Ozolith’s beginning-of-combat counter-moving ability.
  - Ensured counter moves correctly account for unavailable destinations, invalid sources, and prevention effects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->