### PR TITLE
feat(engine): Eternal Central Old School 93/94 + 95 presets (custom-format-engine Phase 2a)

### DIFF
--- a/crates/engine/src/types/custom_format.rs
+++ b/crates/engine/src/types/custom_format.rs
@@ -842,17 +842,201 @@ pub fn swedish_old_school() -> CustomFormatDef {
     }
 }
 
+/// Registry id for [`old_school_93_94`]. See [`SWEDISH_OLD_SCHOOL_ID`] on why
+/// these are stable and never renumbered.
+pub const OLD_SCHOOL_93_94_ID: CustomFormatId = CustomFormatId(2);
+
+/// Registry id for [`old_school_95`].
+pub const OLD_SCHOOL_95_ID: CustomFormatId = CustomFormatId(3);
+
+/// The reprint-fidelity disclosure every `SetCodeApproximation` preset's
+/// `description` must carry, per PLAN.md §1's pairing rule.
+///
+/// Both Eternal Central Old School rulesets define legality partly by
+/// PRINTING — "all non-foil cards from the sets above, that were reprinted in
+/// any language with the original frame and original art" — while this engine
+/// knows only set-code membership (`printed_in_any_set`). Two concrete
+/// divergences, both verified against Scryfall at implementation time rather
+/// than asserted:
+///
+/// - **Frame/foil is not enforced.** A foil or modern-frame copy of a legal
+///   card passes here and would not pass in paper. Over-permissive.
+/// - **The promo carve-outs are not included.** Both rulesets name specific
+///   legal promos — Arena, Sewers of Estark and Nalathni Dragon for 93/94,
+///   plus Giant Badger, Windseeker Centaur and Mana Crypt for 95 — and their
+///   sets are NOT in `legal_sets`, so those cards are rejected. Under-
+///   permissive, and not fixable at set-code granularity for 93/94: four of
+///   those six live in `PHPR` (HarperPrism Book Promos, 5 cards), of which
+///   only Arena and Sewers of Estark are 93/94-legal, so admitting the set
+///   would admit three cards the format does not allow — one of them Mana
+///   Crypt. See this phase's PR discussion.
+const SET_CODE_APPROXIMATION_DISCLOSURE: &str =
+    "Legality is approximated at the set-code level; original-printing frame/foil and the \
+     ruleset's named promo cards are not enforced.";
+
+fn set_codes(codes: &[&str]) -> Vec<SetCode> {
+    codes.iter().map(|code| SetCode(code.to_string())).collect()
+}
+
+fn card_names(names: &[&str]) -> Vec<CardName> {
+    names.iter().map(|name| CardName::from(*name)).collect()
+}
+
+/// Eternal Central's Old School 93/94, per the primary source
+/// (`raw.githubusercontent.com/northern-information/lordsofthepit.com/main/src/pages/formats.md`,
+/// re-fetched 2026-09-09 and matching RESEARCH.md §1 verbatim: 11 legal sets,
+/// 22 restricted, 7 banned, mana burn as the only legacy exception).
+///
+/// **A different ruleset from [`swedish_old_school`], not a duplicate** —
+/// different legal sets (this one includes Revised, Fallen Empires and the
+/// Collectors' Editions but not Summer Magic), a different restricted list,
+/// and a real banned list where the Swedish rules ban nothing.
+///
+/// Its seven banned cards are exactly the CR 407.3 ante class within this
+/// era's pool. `game::ante` already bars them from every deck; the entries are
+/// kept because the source states them, and because they must survive a future
+/// format that legitimately plays for ante.
+///
+/// **Not registerable yet:** `mana_burn: Obsolete` is a `LegacyRuleSet` axis
+/// the engine does not implement, so `custom_format_registry`'s legacy-axis
+/// gate filters this out until Phase 2b lands. That is the gate working as
+/// designed, not a defect — see the registry's own doc comment.
+pub fn old_school_93_94() -> CustomFormatDef {
+    CustomFormatDef {
+        rules: CustomFormatRules {
+            id: OLD_SCHOOL_93_94_ID,
+            structural: StructuralRules::from_format_config(
+                &FormatConfig::standard(),
+                CommandZoneMode::Disabled,
+            ),
+            legality: LegalityRules {
+                // Alpha, Beta, Unlimited, Collectors' Edition, Intl.
+                // Collectors' Edition, Arabian Nights, Antiquities, Revised,
+                // Legends, The Dark, Fallen Empires. Every code verified
+                // against Scryfall's live set list at implementation time.
+                legal_sets: Some(set_codes(&[
+                    "LEA", "LEB", "2ED", "CED", "CEI", "ARN", "ATQ", "3ED", "LEG", "DRK", "FEM",
+                ])),
+                banned: card_names(&[
+                    "Bronze Tablet",
+                    "Contract from Below",
+                    "Darkpact",
+                    "Demonic Attorney",
+                    "Jeweled Bird",
+                    "Rebirth",
+                    "Tempest Efreet",
+                ]),
+                restricted: card_names(&[
+                    "Ancestral Recall",
+                    "Balance",
+                    "Black Lotus",
+                    "Braingeyser",
+                    "Chaos Orb",
+                    "Channel",
+                    "Demonic Tutor",
+                    "Library of Alexandria",
+                    "Mana Drain",
+                    "Mind Twist",
+                    "Mox Emerald",
+                    "Mox Jet",
+                    "Mox Pearl",
+                    "Mox Ruby",
+                    "Mox Sapphire",
+                    "Recall",
+                    "Regrowth",
+                    "Sol Ring",
+                    "Time Vault",
+                    "Time Walk",
+                    "Timetwister",
+                    "Wheel of Fortune",
+                ]),
+                // The source states mana burn as this format's ONLY legacy
+                // exception — no damage on the stack, no pre-M10 Wish
+                // templating, no legend-rule reversion, and it is not played
+                // for ante.
+                legacy: LegacyRuleSet {
+                    mana_burn: ManaBurnPolicy::Obsolete,
+                    ..LegacyRuleSet::default()
+                },
+            },
+        },
+        label: "Old School 93/94".to_string(),
+        short_label: "O94".to_string(),
+        description: format!(
+            "Alpha through Fallen Empires, 22 restricted, 7 banned, mana burn. \
+             {SET_CODE_APPROXIMATION_DISCLOSURE}"
+        ),
+        // The source's reprint rule admits reprints in any language with the
+        // original frame and art, which includes the Collectors' Editions
+        // already present in `legal_sets`.
+        reprint_policy: Some(ReprintPolicy::AllowSpecialReprintSets),
+        printing_fidelity: PrintingFidelity::SetCodeApproximation,
+    }
+}
+
+/// Eternal Central's Old School 95 — published on the same page as an
+/// incremental extension of 93/94's own lists, and built here the same way, so
+/// the shared base can never drift between the two.
+///
+/// Adds five sets (Fourth Edition, Ice Age, Chronicles, Renaissance,
+/// Homelands), two restricted cards (Demonic Consultation, Mana Crypt) and two
+/// banned cards (Amulet of Quoz, Timmerian Fiends) — the last two being the
+/// remaining CR 407.3 ante cards, which this era's pool newly contains.
+///
+/// Everything else is inherited verbatim, including `mana_burn: Obsolete`, so
+/// this preset is withheld by the same legacy-axis gate until Phase 2b.
+pub fn old_school_95() -> CustomFormatDef {
+    let mut def = old_school_93_94();
+
+    // A registry-stable id of its own — inheriting the base's would make two
+    // presets indistinguishable to `GameFormat::Custom(id)`.
+    def.rules.id = OLD_SCHOOL_95_ID;
+
+    // `get_or_insert_with` rather than unwrapping: `legal_sets` is
+    // `Option<Vec<_>>`, and while the base always sets `Some(..)` (a
+    // pool-restricting preset never leaves it `None`), extending in place stays
+    // correct if that invariant ever changes rather than assuming it silently.
+    def.rules
+        .legality
+        .legal_sets
+        .get_or_insert_with(Vec::new)
+        .extend(set_codes(&["4ED", "ICE", "CHR", "REN", "HML"]));
+    def.rules
+        .legality
+        .restricted
+        .extend(card_names(&["Demonic Consultation", "Mana Crypt"]));
+    def.rules
+        .legality
+        .banned
+        .extend(card_names(&["Amulet of Quoz", "Timmerian Fiends"]));
+
+    def.label = "Old School 95".to_string();
+    def.short_label = "O95".to_string();
+    def.description = format!(
+        "Old School 93/94 plus Fourth Edition through Homelands, 24 restricted, 9 banned, \
+         mana burn. {SET_CODE_APPROXIMATION_DISCLOSURE}"
+    );
+    def
+}
+
 /// Authoritative list of bundled custom-format presets, filtered through
 /// both registration gates.
 ///
-/// Still empty, but no longer for Phase 1a's reason ("no presets exist").
-/// [`swedish_old_school`] exists and passes both gates; it is withheld
-/// because CONTEXT.md Open item 6 blocks its REGISTRATION specifically — see
-/// that constructor. A preset is listed here only once every claim it makes
-/// about a paper ruleset is sourced, so the gates below are the last line of
-/// defense, not the only one.
+/// **Still resolves to empty, and every preset here is withheld for a stated
+/// reason rather than by omission.** The two Eternal Central presets are
+/// listed and then REJECTED by `passes_legacy_axis_gate`, because both declare
+/// `mana_burn: Obsolete` and the engine implements no mana burn yet; Phase 2b
+/// adds `LegacyAxis::ManaBurn` to `IMPLEMENTED_LEGACY_AXES` and they become
+/// selectable with no edit here. Listing them is the point — until now the
+/// gates filtered an empty vector and could not fail.
+///
+/// [`swedish_old_school`] is the exception, and is deliberately NOT in this
+/// list: it PASSES both gates, so listing it would register it, and CONTEXT.md
+/// Open item 6 (its unconfirmed reprint-policy metadata) blocks that
+/// separately. A documentation blocker has no gate to express it, so omission
+/// is the only mechanism — see that constructor.
 pub fn custom_format_registry() -> Vec<CustomFormatDef> {
-    let presets: Vec<CustomFormatDef> = Vec::new();
+    let presets: Vec<CustomFormatDef> = vec![old_school_93_94(), old_school_95()];
     assert_no_lobby_save_sentinel_collision(&presets);
     presets
         .into_iter()

--- a/crates/engine/src/types/custom_format.rs
+++ b/crates/engine/src/types/custom_format.rs
@@ -1019,6 +1019,25 @@ pub fn old_school_95() -> CustomFormatDef {
     def
 }
 
+/// Every bundled preset CONSIDERED for registration, before either gate runs.
+///
+/// Split out from [`custom_format_registry`] so the two reasons a preset can
+/// be absent from the registry stay distinguishable — from the outside they
+/// look identical, and only one of them is the gates doing their job:
+///
+/// - **Listed here and filtered out** — it declares something the engine does
+///   not implement yet. The gate is the mechanism, and the preset registers
+///   itself the moment that changes.
+/// - **Not listed here at all** — it would PASS the gates, so being listed
+///   would register it. This is the only way to express a blocker that is not
+///   about engine capability, which is [`swedish_old_school`]'s situation.
+///
+/// A test asserting only that the registry is empty cannot tell those apart,
+/// and would keep passing if a preset were quietly dropped from this list.
+pub fn bundled_presets() -> Vec<CustomFormatDef> {
+    vec![old_school_93_94(), old_school_95()]
+}
+
 /// Authoritative list of bundled custom-format presets, filtered through
 /// both registration gates.
 ///
@@ -1036,7 +1055,7 @@ pub fn old_school_95() -> CustomFormatDef {
 /// separately. A documentation blocker has no gate to express it, so omission
 /// is the only mechanism — see that constructor.
 pub fn custom_format_registry() -> Vec<CustomFormatDef> {
-    let presets: Vec<CustomFormatDef> = vec![old_school_93_94(), old_school_95()];
+    let presets = bundled_presets();
     assert_no_lobby_save_sentinel_collision(&presets);
     presets
         .into_iter()

--- a/crates/engine/tests/integration/custom_format_schema.rs
+++ b/crates/engine/tests/integration/custom_format_schema.rs
@@ -11,11 +11,12 @@
 //! private items directly.
 
 use engine::types::custom_format::{
-    assert_no_lobby_save_sentinel_collision, passes_legacy_axis_gate, passes_reprint_fidelity_gate,
-    swedish_old_school, validate_custom_rules_consistency, AntePolicy, CombatDamageTiming,
-    CommandZoneMode, CommanderEligibilityRule, CustomFormatDef, CustomFormatId, CustomFormatRules,
-    LegacyRuleSet, LegalityRules, ManaBurnPolicy, PrintingFidelity, ReprintPolicy, SetCode,
-    StructuralRules, WishOutsideGameScope, LOBBY_SAVE_CUSTOM_FORMAT_ID,
+    assert_no_lobby_save_sentinel_collision, old_school_93_94, old_school_95,
+    passes_legacy_axis_gate, passes_reprint_fidelity_gate, swedish_old_school,
+    validate_custom_rules_consistency, AntePolicy, CombatDamageTiming, CommandZoneMode,
+    CommanderEligibilityRule, CustomFormatDef, CustomFormatId, CustomFormatRules, LegacyRuleSet,
+    LegalityRules, ManaBurnPolicy, PrintingFidelity, ReprintPolicy, SetCode, StructuralRules,
+    WishOutsideGameScope, LOBBY_SAVE_CUSTOM_FORMAT_ID,
 };
 use engine::types::format::{
     DeckCopyLimit, DeckSizeRule, FormatConfig, GameFormat, RangeOfInfluenceConfig, SelectedFormat,
@@ -233,15 +234,234 @@ fn reprint_fidelity_gate_accepts_agreement() {
     assert!(passes_reprint_fidelity_gate(&def2));
 }
 
+/// Names, not counts. A same-length substitution anywhere in these rosters
+/// changes legal deck construction, and a test that only counted would sail
+/// straight past it — the lesson from the Swedish preset's first review.
+fn names(entries: &[String]) -> BTreeSet<&str> {
+    entries.iter().map(String::as_str).collect()
+}
+
+fn codes(entries: &[SetCode]) -> BTreeSet<&str> {
+    entries.iter().map(|code| code.0.as_str()).collect()
+}
+
+#[test]
+fn old_school_93_94_declares_its_sourced_card_pool() {
+    // Verbatim from `lordsofthepit.com/src/pages/formats.md` (RESEARCH.md §1),
+    // re-fetched 2026-09-09. Every set code checked against Scryfall's live
+    // set list at implementation time.
+    let preset = old_school_93_94();
+    let legality = &preset.rules.legality;
+
+    let sets = legality
+        .legal_sets
+        .as_ref()
+        .expect("Old School 93/94 restricts its pool, so legal_sets is Some(_)");
+    assert_eq!(
+        codes(sets),
+        BTreeSet::from([
+            "LEA", "LEB", "2ED", "CED", "CEI", "ARN", "ATQ", "3ED", "LEG", "DRK", "FEM",
+        ]),
+        "Alpha, Beta, Unlimited, both Collectors' Editions, Arabian Nights, Antiquities, \
+         Revised, Legends, The Dark, Fallen Empires"
+    );
+    assert_eq!(sets.len(), 11, "no duplicate set codes");
+
+    assert_eq!(
+        names(&legality.restricted),
+        BTreeSet::from([
+            "Ancestral Recall",
+            "Balance",
+            "Black Lotus",
+            "Braingeyser",
+            "Chaos Orb",
+            "Channel",
+            "Demonic Tutor",
+            "Library of Alexandria",
+            "Mana Drain",
+            "Mind Twist",
+            "Mox Emerald",
+            "Mox Jet",
+            "Mox Pearl",
+            "Mox Ruby",
+            "Mox Sapphire",
+            "Recall",
+            "Regrowth",
+            "Sol Ring",
+            "Time Vault",
+            "Time Walk",
+            "Timetwister",
+            "Wheel of Fortune",
+        ])
+    );
+    assert_eq!(legality.restricted.len(), 22, "the source states 22");
+
+    assert_eq!(
+        names(&legality.banned),
+        BTreeSet::from([
+            "Bronze Tablet",
+            "Contract from Below",
+            "Darkpact",
+            "Demonic Attorney",
+            "Jeweled Bird",
+            "Rebirth",
+            "Tempest Efreet",
+        ])
+    );
+    assert_eq!(legality.banned.len(), 7, "the source states 7");
+
+    // Mana burn is the source's ONLY stated legacy exception — pinned axis by
+    // axis so a future edit cannot quietly add damage-on-the-stack or a Wish
+    // reversion this ruleset never asked for.
+    assert_eq!(legality.legacy.mana_burn, ManaBurnPolicy::Obsolete);
+    assert_eq!(
+        legality.legacy,
+        LegacyRuleSet {
+            mana_burn: ManaBurnPolicy::Obsolete,
+            ..LegacyRuleSet::default()
+        }
+    );
+}
+
+/// PLAN.md §2's preset-inheritance requirement: 95 must carry every 93/94
+/// entry PLUS exactly its own declared additions. Asserting only that the
+/// additions are present would let a future edit silently drop or duplicate
+/// the inherited base.
+#[test]
+fn old_school_95_extends_93_94_by_exactly_its_declared_deltas() {
+    let base = old_school_93_94();
+    let extended = old_school_95();
+
+    let base_sets = codes(base.rules.legality.legal_sets.as_ref().unwrap());
+    let extended_sets = codes(extended.rules.legality.legal_sets.as_ref().unwrap());
+    assert!(
+        base_sets.is_subset(&extended_sets),
+        "95 must inherit every 93/94 set"
+    );
+    assert_eq!(
+        &extended_sets - &base_sets,
+        BTreeSet::from(["4ED", "ICE", "CHR", "REN", "HML"]),
+        "Fourth Edition, Ice Age, Chronicles, Renaissance, Homelands — and nothing else"
+    );
+
+    let base_restricted = names(&base.rules.legality.restricted);
+    let extended_restricted = names(&extended.rules.legality.restricted);
+    assert!(base_restricted.is_subset(&extended_restricted));
+    assert_eq!(
+        &extended_restricted - &base_restricted,
+        BTreeSet::from(["Demonic Consultation", "Mana Crypt"])
+    );
+
+    let base_banned = names(&base.rules.legality.banned);
+    let extended_banned = names(&extended.rules.legality.banned);
+    assert!(base_banned.is_subset(&extended_banned));
+    assert_eq!(
+        &extended_banned - &base_banned,
+        BTreeSet::from(["Amulet of Quoz", "Timmerian Fiends"])
+    );
+
+    // Set semantics would hide a duplicated inherited entry, which is a real
+    // authoring defect even though it changes no verdict.
+    assert_eq!(
+        extended.rules.legality.legal_sets.as_ref().unwrap().len(),
+        16
+    );
+    assert_eq!(extended.rules.legality.restricted.len(), 24);
+    assert_eq!(extended.rules.legality.banned.len(), 9);
+
+    // Inherited verbatim, not re-declared.
+    assert_eq!(extended.rules.legality.legacy, base.rules.legality.legacy);
+    assert_eq!(extended.printing_fidelity, base.printing_fidelity);
+    assert_eq!(extended.reprint_policy, base.reprint_policy);
+
+    // ...but NOT the identity, which must be its own.
+    assert_ne!(extended.rules.id, base.rules.id);
+    assert_ne!(extended.label, base.label);
+    assert_ne!(extended.short_label, base.short_label);
+}
+
+/// The legacy-axis gate, exercised against real entries for the first time.
+/// Both EC presets declare `mana_burn: Obsolete`, which the engine does not
+/// implement, so `custom_format_registry()` must list and then reject them.
+#[test]
+fn the_eternal_central_presets_are_listed_but_withheld_by_the_legacy_axis_gate() {
+    for preset in [old_school_93_94(), old_school_95()] {
+        let label = preset.label.clone();
+        assert!(
+            !passes_legacy_axis_gate(&preset.rules.legality.legacy),
+            "{label} declares mana burn, which IMPLEMENTED_LEGACY_AXES does not cover yet"
+        );
+        // The OTHER gate must pass, so the rejection above is attributable to
+        // the unimplemented axis and not to mismatched reprint metadata.
+        assert!(passes_reprint_fidelity_gate(&preset), "{label}");
+        assert_no_lobby_save_sentinel_collision(&[preset]);
+    }
+
+    assert!(
+        engine::types::custom_format::custom_format_registry().is_empty(),
+        "neither EC preset is selectable until mana burn lands (Phase 2b)"
+    );
+}
+
+/// PLAN.md §1's pairing rule, run offline: a preset that declares reprint
+/// intent must admit the approximation in text a player can read, or the
+/// label misleads about what the engine actually enforces.
+#[test]
+fn set_code_approximation_presets_disclose_the_limitation() {
+    for preset in [old_school_93_94(), old_school_95(), swedish_old_school()] {
+        let discloses = preset
+            .description
+            .contains("approximated at the set-code level");
+        match preset.printing_fidelity {
+            PrintingFidelity::SetCodeApproximation => assert!(
+                discloses,
+                "{} declares SetCodeApproximation but its description does not say so: {:?}",
+                preset.label, preset.description
+            ),
+            // Paired negative: a preset claiming no printing intent must not
+            // carry the disclosure either, or the text is boilerplate rather
+            // than a real signal.
+            PrintingFidelity::NotApplicable => assert!(
+                !discloses,
+                "{} is NotApplicable but discloses an approximation it does not make",
+                preset.label
+            ),
+        }
+    }
+}
+
+/// Registry ids are persisted in `GameFormat::Custom(id)`, so a collision
+/// between two presets would make saved games ambiguous. Checked across every
+/// bundled constructor, registered or not.
+#[test]
+fn every_bundled_preset_has_a_distinct_non_sentinel_id() {
+    let presets = [old_school_93_94(), old_school_95(), swedish_old_school()];
+    let ids: BTreeSet<u16> = presets.iter().map(|def| def.rules.id.0).collect();
+    assert_eq!(
+        ids.len(),
+        presets.len(),
+        "two bundled presets share a CustomFormatId: {:?}",
+        presets
+            .iter()
+            .map(|def| (&def.label, def.rules.id.0))
+            .collect::<Vec<_>>()
+    );
+    assert!(!ids.contains(&LOBBY_SAVE_CUSTOM_FORMAT_ID.0));
+}
+
 #[test]
 fn custom_format_registry_withholds_swedish_old_school_on_open_item_6() {
-    // The registry is still empty, but no longer because no preset exists:
-    // `swedish_old_school()` is built and passes both registration gates. It
-    // is withheld because its reprint policy is unconfirmed against the
-    // primary source (CONTEXT.md Open item 6), which PLAN.md §7/§8 make a
-    // registration blocker in its own right. Asserting BOTH halves is the
-    // point — an empty-registry assertion alone would keep passing if the
-    // preset silently stopped passing the gates.
+    // Swedish is withheld by a DIFFERENT mechanism from its EC siblings, and
+    // the distinction is the whole point of this test. The EC presets are
+    // listed in the registry and rejected by the legacy-axis gate. Swedish
+    // PASSES both gates, so listing it would register it — its blocker is
+    // CONTEXT.md Open item 6 (unconfirmed reprint-policy metadata), a
+    // documentation-accuracy blocker with no gate to express it, leaving
+    // omission from the list as the only mechanism.
+    //
+    // Asserting both halves is what makes that meaningful: an empty-registry
+    // assertion alone would keep passing if the preset silently started
+    // FAILING a gate, which would hide the real reason it is absent.
     let preset = swedish_old_school();
     assert!(passes_legacy_axis_gate(&preset.rules.legality.legacy));
     assert!(passes_reprint_fidelity_gate(&preset));

--- a/crates/engine/tests/integration/custom_format_schema.rs
+++ b/crates/engine/tests/integration/custom_format_schema.rs
@@ -11,7 +11,7 @@
 //! private items directly.
 
 use engine::types::custom_format::{
-    assert_no_lobby_save_sentinel_collision, old_school_93_94, old_school_95,
+    assert_no_lobby_save_sentinel_collision, bundled_presets, old_school_93_94, old_school_95,
     passes_legacy_axis_gate, passes_reprint_fidelity_gate, swedish_old_school,
     validate_custom_rules_consistency, AntePolicy, CombatDamageTiming, CommandZoneMode,
     CommanderEligibilityRule, CustomFormatDef, CustomFormatId, CustomFormatRules, LegacyRuleSet,
@@ -385,7 +385,22 @@ fn old_school_95_extends_93_94_by_exactly_its_declared_deltas() {
 /// implement, so `custom_format_registry()` must list and then reject them.
 #[test]
 fn the_eternal_central_presets_are_listed_but_withheld_by_the_legacy_axis_gate() {
-    for preset in [old_school_93_94(), old_school_95()] {
+    // "Listed but withheld" is a claim about `bundled_presets()`, so assert it
+    // there. Checking only that the registry is empty would keep passing if
+    // both presets were quietly dropped from the list — the registry would
+    // still be empty, and independently-constructed presets would still fail
+    // the gate, so nothing would catch it.
+    let listed: BTreeSet<u16> = bundled_presets().iter().map(|def| def.rules.id.0).collect();
+    assert!(
+        listed.contains(&old_school_93_94().rules.id.0)
+            && listed.contains(&old_school_95().rules.id.0),
+        "both EC presets must be CONSIDERED for registration; got ids {listed:?}"
+    );
+    // The other half of the mechanism: Swedish is absent from the list
+    // entirely, because it would pass the gates. See its own test.
+    assert!(!listed.contains(&swedish_old_school().rules.id.0));
+
+    for preset in bundled_presets() {
         let label = preset.label.clone();
         assert!(
             !passes_legacy_axis_gate(&preset.rules.legality.legacy),
@@ -465,6 +480,15 @@ fn custom_format_registry_withholds_swedish_old_school_on_open_item_6() {
     let preset = swedish_old_school();
     assert!(passes_legacy_axis_gate(&preset.rules.legality.legacy));
     assert!(passes_reprint_fidelity_gate(&preset));
+
+    // Absent from the CONSIDERED list, not merely from the filtered result —
+    // that absence IS the withholding mechanism here, so it is what to assert.
+    assert!(
+        !bundled_presets()
+            .iter()
+            .any(|def| def.rules.id == preset.rules.id),
+        "Swedish passes both gates, so listing it in bundled_presets() would register it"
+    );
 
     let registry = engine::types::custom_format::custom_format_registry();
     assert!(

--- a/docs/proposals/custom-format-engine/RESEARCH.md
+++ b/docs/proposals/custom-format-engine/RESEARCH.md
@@ -33,6 +33,25 @@ during the match.
   Jeweled Bird, Rebirth, Tempest Efreet.
 - **Reprint policy:** non-foil reprints with original frame + art, any language;
   no proxies.
+- **Named legal promos (ADDED 2026-09-09, Phase 2a implementation):** the
+  source also declares three promotional cards legal — **Arena**, **Sewers of
+  Estark**, and **Nalathni Dragon** (1994) — which the "Legal sets" line above
+  does not cover. This was missed in the original 2026-07-07 capture and is
+  recorded here because it is a real legality difference, not a detail.
+  - Their sets, verified against Scryfall 2026-09-09: Arena and Sewers of
+    Estark are in `PHPR` (HarperPrism Book Promos, **5 cards**); Nalathni
+    Dragon is in `PDRC` (Dragon Con, **1 card**).
+  - **Not expressible for 93-94 at set-code granularity.** The other three
+    PHPR cards — Giant Badger, Windseeker Centaur, Mana Crypt — are Old School
+    *95* promos, not 93-94 legal, and Mana Crypt is restricted even there. So
+    adding `PHPR` to 93-94's `legal_sets` would admit three cards the format
+    forbids, while omitting it rejects two the format allows. `PDRC` has no
+    such problem (one card).
+  - The implemented preset therefore omits both promo sets and is
+    **under-permissive by these three cards**, disclosed in its `description`
+    per the `SetCodeApproximation` pairing rule. Fixing it properly needs
+    card-level pool entries, which `LegalityRules` does not have — flagged, not
+    silently dropped.
 - **Legacy rules:** mana burn only. (Plus Chaos Orb / Falling Star flip Oracle,
   and a "no draws" 50-minute Chaos-Orb tiebreaker — tournament-ops, not engine.)
 
@@ -42,7 +61,16 @@ during the match.
 - **Legal sets:** all of 93-94 **plus** Fourth Edition, Ice Age, Chronicles,
   Renaissance, Homelands.
 - **Restricted:** 93-94's list **plus** Demonic Consultation, Mana Crypt.
-- **Banned:** 93-94's list **plus** Amulet of Quoz, Timmerian Fiends.
+- **Banned:** 93-94's list **plus** Amulet of Quoz, Timmerian Fiends. (Both
+  additions are CR 407.3 ante cards, which this era's pool newly contains —
+  `game::ante` bars them from every deck independently of this list.)
+- **Named legal promos (ADDED 2026-09-09, as above):** 93-94's three **plus**
+  Giant Badger, Windseeker Centaur and Mana Crypt. Unlike 93-94, this IS
+  expressible at set-code granularity — all five `PHPR` cards are 95-legal, so
+  `PHPR` + `PDRC` would be exactly correct here. The implemented preset still
+  omits them, because it inherits 93-94's `legal_sets` wholesale and diverging
+  only for 95 would make the two presets' pools disagree about a shared set for
+  no reason a reader could see. Revisit alongside 93-94's carve-out.
 - **Legacy rules:** mana burn only.
 
 ### Middle School


### PR DESCRIPTION
Phase 2a of the custom-format-engine charter (`docs/proposals/custom-format-engine/IMPLEMENTATION_PLAN.md` §"Phase 2a"), following #7818 (1a), #8225 (1b), #8262 (1c), #8645 (Phase A) and #8736 (Phase B + the preset/ante work).

Two more Axis-B presets, reusing the schema and evaluator from 1a–1d. **No new engine mechanism.**

## The registration gates are exercised for the first time

Both presets are **listed** in `custom_format_registry()` and then **rejected** by `passes_legacy_axis_gate`, because both declare `mana_burn: Obsolete` and the engine implements no mana burn yet. Until now those gates filtered an empty vector and could not fail — this is the first time either one does real work. Phase 2b adds `LegacyAxis::ManaBurn` to `IMPLEMENTED_LEGACY_AXES` and both become selectable **with no edit here**.

`swedish_old_school()` deliberately stays *out* of that list rather than in it, and the asymmetry is the point:

| Preset | Withheld by | Why that mechanism |
|---|---|---|
| Old School 93/94, 95 | listed, rejected by the legacy-axis gate | declares an unimplemented axis — exactly what the gate is for |
| Swedish Old School | omission from the list | it **passes** both gates, so listing it would register it; Open item 6 is a documentation-accuracy blocker with no gate to express it |

Tests assert both mechanisms separately, so neither can silently become the other.

## Data verified, not transcribed

Re-fetched the primary source (`lordsofthepit.com/src/pages/formats.md`) on 2026-09-09: **11 legal sets, 22 restricted, 7 banned**, mana burn as the only stated legacy exception — matching RESEARCH.md §1 name for name. All 16 set codes across both presets checked against Scryfall's live set list, including `CED`/`CEI`.

93/94's seven banned cards are exactly the CR 407.3 ante class within its era pool, and 95's two banned additions are the remaining two. `game::ante` (#8736) already bars all of them from every deck; the entries stay because the source states them, and because they must survive a format that legitimately plays for ante.

95 is composed from the 93/94 base per PLAN.md §2's own sketch, so the shared base cannot drift between the two.

## ⚠️ A source detail RESEARCH.md had missed — needs your call

Both rulesets also declare specific **promo cards** legal, which the captured "legal sets" line never covered:

- **93/94:** Arena, Sewers of Estark, Nalathni Dragon
- **95:** those plus Giant Badger, Windseeker Centaur, Mana Crypt

The presets omit them, so they are **under-permissive by three cards**. I did not silently add set codes the plan doesn't declare, because preset data has been revised twice in review and this is your call.

The reason it isn't a trivial fix (verified against Scryfall, not assumed):

| Set | Cards | 93/94 | 95 |
|---|---|---|---|
| `PHPR` HarperPrism Book Promos | 5: Arena, Sewers of Estark, Giant Badger, Windseeker Centaur, Mana Crypt | only 2 of 5 legal — **adding it would admit Mana Crypt, which 93/94 forbids** | all 5 legal — would be exactly correct |
| `PDRC` Dragon Con | 1: Nalathni Dragon | legal — would be exactly correct | legal |

So `PDRC` could be added to both today, and `PHPR` to 95 only; 93/94's PHPR carve-out is genuinely inexpressible without card-level pool entries, which `LegalityRules` does not have. Options as I see them: (a) leave as-is with the disclosure, (b) add `PDRC` to both and `PHPR` to 95, accepting that the two presets' set lists then differ in a way a reader must check the promos to understand, or (c) add card-level pool entries — its own phase. I've written the analysis into RESEARCH.md either way. Happy to implement (b) in this PR if you prefer it.

Both presets' `description` carries the shared `SetCodeApproximation` disclosure, which now names the promo gap alongside the frame/foil one.

## Tests

Rosters asserted **by name, both directions** — a same-length substitution changes legal deck construction and a count would sail past it, which was the finding on the Swedish preset last round.

- `old_school_95_extends_93_94_by_exactly_its_declared_deltas` — PLAN.md §2's inheritance requirement: base ⊆ 95, and the set difference is *exactly* the declared additions. Length checks alongside it, since set semantics would hide a duplicated inherited entry.
- `the_eternal_central_presets_are_listed_but_withheld_by_the_legacy_axis_gate` — asserts the *other* gate passes, so the rejection is attributable to the unimplemented axis rather than to mismatched reprint metadata.
- `set_code_approximation_presets_disclose_the_limitation` — with a paired negative: a `NotApplicable` preset must **not** carry the disclosure, or the text is boilerplate rather than a signal.
- `every_bundled_preset_has_a_distinct_non_sentinel_id` — ids are persisted in `GameFormat::Custom(id)`, so a collision would make saved games ambiguous.

| Check | Result |
|---|---|
| `--test integration custom_format` | 95 passed, 0 failed |
| `--lib deck_validation::tests` | 150 passed |
| `--lib format` | 123 passed |
| `cargo check -p phase-engine --lib` / `cargo fmt --all` | clean |

Same standing caveat: full-suite and `clippy` runs keep getting OOM-killed on my machine, so CI's workspace clippy + nextest is the gate for the remainder. Nothing I could run is failing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013h1rTnbzGpibH8sbszunhs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the Eternal Central Old School 93/94 and Old School 95 format definitions, including card legality, banned and restricted lists, and historical rules.
  - Added support for reviewing these bundled format presets before compatibility filters are applied.

- **Documentation**
  - Documented legal promotional cards and clarified where the format definitions are under-permissive due to set-code limitations.

- **Bug Fixes**
  - Clarified that both formats remain unavailable in the registry until required mana-burn behavior is supported.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->