### PR TITLE
fix(engine,parser): gate Dragon Whelp's sacrifice on its activation threshold (#8388)

### DIFF
--- a/crates/engine/src/analysis/resource.rs
+++ b/crates/engine/src/analysis/resource.rs
@@ -19,7 +19,9 @@ use serde::{Deserialize, Serialize};
 
 use crate::analysis::decision_template::DecisionSlot;
 use crate::game::game_object::GameObject;
-use crate::types::ability::{ActivationRestriction, DamageModification};
+use crate::types::ability::{
+    AbilityCondition, AbilityDefinition, AbilityUseTally, ActivationRestriction, DamageModification,
+};
 use crate::types::card_type::{CoreType, Supertype};
 use crate::types::counter::CounterType;
 use crate::types::game_state::{loop_states_equal, GameState, StackEntry, StackEntryKind};
@@ -7170,18 +7172,19 @@ fn project_out_resources(state: &GameState) -> GameState {
     //      `ability_has_per_turn_activation_gate` is the single authority.
     //   2. `AbilityCondition::AbilityUseCountThisTurn { tally: Activated }` — a
     //      branch condition (Dragon Whelp's "activated four or more times this
-    //      turn"), which does NOT block repetition and so belongs to the cleared
-    //      "pure pumped history" class, exactly like the `Resolved` tally cleared
-    //      below. Its downstream effect is a delayed sacrifice trigger, i.e. a
-    //      board change caught by `objects_content_eq`. The threshold is also
-    //      MONOTONE under a `GE` comparator: once the count passes n it stays
-    //      passed for the turn, so every post-threshold cycle behaves identically
-    //      and genuinely compares equal. Projecting it out is sound, not merely
-    //      tolerable.
+    //      turn"). This does NOT block repetition, but it is retained anyway,
+    //      via `ability_reads_own_activation_count`, because clearing it would
+    //      make two counts that STRADDLE the printed threshold compare equal
+    //      while `evaluate_condition` answers differently for them. See that
+    //      function for why the straddle argument, and not a per-comparator
+    //      monotonicity argument, is what governs here.
     let keep_turn: HashSet<(ObjectId, usize)> = s
         .activated_abilities_this_turn
         .keys()
-        .filter(|key| ability_has_per_turn_activation_gate(&s, key))
+        .filter(|key| {
+            ability_has_per_turn_activation_gate(&s, key)
+                || ability_reads_own_activation_count(&s, key)
+        })
         .copied()
         .collect();
     s.activated_abilities_this_turn
@@ -7498,6 +7501,68 @@ fn ability_has_per_turn_activation_gate(state: &GameState, key: &(ObjectId, usiz
                 )
             })
         })
+}
+
+/// CR 602.2a + CR 608.2c: does the printed ability at `key` gate anything on its
+/// own per-turn ACTIVATION count (`AbilityUseCountThisTurn { tally: Activated }`,
+/// Dragon Whelp's "activated four or more times this turn")?
+///
+/// Retention rule, and why it is not the `== n` argument used for the `Resolved`
+/// tally below: projecting a count out makes two states compare EQUAL, so it is
+/// only sound while every condition reading that count returns the same answer
+/// for both. That holds once both counts sit on the same side of a threshold,
+/// but NOT for two counts that straddle one — 3 vs 4 under `GE 4` project equal
+/// and evaluate differently, and `EQ`/`LT`/`LE` straddle their thresholds the
+/// same way. Rather than reason per comparator about which straddles are
+/// reachable, retain the count for any ability that reads it at all: retention
+/// can only make states compare DIFFERENT, which is the fail-closed direction
+/// (a loop is rejected, never falsely certified).
+fn ability_reads_own_activation_count(state: &GameState, key: &(ObjectId, usize)) -> bool {
+    fn condition_reads_activation_tally(condition: &AbilityCondition) -> bool {
+        match condition {
+            AbilityCondition::AbilityUseCountThisTurn {
+                tally: AbilityUseTally::Activated,
+                ..
+            } => true,
+            AbilityCondition::AbilityUseCountThisTurn { .. } => false,
+            AbilityCondition::And { conditions } | AbilityCondition::Or { conditions } => {
+                conditions.iter().any(condition_reads_activation_tally)
+            }
+            AbilityCondition::Not { condition }
+            | AbilityCondition::ConditionInstead { inner: condition } => {
+                condition_reads_activation_tally(condition)
+            }
+            _ => false,
+        }
+    }
+
+    // The condition lives on whichever chain node carries the gated clause — for
+    // the Dragon Whelp class it is the `SequentialSibling` holding
+    // `CreateDelayedTrigger`, not the ability root — so the whole definition tree
+    // is walked, not just `def.condition`.
+    fn definition_reads_activation_tally(def: &AbilityDefinition) -> bool {
+        def.condition
+            .as_ref()
+            .is_some_and(condition_reads_activation_tally)
+            || def
+                .sub_ability
+                .as_deref()
+                .is_some_and(definition_reads_activation_tally)
+            || def
+                .else_ability
+                .as_deref()
+                .is_some_and(definition_reads_activation_tally)
+            || def
+                .mode_abilities
+                .iter()
+                .any(definition_reads_activation_tally)
+    }
+
+    state
+        .objects
+        .get(&key.0)
+        .and_then(|o| o.abilities.get(key.1))
+        .is_some_and(definition_reads_activation_tally)
 }
 
 /// CR 602.5b: per-GAME activation gate. Single authority.
@@ -12735,6 +12800,77 @@ mod tests {
     /// `projected_only_leaves_carry_no_sibling_axis` (`Axes` is private there).
     ///
     /// REVERT-PROBE: repoint the four conjunct-(a) sites to a `.sibling`-only reader ⇒ both
+    /// CR 602.2a: an ability that gates on its OWN per-turn activation count
+    /// (Dragon Whelp's "activated four or more times this turn") must keep that
+    /// count through `project_out_resources`, even though the count is not a
+    /// CR 602.5b legality gate.
+    ///
+    /// Clearing it would make two counts that STRADDLE the printed threshold
+    /// project equal while `evaluate_condition` answers differently for them
+    /// (3 vs 4 under `GE 4`). The paired negative is what gives the positive its
+    /// meaning: an ability that neither gates nor reads the count is still
+    /// projected out, so this is a targeted retention and not a blanket one that
+    /// would stop unrestricted loops from ever comparing equal.
+    #[test]
+    fn projection_retains_activation_counts_an_ability_gates_itself_on() {
+        use crate::types::ability::{
+            AbilityCondition, AbilityDefinition, AbilityKind, AbilityUseTally, Comparator, Effect,
+            EffectScope, TapStateChange, TargetFilter, TypedFilter,
+        };
+        use std::sync::Arc;
+
+        let mut state = GameState::new_two_player(7);
+        state.phase = Phase::PreCombatMain;
+
+        let gated = inert_token(&mut state, 901, 0, "Dragon Whelp");
+        let plain = inert_token(&mut state, 902, 0, "Ungated Pumper");
+
+        let inert = || Effect::SetTapState {
+            target: TargetFilter::Typed(TypedFilter::creature()),
+            scope: EffectScope::All,
+            state: TapStateChange::Untap,
+        };
+
+        // The threshold sits on the chain node carrying the gated clause, not on
+        // the ability root — the shape the parser actually produces for this class.
+        let mut whelp_ability = AbilityDefinition::new(AbilityKind::Activated, inert());
+        let mut rider = AbilityDefinition::new(AbilityKind::Spell, inert());
+        rider.condition = Some(AbilityCondition::AbilityUseCountThisTurn {
+            tally: AbilityUseTally::Activated,
+            comparator: Comparator::GE,
+            n: 4,
+        });
+        whelp_ability.sub_ability = Some(Box::new(rider));
+        state.objects.get_mut(&gated).unwrap().abilities = Arc::new(vec![whelp_ability]);
+        state.objects.get_mut(&plain).unwrap().abilities = Arc::new(vec![AbilityDefinition::new(
+            AbilityKind::Activated,
+            inert(),
+        )]);
+
+        state.activated_abilities_this_turn.insert((gated, 0), 3);
+        state.activated_abilities_this_turn.insert((plain, 0), 3);
+
+        let projected = project_out_resources(&state);
+
+        assert_eq!(
+            projected
+                .activated_abilities_this_turn
+                .get(&(gated, 0))
+                .copied(),
+            Some(3),
+            "a count the ability's own condition reads must survive projection"
+        );
+        assert_eq!(
+            projected
+                .activated_abilities_this_turn
+                .get(&(plain, 0))
+                .copied(),
+            None,
+            "an ability that neither gates nor reads the count keeps the existing \
+             pumped-history projection"
+        );
+    }
+
     /// predicates relieve their fixtures ⇒ **FAILS**.
     #[test]
     fn residual_probe_refuses_a_def_with_a_projected_read_elsewhere() {

--- a/crates/engine/src/analysis/resource.rs
+++ b/crates/engine/src/analysis/resource.rs
@@ -7162,6 +7162,22 @@ fn project_out_resources(state: &GameState) -> GameState {
     // whose ability actually carries the matching restriction so two cycles of a GATED
     // activation compare DIFFERENT (the gate progressed) while pure pumped history is
     // still projected out (unrestricted loops compare equal).
+    //
+    // These tallies now have TWO classes of reader, and only the first justifies
+    // retention:
+    //   1. CR 602.5b legality gates (`ActivationRestriction::OnlyOnceEachTurn` /
+    //      `MaxTimesEachTurn`) — BLOCK repetition, so they must survive projection.
+    //      `ability_has_per_turn_activation_gate` is the single authority.
+    //   2. `AbilityCondition::AbilityUseCountThisTurn { tally: Activated }` — a
+    //      branch condition (Dragon Whelp's "activated four or more times this
+    //      turn"), which does NOT block repetition and so belongs to the cleared
+    //      "pure pumped history" class, exactly like the `Resolved` tally cleared
+    //      below. Its downstream effect is a delayed sacrifice trigger, i.e. a
+    //      board change caught by `objects_content_eq`. The threshold is also
+    //      MONOTONE under a `GE` comparator: once the count passes n it stays
+    //      passed for the turn, so every post-threshold cycle behaves identically
+    //      and genuinely compares equal. Projecting it out is sound, not merely
+    //      tolerable.
     let keep_turn: HashSet<(ObjectId, usize)> = s
         .activated_abilities_this_turn
         .keys()
@@ -7178,7 +7194,7 @@ fn project_out_resources(state: &GameState) -> GameState {
         .collect();
     s.activated_abilities_this_game
         .retain(|key, _| keep_game.contains(key));
-    // CR 603.4: NthResolutionThisTurn{n} is a one-shot branch SELECTOR (an effect
+    // CR 608.2c: AbilityUseCountThisTurn{n} is a one-shot branch SELECTOR (an effect
     // branch fires when the per-ability resolution count == n), NOT a repetition-
     // blocking legality gate. Clearing it is sound: a board-divergent Nth branch is
     // caught by objects_content_eq, and a resource-only Nth branch is a one-time bonus
@@ -11000,14 +11016,14 @@ mod tests {
     }
 
     /// (j) JOURNAL-READER (R2 B-R2-1): a fixed-amount drain churner whose embedded
-    /// ability carries an `NthResolutionThisTurn`-gated branch reads the cleared
+    /// ability carries an `AbilityUseCountThisTurn`-gated branch reads the cleared
     /// per-ability resolution journal ⇒ false. Revert-fail: narrowing the walker
     /// guard axis back to resources-only (dropping journal readers) flips this true.
     #[test]
     fn n1_j_journal_reader_false() {
         let j = |id| {
             let mut ability = gain_ability(1);
-            ability.condition = Some(AbilityCondition::NthResolutionThisTurn { n: 10 });
+            ability.condition = Some(AbilityCondition::nth_resolution_this_turn(10));
             churn_entry(id, 0, ability, None)
         };
         let mut prior = GameState::new_two_player(7);
@@ -12622,7 +12638,7 @@ mod tests {
     /// projected resource.
     ///
     /// Two shipped ASTs that reach different probes: Harvestrite Host carries the read on
-    /// `execute.sub_ability.condition` (`NthResolutionThisTurn{n: 2}`), Poisoner's
+    /// `execute.sub_ability.condition` (`AbilityUseCountThisTurn{n: 2}`), Poisoner's
     /// Apprentice on the def's OWN `condition`
     /// (`QuantityCheck{Ref(LifeGainedThisTurn{Controller}), GE, Fixed(1)}`). Both pump legs
     /// are `PtValue::Fixed` with a `Typed{Creature}` target, so the descent reads nothing
@@ -12771,7 +12787,7 @@ mod tests {
         let ledger_relieved = ledger.clone();
         let mut projected_rider = ledger.clone();
         *projected_rider.effect = Effect::NoOp;
-        projected_rider.condition = Some(AbilityCondition::NthResolutionThisTurn { n: 2 });
+        projected_rider.condition = Some(AbilityCondition::nth_resolution_this_turn(2));
         projected_rider.sub_ability = None;
         ledger.sub_ability = Some(Box::new(projected_rider));
 
@@ -12934,7 +12950,7 @@ mod tests {
 
         let mut rider = hawk_pump.clone();
         *rider.effect = Effect::NoOp;
-        rider.condition = Some(AbilityCondition::NthResolutionThisTurn { n: 2 });
+        rider.condition = Some(AbilityCondition::nth_resolution_this_turn(2));
         rider.sub_ability = None;
         let mut multi = hawk_pump.clone();
         multi.sub_ability = Some(Box::new(rider));
@@ -24262,12 +24278,12 @@ mod tests {
         // ── (a) the same field carrying a PROJECTED-ONLY read ───────────────────────
         // The `ObjectCount` residual above is `{sibling: true, projected: false}`, so a
         // `.sibling`-only conjunct (a) sees it too and cannot attribute this arm's
-        // repoint. `NthResolutionThisTurn` is projected-ONLY — pinned as a shape by
+        // repoint. `AbilityUseCountThisTurn` is projected-ONLY — pinned as a shape by
         // `ability_scan`'s `projected_only_leaves_carry_no_sibling_axis` — so only the
         // both-axes reader sees the rider below.
         let mut projected_rider = base.clone();
         *projected_rider.effect = Effect::NoOp;
-        projected_rider.condition = Some(AbilityCondition::NthResolutionThisTurn { n: 2 });
+        projected_rider.condition = Some(AbilityCondition::nth_resolution_this_turn(2));
         projected_rider.sub_ability = None;
         let mut with_projected = base.clone();
         with_projected.sub_ability = Some(Box::new(projected_rider));
@@ -24387,7 +24403,7 @@ mod tests {
         // cannot attribute this arm's repoint to a `.sibling`-only reader.
         let mut projected_rider = base.clone();
         *projected_rider.effect = Effect::NoOp;
-        projected_rider.condition = Some(AbilityCondition::NthResolutionThisTurn { n: 2 });
+        projected_rider.condition = Some(AbilityCondition::nth_resolution_this_turn(2));
         projected_rider.else_ability = None;
         let mut with_projected = base.clone();
         with_projected.else_ability = Some(Box::new(projected_rider));

--- a/crates/engine/src/game/ability_rw.rs
+++ b/crates/engine/src/game/ability_rw.rs
@@ -1996,7 +1996,7 @@ fn legacy_ability_condition(x: &AbilityCondition) -> bool {
         | AbilityCondition::EventOutcomeWon
         | AbilityCondition::CoinFlipOutcome { .. }
         | AbilityCondition::SpellCastWithVariantThisTurn { .. }
-        | AbilityCondition::NthResolutionThisTurn { .. }
+        | AbilityCondition::AbilityUseCountThisTurn { .. }
         | AbilityCondition::RevealedHasCardType { .. }
         | AbilityCondition::SourceEnteredThisTurn
         | AbilityCondition::AdditionalCostPaid { .. }
@@ -6582,10 +6582,19 @@ fn rw_ability_condition(x: &AbilityCondition) -> RwProfile {
         // CR 705.2: reads resolution-local `state.resolution_coin_flip` — a live
         // in-resolution signal, same read-bucket as `EventOutcomeWon`.
         AbilityCondition::CoinFlipOutcome { result: _ } => reads_event_live(),
+        // Both `AbilityUseCountThisTurn` tallies read a per-turn journal keyed
+        // by this ability's own `(source_id, ability_index)` — the same read
+        // bucket for `Resolved` (`ability_resolutions_this_turn`) and
+        // `Activated` (`activated_abilities_this_turn`). Neither field selects a
+        // different KIND or SCOPE of state, so the profile is unchanged by the
+        // tally axis; both are destructured without `..` so a future field
+        // forces re-classification.
         AbilityCondition::SpellCastWithVariantThisTurn { variant: _ }
-        | AbilityCondition::NthResolutionThisTurn { n: _ } => {
-            reads_player_of(StateKind::JournalCast)
-        }
+        | AbilityCondition::AbilityUseCountThisTurn {
+            tally: _,
+            comparator: _,
+            n: _,
+        } => reads_player_of(StateKind::JournalCast),
         // CR 701.20 + CR 603.3b: "if a card revealed THIS WAY has card type T" —
         // a read of the card the member's OWN parent reveal surfaced (a per-
         // resolution local, like an `ObjectScope::Recipient` read-modify-write:

--- a/crates/engine/src/game/ability_scan.rs
+++ b/crates/engine/src/game/ability_scan.rs
@@ -3107,7 +3107,16 @@ fn scan_ability_condition(x: &AbilityCondition, mode: ScanMode) -> Axes {
         }
         AbilityCondition::DayNightIsNeither => Axes::NONE,
         AbilityCondition::DayNightIs { state: _ } => Axes::NONE,
-        AbilityCondition::NthResolutionThisTurn { n: _ } => Axes {
+        // Both tallies are per-turn counters projected from this ability's own
+        // `(source_id, ability_index)` ledger entry — neither reads the
+        // triggering event nor any sibling's output, so the axes are identical
+        // for `Resolved` and `Activated`. Destructured without `..` so a future
+        // field forces re-classification here.
+        AbilityCondition::AbilityUseCountThisTurn {
+            tally: _,
+            comparator: _,
+            n: _,
+        } => Axes {
             event: false,
             sibling: false,
             projected: true,
@@ -7562,7 +7571,7 @@ mod tests {
         // from `typed_filter_axes`, so this IS that arm's verdict for this shape.
         let by_target = typed_filter_axes(&target, ScanMode::LoopFirewall);
         let by_condition = scan_ability_condition(
-            &AbilityCondition::NthResolutionThisTurn { n: 2 },
+            &AbilityCondition::nth_resolution_this_turn(2),
             ScanMode::LoopFirewall,
         );
         let refs = [
@@ -7596,7 +7605,7 @@ mod tests {
         ];
         for (label, axes) in [
             ("ControllerMatches{OpponentLostLife}", by_target),
-            ("NthResolutionThisTurn", by_condition),
+            ("AbilityUseCountThisTurn", by_condition),
         ]
         .into_iter()
         .chain(
@@ -9085,7 +9094,7 @@ mod tests {
         ));
         // Ability-condition branch selector reading the per-ability resolution count.
         assert!(ability_condition_reads_projected_resource(
-            &AbilityCondition::NthResolutionThisTurn { n: 10 }
+            &AbilityCondition::nth_resolution_this_turn(10)
         ));
         // Static-condition dormant reader (poison).
         assert!(static_condition_reads_projected_resource(

--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -17,17 +17,18 @@ use crate::parser::oracle_casting::parse_casting_restriction_line;
 use crate::parser::oracle_ir::diagnostic::OracleDiagnostic;
 use crate::parser::oracle_util::normalize_card_name_refs;
 use crate::types::ability::{
-    AbilityCondition, AbilityCost, AbilityDefinition, AbilityKind, ActivationRestriction,
-    AdditionalCost, AggregateFunction, AttackScope, AttackSubject, CardTypeSetSource, ChoiceType,
-    CoinFlipResult, CommanderOwnership, Comparator, ContinuousModification, ControllerRef,
-    CountScope, CounterKindChooser, CounterKindDomain, CounterSourceRider, DelayedTriggerCondition,
-    DieRollModifier, DoublePTMode, Duration, EachDamageRecipient, Effect, EffectOutcomeSignal,
-    EffectScope, FilterProp, ForEachCategoryAction, GameRestriction, LibraryPosition,
-    ManaProduction, MassLibraryShuffleMode, ObjectProperty, ObjectScope,
-    ObjectSelectionCardinality, ObjectSelectionEligibility, ParsedCondition, PerpetualModification,
-    PlayerFilter, PlayerRelation, PlayerScope, PtStat, PtValue, PtValueScope, QuantityExpr,
-    QuantityRef, ReplacementCondition, ReplacementDefinition, ReplacementMode, SeatDirection,
-    SharedQuality, SharedQualityRelation, SpeedDelta, SpellCastingOption, SpellCastingOptionKind,
+    AbilityCondition, AbilityCost, AbilityDefinition, AbilityKind, AbilityUseTally,
+    ActivationRestriction, AdditionalCost, AggregateFunction, AttackScope, AttackSubject,
+    CardTypeSetSource, ChoiceType, CoinFlipResult, CommanderOwnership, Comparator,
+    ContinuousModification, ControllerRef, CountScope, CounterKindChooser, CounterKindDomain,
+    CounterSourceRider, DelayedTriggerCondition, DieRollModifier, DoublePTMode, Duration,
+    EachDamageRecipient, Effect, EffectOutcomeSignal, EffectScope, FilterProp,
+    ForEachCategoryAction, GameRestriction, LibraryPosition, ManaProduction,
+    MassLibraryShuffleMode, ObjectProperty, ObjectScope, ObjectSelectionCardinality,
+    ObjectSelectionEligibility, ParsedCondition, PerpetualModification, PlayerFilter,
+    PlayerRelation, PlayerScope, PtStat, PtValue, PtValueScope, QuantityExpr, QuantityRef,
+    ReplacementCondition, ReplacementDefinition, ReplacementMode, SeatDirection, SharedQuality,
+    SharedQualityRelation, SpeedDelta, SpellCastingOption, SpellCastingOptionKind,
     SpellStackToGraveyardReplacement, StackAbilityKind, StaticCondition, StaticDefinition,
     TapStateChange, TargetFilter, TriggerDefinition, TypeFilter, TypedFilter, VoteSubject, ZoneRef,
 };
@@ -4514,8 +4515,19 @@ fn fmt_ability_condition(cond: &AbilityCondition) -> String {
         }
         AbilityCondition::DayNightIsNeither => "neither day nor night".into(),
         AbilityCondition::DayNightIs { state } => format!("it is {state:?}"),
-        AbilityCondition::NthResolutionThisTurn { n } => {
-            format!("{n} resolution this turn")
+        AbilityCondition::AbilityUseCountThisTurn {
+            tally,
+            comparator,
+            n,
+        } => {
+            let verb = match tally {
+                AbilityUseTally::Resolved => "resolved",
+                AbilityUseTally::Activated => "activated",
+            };
+            format!(
+                "this ability {verb} {} {n} times this turn",
+                fmt_comparator(comparator)
+            )
         }
         AbilityCondition::SourceLacksKeyword { keyword } => {
             format!("source lacks {}", keyword_label(keyword))
@@ -9502,7 +9514,7 @@ fn condition_feature(cond: &AbilityCondition) -> (&'static str, FeatureSupport) 
         // CR 731.1: Day/night designation check — handled by evaluate_condition.
         AbilityCondition::DayNightIs { .. } => ("DayNightIs", Handled),
         // CR 603.4: Per-ability per-turn resolution counter — handled by evaluate_condition.
-        AbilityCondition::NthResolutionThisTurn { .. } => ("NthResolutionThisTurn", Handled),
+        AbilityCondition::AbilityUseCountThisTurn { .. } => ("AbilityUseCountThisTurn", Handled),
         AbilityCondition::CostPaidObjectMatchesFilter { .. } => {
             ("CostPaidObjectMatchesFilter", Handled)
         }
@@ -11991,8 +12003,6 @@ fn line_has_condition_text(lower: &str) -> Option<&'static str> {
             // typically on triggers that the auditor already checks. The ability description
             // uses the keyword name, not a standalone condition. Mark as structural.
             || (lower.starts_with("coven") && lower.contains("if "))
-            // --- Activation/resolution count conditions ---
-            || lower.contains("this ability has been activated")
             // --- Zone-referential conditions (structural, not board-state) ---
             // "if this card is suspended" / "if this card is in your graveyard"
             || lower.contains("is suspended")

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -9,17 +9,18 @@ use crate::game::conditions::{
 use crate::game::filter;
 use crate::game::speed::has_max_speed;
 use crate::types::ability::{
-    AbilityCondition, AbilityCost, AbilityDefinition, AbilityKind, CardPlayMode, CardTypeSetSource,
-    CastFromZoneDriver, ChosenAttribute, CommanderOwnership, ControllerRef, CopyRetargetPermission,
-    CostPaidObjectSnapshot, CounterKindDomain, DetachedRemainder, EachDamageRecipient, Effect,
-    EffectError, EffectKind, EffectOutcomeSignal, EffectResolutionResult, EffectScope, FilterProp,
-    ForEachCategoryAction, ForwardedResultContext, ManaProduction, MassLibraryShuffleMode,
-    ObjectSelectionCardinality, OpponentMayScope, PlayerFilter, PlayerRelation, PlayerScope,
-    PossessionAxis, QuantityExpr, QuantityRef, ReciprocalZoneChoiceRole, RepeatContinuation,
-    ResolvedAbility, RevealUntilDisposition, SacrificeCost, SacrificeRequirement, SharedQuality,
-    SharedQualityRelation, SiblingCondition, StaticDefinition, SubAbilityLink, TapStateChange,
-    TargetChoiceTiming, TargetDamageSourceBinding, TargetFilter, TargetRef, ThisWayCause,
-    ZoneChoiceCandidateSource, ZoneChoiceChooser,
+    AbilityCondition, AbilityCost, AbilityDefinition, AbilityKind, AbilityUseTally, CardPlayMode,
+    CardTypeSetSource, CastFromZoneDriver, ChosenAttribute, CommanderOwnership, ControllerRef,
+    CopyRetargetPermission, CostPaidObjectSnapshot, CounterKindDomain, DetachedRemainder,
+    EachDamageRecipient, Effect, EffectError, EffectKind, EffectOutcomeSignal,
+    EffectResolutionResult, EffectScope, FilterProp, ForEachCategoryAction, ForwardedResultContext,
+    ManaProduction, MassLibraryShuffleMode, ObjectSelectionCardinality, OpponentMayScope,
+    PlayerFilter, PlayerRelation, PlayerScope, PossessionAxis, QuantityExpr, QuantityRef,
+    ReciprocalZoneChoiceRole, RepeatContinuation, ResolvedAbility, RevealUntilDisposition,
+    SacrificeCost, SacrificeRequirement, SharedQuality, SharedQualityRelation, SiblingCondition,
+    StaticDefinition, SubAbilityLink, TapStateChange, TargetChoiceTiming,
+    TargetDamageSourceBinding, TargetFilter, TargetRef, ThisWayCause, ZoneChoiceCandidateSource,
+    ZoneChoiceChooser,
 };
 #[cfg(test)]
 use crate::types::ability::{AttackScope, AttackSubject};
@@ -3134,7 +3135,7 @@ fn apply_parent_chain_context(
     // CR 608.2c: A sub-ability is part of the same printed ability instance as
     // its parent; its instructions are followed in order during a single
     // resolution. Propagate the parent's `ability_index` so chain-level
-    // `AbilityCondition::NthResolutionThisTurn` gates can identify "this ability"
+    // `AbilityCondition::AbilityUseCountThisTurn` gates can identify "this ability"
     // when evaluated on a chained sub-ability. The per-turn resolution counter is
     // keyed on `(source_id, ability_index)`; without this the sub carries no
     // index and the gate always evaluates false, so e.g. Nissa, Resurgent
@@ -4013,7 +4014,7 @@ fn condition_reads_filter_population(
         | AbilityCondition::SourceAttachedToCreature
         | AbilityCondition::DayNightIsNeither
         | AbilityCondition::DayNightIs { .. }
-        | AbilityCondition::NthResolutionThisTurn { .. }
+        | AbilityCondition::AbilityUseCountThisTurn { .. }
         | AbilityCondition::SourceLacksKeyword { .. } => false,
     }
 }
@@ -4490,7 +4491,7 @@ fn should_resolve_subability_on_optional_decline(ability: &ResolvedAbility) -> b
             | AbilityCondition::ConditionInstead { .. }
             | AbilityCondition::DayNightIsNeither
             | AbilityCondition::DayNightIs { .. }
-            | AbilityCondition::NthResolutionThisTurn { .. }
+            | AbilityCondition::AbilityUseCountThisTurn { .. }
             | AbilityCondition::SourceLacksKeyword { .. }
             | AbilityCondition::ScopedPlayerMatches { .. }
             | AbilityCondition::EffectOutcome {
@@ -11599,12 +11600,14 @@ pub fn resolve_ability_chain(
 
     // CR 608.2c: Bump the per-ability per-turn resolution counter at the start of
     // top-level resolution so that the ordinary resolution-time
-    // `AbilityCondition::NthResolutionThisTurn` condition can see the current
+    // `AbilityCondition::AbilityUseCountThisTurn` condition can see the current
     // resolution included in the count. This is not an intervening-if condition
     // governed by CR 603.4. Sub-abilities (depth > 0) share the parent's count —
-    // they belong to the same printed ability instance. Synthesized/runtime-only
-    // abilities (prowess, firebending) and activated abilities lack an
-    // `ability_index` stamp and skip this hook.
+    // they belong to the same printed ability instance. Only synthesized/
+    // runtime-only abilities (prowess, firebending) lack an `ability_index`
+    // stamp and skip this hook; activated abilities are stamped in
+    // `casting_costs::push_ability_entry` (and the loyalty path in
+    // `planeswalker`), so they DO bump this counter.
     if depth == 0 {
         if let Some(idx) = ability.ability_index {
             let count = state
@@ -12591,7 +12594,7 @@ fn resolve_chain_body(
                 // sibling escape hatch (the `next.sub_link == SequentialSibling`
                 // branch below).
                 // CR 608.2c: A dependent `SequentialSibling` whose direct condition
-                // is `NthResolutionThisTurn` is the next ordinal instruction of the
+                // is `AbilityUseCountThisTurn` is the next ordinal instruction of the
                 // same resolving ability (Belladonna Took / Omnath class). It must
                 // reach and evaluate its OWN ordinal condition when the preceding
                 // ordinal is false. Keep this exact escape local: other dependent
@@ -12627,12 +12630,23 @@ fn resolve_chain_body(
                 // shapes. The unconditional and ordinal `SequentialSibling` escapes
                 // below are local to this call site: neither is an independent
                 // intervening-if path that the delayed-body hoist may preserve.
+                // The escape is deliberately scoped to the ORDINAL reading
+                // (`Resolved`) of `AbilityUseCountThisTurn`, which is exactly
+                // what it covered before the tally axis existed. The `Activated`
+                // reading is a single terminal rider ("sacrifice this creature at
+                // the beginning of the next end step", Dragon Whelp class), never
+                // one of several ordinal clauses chained in written order, so it
+                // has no claim on an escape whose whole justification is CR 608.2c
+                // written-order evaluation of successive ordinals.
                 let is_ordinal_sequential_sibling = sub.sub_link
                     == SubAbilityLink::SequentialSibling
                     && sub.sibling_condition == SiblingCondition::Dependent
                     && matches!(
                         sub.condition.as_ref(),
-                        Some(AbilityCondition::NthResolutionThisTurn { .. })
+                        Some(AbilityCondition::AbilityUseCountThisTurn {
+                            tally: AbilityUseTally::Resolved,
+                            ..
+                        })
                     );
                 if sub_outlives_false_parent_gate(sub)
                     || (sub.sub_link == SubAbilityLink::SequentialSibling
@@ -12655,7 +12669,7 @@ fn resolve_chain_body(
                     // CR 608.2c: The false-parent ordinal escape bypasses the
                     // ordinary post-effect chain handoff, so it must explicitly
                     // carry this printed ability's index to the next ordinal
-                    // instruction. Otherwise `NthResolutionThisTurn` reads no
+                    // instruction. Otherwise `AbilityUseCountThisTurn` reads no
                     // `(source, ability_index)` ledger entry and can never match.
                     if is_ordinal_sequential_sibling {
                         apply_parent_chain_context(&mut sub_resolved, ability, None, state);
@@ -16304,22 +16318,41 @@ pub(crate) fn evaluate_condition(
         AbilityCondition::DayNightIs {
             state: DayNight::Night,
         } => state.day_night == Some(DayNight::Night),
-        // CR 608.2c: "if this is the [Nth] time this ability has resolved this
-        // turn" is an ordinary resolution-time condition, not an intervening-if
-        // condition under CR 603.4. The counter is bumped at the top of
-        // `resolve_ability_chain` (depth 0) before this evaluator runs, so a
-        // freshly-incremented count of `n` satisfies the condition for the Nth
-        // resolution. Abilities without an `ability_index` stamp (synthesized
-        // triggers, activated abilities) never increment the counter and therefore
-        // evaluate as `count == 0`, which matches no `n >= 1` print.
-        AbilityCondition::NthResolutionThisTurn { n } => {
+        // CR 608.2c: an ordinary resolution-time condition on how many times
+        // THIS printed ability has been used this turn, not an intervening-if
+        // condition under CR 603.4. Both tallies are keyed by the same
+        // `(source_id, ability_index)` pair, so one lookup serves both:
+        //
+        // - `Resolved` ("if this is the [Nth] time this ability has resolved
+        //   this turn") reads a counter bumped at the top of
+        //   `resolve_ability_chain` (depth 0) before this evaluator runs, so the
+        //   current resolution is already included and a freshly-incremented
+        //   count of `n` satisfies `EQ n` for the Nth resolution.
+        // - `Activated` ("if this ability has been activated [N] or more times
+        //   this turn") reads the CR 602.2a announcement counter incremented in
+        //   `ledger::record_ability_activation`, so the activation now resolving
+        //   is likewise already included, and an activation countered before it
+        //   resolved still counts.
+        //
+        // An ability with no `ability_index` stamp (synthesized/runtime-only
+        // abilities such as prowess and firebending) has no entry in either
+        // ledger and evaluates as `count == 0`, which no `n >= 1` print matches
+        // under `EQ`/`GE`. Fail-closed by construction rather than by a guard.
+        AbilityCondition::AbilityUseCountThisTurn {
+            tally,
+            comparator,
+            n,
+        } => {
             if let Some(idx) = ability.ability_index {
-                let count = state
-                    .ability_resolutions_this_turn
-                    .get(&(ability.source_id, idx))
-                    .copied()
-                    .unwrap_or(0);
-                count == *n
+                let ledger = match tally {
+                    AbilityUseTally::Resolved => &state.ability_resolutions_this_turn,
+                    AbilityUseTally::Activated => &state.activated_abilities_this_turn,
+                };
+                let count = ledger.get(&(ability.source_id, idx)).copied().unwrap_or(0);
+                comparator.evaluate(
+                    crate::game::arithmetic::u32_to_i32_saturating(count),
+                    crate::game::arithmetic::u32_to_i32_saturating(*n),
+                )
             } else {
                 false
             }
@@ -31484,7 +31517,7 @@ mod tests {
     }
 
     // CR 608.2c: Runtime tests for the ordinary resolution-time
-    // `AbilityCondition::NthResolutionThisTurn` condition (not CR 603.4
+    // `AbilityCondition::AbilityUseCountThisTurn` condition (not CR 603.4
     // intervening-if).
 
     /// Build a minimal `ResolvedAbility` with a stamped `ability_index` for
@@ -31504,7 +31537,7 @@ mod tests {
     }
 
     /// Issue #1595 — Nissa, Resurgent Animist. A chained `SequentialSibling`
-    /// sub-ability gated on `NthResolutionThisTurn{2}` must fire on the SECOND
+    /// sub-ability gated on `AbilityUseCountThisTurn{2}` must fire on the SECOND
     /// resolution this turn. Before the fix, sub-abilities carried no
     /// `ability_index`, so the gate evaluated false forever and the second-
     /// resolution half never happened (the reported "only did the first portion
@@ -31525,7 +31558,7 @@ mod tests {
             source_id,
             PlayerId(0),
         );
-        sub.condition = Some(AbilityCondition::NthResolutionThisTurn { n: 2 });
+        sub.condition = Some(AbilityCondition::nth_resolution_this_turn(2));
         sub.sub_link = SubAbilityLink::SequentialSibling;
         // The sub is built WITHOUT an ability_index, exactly as the trigger
         // pipeline produces it (only the top-level trigger gets a stamp).
@@ -31599,7 +31632,7 @@ mod tests {
             source_id,
             PlayerId(0),
         );
-        branch3.condition = Some(AbilityCondition::NthResolutionThisTurn { n: 3 });
+        branch3.condition = Some(AbilityCondition::nth_resolution_this_turn(3));
         branch3.sub_link = SubAbilityLink::SequentialSibling;
         assert!(branch3.ability_index.is_none());
 
@@ -31613,7 +31646,7 @@ mod tests {
             source_id,
             PlayerId(0),
         );
-        branch2.condition = Some(AbilityCondition::NthResolutionThisTurn { n: 2 });
+        branch2.condition = Some(AbilityCondition::nth_resolution_this_turn(2));
         branch2.sub_link = SubAbilityLink::SequentialSibling;
         branch2.sub_ability = Some(Box::new(branch3));
         assert!(branch2.ability_index.is_none());
@@ -31629,7 +31662,7 @@ mod tests {
             source_id,
             PlayerId(0),
         )
-        .condition(AbilityCondition::NthResolutionThisTurn { n: 1 })
+        .condition(AbilityCondition::nth_resolution_this_turn(1))
         .sub_ability(branch2);
         ability.ability_index = Some(0);
 
@@ -31749,7 +31782,7 @@ mod tests {
             source_id,
             PlayerId(0),
         )
-        .condition(AbilityCondition::NthResolutionThisTurn { n: 2 })
+        .condition(AbilityCondition::nth_resolution_this_turn(2))
         .sub_ability(child);
         parent.ability_index = Some(0);
 
@@ -31788,7 +31821,7 @@ mod tests {
             source_id,
             PlayerId(0),
         );
-        branch3.condition = Some(AbilityCondition::NthResolutionThisTurn { n: 1 });
+        branch3.condition = Some(AbilityCondition::nth_resolution_this_turn(1));
         branch3.sub_link = SubAbilityLink::SequentialSibling;
 
         let mut branch2 = ResolvedAbility::new(
@@ -31800,7 +31833,7 @@ mod tests {
             source_id,
             PlayerId(0),
         );
-        branch2.condition = Some(AbilityCondition::NthResolutionThisTurn { n: 1 });
+        branch2.condition = Some(AbilityCondition::nth_resolution_this_turn(1));
         branch2.sub_link = SubAbilityLink::SequentialSibling;
         branch2.sub_ability = Some(Box::new(branch3));
 
@@ -31813,7 +31846,7 @@ mod tests {
             source_id,
             PlayerId(0),
         );
-        branch1.condition = Some(AbilityCondition::NthResolutionThisTurn { n: 2 });
+        branch1.condition = Some(AbilityCondition::nth_resolution_this_turn(2));
         branch1.sub_link = SubAbilityLink::SequentialSibling;
         branch1.sub_ability = Some(Box::new(branch2));
 
@@ -31853,7 +31886,7 @@ mod tests {
         // Initial state: counter is 0; n=1 should be false BEFORE any resolution.
         assert!(
             !evaluate_condition(
-                &AbilityCondition::NthResolutionThisTurn { n: 1 },
+                &AbilityCondition::nth_resolution_this_turn(1),
                 &state,
                 &ability
             ),
@@ -31872,7 +31905,7 @@ mod tests {
         );
         assert!(
             evaluate_condition(
-                &AbilityCondition::NthResolutionThisTurn { n: 1 },
+                &AbilityCondition::nth_resolution_this_turn(1),
                 &state,
                 &ability
             ),
@@ -31880,7 +31913,7 @@ mod tests {
         );
         assert!(
             !evaluate_condition(
-                &AbilityCondition::NthResolutionThisTurn { n: 2 },
+                &AbilityCondition::nth_resolution_this_turn(2),
                 &state,
                 &ability
             ),
@@ -31896,7 +31929,7 @@ mod tests {
         );
         assert!(
             !evaluate_condition(
-                &AbilityCondition::NthResolutionThisTurn { n: 1 },
+                &AbilityCondition::nth_resolution_this_turn(1),
                 &state,
                 &ability
             ),
@@ -31904,7 +31937,7 @@ mod tests {
         );
         assert!(
             evaluate_condition(
-                &AbilityCondition::NthResolutionThisTurn { n: 2 },
+                &AbilityCondition::nth_resolution_this_turn(2),
                 &state,
                 &ability
             ),
@@ -31915,7 +31948,7 @@ mod tests {
         resolve_ability_chain(&mut state, &ability, &mut events, 0).unwrap();
         assert!(
             evaluate_condition(
-                &AbilityCondition::NthResolutionThisTurn { n: 3 },
+                &AbilityCondition::nth_resolution_this_turn(3),
                 &state,
                 &ability
             ),
@@ -31923,7 +31956,7 @@ mod tests {
         );
         assert!(
             !evaluate_condition(
-                &AbilityCondition::NthResolutionThisTurn { n: 2 },
+                &AbilityCondition::nth_resolution_this_turn(2),
                 &state,
                 &ability
             ),
@@ -31997,7 +32030,7 @@ mod tests {
     #[test]
     fn nth_resolution_no_index_does_not_increment_or_match() {
         // Synthesized abilities (prowess, firebending) lack an ability_index.
-        // They must NOT bump the counter and NthResolutionThisTurn must
+        // They must NOT bump the counter and AbilityUseCountThisTurn must
         // evaluate false against them (count is implicitly 0 / no key).
         let mut state = GameState::new_two_player(42);
         let source_id = ObjectId(1);
@@ -32020,11 +32053,112 @@ mod tests {
         );
         assert!(
             !evaluate_condition(
-                &AbilityCondition::NthResolutionThisTurn { n: 1 },
+                &AbilityCondition::nth_resolution_this_turn(1),
                 &state,
                 &ability
             ),
-            "NthResolutionThisTurn must evaluate false when ability lacks an index"
+            "AbilityUseCountThisTurn must evaluate false when ability lacks an index"
+        );
+    }
+
+    /// CR 602.2a + CR 608.2c: Dragon Whelp's threshold — "If this ability has
+    /// been activated four or more times this turn, sacrifice this creature at
+    /// the beginning of the next end step."
+    ///
+    /// The reported bug (#8388) was that the sacrifice fired after three
+    /// activations, because the clause parsed to no condition at all and the
+    /// rider therefore ran unconditionally. The boundary is the whole assertion
+    /// here: false at 3, true at 4.
+    #[test]
+    fn activation_tally_gates_on_the_printed_threshold() {
+        let mut state = GameState::new_two_player(42);
+        let source_id = ObjectId(1);
+        let mut ability = ResolvedAbility::new(
+            Effect::Draw {
+                count: QuantityExpr::Fixed { value: 1 },
+                target: TargetFilter::Controller,
+            },
+            vec![],
+            source_id,
+            PlayerId(0),
+        );
+        // Both activated-ability stack paths stamp this; see
+        // `casting_costs::push_ability_entry`.
+        ability.ability_index = Some(0);
+        let condition = AbilityCondition::AbilityUseCountThisTurn {
+            tally: AbilityUseTally::Activated,
+            comparator: Comparator::GE,
+            n: 4,
+        };
+
+        for activations in 0..4 {
+            state
+                .activated_abilities_this_turn
+                .insert((source_id, 0), activations);
+            assert!(
+                !evaluate_condition(&condition, &state, &ability),
+                "must not fire at {activations} activations — the printed \
+                 threshold is four"
+            );
+        }
+
+        state
+            .activated_abilities_this_turn
+            .insert((source_id, 0), 4);
+        assert!(
+            evaluate_condition(&condition, &state, &ability),
+            "must fire once the fourth activation is recorded"
+        );
+        // "four OR MORE" — the gate stays satisfied past the boundary.
+        state
+            .activated_abilities_this_turn
+            .insert((source_id, 0), 7);
+        assert!(evaluate_condition(&condition, &state, &ability));
+    }
+
+    /// The two tallies read different ledgers, so neither may be satisfied by
+    /// the other's counter. Without this, a single-ledger implementation would
+    /// pass every threshold assertion above while making a countered activation
+    /// (which never resolves) invisible to Dragon Whelp.
+    #[test]
+    fn activation_and_resolution_tallies_read_separate_ledgers() {
+        let mut state = GameState::new_two_player(42);
+        let source_id = ObjectId(1);
+        let mut ability = ResolvedAbility::new(
+            Effect::Draw {
+                count: QuantityExpr::Fixed { value: 1 },
+                target: TargetFilter::Controller,
+            },
+            vec![],
+            source_id,
+            PlayerId(0),
+        );
+        ability.ability_index = Some(0);
+
+        // Four activations recorded, none of them resolved.
+        state
+            .activated_abilities_this_turn
+            .insert((source_id, 0), 4);
+
+        assert!(
+            evaluate_condition(
+                &AbilityCondition::AbilityUseCountThisTurn {
+                    tally: AbilityUseTally::Activated,
+                    comparator: Comparator::GE,
+                    n: 4,
+                },
+                &state,
+                &ability
+            ),
+            "activation tally must see the activation ledger"
+        );
+        assert!(
+            !evaluate_condition(
+                &AbilityCondition::nth_resolution_this_turn(4),
+                &state,
+                &ability
+            ),
+            "resolution tally must NOT be satisfied by activation counts"
         );
     }
 

--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -2620,7 +2620,7 @@ fn collect_matching_triggers_inner(
             // than the self-ref `ChangesController` case above.
             ability.set_controller_recursive(controller);
             // CR 603.4: Stamp the printed-trigger index so per-turn resolution
-            // tracking (`AbilityCondition::NthResolutionThisTurn`) can identify
+            // tracking (`AbilityCondition::AbilityUseCountThisTurn`) can identify
             // "this ability" at resolution time.
             ability.ability_index = Some(trig_idx);
             // CR 605.4a: A `TapsForMana` triggered mana ability coupled to an
@@ -11276,7 +11276,7 @@ fn gate_binding_diverges_at_fire_time(condition: &AbilityCondition) -> bool {
         | AbilityCondition::WhenYouDo
         | AbilityCondition::RevealedHasCardType { .. }
         | AbilityCondition::PreviousEffectAmount { .. }
-        | AbilityCondition::NthResolutionThisTurn { .. }
+        | AbilityCondition::AbilityUseCountThisTurn { .. }
         | AbilityCondition::DiscardedCardMatchesFilter { .. }
         // CR 608.2c: the "this way" ledgers — `state.last_zone_changed_ids` and
         // the tracked sets — declined for exactly the reason their

--- a/crates/engine/src/parser/oracle_effect/conditions.rs
+++ b/crates/engine/src/parser/oracle_effect/conditions.rs
@@ -35,11 +35,11 @@ use crate::parser::oracle_ir::effect_chain::{
     AbilityIr, AbilityRootTransform, AbilityShellIr, EffectChainIr,
 };
 use crate::types::ability::{
-    AbilityCondition, AbilityDefinition, AbilityKind, AdditionalCostOrigin, CastManaObjectScope,
-    CastManaSpentMetric, CastVariantPaid, CoinFlipResult, Comparator, ControllerRef, CountScope,
-    DamageChannel, DigSource, Duration, Effect, EffectOutcomeSignal, FilterProp, GuessOutcome,
-    ObjectScope, ParsedCondition, PlayerScope, PtStat, PtValueScope, QuantityExpr, QuantityRef,
-    StaticCondition, TargetFilter, TypeFilter, TypedFilter,
+    AbilityCondition, AbilityDefinition, AbilityKind, AbilityUseTally, AdditionalCostOrigin,
+    CastManaObjectScope, CastManaSpentMetric, CastVariantPaid, CoinFlipResult, Comparator,
+    ControllerRef, CountScope, DamageChannel, DigSource, Duration, Effect, EffectOutcomeSignal,
+    FilterProp, GuessOutcome, ObjectScope, ParsedCondition, PlayerScope, PtStat, PtValueScope,
+    QuantityExpr, QuantityRef, StaticCondition, TargetFilter, TypeFilter, TypedFilter,
 };
 use crate::types::card_type::{CoreType, Supertype};
 use crate::types::counter::{CounterMatch, CounterType};
@@ -5221,7 +5221,7 @@ pub(crate) fn ability_condition_to_static_condition(
         | AbilityCondition::ZoneChangedThisWay { .. }
         | AbilityCondition::CostPaidObjectMatchesFilter { .. }
         | AbilityCondition::ConditionInstead { .. }
-        | AbilityCondition::NthResolutionThisTurn { .. }
+        | AbilityCondition::AbilityUseCountThisTurn { .. }
         | AbilityCondition::ScopedPlayerMatches { .. } => None,
         AbilityCondition::DiscardedCardMatchesFilter { .. } => None,
 
@@ -5886,15 +5886,16 @@ pub(super) fn try_nom_condition_as_ability_condition(
         return Some(AbilityCondition::FirstEndStepOfTurn);
     }
 
-    // CR 603.4: "if this is the [Nth] time this ability has resolved this turn"
-    // and the abbreviated continuation form "if it's the [Nth] time" used by
-    // Omnath's later sentences (the "this ability has resolved this turn" tail
-    // is anaphoric to the prior sentence and is dropped). Composes:
-    //   subject: "this is" | "it's" | "it is"
-    //   ordinal: "first" | "second" | ...
-    //   tail:    optional " this ability has resolved this turn"
-    if let Some(n) = parse_nth_resolution_condition(lower.as_str()) {
-        return Some(AbilityCondition::NthResolutionThisTurn { n });
+    // CR 608.2c + CR 602.2a: "how many times has THIS ability been used this
+    // turn" — the ordinal resolution reading ("if this is the [Nth] time this
+    // ability has resolved this turn") and the activation-threshold reading
+    // ("if this ability has been activated four or more times this turn").
+    if let Some((tally, comparator, n)) = parse_ability_use_count_condition(lower.as_str()) {
+        return Some(AbilityCondition::AbilityUseCountThisTurn {
+            tally,
+            comparator,
+            n,
+        });
     }
 
     if let Ok((rest, _)) = tag::<_, _, OracleError<'_>>("you do or if ").parse(lower.as_str()) {
@@ -7784,17 +7785,13 @@ fn parse_a_type_was_verbed_this_way(lower: &str) -> Option<(TypeFilter, bool)> {
 /// anaphoric continuations whose "this ability has resolved this turn" tail was
 /// printed in a prior sentence. Ordinals span first–tenth (Omnath/Ashling print
 /// up to third; the broader ceiling is conservative).
-fn parse_nth_resolution_condition(lower: &str) -> Option<u32> {
-    type E<'a> = OracleError<'a>;
-    let (rest, _) = alt((
-        tag::<_, _, E>("this is the "),
-        tag("it's the "),
-        tag("it is the "),
-    ))
-    .parse(lower)
-    .ok()?;
-    let (rest, n) = alt((
-        value(1u32, tag::<_, _, E>("first")),
+/// CR 608.2c: an English ordinal word as its 1-based value.
+///
+/// The trailing `" time"` tag in [`parse_nth_resolution_clause`] supplies the
+/// word boundary, so "firstborn" can never partial-match.
+fn parse_ordinal_word(i: &str) -> OracleResult<'_, u32> {
+    alt((
+        value(1u32, tag("first")),
         value(2u32, tag("second")),
         value(3u32, tag("third")),
         value(4u32, tag("fourth")),
@@ -7805,15 +7802,59 @@ fn parse_nth_resolution_condition(lower: &str) -> Option<u32> {
         value(9u32, tag("ninth")),
         value(10u32, tag("tenth")),
     ))
-    .parse(rest)
-    .ok()?;
-    let (rest, _) = tag::<_, _, E>(" time").parse(rest).ok()?;
-    let rest = rest.trim_end_matches('.').trim();
-    // Tail is optional — anaphoric forms ("if it's the second time") drop it
-    // because the prior sentence already established "this ability has resolved
-    // this turn" as the subject.
-    if rest.is_empty() || rest == "this ability has resolved this turn" {
-        Some(n)
+    .parse(i)
+}
+
+/// CR 608.2c: "this is the [Nth] time this ability has resolved this turn", and
+/// the abbreviated continuation form "it's the [Nth] time" used by Omnath's
+/// later sentences (the tail is anaphoric to the prior sentence and dropped).
+///
+/// Composes three independent axes, one `alt` each — no permutation is
+/// enumerated:
+///   subject: "this is" | "it's" | "it is"
+///   ordinal: `parse_ordinal_word`
+///   tail:    optional " this ability has resolved this turn"
+fn parse_nth_resolution_clause(
+    input: &str,
+) -> OracleResult<'_, (AbilityUseTally, Comparator, u32)> {
+    let (rest, _) = alt((tag("this is the "), tag("it's the "), tag("it is the "))).parse(input)?;
+    let (rest, n) = parse_ordinal_word(rest)?;
+    let (rest, _) = tag(" time").parse(rest)?;
+    let (rest, _) = opt(tag(" this ability has resolved this turn")).parse(rest)?;
+    Ok((rest, (AbilityUseTally::Resolved, Comparator::EQ, n)))
+}
+
+/// CR 602.2a: "this ability has been activated [N] or more times this turn"
+/// (Dragon Whelp, Nalathni Dragon, Farrelite Priest, Initiates of the Ebon
+/// Hand).
+///
+/// The count phrase sits between two fixed anchors, so the middle is handed to
+/// the shared [`parse_comparison_suffix`] authority rather than enumerating
+/// comparator arms here. That covers the whole comparison class in one call —
+/// "four or more", "two or fewer", "greater than three", bare "four" — so a
+/// future print with a different comparator needs no edit to this combinator.
+fn parse_activation_count_clause(
+    input: &str,
+) -> OracleResult<'_, (AbilityUseTally, Comparator, u32)> {
+    let (rest, _) = tag("this ability has been activated ").parse(input)?;
+    let (rest, count_phrase) = take_until(" times this turn").parse(rest)?;
+    let (rest, _) = tag(" times this turn").parse(rest)?;
+    let (comparator, n) = parse_comparison_suffix(count_phrase).ok_or_else(|| oracle_err(input))?;
+    let n = u32::try_from(n).map_err(|_| oracle_err(input))?;
+    Ok((rest, (AbilityUseTally::Activated, comparator, n)))
+}
+
+/// CR 608.2c: the two printed templates for
+/// [`AbilityCondition::AbilityUseCountThisTurn`] — how many times THIS ability
+/// has resolved, or been activated, so far this turn.
+fn parse_ability_use_count_condition(lower: &str) -> Option<(AbilityUseTally, Comparator, u32)> {
+    let (rest, parsed) = alt((parse_nth_resolution_clause, parse_activation_count_clause))
+        .parse(lower)
+        .ok()?;
+    // Both templates are whole-clause conditions; a leftover tail means the
+    // fragment was something else that merely shares a prefix.
+    if rest.trim_end_matches('.').trim().is_empty() {
+        Some(parsed)
     } else {
         None
     }

--- a/crates/engine/src/parser/oracle_effect/tests.rs
+++ b/crates/engine/src/parser/oracle_effect/tests.rs
@@ -62915,7 +62915,10 @@ fn dragon_whelp_activation_threshold_gates_the_sacrifice_rider() {
          activated four or more times this turn, sacrifice this creature at the beginning of \
          the next end step.",
         "Dragon Whelp",
-        &[],
+        // Production supplies MTGJSON's keyword list; passing `&[]` here would
+        // leave the "Flying" line as `Effect::Unimplemented` for a reason that
+        // has nothing to do with the clause under test.
+        &["Flying".to_string()],
         &["Creature".to_string()],
         &["Dragon".to_string()],
     );
@@ -62938,8 +62941,26 @@ fn dragon_whelp_activation_threshold_gates_the_sacrifice_rider() {
         }
     }
 
+    fn assert_no_unimplemented(def: &AbilityDefinition) {
+        assert!(
+            !matches!(def.effect.as_ref(), Effect::Unimplemented { .. }),
+            "coverage honesty: the whole line must lower, got {def:#?}"
+        );
+        if let Some(sub) = def.sub_ability.as_deref() {
+            assert_no_unimplemented(sub);
+        }
+        if let Some(alt) = def.else_ability.as_deref() {
+            assert_no_unimplemented(alt);
+        }
+    }
+
     let mut conditions = Vec::new();
     for ability in &parsed.abilities {
+        // Removing the `line_has_condition_text` structural exemption only makes
+        // coverage honest if the clause genuinely lowers. If it degraded to
+        // `Effect::Unimplemented` instead, the card would flip to unsupported —
+        // which is honest but is NOT this fix's claim.
+        assert_no_unimplemented(ability);
         chain_conditions(ability, &mut conditions);
     }
 

--- a/crates/engine/src/parser/oracle_effect/tests.rs
+++ b/crates/engine/src/parser/oracle_effect/tests.rs
@@ -10,7 +10,7 @@ use crate::parser::parse_oracle_text;
 use crate::types::ability::CardPlayMode::{Cast, Play};
 use crate::types::ability::CastFromZoneDriver::{DuringResolution, LingeringPermission};
 use crate::types::ability::{
-    AttachmentKind, CardSelectionMode, CastManaObjectScope, CastManaSpentMetric,
+    AbilityUseTally, AttachmentKind, CardSelectionMode, CastManaObjectScope, CastManaSpentMetric,
     CommanderOwnership, DigRestOrder, ExcessRecipient, ForEachCategoryAction,
     MassLibraryShuffleMode, ModalChoice, PerpetualModification, SeatDirection, TurnJournalKind,
 };
@@ -49706,7 +49706,7 @@ fn veil_of_summer_effect_chain_parses_supported_clauses() {
     )));
 }
 
-// CR 603.4: Parser arms for `AbilityCondition::NthResolutionThisTurn`.
+// CR 603.4: Parser arms for `AbilityCondition::AbilityUseCountThisTurn`.
 // Covers Omnath / Ashling / Nissa / Sephiroth / Teething Wurmlet class.
 
 #[test]
@@ -49717,10 +49717,7 @@ fn nth_resolution_first_full_form() {
         "this is the first time this ability has resolved this turn",
         &mut ParseContext::default(),
     );
-    assert_eq!(
-        result,
-        Some(AbilityCondition::NthResolutionThisTurn { n: 1 })
-    );
+    assert_eq!(result, Some(AbilityCondition::nth_resolution_this_turn(1)));
 }
 
 #[test]
@@ -49730,10 +49727,7 @@ fn nth_resolution_third_full_form() {
         "this is the third time this ability has resolved this turn",
         &mut ParseContext::default(),
     );
-    assert_eq!(
-        result,
-        Some(AbilityCondition::NthResolutionThisTurn { n: 3 })
-    );
+    assert_eq!(result, Some(AbilityCondition::nth_resolution_this_turn(3)));
 }
 
 #[test]
@@ -49744,20 +49738,14 @@ fn nth_resolution_anaphoric_second() {
         "it's the second time",
         &mut ParseContext::default(),
     );
-    assert_eq!(
-        result,
-        Some(AbilityCondition::NthResolutionThisTurn { n: 2 })
-    );
+    assert_eq!(result, Some(AbilityCondition::nth_resolution_this_turn(2)));
 }
 
 #[test]
 fn nth_resolution_anaphoric_third() {
     let result =
         try_nom_condition_as_ability_condition("it's the third time", &mut ParseContext::default());
-    assert_eq!(
-        result,
-        Some(AbilityCondition::NthResolutionThisTurn { n: 3 })
-    );
+    assert_eq!(result, Some(AbilityCondition::nth_resolution_this_turn(3)));
 }
 
 #[test]
@@ -49767,10 +49755,109 @@ fn nth_resolution_fourth() {
         "this is the fourth time this ability has resolved this turn",
         &mut ParseContext::default(),
     );
+    assert_eq!(result, Some(AbilityCondition::nth_resolution_this_turn(4)));
+}
+
+// CR 602.2a: Parser arms for the ACTIVATION tally of
+// `AbilityCondition::AbilityUseCountThisTurn` — the four-card class printing
+// "If this ability has been activated four or more times this turn, sacrifice
+// this creature at the beginning of the next end step" (Dragon Whelp, Nalathni
+// Dragon, Farrelite Priest, Initiates of the Ebon Hand).
+
+#[test]
+fn activation_count_four_or_more() {
+    // Dragon Whelp / Nalathni Dragon / Farrelite Priest / Initiates of the
+    // Ebon Hand — all four print this clause verbatim.
+    let result = try_nom_condition_as_ability_condition(
+        "this ability has been activated four or more times this turn",
+        &mut ParseContext::default(),
+    );
     assert_eq!(
         result,
-        Some(AbilityCondition::NthResolutionThisTurn { n: 4 })
+        Some(AbilityCondition::AbilityUseCountThisTurn {
+            tally: AbilityUseTally::Activated,
+            comparator: Comparator::GE,
+            n: 4,
+        })
     );
+}
+
+#[test]
+fn activation_count_reads_the_whole_comparison_class() {
+    // The count phrase is delegated to the shared `parse_comparison_suffix`
+    // authority, so the comparator axis is covered for the class rather than
+    // for the one printed comparator. These forms are not printed today; the
+    // point of the assertion is that no per-comparator parser edit is needed
+    // when one is.
+    for (text, comparator, n) in [
+        (
+            "this ability has been activated two or fewer times this turn",
+            Comparator::LE,
+            2,
+        ),
+        (
+            "this ability has been activated greater than three times this turn",
+            Comparator::GT,
+            3,
+        ),
+        (
+            "this ability has been activated 4 times this turn",
+            Comparator::EQ,
+            4,
+        ),
+    ] {
+        assert_eq!(
+            try_nom_condition_as_ability_condition(text, &mut ParseContext::default()),
+            Some(AbilityCondition::AbilityUseCountThisTurn {
+                tally: AbilityUseTally::Activated,
+                comparator,
+                n,
+            }),
+            "failed for {text}"
+        );
+    }
+}
+
+#[test]
+fn activation_count_does_not_collapse_into_the_resolution_tally() {
+    // The two tallies are rules-distinct (CR 602.2a announcement vs CR 608.2c
+    // resolution): a countered activation counts for one and not the other. A
+    // parser that mapped both templates onto one tally would pass every
+    // single-template test above, so pin the discrimination directly.
+    let activated = try_nom_condition_as_ability_condition(
+        "this ability has been activated four or more times this turn",
+        &mut ParseContext::default(),
+    );
+    let resolved = try_nom_condition_as_ability_condition(
+        "this is the fourth time this ability has resolved this turn",
+        &mut ParseContext::default(),
+    );
+    assert!(matches!(
+        activated,
+        Some(AbilityCondition::AbilityUseCountThisTurn {
+            tally: AbilityUseTally::Activated,
+            ..
+        })
+    ));
+    assert!(matches!(
+        resolved,
+        Some(AbilityCondition::AbilityUseCountThisTurn {
+            tally: AbilityUseTally::Resolved,
+            ..
+        })
+    ));
+    assert_ne!(activated, resolved);
+}
+
+#[test]
+fn activation_count_partial_text_returns_none() {
+    // Shares the "this ability has been activated " prefix but is not a count
+    // clause — must not match rather than silently dropping the tail.
+    let result = try_nom_condition_as_ability_condition(
+        "this ability has been activated four or more times this game",
+        &mut ParseContext::default(),
+    );
+    assert!(result.is_none());
 }
 
 #[test]
@@ -49787,7 +49874,7 @@ fn nth_resolution_partial_text_returns_none() {
 #[test]
 fn nth_resolution_omnath_chain_populates_three_branches() {
     // End-to-end: Omnath's landfall trigger description should chain three
-    // sub-abilities, each gated on `NthResolutionThisTurn { n: 1/2/3 }`.
+    // sub-abilities, each gated on `AbilityUseCountThisTurn { n: 1/2/3 }`.
     std::thread::Builder::new()
         .name("omnath-nth".into())
         .stack_size(32 * 1024 * 1024)
@@ -49805,21 +49892,21 @@ fn nth_resolution_omnath_chain_populates_three_branches() {
             );
             assert_eq!(
                 def.condition,
-                Some(AbilityCondition::NthResolutionThisTurn { n: 1 }),
+                Some(AbilityCondition::nth_resolution_this_turn(1)),
                 "first branch must gate on n=1, got {:?}",
                 def.condition
             );
             let sub_n2 = def.sub_ability.as_ref().expect("must have n=2 branch");
             assert_eq!(
                 sub_n2.condition,
-                Some(AbilityCondition::NthResolutionThisTurn { n: 2 }),
+                Some(AbilityCondition::nth_resolution_this_turn(2)),
                 "second branch must gate on n=2, got {:?}",
                 sub_n2.condition
             );
             let sub_n3 = sub_n2.sub_ability.as_ref().expect("must have n=3 branch");
             assert_eq!(
                 sub_n3.condition,
-                Some(AbilityCondition::NthResolutionThisTurn { n: 3 }),
+                Some(AbilityCondition::nth_resolution_this_turn(3)),
                 "third branch must gate on n=3, got {:?}",
                 sub_n3.condition
             );
@@ -62803,4 +62890,63 @@ fn collect_cast_from_zone_defs(def: &AbilityDefinition, out: &mut Vec<AbilityDef
     if let Some(sub) = def.sub_ability.as_ref() {
         collect_cast_from_zone_defs(sub, out);
     }
+}
+
+/// CR 602.2a: Dragon Whelp (issue #8388) — the whole printed activated ability,
+/// not just the condition fragment.
+///
+/// The reported defect was that the sacrifice fired after three activations. The
+/// cause was that the threshold clause reached no condition parser at all (the
+/// phrase was on `coverage.rs`'s structural-exemption list, so the gap did not
+/// even surface as unsupported), leaving the sacrifice rider ungated. Asserting
+/// the fragment alone would not have caught that: the fragment parser can be
+/// correct while the clause never reaches it. So this walks the parsed ability
+/// and requires the threshold to be attached to a real gate somewhere in the
+/// chain.
+///
+/// All four cards in the class print this second sentence verbatim; the first
+/// sentence differs (a pump for Dragon Whelp and Nalathni Dragon, a mana ability
+/// for Farrelite Priest and Initiates of the Ebon Hand), which is why the
+/// assertion is on the gated rider rather than on the ability root.
+#[test]
+fn dragon_whelp_activation_threshold_gates_the_sacrifice_rider() {
+    let parsed = parse_oracle_text(
+        "Flying\n{R}: This creature gets +1/+0 until end of turn. If this ability has been \
+         activated four or more times this turn, sacrifice this creature at the beginning of \
+         the next end step.",
+        "Dragon Whelp",
+        &[],
+        &["Creature".to_string()],
+        &["Dragon".to_string()],
+    );
+
+    let expected = AbilityCondition::AbilityUseCountThisTurn {
+        tally: AbilityUseTally::Activated,
+        comparator: Comparator::GE,
+        n: 4,
+    };
+
+    fn chain_conditions(def: &AbilityDefinition, out: &mut Vec<AbilityCondition>) {
+        if let Some(condition) = def.condition.as_ref() {
+            out.push(condition.clone());
+        }
+        if let Some(sub) = def.sub_ability.as_deref() {
+            chain_conditions(sub, out);
+        }
+        if let Some(alt) = def.else_ability.as_deref() {
+            chain_conditions(alt, out);
+        }
+    }
+
+    let mut conditions = Vec::new();
+    for ability in &parsed.abilities {
+        chain_conditions(ability, &mut conditions);
+    }
+
+    assert!(
+        conditions.contains(&expected),
+        "the four-or-more-activations threshold must gate a clause in the parsed \
+         chain; got conditions {conditions:#?} from {:#?}",
+        parsed.abilities
+    );
 }

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -584,7 +584,7 @@ fn rewrite_cost_x_in_condition(cond: &mut crate::types::ability::AbilityConditio
         | AbilityCondition::SourceAttachedToCreature
         | AbilityCondition::DayNightIsNeither
         | AbilityCondition::DayNightIs { .. }
-        | AbilityCondition::NthResolutionThisTurn { .. }
+        | AbilityCondition::AbilityUseCountThisTurn { .. }
         | AbilityCondition::SourceLacksKeyword { .. }
         | AbilityCondition::ScopedPlayerMatches { .. } => {}
     }

--- a/crates/engine/src/parser/swallow_check.rs
+++ b/crates/engine/src/parser/swallow_check.rs
@@ -4618,7 +4618,7 @@ fn detect_duration_this_turn(
             x,
             AbilityCondition::SourceEnteredThisTurn
                 | AbilityCondition::SpellCastWithVariantThisTurn { .. }
-                | AbilityCondition::NthResolutionThisTurn { .. }
+                | AbilityCondition::AbilityUseCountThisTurn { .. }
         )
     }) {
         return;

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -23997,7 +23997,7 @@ impl SubAbilityLink {
 /// (Thieving Skydiver's "If that artifact is an Equipment" presupposes
 /// `GainControl` produced a target), so it is skipped alongside a failed
 /// predecessor. The sole narrow exception is a direct dependent
-/// `SequentialSibling` whose condition is `NthResolutionThisTurn`: ordinal
+/// `SequentialSibling` whose condition is `AbilityUseCountThisTurn`: ordinal
 /// clauses are evaluated in their written order under CR 608.2c even after an
 /// earlier ordinal is false. `ReplicatedOrBranch` marks a sibling produced by per-item
 /// keyword-list replication ("The same is true for…" is CR 702.1c; "Repeat
@@ -24413,6 +24413,32 @@ pub enum EffectOutcomeSignal {
     /// happened (impossible commit per CR 609.3, empty hand) the source
     /// `SpellContext::guess_outcome` is `None` and NEITHER polarity fires.
     Guessed { outcome: GuessOutcome },
+}
+
+/// CR 602.2a + CR 608.2c: which per-turn tally of a single printed ability
+/// [`AbilityCondition::AbilityUseCountThisTurn`] reads.
+///
+/// Both tallies are keyed `(source_id, ability_index)` and cleared together at
+/// end-of-turn cleanup; they differ only in which point of an ability's life
+/// increments them. The distinction is rules-visible: an activation that is
+/// countered before it resolves still counts as an activation (CR 602.2a puts
+/// the ability on the stack at announcement) but never counts as a resolution.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Default)]
+pub enum AbilityUseTally {
+    /// CR 608.2c: times this ability has RESOLVED this turn.
+    /// Reads `GameState::ability_resolutions_this_turn`.
+    #[default]
+    Resolved,
+    /// CR 602.2a: times this ability has been ACTIVATED this turn.
+    /// Reads `GameState::activated_abilities_this_turn`.
+    Activated,
+}
+
+impl AbilityUseTally {
+    /// `skip_serializing_if` predicate — the historical default needs no JSON byte.
+    pub fn is_resolved(tally: &Self) -> bool {
+        matches!(tally, Self::Resolved)
+    }
 }
 
 /// Condition on an ability within a sub_ability chain.
@@ -24901,14 +24927,45 @@ pub enum AbilityCondition {
         state: crate::types::game_state::DayNight,
     },
     /// CR 608.2c: Ordinary resolution-time condition (not an intervening-if
-    /// condition under CR 603.4) for "if this is the [Nth] time this ability has
-    /// resolved this turn". Counter is keyed by `(source_id, ability_index)` and
-    /// incremented at the top of `resolve_ability_chain` (depth 0). The condition is
-    /// satisfied when, after the increment, the per-turn resolution count equals `n`.
-    /// Cleared at end-of-turn cleanup alongside other per-turn counters.
-    /// Used by Omnath, Locus of Creation and the broader nth-resolution class
-    /// (Ashling the Pilgrim, Nissa Resurgent Animist, Teething Wurmlet, etc.).
-    NthResolutionThisTurn { n: u32 },
+    /// condition under CR 603.4) gating on how many times THIS printed ability
+    /// has been used so far this turn.
+    ///
+    /// Both tallies this reads are keyed by the same `(source_id,
+    /// ability_index)` pair, are cleared together at end-of-turn cleanup, and
+    /// address the same subject — one printed ability on one object — so
+    /// `tally` is a leaf parameter here rather than a second variant:
+    ///
+    /// - [`AbilityUseTally::Resolved`] reads
+    ///   `GameState::ability_resolutions_this_turn`, incremented at the top of
+    ///   `resolve_ability_chain` (depth 0), so the current resolution is already
+    ///   included. Prints as "if this is the [Nth] time this ability has
+    ///   resolved this turn" (Omnath, Locus of Creation; Ashling the Pilgrim;
+    ///   Nissa, Resurgent Animist; Teething Wurmlet).
+    /// - [`AbilityUseTally::Activated`] reads
+    ///   `GameState::activated_abilities_this_turn`, incremented in
+    ///   `ledger::record_ability_activation` from `push_ability_entry` — i.e. at
+    ///   CR 602.2a announcement, so an activation that is later countered still
+    ///   counts, and the announcing activation is included by the time it
+    ///   resolves. Prints as "if this ability has been activated [N] or more
+    ///   times this turn" (Dragon Whelp, Nalathni Dragon, Farrelite Priest,
+    ///   Initiates of the Ebon Hand).
+    ///
+    /// `comparator` is the second printed axis: the resolved family compares
+    /// `EQ` ("the second time"), the activated family `GE` ("four or more
+    /// times"). Both serde-elide their historical defaults, so every card that
+    /// parsed to the former `NthResolutionThisTurn { n }` is byte-identical
+    /// apart from the variant tag, which `serde(alias)` still accepts.
+    #[serde(alias = "NthResolutionThisTurn")]
+    AbilityUseCountThisTurn {
+        #[serde(default, skip_serializing_if = "AbilityUseTally::is_resolved")]
+        tally: AbilityUseTally,
+        #[serde(
+            default = "AbilityCondition::default_use_comparator",
+            skip_serializing_if = "AbilityCondition::is_default_use_comparator"
+        )]
+        comparator: Comparator,
+        n: u32,
+    },
     /// CR 702.x: True when the source permanent does not have the specified keyword.
     /// Inverse of keyword presence check — used by "if ~ doesn't have [keyword]" gates.
     SourceLacksKeyword { keyword: Keyword },
@@ -25053,7 +25110,7 @@ impl AbilityCondition {
             | AbilityCondition::Or { .. }
             | AbilityCondition::Not { .. }
             | AbilityCondition::DayNightIs { .. }
-            | AbilityCondition::NthResolutionThisTurn { .. }
+            | AbilityCondition::AbilityUseCountThisTurn { .. }
             | AbilityCondition::SourceLacksKeyword { .. }
             | AbilityCondition::ScopedPlayerMatches { .. } => false,
         }
@@ -25104,6 +25161,35 @@ impl AbilityCondition {
     #[allow(clippy::trivially_copy_pass_by_ref)]
     pub(crate) fn is_subject_source(value: &ObjectScope) -> bool {
         matches!(value, ObjectScope::Source)
+    }
+
+    /// CR 608.2c: Default `comparator` for `AbilityUseCountThisTurn` is `EQ` —
+    /// the ordinal "if this is the [Nth] time" reading the variant had before
+    /// the comparator axis existed. Used by serde `#[serde(default = ...)]` so
+    /// every previously-serialized ordinal payload round-trips unchanged.
+    pub(crate) fn default_use_comparator() -> Comparator {
+        Comparator::EQ
+    }
+
+    /// Skip-serialization predicate: omit `comparator` from JSON when it equals
+    /// the default (`EQ`). Keeps card-data.json compact for the ordinal family.
+    #[allow(clippy::trivially_copy_pass_by_ref)]
+    pub(crate) fn is_default_use_comparator(value: &Comparator) -> bool {
+        matches!(value, Comparator::EQ)
+    }
+
+    /// CR 608.2c: Construct the ordinal-shape `AbilityUseCountThisTurn`
+    /// condition — "if this is the [Nth] time this ability has resolved this
+    /// turn". Equivalent to the legacy `NthResolutionThisTurn { n }` variant;
+    /// preserves call sites in `parser/oracle_effect/conditions.rs` and the
+    /// resolution-ordering tests in `game/effects/mod.rs` and
+    /// `analysis/resource.rs`.
+    pub fn nth_resolution_this_turn(n: u32) -> Self {
+        AbilityCondition::AbilityUseCountThisTurn {
+            tally: AbilityUseTally::Resolved,
+            comparator: Comparator::EQ,
+            n,
+        }
     }
 
     /// Construct the default-shape `AdditionalCostPaid` condition: any single
@@ -30048,10 +30134,15 @@ pub struct ResolvedAbility {
     pub amassed_army_object: Option<CostPaidObjectSnapshot>,
     /// CR 608.2c: Index of the printed ability this resolution came from on the
     /// source object's ability list. Identifies "this ability" for per-turn
-    /// ordinary-resolution-condition tracking (`AbilityCondition::NthResolutionThisTurn`),
-    /// not an intervening-if condition under CR 603.4. `None` for
-    /// synthesized/runtime-only abilities (prowess, firebending) and activated
-    /// abilities for which nth-resolution gating is not yet wired through.
+    /// ordinary-resolution-condition tracking (`AbilityCondition::AbilityUseCountThisTurn`),
+    /// not an intervening-if condition under CR 603.4. `None` ONLY for
+    /// synthesized/runtime-only abilities (prowess, firebending), which have no
+    /// printed `abilities[]` entry to index. Activated abilities ARE stamped:
+    /// both paths that put one on the stack — `casting_costs::push_ability_entry`
+    /// and `planeswalker::push_loyalty_ability_entry` — assign this field
+    /// immediately before `push_to_stack`, and each pairs that stamp with the
+    /// `restrictions::record_ability_activation` call that keys
+    /// `GameState::activated_abilities_this_turn` by the SAME index.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub ability_index: Option<usize>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -30108,7 +30199,7 @@ pub struct ResolvedAbility {
     /// Kathril) and must be evaluated by `resolve_chain_body` regardless of a
     /// preceding sibling's failed gate. `Dependent` (default) preserves the
     /// prior skip-with-failed-predecessor behavior, except the narrow direct
-    /// `NthResolutionThisTurn` ordinal-sibling case described by
+    /// `AbilityUseCountThisTurn` ordinal-sibling case described by
     /// [`SiblingCondition`]. See [`SiblingCondition`].
     #[serde(default, skip_serializing_if = "SiblingCondition::is_default")]
     pub sibling_condition: SiblingCondition,
@@ -36846,6 +36937,51 @@ mod static_condition_traversal_tests {
         assert_eq!(
             serde_json::from_value::<Effect>(terminal_json).expect("terminal mode deserializes"),
             terminal
+        );
+    }
+}
+
+#[cfg(test)]
+mod ability_use_count_serde_tests {
+    use super::*;
+
+    /// CR 608.2c: Every card serialized before the tally/comparator axes existed
+    /// carried the `NthResolutionThisTurn` tag with a bare `n`. That payload
+    /// still lives in saved game states (an `AbilityCondition` reaches the wire
+    /// inside a `ResolvedAbility` on the stack), so the legacy tag must
+    /// deserialize to the ordinal reading rather than failing the whole state.
+    #[test]
+    fn legacy_nth_resolution_tag_deserializes_to_the_ordinal_reading() {
+        let legacy = r#"{"type":"NthResolutionThisTurn","n":3}"#;
+        let parsed: AbilityCondition = serde_json::from_str(legacy).unwrap();
+        assert_eq!(parsed, AbilityCondition::nth_resolution_this_turn(3));
+    }
+
+    /// The two new axes serde-elide their historical defaults, so an ordinal
+    /// condition's JSON gains no bytes beyond the renamed tag. This is what
+    /// keeps the card-data diff for the 27-card resolved family a pure rename.
+    #[test]
+    fn ordinal_reading_elides_both_new_axes() {
+        let json = serde_json::to_string(&AbilityCondition::nth_resolution_this_turn(2)).unwrap();
+        assert_eq!(json, r#"{"type":"AbilityUseCountThisTurn","n":2}"#);
+    }
+
+    /// The activation reading must serialize both axes — eliding either would
+    /// silently reinterpret Dragon Whelp as the ordinal "second time it
+    /// resolved" condition on the next load.
+    #[test]
+    fn activation_reading_serializes_both_axes_and_round_trips() {
+        let condition = AbilityCondition::AbilityUseCountThisTurn {
+            tally: AbilityUseTally::Activated,
+            comparator: Comparator::GE,
+            n: 4,
+        };
+        let json = serde_json::to_string(&condition).unwrap();
+        assert!(json.contains(r#""tally":"Activated""#), "got {json}");
+        assert!(json.contains(r#""comparator":"GE""#), "got {json}");
+        assert_eq!(
+            serde_json::from_str::<AbilityCondition>(&json).unwrap(),
+            condition
         );
     }
 }

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -18639,7 +18639,7 @@ declare_game_state! {
     /// ability on a specific source object. Incremented at the top of
     /// `resolve_ability_chain` (depth 0) when the resolving ability has a
     /// `Some(ability_index)` stamp; read by
-    /// `AbilityCondition::NthResolutionThisTurn` to gate Omnath-style
+    /// `AbilityCondition::AbilityUseCountThisTurn` to gate Omnath-style
     /// "if this is the [Nth] time this ability has resolved this turn" patterns.
     /// Cleared in `start_next_turn` alongside other per-turn counters.
     #[serde(

--- a/crates/engine/tests/integration/dragon_whelp_activation_threshold_8388.rs
+++ b/crates/engine/tests/integration/dragon_whelp_activation_threshold_8388.rs
@@ -1,0 +1,178 @@
+//! Issue #8388: Dragon Whelp was sacrificed without reaching its threshold.
+//!
+//! "{R}: This creature gets +1/+0 until end of turn. If this ability has been
+//! activated four or more times this turn, sacrifice this creature at the
+//! beginning of the next end step." — the threshold clause reached no condition
+//! parser at all, so the sacrifice rider ran unconditionally and the Whelp died
+//! after a single activation. The gap was invisible to coverage because
+//! `line_has_condition_text` carried "this ability has been activated" on its
+//! structural-exemption list.
+//!
+//! Fix: `AbilityCondition::AbilityUseCountThisTurn { tally: Activated, .. }`
+//! reads the CR 602.2a announcement ledger
+//! (`GameState::activated_abilities_this_turn`, keyed by the same
+//! `(source_id, ability_index)` the stamp in `push_ability_entry` uses).
+//!
+//! These tests drive the real production path — `GameAction::ActivateAbility`
+//! through the stack, then the end step — rather than calling the condition
+//! evaluator directly, because the defect was that the condition never reached
+//! the ability at all. A parser-shape or direct-evaluator test passes on the
+//! broken build.
+//!
+//! Discriminators (flip when the fix is reverted): pre-fix the Whelp is in the
+//! graveyard after ONE activation, so tests 1 and 2 both fail.
+
+use engine::game::scenario::{GameRunner, GameScenario, P0};
+use engine::types::actions::GameAction;
+use engine::types::identifiers::ObjectId;
+use engine::types::mana::{ManaType, ManaUnit};
+use engine::types::phase::Phase;
+use engine::types::zones::Zone;
+
+// Verbatim Oracle text (Scryfall, verified 2026-09-09). Nalathni Dragon,
+// Farrelite Priest and Initiates of the Ebon Hand print the same second
+// sentence; only the first clause differs.
+const DRAGON_WHELP_ORACLE: &str = "Flying\n{R}: This creature gets +1/+0 until end of turn. If this ability has been activated four or more times this turn, sacrifice this creature at the beginning of the next end step.";
+
+fn whelp_scenario(activations: usize) -> (GameRunner, ObjectId) {
+    let mut scenario = GameScenario::new_n_player(2, 42);
+    scenario.at_phase(Phase::PreCombatMain);
+    // One red mana per planned activation — the {R} cost is what makes each
+    // `ActivateAbility` legal, so an under-funded pool would fail the
+    // activation rather than test the threshold.
+    scenario.with_mana_pool(
+        P0,
+        (0..activations)
+            .map(|_| ManaUnit::new(ManaType::Red, ObjectId(0), false, vec![]))
+            .collect(),
+    );
+    let whelp = scenario
+        .add_creature_from_oracle(P0, "Dragon Whelp", 2, 3, DRAGON_WHELP_ORACLE)
+        .id();
+    (scenario.build(), whelp)
+}
+
+fn activate(runner: &mut GameRunner, whelp: ObjectId, nth: usize) {
+    runner
+        .act(GameAction::ActivateAbility {
+            source_id: whelp,
+            ability_index: 0,
+        })
+        .unwrap_or_else(|e| panic!("activation {nth} must be payable: {e:?}"));
+    runner.resolve_top();
+}
+
+fn zone_of(runner: &GameRunner, id: ObjectId) -> Zone {
+    runner.state().objects[&id].zone
+}
+
+/// Cross combat and the end step, resolving whatever fires.
+///
+/// `advance_to_phase` stops at any non-priority wait, and the harness surfaces
+/// `WaitingFor::DeclareAttackers` as a turn-based action that plain priority
+/// passes cannot answer — so combat is crossed explicitly. The
+/// `advance_until_stack_empty` is what actually RESOLVES a delayed trigger that
+/// fired at the end step; without it the Whelp survives no matter what the
+/// condition decided, and both assertions below would pass vacuously.
+fn cross_to_resolved_end_step(runner: &mut GameRunner) {
+    runner.advance_to_combat();
+    runner
+        .act(GameAction::DeclareAttackers {
+            attacks: vec![],
+            bands: vec![],
+        })
+        .expect("declare no attackers to cross combat");
+    runner.advance_to_end_step();
+    runner.advance_until_stack_empty();
+    assert_eq!(
+        runner.state().phase,
+        Phase::End,
+        "the delayed sacrifice is timed to the next end step (CR 603.7a)"
+    );
+}
+
+fn activation_count(runner: &GameRunner, whelp: ObjectId) -> u32 {
+    runner
+        .state()
+        .activated_abilities_this_turn
+        .get(&(whelp, 0))
+        .copied()
+        .unwrap_or(0)
+}
+
+/// Test 1 (the reported bug, discriminating): three activations are BELOW the
+/// printed threshold of four, so the rider must not arm and the Whelp must
+/// survive its end step.
+///
+/// The `delayed_triggers` assertion is the load-bearing one. Checking only the
+/// final zone would pass on a build where the rider armed correctly but nothing
+/// resolved it — the trigger has to be shown ABSENT, not merely inconsequential.
+#[test]
+fn three_activations_do_not_arm_the_sacrifice() {
+    let (mut runner, whelp) = whelp_scenario(3);
+
+    for nth in 1..=3 {
+        activate(&mut runner, whelp, nth);
+    }
+
+    // Reach-guard: the ability really resolved three times.
+    assert_eq!(
+        activation_count(&runner, whelp),
+        3,
+        "three activations must be recorded on the CR 602.2a ledger"
+    );
+    assert!(
+        runner.state().delayed_triggers.is_empty(),
+        "three activations is below the printed four-or-more threshold, so the \
+         delayed sacrifice must never be installed; got {:?}",
+        runner.state().delayed_triggers
+    );
+
+    cross_to_resolved_end_step(&mut runner);
+
+    assert_eq!(
+        zone_of(&runner, whelp),
+        Zone::Battlefield,
+        "the Whelp must survive below its threshold (pre-fix the ungated rider \
+         sacrificed it after the very first activation — issue #8388)"
+    );
+}
+
+/// Test 2 (the other side of the boundary): the fourth activation arms the
+/// delayed trigger, which sacrifices the Whelp at the next end step.
+///
+/// Paired with test 1 deliberately — a fix that simply never fired the rider
+/// would satisfy test 1 on its own, and that is precisely the regression this
+/// pairing is here to catch.
+#[test]
+fn four_activations_sacrifice_the_whelp_at_the_next_end_step() {
+    let (mut runner, whelp) = whelp_scenario(4);
+
+    for nth in 1..=4 {
+        activate(&mut runner, whelp, nth);
+    }
+
+    assert_eq!(
+        activation_count(&runner, whelp),
+        4,
+        "four activations must be recorded on the CR 602.2a ledger"
+    );
+    assert!(
+        !runner.state().delayed_triggers.is_empty(),
+        "the fourth activation must install the delayed end-step sacrifice"
+    );
+    // CR 603.7a: the sacrifice is delayed, so the Whelp is still around now.
+    assert_eq!(
+        zone_of(&runner, whelp),
+        Zone::Battlefield,
+        "the rider is delayed to the next end step, not immediate"
+    );
+
+    cross_to_resolved_end_step(&mut runner);
+
+    assert_eq!(
+        zone_of(&runner, whelp),
+        Zone::Graveyard,
+        "the armed delayed trigger must sacrifice the Whelp at the end step"
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -235,6 +235,7 @@ mod doomsday;
 mod doran_attack_block_pump;
 mod double_strike_first_strike_trigger_removes_attacker;
 mod dragon_man_reformed_robot_graveyard_discard_cost;
+mod dragon_whelp_activation_threshold_8388;
 mod dragonstorm_forecaster_named_or_tutor;
 mod draw_delivery_preview;
 mod draw_from_general_post_replacement;


### PR DESCRIPTION
Fixes #8388.

## The bug

Dragon Whelp: `{R}: This creature gets +1/+0 until end of turn. If this ability has been activated four or more times this turn, sacrifice this creature at the beginning of the next end step.`

The threshold clause reached no condition parser at all, so the sacrifice rider ran **unconditionally** — the Whelp was sacrificed after a single activation. The Discord report ("controller pumped it only three times, yet the sacrifice trigger was executed") is exactly this.

The gap was invisible to coverage: `line_has_condition_text` carried `"this ability has been activated"` on its structural-exemption list, so the card reported as *supported* while the clause was silently dropped. That exemption is removed here.

## The fix: parameterize, don't proliferate

Rather than add an `NthActivationThisTurn` sibling next to the existing `AbilityCondition::NthResolutionThisTurn { n }`, this parameterizes the latter into:

```rust
AbilityUseCountThisTurn { tally: AbilityUseTally, comparator: Comparator, n: u32 }
```

Both axes are demanded by printed cards, so neither is speculative:

| axis | values in the corpus |
|---|---|
| `tally` | `Resolved` (27 cards) / `Activated` (4 cards) |
| `comparator` | `EQ` "the second time" (26) / `GE` "four or more" (4) — and **Rose Room Treasurer** already prints "first **or second** time", which the EQ-only shape could not express at all |

Both readings address the **same subject** — one printed ability on one object, keyed `(ObjectId, ability_index)` — read the same-shaped ledger, and are cleared at the same point, so the axis is a leaf parameter and not a cross-section unification. The tallies stay rules-distinct: CR 602.2a counts an activation at *announcement*, so an activation countered before resolution counts for `Activated` and never for `Resolved`.

The parser delegates the count phrase to the shared `parse_comparison_suffix` authority instead of enumerating comparator arms, so the whole comparison class is covered by one call.

## Cards fixed

Dragon Whelp, Nalathni Dragon, Farrelite Priest, Initiates of the Ebon Hand — the complete class printing this template.

## Serialized surface

`AbilityCondition` reaches the wire inside a `ResolvedAbility` on the stack. The legacy tag keeps loading via `#[serde(alias = "NthResolutionThisTurn")]`, and both new fields elide their historical defaults, so an ordinal condition's JSON gains no bytes beyond the renamed tag. Pinned by three serde tests.

## Also corrected

Two comments asserted that activated abilities carry no `ability_index` stamp. Both stack paths (`casting_costs::push_ability_entry` and the loyalty path in `planeswalker`) *do* stamp it, and each pairs that stamp with the `record_ability_activation` call keying the same index — which is what makes this fix work for an activated ability at all.

## Verification

- `cargo fmt --all` clean.
- **21,040 lib tests pass, 0 failures** — including every pre-existing `nth_resolution` test, so the parameterization does not regress the 27-card resolved family.
- New integration test `dragon_whelp_activation_threshold_8388` drives the real `GameAction::ActivateAbility` → stack → end-step path, asserting on `delayed_triggers` rather than the final zone alone.
- **Demonstrated as a discriminator:** disabling the activation arm reproduces the bug and fails the test with *three* installed sacrifice triggers after three activations — one per activation.
- `clippy --all-targets -D warnings` ran clean on the production diff. It could not be re-run after the test-only commit: this machine's swap is pinned at 100%, and the sandbox's memory reaper kills any build that needs an uninterrupted ~20-minute window. CI covers it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TJ4SDW7uZMSdKXtinzFuHe

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added ability conditions based on how many times an ability has been activated or resolved during the current turn.
  - Added comparison operators for per-turn ability-use conditions.
  - Preserved compatibility with existing serialized resolution-count conditions.

- **Bug Fixes**
  - Corrected parsing and gameplay handling for activation thresholds, including Dragon Whelp’s “activated four or more times” condition.
  - Activation-based effects now trigger only when their stated threshold is reached.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->