### PR TITLE
feat(engine): mana burn (custom-format-engine Phase 2b)

### DIFF
--- a/crates/engine/src/game/combat_damage.rs
+++ b/crates/engine/src/game/combat_damage.rs
@@ -1823,7 +1823,7 @@ fn drain_combat_lifelink(
             // `mark_phase_transition_awaiting_post_replacement` only for the
             // substitution variant), so the divergence here is deliberate, not an
             // oversight.
-            Err(ReplacementDeferred::SubstitutionContinuation) => {
+            Err(ReplacementDeferred::SubstitutionContinuation { .. }) => {
                 state.waiting_for = waiting_before.clone();
             }
         }

--- a/crates/engine/src/game/deck_validation.rs
+++ b/crates/engine/src/game/deck_validation.rs
@@ -4249,8 +4249,8 @@ mod tests {
 
     use crate::types::custom_format::{
         CombatDamageTiming, CommanderEligibilityRule, CustomFormatDef, CustomFormatId,
-        CustomFormatRules, LegacyRuleSet, LegendRuleScope, ManaBurnPolicy, PrintingFidelity,
-        ReprintPolicy, StructuralRules, WishOutsideGameScope,
+        CustomFormatRules, LegacyRuleSet, LegendRuleScope, PrintingFidelity, ReprintPolicy,
+        StructuralRules, WishOutsideGameScope,
     };
     use crate::types::format::DeckSizeRule;
     use crate::types::keywords::PartnerType;
@@ -9939,10 +9939,10 @@ mod tests {
         // freshly-implemented axis fails loudly here instead of silently
         // dropping out).
         let non_default_rulesets = [
-            LegacyRuleSet {
-                mana_burn: ManaBurnPolicy::Obsolete,
-                ..LegacyRuleSet::default()
-            },
+            // Mana burn is NOT in this list any more: Phase 2b implemented it,
+            // so it is no longer an undeclared axis and the gate correctly
+            // accepts it. This is the loop narrowing itself exactly as its
+            // comment above promised.
             LegacyRuleSet {
                 damage_timing: CombatDamageTiming::OnStack,
                 ..LegacyRuleSet::default()
@@ -10036,7 +10036,9 @@ mod tests {
 
         let mut legacy_rules =
             base_custom_rules(DeckSizeRule::Minimum(60), DeckCopyLimit::Unlimited);
-        legacy_rules.legality.legacy.mana_burn = ManaBurnPolicy::Obsolete;
+        // Damage timing, not mana burn: Phase 2b implemented mana burn, so a
+        // mana-burn config is no longer rejected here.
+        legacy_rules.legality.legacy.damage_timing = CombatDamageTiming::OnStack;
         let legacy_config = FormatConfig::for_custom_rules(&legacy_rules);
         let legacy_request = DeckCompatibilityRequest {
             main_deck: expand("Plains", 60),

--- a/crates/engine/src/game/effects/life.rs
+++ b/crates/engine/src/game/effects/life.rs
@@ -21,8 +21,20 @@ use crate::types::resolved_commands::ResolvedPlayerEdit;
 /// paused on its own interactive continuation.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ReplacementDeferred {
+    /// CR 616.1: paused on the ordering choice BEFORE anything was applied.
+    /// The pipeline reports the real amount when the choice resumes.
     ReplacementChoice,
-    SubstitutionContinuation,
+    /// CR 614.6: the root event already finished for `applied`; what paused is
+    /// the substitute effect that must resolve before the original resolution
+    /// may continue.
+    ///
+    /// Carrying the amount is load-bearing, not decorative: a caller that needs
+    /// to narrate WHY the life changed (the empty-pool drain's mana burn) learns
+    /// the true figure here and nowhere else. Dropping it forced that caller to
+    /// park provenance and hope a later resume would hand the number back — and
+    /// the resume that completes a substitute is not the one that applied the
+    /// root, so the number never came.
+    SubstitutionContinuation { applied: u32 },
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -153,7 +165,7 @@ pub fn apply_life_gain(
             match drain_substitution_continuation(state, events) {
                 SubstitutionDrainOutcome::Completed => Ok(gained),
                 SubstitutionDrainOutcome::Deferred => {
-                    Err(ReplacementDeferred::SubstitutionContinuation)
+                    Err(ReplacementDeferred::SubstitutionContinuation { applied: gained })
                 }
             }
         }
@@ -163,7 +175,9 @@ pub fn apply_life_gain(
             match drain_substitution_continuation(state, events) {
                 SubstitutionDrainOutcome::Completed => Ok(0),
                 SubstitutionDrainOutcome::Deferred => {
-                    Err(ReplacementDeferred::SubstitutionContinuation)
+                    // Fully prevented: the root gained nothing, whatever the
+                    // substitute goes on to do.
+                    Err(ReplacementDeferred::SubstitutionContinuation { applied: 0 })
                 }
             }
         }
@@ -293,7 +307,9 @@ pub fn apply_life_loss(
             match drain_substitution_continuation(state, events) {
                 SubstitutionDrainOutcome::Completed => Ok(lost),
                 SubstitutionDrainOutcome::Deferred => {
-                    Err(ReplacementDeferred::SubstitutionContinuation)
+                    // The root loss is FINAL at this point — `lost` is what the
+                    // player actually paid. Only the substitute is unfinished.
+                    Err(ReplacementDeferred::SubstitutionContinuation { applied: lost })
                 }
             }
         }
@@ -303,7 +319,9 @@ pub fn apply_life_loss(
             match drain_substitution_continuation(state, events) {
                 SubstitutionDrainOutcome::Completed => Ok(0),
                 SubstitutionDrainOutcome::Deferred => {
-                    Err(ReplacementDeferred::SubstitutionContinuation)
+                    // Fully prevented: no life left the player, so nothing
+                    // downstream may narrate a loss.
+                    Err(ReplacementDeferred::SubstitutionContinuation { applied: 0 })
                 }
             }
         }
@@ -1736,7 +1754,14 @@ mod tests {
 
         let outcome = apply_life_gain(&mut state, PlayerId(0), 4, &mut Vec::new());
 
-        assert_eq!(outcome, Err(ReplacementDeferred::SubstitutionContinuation));
+        // The branch prompt fully REPLACES the gain, so the root added nothing
+        // before pausing. The deferral says so, which is the point of carrying
+        // the figure: a caller narrating this event must report what actually
+        // happened (0), not the 4 that was proposed.
+        assert_eq!(
+            outcome,
+            Err(ReplacementDeferred::SubstitutionContinuation { applied: 0 })
+        );
         assert!(matches!(
             state.waiting_for,
             WaitingFor::ChooseOneOfBranch { .. }

--- a/crates/engine/src/game/engine_replacement.rs
+++ b/crates/engine/src/game/engine_replacement.rs
@@ -236,16 +236,26 @@ fn handle_replacement_choice_inner(
     // ownership before `continue_replacement` consumes the pending record.
     // The LifeLoss event is the sole resume authority; the already-applied
     // EmptyManaPool event must never be replayed.
-    let pending_was_phase_drain_life_loss = state
+    //
+    // Carries the LOSER rather than a bare bool: the `Prevented` arm has to
+    // consume that player's parked empty-pool provenance, and reading it back
+    // after `continue_replacement` is impossible — the record is gone.
+    let pending_phase_drain_life_loser = state
         .pending_phase_transition_progress
         .as_ref()
         .is_some_and(|progress| {
             progress.drain_state == crate::types::game_state::PhaseTransitionDrainState::Ready
         })
-        && state
-            .pending_replacement
-            .as_ref()
-            .is_some_and(|pending| matches!(pending.proposed, ProposedEvent::LifeLoss { .. }));
+        .then(|| {
+            state
+                .pending_replacement
+                .as_ref()
+                .and_then(|pending| match pending.proposed {
+                    ProposedEvent::LifeLoss { player_id, .. } => Some(player_id),
+                    _ => None,
+                })
+        })
+        .flatten();
     // CR 701.24a: capture the parked library placement (W3) BEFORE
     // `continue_replacement` consumes (`.take()`s) the pending record, so the
     // ZoneChange resume arm below can thread it into the delivery `DeliveryCtx`
@@ -1435,7 +1445,14 @@ fn handle_replacement_choice_inner(
             {
                 return Ok(state.waiting_for.clone());
             }
-            if pending_was_phase_drain_life_loss {
+            if let Some(loser) = pending_phase_drain_life_loser {
+                // CR 614.1a: the chosen replacement prevented the loss outright,
+                // so no life left this player and nothing may narrate one.
+                // Consume the parked provenance anyway — left behind, it is a
+                // record with no event, and the next same-player loss to resume
+                // through this pipeline would claim it and be logged as mana
+                // burn. `actual: 0` consumes without emitting.
+                super::turns::note_empty_pool_life_loss_resolved(state, loser, 0, events);
                 state.waiting_for = WaitingFor::Priority {
                     player: state.active_player,
                 };

--- a/crates/engine/src/game/engine_replacement.rs
+++ b/crates/engine/src/game/engine_replacement.rs
@@ -716,7 +716,21 @@ fn handle_replacement_choice_inner(
                 }
                 // CR 120.3: Life loss accepted after replacement choice.
                 loss @ ProposedEvent::LifeLoss { .. } => {
-                    apply_life_loss_after_replacement(state, loss, events);
+                    // Captured before the move: an empty-pool loss that
+                    // deferred here never returns to the phase-transition
+                    // drain, so this is the only place its cause can still be
+                    // named (a mana burn would otherwise land as an unexplained
+                    // life change).
+                    let loser = match &loss {
+                        ProposedEvent::LifeLoss { player_id, .. } => Some(*player_id),
+                        _ => None,
+                    };
+                    let actual = apply_life_loss_after_replacement(state, loss, events);
+                    if let Some(player_id) = loser {
+                        crate::game::turns::note_empty_pool_life_loss_resolved(
+                            state, player_id, actual, events,
+                        );
+                    }
                 }
                 // CR 701.9a: Discard accepted after replacement choice — move the
                 // object hand → graveyard and record/emit the discard event. The

--- a/crates/engine/src/game/life_costs.rs
+++ b/crates/engine/src/game/life_costs.rs
@@ -169,7 +169,7 @@ pub fn pay_life_as_cost(
                 choice_player: *choice_player,
             }
         }
-        Err(ReplacementDeferred::SubstitutionContinuation) => {
+        Err(ReplacementDeferred::SubstitutionContinuation { .. }) => {
             PayLifeCostResult::PaidWithDeferredSubstitution { amount }
         }
     }

--- a/crates/engine/src/game/log.rs
+++ b/crates/engine/src/game/log.rs
@@ -103,6 +103,7 @@ fn importance(event: &GameEvent) -> LogImportance {
         | GameEvent::DamageDealt { .. }
         | GameEvent::CombatDamageDealtToPlayer { .. }
         | GameEvent::LifeChanged { .. }
+        | GameEvent::ManaBurn { .. }
         | GameEvent::CreatureDestroyed { .. }
         | GameEvent::PermanentSacrificed { .. }
         | GameEvent::TokenCreated { .. }
@@ -261,6 +262,8 @@ fn tone(event: &GameEvent) -> LogTone {
         | GameEvent::PlayerLost { .. }
         | GameEvent::PlayerEliminated { .. } => LogTone::Negative,
         GameEvent::LifeChanged { amount, .. } if *amount < 0 => LogTone::Negative,
+        // Mana burn only ever costs life.
+        GameEvent::ManaBurn { .. } => LogTone::Negative,
         GameEvent::SpellCast { .. }
         | GameEvent::SpellCopied { .. }
         | GameEvent::AbilityActivated { .. }
@@ -590,7 +593,9 @@ fn categorize(event: &GameEvent) -> LogCategory {
         | GameEvent::TappedForMana { .. }
         | GameEvent::ManaAbilityProduced { .. }
         | GameEvent::ManaPoolEmptied { .. }
-        | GameEvent::ManaRecolored { .. } => LogCategory::Mana,
+        | GameEvent::ManaRecolored { .. }
+        // The mana-side explanation; the LifeChanged it causes is categorized Life.
+        | GameEvent::ManaBurn { .. } => LogCategory::Mana,
 
         GameEvent::PermanentTapped { .. }
         | GameEvent::PermanentUntapped { .. }
@@ -1016,6 +1021,15 @@ fn format_segments(event: &GameEvent, state: &GameState) -> Vec<LogSegment> {
                 ]
             }
         }
+
+        // Names the rule, not just the loss: the `LifeChanged` event that
+        // follows says a player lost life, and only this says why.
+        GameEvent::ManaBurn { player_id, amount } => vec![
+            player_seg(state, *player_id),
+            text(" loses "),
+            num(*amount as i32),
+            text(" life to mana burn"),
+        ],
 
         GameEvent::SpeedChanged {
             player,

--- a/crates/engine/src/game/mana_burn.rs
+++ b/crates/engine/src/game/mana_burn.rs
@@ -1,0 +1,42 @@
+//! Mana burn — the pre-M10 rule that unspent mana costs a player life.
+//!
+//! The current Comprehensive Rules have no mana-burn rule; the glossary entry
+//! "Mana Burn (Obsolete)" records what it was: "Older versions of the rules
+//! stated that unspent mana caused a player to **lose life**." Life loss, not
+//! damage — the two are behaviorally different here (damage can be prevented
+//! or redirected and triggers "dealt damage" abilities; life loss does
+//! neither).
+//!
+//! It differs from the modern rule on two axes, and both matter:
+//!
+//! 1. **When the pool empties.** CR 106.4 and CR 500.5 empty pools at the end
+//!    of every step AND phase. The pre-M10 rule emptied at the end of each
+//!    PHASE — CR 500.1's five — so mana survived the steps within one.
+//! 2. **What emptying costs.** Modern emptying is free; here the emptied count
+//!    is life lost.
+//!
+//! Only a custom format declaring `LegacyRuleSet.mana_burn` opts in, so every
+//! built-in format is unaffected by construction rather than by a check.
+
+use crate::types::custom_format::ManaBurnPolicy;
+use crate::types::format::FormatConfig;
+use crate::types::game_state::GameState;
+
+/// The mana-burn policy a format declares.
+///
+/// A built-in format carries no `custom_rules` and resolves to the modern
+/// default. Mirrors `game::ante::policy_of`, and for the same reason: the
+/// policy lives on the resolved `FormatConfig`, so anything holding one can
+/// ask without needing a running game.
+pub(crate) fn policy_of(format_config: &FormatConfig) -> ManaBurnPolicy {
+    format_config
+        .custom_rules
+        .as_deref()
+        .map(|rules| rules.legality.legacy.mana_burn)
+        .unwrap_or_default()
+}
+
+/// Whether this game empties mana pools the pre-M10 way.
+pub(crate) fn applies(state: &GameState) -> bool {
+    matches!(policy_of(&state.format_config), ManaBurnPolicy::Obsolete)
+}

--- a/crates/engine/src/game/mod.rs
+++ b/crates/engine/src/game/mod.rs
@@ -86,6 +86,7 @@ pub mod life_safety;
 mod lifecycle;
 pub mod log;
 pub mod mana_abilities;
+pub(crate) mod mana_burn;
 pub mod mana_payment;
 pub mod mana_sources;
 pub mod match_flow;

--- a/crates/engine/src/game/public_state.rs
+++ b/crates/engine/src/game/public_state.rs
@@ -333,6 +333,7 @@ pub fn mark_public_state_from_events(state: &mut GameState, events: &[GameEvent]
             }
             GameEvent::ManaAdded { player_id, .. }
             | GameEvent::ManaPoolEmptied { player_id, .. }
+            | GameEvent::ManaBurn { player_id, .. }
             | GameEvent::ManaRecolored { player_id, .. } => {
                 mark_public_state_player_dirty(state, *player_id);
                 mark_mana_display_dirty(state);

--- a/crates/engine/src/game/targeting.rs
+++ b/crates/engine/src/game/targeting.rs
@@ -1874,6 +1874,7 @@ pub(crate) fn extract_target_object_from_event(
         | GameEvent::TappedForMana { .. }
         | GameEvent::ManaAbilityProduced { .. }
         | GameEvent::ManaPoolEmptied { .. }
+        | GameEvent::ManaBurn { .. }
         | GameEvent::ManaRecolored { .. }
         | GameEvent::PermanentTapped { .. }
         | GameEvent::CreatureExerted { .. }

--- a/crates/engine/src/game/trigger_index.rs
+++ b/crates/engine/src/game/trigger_index.rs
@@ -590,7 +590,11 @@ pub(crate) fn keys_from_event(event: &GameEvent, state: &GameState) -> Keys {
             push(TriggerEventKey::ManaProduced);
             push(TriggerEventKey::TapsForMana);
         }
-        GameEvent::ManaPoolEmptied { .. } | GameEvent::ManaRecolored { .. } => {}
+        // No trigger key: no card triggers on mana burn. The life loss it
+        // causes is itself a `LifeChanged` event, which carries its own keys.
+        GameEvent::ManaPoolEmptied { .. }
+        | GameEvent::ManaBurn { .. }
+        | GameEvent::ManaRecolored { .. } => {}
         GameEvent::PermanentTapped { .. } => push(TriggerEventKey::Taps),
         GameEvent::PlayerLost { .. } => push(TriggerEventKey::PlayerLost),
         // CR 800.4: Administrative control transfers on elimination do NOT

--- a/crates/engine/src/game/trigger_matchers.rs
+++ b/crates/engine/src/game/trigger_matchers.rs
@@ -1013,6 +1013,7 @@ fn count_matching_trigger_event_subjects(
         | GameEvent::TappedForMana { .. }
         | GameEvent::ManaAbilityProduced { .. }
         | GameEvent::ManaPoolEmptied { .. }
+        | GameEvent::ManaBurn { .. }
         | GameEvent::ManaRecolored { .. }
         | GameEvent::PlayerLost { .. }
         | GameEvent::MulliganStarted

--- a/crates/engine/src/game/turns.rs
+++ b/crates/engine/src/game/turns.rs
@@ -556,19 +556,35 @@ pub(super) fn discharge_owed_life_losses(
             // count instead would tell a player they lost life they still have.
             Ok(actual) => emit_life_loss_cause(next, actual, events),
             Err(deferred) => {
-                // This loss is mid-flight and will complete through the
-                // replacement pipeline; only what has NOT been attempted is
-                // parked. Re-queuing `next` would apply it twice — but its
-                // CAUSE still has to survive, or the event that explains it is
-                // lost when it lands. See `note_empty_pool_life_loss_resolved`.
-                park_in_flight_life_loss(state, next);
-                park_owed_life_losses(state, owed);
-                if matches!(
-                    deferred,
-                    crate::game::effects::life::ReplacementDeferred::SubstitutionContinuation
-                ) {
-                    mark_phase_transition_awaiting_post_replacement(state);
+                // Either way this loss is mid-flight and must NOT be re-queued
+                // — re-applying it would take the life a second time. Only what
+                // has not been attempted yet is parked. The two deferral kinds
+                // differ in whether the ROOT loss has already happened, and so
+                // in where its cause can still be named.
+                match deferred {
+                    // CR 616.1: nothing applied yet. How much is lost is
+                    // unknowable until the ordering choice resumes, so park the
+                    // cause and let the resume path name it. See
+                    // `note_empty_pool_life_loss_resolved`.
+                    crate::game::effects::life::ReplacementDeferred::ReplacementChoice => {
+                        park_in_flight_life_loss(state, next);
+                    }
+                    // CR 614.6: the root loss is DONE, for exactly `applied`;
+                    // only the substitute effect is still running. Narrate it
+                    // HERE, where the true figure is in hand. Parking it instead
+                    // would strand the provenance, because the resume that
+                    // finishes a substitute is not the one that applied the root
+                    // and never hands that number back. This also matches the
+                    // `Ok` arm's event ordering: there too the cause follows the
+                    // substitute's own events, because the drain already ran.
+                    crate::game::effects::life::ReplacementDeferred::SubstitutionContinuation {
+                        applied,
+                    } => {
+                        emit_life_loss_cause(next, applied, events);
+                        mark_phase_transition_awaiting_post_replacement(state);
+                    }
                 }
+                park_owed_life_losses(state, owed);
                 return EmptyManaPoolApplyOutcome::Deferred;
             }
         }
@@ -601,12 +617,18 @@ fn park_in_flight_life_loss(state: &mut GameState, loss: PendingEmptyPoolLifeLos
 }
 
 /// Emit the event explaining an empty-pool life loss that completed through the
-/// CR 616.1 replacement pipeline rather than returning to
+/// CR 616.1 ordering choice rather than returning to
 /// `discharge_owed_life_losses`.
 ///
 /// Called from the replacement resume path, which handles EVERY life loss — so
 /// this fires only when a parked record names this same player, and consumes it
 /// either way so a later unrelated loss cannot inherit the provenance.
+///
+/// It must be called on EVERY terminal outcome of the choice, including
+/// `Prevented`: a record left parked outlives its own event and is then claimed
+/// by the next same-player loss to resume, which would log an unrelated loss as
+/// mana burn. Passing `actual: 0` consumes it and emits nothing, which is the
+/// correct narration for a prevented loss.
 ///
 /// `actual` is what the pipeline really took, which is the point: a replacement
 /// effect may have reduced it, and CR 119.8 can make it zero.

--- a/crates/engine/src/game/turns.rs
+++ b/crates/engine/src/game/turns.rs
@@ -186,6 +186,15 @@ pub(in crate::game) fn advance_phase_once(
         complete_end_combat_teardown(state);
     }
 
+    // CR 500.5 + CR 101.4: the empty-pool events this transition raises belong
+    // to the ENDING phase of the outgoing turn, and replacement-choice ordering
+    // is APNAP — so their order must start at the outgoing active player.
+    // `start_next_turn` below rotates `active_player`, and phase entry builds
+    // its queue afterwards, so the anchor has to be captured here or the
+    // incoming turn's player would be asked first.
+    let apnap_anchor =
+        (state.phase == Phase::Cleanup && next == Phase::Untap).then_some(state.active_player);
+
     // If wrapping from Cleanup to Untap, start next turn. Turn-level skip
     // replacements (CR 614.10) are handled inside `start_next_turn` — the
     // per-phase pipeline below runs only for within-turn phase advances.
@@ -229,7 +238,7 @@ pub(in crate::game) fn advance_phase_once(
             .and_then(|ep| ep.attacker_restriction_source);
     }
 
-    AdvancePhaseOnce::Entry(Box::new(enter_phase(state, next, events)))
+    AdvancePhaseOnce::Entry(Box::new(enter_phase(state, next, events, apnap_anchor)))
 }
 
 /// CR 724.1d: End the current turn by skipping straight to the cleanup step.
@@ -251,7 +260,7 @@ pub fn end_turn_to_cleanup(state: &mut GameState, events: &mut Vec<GameEvent>) {
     // is skipped, so we must expire the restriction here.
     state.current_combat_attacker_restriction = None;
     state.current_combat_attacker_restriction_source = None;
-    enter_phase(state, Phase::Cleanup, events);
+    enter_phase(state, Phase::Cleanup, events, None);
 }
 
 /// CR 511.2 + CR 511.3: End Combat effects expire and combat objects leave
@@ -291,7 +300,7 @@ pub fn end_combat_phase_to_postcombat(state: &mut GameState, events: &mut Vec<Ga
     // CR 500.8 + CR 724.2d: extra phases scheduled for this turn are skipped, so
     // drop any inserted-beginning-phase resume anchors along with them.
     state.extra_phase_resume.clear();
-    enter_phase(state, Phase::PostCombatMain, events);
+    enter_phase(state, Phase::PostCombatMain, events, None);
 }
 
 /// CR 508.8: Mark the end-of-combat step after no attackers remain, so the
@@ -330,10 +339,15 @@ pub(super) fn advance_after_empty_attackers(
 /// drain stores progress in `state.pending_phase_transition_progress` and
 /// sets `state.waiting_for`; resume happens via the `EmptyManaPool` arm of
 /// `handle_replacement_choice`, which re-calls `drain_pending_phase_transition_progress`.
+/// `apnap_anchor` overrides whom CR 101.4's APNAP order starts from. `None`
+/// means the current active player, which is right for every within-turn
+/// advance. It is `Some` only for Cleanup -> Untap, where the turn has already
+/// rotated but the empty-pool events still belong to the outgoing turn.
 fn enter_phase(
     state: &mut GameState,
     next: Phase,
     events: &mut Vec<GameEvent>,
+    apnap_anchor: Option<PlayerId>,
 ) -> PhaseEntryOutcome {
     use std::collections::VecDeque;
 
@@ -402,10 +416,24 @@ fn enter_phase(
 
     state.pending_phase_transition_progress =
         Some(crate::types::game_state::PhaseTransitionProgress {
-            remaining_players: VecDeque::from(super::players::apnap_order(state)),
+            remaining_players: VecDeque::from(match apnap_anchor {
+                // `SpecificPlayer` and NOT `None`: with `None` the anchor
+                // argument is ignored and the order falls back to the ACTIVE
+                // player — which by this point is the incoming turn's, the
+                // exact bug this override exists to prevent. That variant's own
+                // doc names this case: a snapshotted anchor that is not the
+                // active player.
+                Some(anchor) => super::players::apnap_order_from(
+                    state,
+                    Some(crate::types::ability::ControllerRef::SpecificPlayer { id: anchor }),
+                    anchor,
+                ),
+                None => super::players::apnap_order(state),
+            }),
             next_phase: next,
             previous_phase: Some(previous),
             owed_life_loss: VecDeque::new(),
+            in_flight_life_loss: None,
             entering_cleanup,
             drain_state: crate::types::game_state::PhaseTransitionDrainState::Ready,
         });
@@ -530,7 +558,10 @@ pub(super) fn discharge_owed_life_losses(
             Err(deferred) => {
                 // This loss is mid-flight and will complete through the
                 // replacement pipeline; only what has NOT been attempted is
-                // parked. Re-queuing `next` would apply it twice.
+                // parked. Re-queuing `next` would apply it twice — but its
+                // CAUSE still has to survive, or the event that explains it is
+                // lost when it lands. See `note_empty_pool_life_loss_resolved`.
+                park_in_flight_life_loss(state, next);
                 park_owed_life_losses(state, owed);
                 if matches!(
                     deferred,
@@ -561,6 +592,41 @@ fn emit_life_loss_cause(loss: PendingEmptyPoolLifeLoss, actual: u32, events: &mu
         }),
         EmptyPoolLifeLossCause::UnspentManaStatic => {}
     }
+}
+
+fn park_in_flight_life_loss(state: &mut GameState, loss: PendingEmptyPoolLifeLoss) {
+    if let Some(progress) = state.pending_phase_transition_progress.as_mut() {
+        progress.in_flight_life_loss = Some(loss);
+    }
+}
+
+/// Emit the event explaining an empty-pool life loss that completed through the
+/// CR 616.1 replacement pipeline rather than returning to
+/// `discharge_owed_life_losses`.
+///
+/// Called from the replacement resume path, which handles EVERY life loss — so
+/// this fires only when a parked record names this same player, and consumes it
+/// either way so a later unrelated loss cannot inherit the provenance.
+///
+/// `actual` is what the pipeline really took, which is the point: a replacement
+/// effect may have reduced it, and CR 119.8 can make it zero.
+pub(super) fn note_empty_pool_life_loss_resolved(
+    state: &mut GameState,
+    player_id: PlayerId,
+    actual: u32,
+    events: &mut Vec<GameEvent>,
+) {
+    let Some(progress) = state.pending_phase_transition_progress.as_mut() else {
+        return;
+    };
+    let Some(parked) = progress.in_flight_life_loss else {
+        return;
+    };
+    if parked.player_id != player_id {
+        return;
+    }
+    progress.in_flight_life_loss = None;
+    emit_life_loss_cause(parked, actual, events);
 }
 
 fn park_owed_life_losses(state: &mut GameState, owed: VecDeque<PendingEmptyPoolLifeLoss>) {
@@ -9670,6 +9736,112 @@ mod tests {
             });
     }
 
+    /// CR 500.5 + CR 101.4: the ending phase's empty-pool events belong to the
+    /// OUTGOING turn, so their APNAP order starts at the outgoing active
+    /// player — even though `start_next_turn` has already rotated the turn by
+    /// the time phase entry builds the queue.
+    ///
+    /// Three players, so "starts at the outgoing active player" and "starts at
+    /// the incoming one" are distinguishable orders rather than a 2-seat swap.
+    /// Mana burn makes the order observable: each player's emptied pool emits
+    /// its own `ManaBurn`, in the order the drain processed them.
+    #[test]
+    fn cleanup_to_untap_empties_pools_in_the_outgoing_turn_apnap_order() {
+        use crate::types::mana::{ManaType, ManaUnit};
+
+        let mut state = GameState::new(crate::types::format::FormatConfig::standard(), 3, 42);
+        state.turn_number = 1;
+        // Mana burn is a custom-format axis; `for_custom_rules` applies no gate
+        // of its own, which is what lets a test reach it.
+        let mut rules = crate::types::custom_format::old_school_93_94().rules;
+        rules.legality.legal_sets = None;
+        state.format_config = crate::types::format::FormatConfig::for_custom_rules(&rules);
+
+        // Every player holds unspent mana, so every player burns and each one
+        // contributes an event whose position reveals the order.
+        for player in &mut state.players {
+            player
+                .mana_pool
+                .add(ManaUnit::new(ManaType::Red, ObjectId(9_100), false, vec![]));
+        }
+
+        // The outgoing turn belongs to seat 1, so APNAP is 1, 2, 0. If the
+        // anchor were taken after `start_next_turn`, it would be 2, 0, 1.
+        state.active_player = PlayerId(1);
+        state.phase = Phase::Cleanup;
+
+        let mut events = Vec::new();
+        advance_phase_once(&mut state, &mut events);
+
+        let burn_order: Vec<PlayerId> = events
+            .iter()
+            .filter_map(|e| match e {
+                GameEvent::ManaBurn { player_id, .. } => Some(*player_id),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(
+            burn_order,
+            vec![PlayerId(1), PlayerId(2), PlayerId(0)],
+            "CR 101.4: the ending phase's APNAP order starts at the OUTGOING \
+             active player, not the incoming one"
+        );
+        // Paired control: the turn really did roll over, so this is the
+        // Cleanup -> Untap boundary and not an intra-turn step that never
+        // exercised the anchor.
+        assert_eq!(state.active_player, PlayerId(2));
+    }
+
+    /// A mana burn that defers through the CR 616.1 replacement pipeline still
+    /// reports WHY life was lost.
+    ///
+    /// The deferred loss completes in `apply_life_loss_after_replacement` and
+    /// never returns to `discharge_owed_life_losses`, so without the parked
+    /// provenance the `ManaBurn` event is simply never emitted and the player
+    /// sees life vanish with no stated cause.
+    #[test]
+    fn a_deferred_empty_pool_loss_still_names_its_cause_on_resume() {
+        let mut state = GameState::new_two_player(42);
+        state.pending_phase_transition_progress =
+            Some(crate::types::game_state::PhaseTransitionProgress {
+                remaining_players: VecDeque::new(),
+                next_phase: Phase::Untap,
+                previous_phase: Some(Phase::Cleanup),
+                owed_life_loss: VecDeque::new(),
+                in_flight_life_loss: Some(PendingEmptyPoolLifeLoss {
+                    player_id: PlayerId(0),
+                    amount: 2,
+                    cause: EmptyPoolLifeLossCause::ManaBurn,
+                }),
+                entering_cleanup: false,
+                drain_state: crate::types::game_state::PhaseTransitionDrainState::Ready,
+            });
+
+        // A replacement effect may have changed what was actually lost, so the
+        // event must carry the pipeline's number (1), not the parked one (2).
+        let mut events = Vec::new();
+        note_empty_pool_life_loss_resolved(&mut state, PlayerId(0), 1, &mut events);
+        assert_eq!(
+            events
+                .iter()
+                .filter_map(|e| match e {
+                    GameEvent::ManaBurn { player_id, amount } => Some((*player_id, *amount)),
+                    _ => None,
+                })
+                .collect::<Vec<_>>(),
+            vec![(PlayerId(0), 1)],
+            "the resumed loss must emit ManaBurn with the ACTUAL amount"
+        );
+
+        // Consumed: a later unrelated life loss must not inherit the cause.
+        let mut again = Vec::new();
+        note_empty_pool_life_loss_resolved(&mut state, PlayerId(0), 1, &mut again);
+        assert!(
+            again.is_empty(),
+            "the parked provenance is consumed once, not reusable"
+        );
+    }
+
     // CR 723.2 + CR 506.1 + CR 511.3 (test 7.1 — the discriminating core): control
     // under a NextCombatPhase entry is active EXACTLY within the target's combat
     // phase. Owner decides upkeep/draw/precombat-main and postcombat-main/end;
@@ -9687,7 +9859,7 @@ mod tests {
         let mut events = Vec::new();
 
         for phase in [Phase::Upkeep, Phase::Draw, Phase::PreCombatMain] {
-            enter_phase(&mut state, phase, &mut events);
+            enter_phase(&mut state, phase, &mut events, None);
             assert_eq!(
                 turn_control::turn_decision_maker(&state),
                 owner,
@@ -9701,7 +9873,7 @@ mod tests {
             Phase::CombatDamage,
             Phase::EndCombat,
         ] {
-            enter_phase(&mut state, phase, &mut events);
+            enter_phase(&mut state, phase, &mut events, None);
             assert_eq!(
                 turn_control::turn_decision_maker(&state),
                 controller,
@@ -9709,7 +9881,7 @@ mod tests {
             );
         }
         for phase in [Phase::PostCombatMain, Phase::End] {
-            enter_phase(&mut state, phase, &mut events);
+            enter_phase(&mut state, phase, &mut events, None);
             assert_eq!(
                 turn_control::turn_decision_maker(&state),
                 owner,
@@ -9762,14 +9934,14 @@ mod tests {
             "the full-turn control applies before combat"
         );
 
-        enter_phase(&mut state, Phase::BeginCombat, &mut events);
+        enter_phase(&mut state, Phase::BeginCombat, &mut events, None);
         assert_eq!(
             turn_control::turn_decision_maker(&state),
             expected_combat_controller,
             "the newest currently applicable effect controls combat"
         );
 
-        enter_phase(&mut state, Phase::PostCombatMain, &mut events);
+        enter_phase(&mut state, Phase::PostCombatMain, &mut events, None);
         assert_eq!(
             turn_control::turn_decision_maker(&state),
             full_turn_controller,
@@ -9817,11 +9989,11 @@ mod tests {
         }
         let mut events = Vec::new();
 
-        enter_phase(&mut state, Phase::BeginCombat, &mut events);
+        enter_phase(&mut state, Phase::BeginCombat, &mut events, None);
         assert_eq!(turn_control::turn_decision_maker(&state), PlayerId(2));
         assert_eq!(state.scheduled_turn_controls.len(), 1);
 
-        enter_phase(&mut state, Phase::PostCombatMain, &mut events);
+        enter_phase(&mut state, Phase::PostCombatMain, &mut events, None);
         assert!(state.scheduled_turn_controls.is_empty());
         assert_eq!(turn_control::turn_decision_maker(&state), PlayerId(1));
     }
@@ -9840,17 +10012,17 @@ mod tests {
         schedule_combat_phase_control(&mut state, owner, controller);
         let mut events = Vec::new();
 
-        enter_phase(&mut state, Phase::BeginCombat, &mut events);
+        enter_phase(&mut state, Phase::BeginCombat, &mut events, None);
         assert_eq!(
             turn_control::turn_decision_maker(&state),
             controller,
             "combat phase 1: controller pilots"
         );
-        enter_phase(&mut state, Phase::EndCombat, &mut events);
+        enter_phase(&mut state, Phase::EndCombat, &mut events, None);
         assert_eq!(turn_control::turn_decision_maker(&state), controller);
 
         // CR 500.8: a second (extra) combat phase begins.
-        enter_phase(&mut state, Phase::BeginCombat, &mut events);
+        enter_phase(&mut state, Phase::BeginCombat, &mut events, None);
         assert_eq!(
             turn_control::turn_decision_maker(&state),
             owner,
@@ -9888,7 +10060,7 @@ mod tests {
             Phase::End,
             Phase::Cleanup,
         ] {
-            enter_phase(&mut state, phase, &mut events);
+            enter_phase(&mut state, phase, &mut events, None);
         }
         assert_eq!(
             state.turn_decision_controller, None,
@@ -9907,7 +10079,7 @@ mod tests {
         assert_eq!(state.active_player, owner);
 
         // Owner now actually takes a combat phase → control activates.
-        enter_phase(&mut state, Phase::BeginCombat, &mut events);
+        enter_phase(&mut state, Phase::BeginCombat, &mut events, None);
         assert_eq!(
             turn_control::turn_decision_maker(&state),
             controller,
@@ -9930,7 +10102,7 @@ mod tests {
         schedule_combat_phase_control(&mut state, owner, controller);
         let mut events = Vec::new();
 
-        enter_phase(&mut state, Phase::BeginCombat, &mut events);
+        enter_phase(&mut state, Phase::BeginCombat, &mut events, None);
         assert_eq!(turn_control::turn_decision_maker(&state), controller);
         assert_eq!(
             state.priority_player, controller,

--- a/crates/engine/src/game/turns.rs
+++ b/crates/engine/src/game/turns.rs
@@ -374,6 +374,12 @@ fn enter_phase(
     //     the line below can therefore no longer have come from that door.
     state.pending_combat_lifelink = None;
 
+    // CR 500.1: captured BEFORE the assignment below, which is the only place
+    // the outgoing phase still exists. A phase-group crossing is a property of
+    // the pair, and every later reader of `state.phase` sees the destination on
+    // both sides.
+    let previous = state.phase;
+
     state.phase = next;
     if next == Phase::BeginCombat {
         state.combat_phases_started_this_turn =
@@ -387,23 +393,17 @@ fn enter_phase(
         state.end_steps_started_this_turn = state.end_steps_started_this_turn.saturating_add(1);
     }
 
-    // CR 500.5: Mana pools empty between phases/steps.
-    // Firebending mana (EndOfCombat expiry) persists within combat steps.
-    let in_combat = matches!(
-        next,
-        Phase::BeginCombat
-            | Phase::DeclareAttackers
-            | Phase::DeclareBlockers
-            | Phase::CombatDamage
-            | Phase::EndCombat
-    );
+    // CR 500.5: Mana pools empty between phases/steps. Retention-bound mana
+    // (Firebending's `EndOfCombat`, mana burn's `EndOfPhaseGroup`) survives
+    // until its own boundary, which is identified by the PAIR of phases — see
+    // `ManaPool::clear_expired_retention_markers`.
     let entering_cleanup = next == Phase::Cleanup;
 
     state.pending_phase_transition_progress =
         Some(crate::types::game_state::PhaseTransitionProgress {
             remaining_players: VecDeque::from(super::players::apnap_order(state)),
             next_phase: next,
-            in_combat,
+            previous_phase: Some(previous),
             entering_cleanup,
             drain_state: crate::types::game_state::PhaseTransitionDrainState::Ready,
         });
@@ -462,11 +462,45 @@ pub(super) fn apply_empty_mana_pool_event(
     // player's aggregate empty-pool event.
     let causes_life_loss =
         crate::game::static_abilities::player_unspent_mana_loss_causes_life_loss(state, player_id);
+    // Mana burn is a property of the FORMAT, read from the same resolved rules
+    // the deck gate uses, and is deliberately independent of the Yurlok-class
+    // query above: a card-granted static and an older rules set are different
+    // reasons to lose life, and neither implies the other.
+    let burns = crate::game::mana_burn::applies(state);
     let amount =
         crate::types::mana::apply_empty_mana_pool_decisions(state, player_id, &units, events);
     state.pending_step_end_mana_handlers.clear();
 
-    if !causes_life_loss || amount == 0 {
+    if amount == 0 {
+        return EmptyManaPoolApplyOutcome::Applied;
+    }
+
+    // Mana burn first, so its event precedes any Yurlok-class loss in the log
+    // and reads in rules order: the format's own rule, then a card's ability.
+    //
+    // A deferral here returns before the Yurlok branch runs, which would drop
+    // that loss for this event. That combination is unreachable rather than
+    // handled: the only formats declaring `mana_burn` are the Old School
+    // presets, whose card pools end decades before any Yurlok-class card was
+    // printed, and a lobby-saved custom format cannot declare the axis at all
+    // while `passes_legacy_axis_gate` rejects it. Left explicit instead of
+    // silently coincidental — if a format ever makes both reachable, this
+    // needs a continuation, not a reordering.
+    if burns {
+        events.push(GameEvent::ManaBurn { player_id, amount });
+        match crate::game::effects::life::apply_life_loss(state, player_id, amount, events) {
+            Ok(_) => {}
+            Err(crate::game::effects::life::ReplacementDeferred::ReplacementChoice) => {
+                return EmptyManaPoolApplyOutcome::Deferred
+            }
+            Err(crate::game::effects::life::ReplacementDeferred::SubstitutionContinuation) => {
+                mark_phase_transition_awaiting_post_replacement(state);
+                return EmptyManaPoolApplyOutcome::Deferred;
+            }
+        }
+    }
+
+    if !causes_life_loss {
         return EmptyManaPoolApplyOutcome::Applied;
     }
 
@@ -639,15 +673,28 @@ pub(super) fn drain_pending_phase_transition_progress(
             finish_enter_phase(state, next_phase, events);
             return;
         };
-        let in_combat = progress.in_combat;
+        let (previous_phase, next_phase_for_retention) =
+            (progress.previous_phase, progress.next_phase);
+        // Mana burn (pre-M10) holds unspent mana across the steps within one of
+        // CR 500.1's five phases, so it reaches the empty-pool pipeline only at
+        // the phase boundary. Marking runs BEFORE the clearing pass below: on an
+        // intra-phase step the marks are applied and then survive it, and at a
+        // crossing nothing is marked and the pass clears the marks left by
+        // earlier steps — so the units drop, and the drop count IS the burn.
+        let burns = crate::game::mana_burn::applies(state);
         // CR 500.5 + CR 703.4q: End reached retention durations first, then
         // route the still-unspent units through the ordinary empty-pool event.
         // Clearing only the marker preserves composition with any other active
         // retain / transform handler and lets Yurlok count actual loss.
         if let Some(player) = state.players.iter_mut().find(|p| p.id == player_id) {
+            if burns {
+                player
+                    .mana_pool
+                    .retain_across_phase_group_steps(previous_phase, next_phase_for_retention);
+            }
             player
                 .mana_pool
-                .clear_expired_end_of_combat_retention_markers(in_combat);
+                .clear_expired_retention_markers(previous_phase, next_phase_for_retention);
         }
 
         // Scan active step-end mana handlers for this player. Inlines the

--- a/crates/engine/src/game/turns.rs
+++ b/crates/engine/src/game/turns.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use std::collections::{HashSet, VecDeque};
 
 use crate::analysis::resource::ResourceAxis;
 use crate::game::filter::{matches_target_filter_including_phased_out, FilterContext};
@@ -10,8 +10,9 @@ use crate::types::counter::CounterType;
 use crate::types::events::GameEvent;
 use crate::types::format::GameFormat;
 use crate::types::game_state::{
-    AutoPassMode, ExtraPhase, ExtraTurn, GameState, LoopCollapseAxis, PayableResource,
-    PendingCounterAddition, PendingEffectResolved, TurnBoundary, WaitingFor,
+    AutoPassMode, EmptyPoolLifeLossCause, ExtraPhase, ExtraTurn, GameState, LoopCollapseAxis,
+    PayableResource, PendingCounterAddition, PendingEffectResolved, PendingEmptyPoolLifeLoss,
+    TurnBoundary, WaitingFor,
 };
 use crate::types::identifiers::ObjectId;
 use crate::types::phase::Phase;
@@ -404,6 +405,7 @@ fn enter_phase(
             remaining_players: VecDeque::from(super::players::apnap_order(state)),
             next_phase: next,
             previous_phase: Some(previous),
+            owed_life_loss: VecDeque::new(),
             entering_cleanup,
             drain_state: crate::types::game_state::PhaseTransitionDrainState::Ready,
         });
@@ -475,44 +477,103 @@ pub(super) fn apply_empty_mana_pool_event(
         return EmptyManaPoolApplyOutcome::Applied;
     }
 
-    // Mana burn first, so its event precedes any Yurlok-class loss in the log
-    // and reads in rules order: the format's own rule, then a card's ability.
+    // Both causes can apply to the same event and neither implies the other, so
+    // they are queued as independent losses rather than summed: a replacement
+    // effect sees two loss events in paper, and summing would show it one.
     //
-    // A deferral here returns before the Yurlok branch runs, which would drop
-    // that loss for this event. That combination is unreachable rather than
-    // handled: the only formats declaring `mana_burn` are the Old School
-    // presets, whose card pools end decades before any Yurlok-class card was
-    // printed, and a lobby-saved custom format cannot declare the axis at all
-    // while `passes_legacy_axis_gate` rejects it. Left explicit instead of
-    // silently coincidental — if a format ever makes both reachable, this
-    // needs a continuation, not a reordering.
+    // Mana burn is ordered first so it reads in rules order — the format's own
+    // rule, then a card's ability.
+    let mut owed: VecDeque<PendingEmptyPoolLifeLoss> = VecDeque::new();
     if burns {
-        events.push(GameEvent::ManaBurn { player_id, amount });
-        match crate::game::effects::life::apply_life_loss(state, player_id, amount, events) {
-            Ok(_) => {}
-            Err(crate::game::effects::life::ReplacementDeferred::ReplacementChoice) => {
-                return EmptyManaPoolApplyOutcome::Deferred
-            }
-            Err(crate::game::effects::life::ReplacementDeferred::SubstitutionContinuation) => {
-                mark_phase_transition_awaiting_post_replacement(state);
+        owed.push_back(PendingEmptyPoolLifeLoss {
+            player_id,
+            amount,
+            cause: EmptyPoolLifeLossCause::ManaBurn,
+        });
+    }
+    if causes_life_loss {
+        owed.push_back(PendingEmptyPoolLifeLoss {
+            player_id,
+            amount,
+            cause: EmptyPoolLifeLossCause::UnspentManaStatic,
+        });
+    }
+
+    discharge_owed_life_losses(state, owed, events)
+}
+
+/// Apply each life loss an empty-pool event owes, parking the remainder on the
+/// phase transition if one defers.
+///
+/// A deferral pauses mid-event with the player ALREADY popped from the APNAP
+/// queue, so anything still owed has to outlive this call or it is lost. The
+/// leftovers ride on `PhaseTransitionProgress::owed_life_loss`, which
+/// `drain_pending_phase_transition_progress` discharges before it moves on to
+/// the next player.
+pub(super) fn discharge_owed_life_losses(
+    state: &mut GameState,
+    mut owed: VecDeque<PendingEmptyPoolLifeLoss>,
+    events: &mut Vec<GameEvent>,
+) -> EmptyManaPoolApplyOutcome {
+    while let Some(next) = owed.pop_front() {
+        match crate::game::effects::life::apply_life_loss(
+            state,
+            next.player_id,
+            next.amount,
+            events,
+        ) {
+            // The ACTUAL life lost, which is not always what emptied: CR 119.8
+            // ("a player who can't lose life is unaffected") and prevention or
+            // replacement effects can reduce it, to zero. Narrating the pool
+            // count instead would tell a player they lost life they still have.
+            Ok(actual) => emit_life_loss_cause(next, actual, events),
+            Err(deferred) => {
+                // This loss is mid-flight and will complete through the
+                // replacement pipeline; only what has NOT been attempted is
+                // parked. Re-queuing `next` would apply it twice.
+                park_owed_life_losses(state, owed);
+                if matches!(
+                    deferred,
+                    crate::game::effects::life::ReplacementDeferred::SubstitutionContinuation
+                ) {
+                    mark_phase_transition_awaiting_post_replacement(state);
+                }
                 return EmptyManaPoolApplyOutcome::Deferred;
             }
         }
     }
+    EmptyManaPoolApplyOutcome::Applied
+}
 
-    if !causes_life_loss {
-        return EmptyManaPoolApplyOutcome::Applied;
+/// Emit the event that explains a completed empty-pool life loss.
+///
+/// Only mana burn has one: a Yurlok-class loss is already fully described by
+/// the `LifeChanged` its own resolution emits, whereas nothing else in the log
+/// would say that the FORMAT is why life was lost.
+fn emit_life_loss_cause(loss: PendingEmptyPoolLifeLoss, actual: u32, events: &mut Vec<GameEvent>) {
+    if actual == 0 {
+        return;
     }
+    match loss.cause {
+        EmptyPoolLifeLossCause::ManaBurn => events.push(GameEvent::ManaBurn {
+            player_id: loss.player_id,
+            amount: actual,
+        }),
+        EmptyPoolLifeLossCause::UnspentManaStatic => {}
+    }
+}
 
-    match crate::game::effects::life::apply_life_loss(state, player_id, amount, events) {
-        Ok(_) => EmptyManaPoolApplyOutcome::Applied,
-        Err(crate::game::effects::life::ReplacementDeferred::ReplacementChoice) => {
-            EmptyManaPoolApplyOutcome::Deferred
-        }
-        Err(crate::game::effects::life::ReplacementDeferred::SubstitutionContinuation) => {
-            mark_phase_transition_awaiting_post_replacement(state);
-            EmptyManaPoolApplyOutcome::Deferred
-        }
+fn park_owed_life_losses(state: &mut GameState, owed: VecDeque<PendingEmptyPoolLifeLoss>) {
+    if owed.is_empty() {
+        return;
+    }
+    if let Some(progress) = state.pending_phase_transition_progress.as_mut() {
+        progress.owed_life_loss = owed;
+    } else {
+        debug_assert!(
+            false,
+            "an empty-pool life loss deferred with no phase transition to park the remainder on"
+        );
     }
 }
 
@@ -572,6 +633,21 @@ pub(super) fn drain_pending_phase_transition_progress(
         .is_some_and(|progress| {
             progress.drain_state != crate::types::game_state::PhaseTransitionDrainState::Ready
         })
+    {
+        return;
+    }
+
+    // Finish the previous player's operation before starting anyone else's. A
+    // life loss that deferred through the replacement pipeline left the rest of
+    // its event parked here; the APNAP player it belongs to was popped before
+    // the pause, so nothing else would ever come back for it.
+    let owed = state
+        .pending_phase_transition_progress
+        .as_mut()
+        .map(|progress| std::mem::take(&mut progress.owed_life_loss))
+        .unwrap_or_default();
+    if !owed.is_empty()
+        && discharge_owed_life_losses(state, owed, events) == EmptyManaPoolApplyOutcome::Deferred
     {
         return;
     }

--- a/crates/engine/src/types/custom_format.rs
+++ b/crates/engine/src/types/custom_format.rs
@@ -644,7 +644,12 @@ pub enum LegacyAxis {
 
 /// Axes of `LegacyRuleSet` the engine actually enforces at runtime. Empty in
 /// Phase 1a; later phases populate this as each axis's behavior is wired in.
-pub const IMPLEMENTED_LEGACY_AXES: &[LegacyAxis] = &[];
+///
+/// `ManaBurn` joined in Phase 2b, which is what makes the Eternal Central Old
+/// School presets selectable — they were listed in `custom_format_registry`
+/// and rejected here from the moment they existed, and this one entry is the
+/// whole of what changed for them. See `game::mana_burn`.
+pub const IMPLEMENTED_LEGACY_AXES: &[LegacyAxis] = &[LegacyAxis::ManaBurn];
 
 fn declared_legacy_axes(rules: &LegacyRuleSet) -> Vec<LegacyAxis> {
     let mut axes = Vec::new();
@@ -897,10 +902,10 @@ fn card_names(names: &[&str]) -> Vec<CardName> {
 /// kept because the source states them, and because they must survive a future
 /// format that legitimately plays for ante.
 ///
-/// **Not registerable yet:** `mana_burn: Obsolete` is a `LegacyRuleSet` axis
-/// the engine does not implement, so `custom_format_registry`'s legacy-axis
-/// gate filters this out until Phase 2b lands. That is the gate working as
-/// designed, not a defect — see the registry's own doc comment.
+/// **Selectable as of Phase 2b.** `mana_burn: Obsolete` held this preset out
+/// of the registry from the moment it existed; adding `LegacyAxis::ManaBurn`
+/// to [`IMPLEMENTED_LEGACY_AXES`] is the entire change that released it — this
+/// constructor was not touched. See `game::mana_burn`.
 pub fn old_school_93_94() -> CustomFormatDef {
     CustomFormatDef {
         rules: CustomFormatRules {
@@ -984,7 +989,7 @@ pub fn old_school_93_94() -> CustomFormatDef {
 /// remaining CR 407.3 ante cards, which this era's pool newly contains.
 ///
 /// Everything else is inherited verbatim, including `mana_burn: Obsolete`, so
-/// this preset is withheld by the same legacy-axis gate until Phase 2b.
+/// this preset became selectable alongside its base in Phase 2b.
 pub fn old_school_95() -> CustomFormatDef {
     let mut def = old_school_93_94();
 
@@ -1041,13 +1046,12 @@ pub fn bundled_presets() -> Vec<CustomFormatDef> {
 /// Authoritative list of bundled custom-format presets, filtered through
 /// both registration gates.
 ///
-/// **Still resolves to empty, and every preset here is withheld for a stated
-/// reason rather than by omission.** The two Eternal Central presets are
-/// listed and then REJECTED by `passes_legacy_axis_gate`, because both declare
-/// `mana_burn: Obsolete` and the engine implements no mana burn yet; Phase 2b
-/// adds `LegacyAxis::ManaBurn` to `IMPLEMENTED_LEGACY_AXES` and they become
-/// selectable with no edit here. Listing them is the point — until now the
-/// gates filtered an empty vector and could not fail.
+/// **As of Phase 2b this returns the two Eternal Central presets** — the first
+/// custom formats the engine actually offers. They were listed here from the
+/// start and rejected by `passes_legacy_axis_gate` for declaring
+/// `mana_burn: Obsolete`; adding `LegacyAxis::ManaBurn` to
+/// [`IMPLEMENTED_LEGACY_AXES`] released both without touching either
+/// constructor, which is exactly what listing-then-filtering was for.
 ///
 /// [`swedish_old_school`] is the exception, and is deliberately NOT in this
 /// list: it PASSES both gates, so listing it would register it, and CONTEXT.md

--- a/crates/engine/src/types/events.rs
+++ b/crates/engine/src/types/events.rs
@@ -926,6 +926,23 @@ pub enum GameEvent {
         source_id: ObjectId,
         color: ManaType,
     },
+    /// Mana burn: a player lost life for mana unspent when one of CR 500.1's
+    /// five phases ended. Pre-M10 only — the current rules have no such rule
+    /// (glossary "Mana Burn (Obsolete)": "Older versions of the rules stated
+    /// that unspent mana caused a player to lose life"), so this is emitted
+    /// only for a custom format declaring `LegacyRuleSet.mana_burn`.
+    ///
+    /// Distinct from the Yurlok-class life loss a card's static ability
+    /// causes at the same seam: that is a card doing something, this is the
+    /// format's rules being older. A log that conflated them would tell a
+    /// player the wrong reason they are at 14 life.
+    ManaBurn {
+        player_id: PlayerId,
+        /// The number of mana units that emptied — a count, so `u32` like
+        /// `apply_empty_mana_pool_decisions` returns. Under mana burn the
+        /// emptied count IS the life lost, which is why no second tally exists.
+        amount: u32,
+    },
     /// CR 614.1a + CR 703.4q: A `Transform(_)` step-end mana handler (Horizon
     /// Stone, Kruphix, Omnath, Ozai) recolored a unit in place during the
     /// step-end empty event. The unit stays in the pool with its new color.

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -21161,7 +21161,18 @@ pub enum PhaseTransitionDrainState {
 pub struct PhaseTransitionProgress {
     pub remaining_players: VecDeque<PlayerId>,
     pub next_phase: Phase,
-    pub in_combat: bool,
+    /// The phase the turn is leaving, paired with `next_phase` to identify the
+    /// boundary being crossed. Replaces a derived `in_combat: bool`, which
+    /// carried strictly less information than the phase it was computed from
+    /// and could contradict `next_phase` if either were ever set separately —
+    /// CR 500.1's phase-group crossing cannot be recovered from the
+    /// destination alone.
+    ///
+    /// `#[serde(default)]` `None` for a `GameState` saved before this field
+    /// existed; see `ManaPool::clear_expired_retention_markers` for why that
+    /// resolves conservatively rather than guessing a crossing.
+    #[serde(default)]
+    pub previous_phase: Option<Phase>,
     pub entering_cleanup: bool,
     #[serde(default)]
     pub drain_state: PhaseTransitionDrainState,
@@ -21176,7 +21187,7 @@ mod phase_transition_progress_serde_tests {
         let progress = PhaseTransitionProgress {
             remaining_players: VecDeque::from([PlayerId(1)]),
             next_phase: Phase::Upkeep,
-            in_combat: false,
+            previous_phase: Some(Phase::Untap),
             entering_cleanup: false,
             drain_state: PhaseTransitionDrainState::AwaitingPostReplacementContinuation,
         };

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -21192,15 +21192,25 @@ pub struct PhaseTransitionProgress {
     /// it before advancing to the next player.
     #[serde(default)]
     pub owed_life_loss: VecDeque<PendingEmptyPoolLifeLoss>,
-    /// The empty-pool life loss currently IN FLIGHT through the CR 616.1
-    /// replacement pipeline, kept only to name its cause when it lands.
+    /// The empty-pool life loss currently IN FLIGHT through a CR 616.1 ordering
+    /// choice, kept only to name its cause when it lands.
     ///
-    /// Distinct from `owed_life_loss`, which holds losses not yet attempted:
-    /// this one has been applied and will complete elsewhere
-    /// (`apply_life_loss_after_replacement`), so re-applying it would double
-    /// it. Without this the loss still resolves correctly, but nothing records
-    /// WHY — a deferred mana burn would silently lose its `ManaBurn` event and
-    /// the player would see life vanish with no stated reason.
+    /// Distinct from `owed_life_loss`, which holds losses not yet ATTEMPTED:
+    /// this one has entered the pipeline and will complete elsewhere
+    /// (`apply_life_loss_after_replacement`), so re-queuing it would double it.
+    /// Without this the loss still resolves correctly, but nothing records WHY
+    /// — a deferred mana burn would silently lose its `ManaBurn` event and the
+    /// player would see life vanish with no stated reason.
+    ///
+    /// Set ONLY for `ReplacementDeferred::ReplacementChoice`, where the amount
+    /// is still unknown. A `SubstitutionContinuation` deferral has already
+    /// applied the root loss and carries the figure back to the drain, which
+    /// narrates it on the spot — parking that case would strand the record,
+    /// since the resume that finishes a substitute is not the one that applied
+    /// the root.
+    ///
+    /// Every terminal outcome of that choice must consume this, `Prevented`
+    /// included; see `turns::note_empty_pool_life_loss_resolved`.
     #[serde(default)]
     pub in_flight_life_loss: Option<PendingEmptyPoolLifeLoss>,
     /// The phase the turn is leaving, paired with `next_phase` to identify the

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -21192,6 +21192,17 @@ pub struct PhaseTransitionProgress {
     /// it before advancing to the next player.
     #[serde(default)]
     pub owed_life_loss: VecDeque<PendingEmptyPoolLifeLoss>,
+    /// The empty-pool life loss currently IN FLIGHT through the CR 616.1
+    /// replacement pipeline, kept only to name its cause when it lands.
+    ///
+    /// Distinct from `owed_life_loss`, which holds losses not yet attempted:
+    /// this one has been applied and will complete elsewhere
+    /// (`apply_life_loss_after_replacement`), so re-applying it would double
+    /// it. Without this the loss still resolves correctly, but nothing records
+    /// WHY — a deferred mana burn would silently lose its `ManaBurn` event and
+    /// the player would see life vanish with no stated reason.
+    #[serde(default)]
+    pub in_flight_life_loss: Option<PendingEmptyPoolLifeLoss>,
     /// The phase the turn is leaving, paired with `next_phase` to identify the
     /// boundary being crossed. Replaces a derived `in_combat: bool`, which
     /// carried strictly less information than the phase it was computed from
@@ -21220,6 +21231,7 @@ mod phase_transition_progress_serde_tests {
             next_phase: Phase::Upkeep,
             previous_phase: Some(Phase::Untap),
             owed_life_loss: VecDeque::new(),
+            in_flight_life_loss: None,
             entering_cleanup: false,
             drain_state: PhaseTransitionDrainState::AwaitingPostReplacementContinuation,
         };

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -21157,10 +21157,41 @@ pub enum PhaseTransitionDrainState {
     AwaitingPostReplacementContinuation,
 }
 
+/// Why an empty-pool event is costing a player life. Two independent causes
+/// can apply to the SAME event, and they are not interchangeable: one is the
+/// format's rules being older, the other is a card doing something.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum EmptyPoolLifeLossCause {
+    /// The pre-M10 mana-burn rule, per `LegacyRuleSet.mana_burn`. Emits
+    /// `GameEvent::ManaBurn` once the loss actually completes.
+    ManaBurn,
+    /// A Yurlok-class static ability that makes unspent mana cost life.
+    UnspentManaStatic,
+}
+
+/// A life loss an empty-pool event still owes, carried across a replacement
+/// deferral.
+///
+/// CR 616.1 life-loss replacement can pause mid-event, and the player was
+/// already popped from the APNAP queue by then — so without this the rest of
+/// that player's operation would be silently skipped when the transition
+/// resumes, and the next player would be processed instead.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PendingEmptyPoolLifeLoss {
+    pub player_id: PlayerId,
+    pub amount: u32,
+    pub cause: EmptyPoolLifeLossCause,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PhaseTransitionProgress {
     pub remaining_players: VecDeque<PlayerId>,
     pub next_phase: Phase,
+    /// Life losses this transition still owes, in the order they must apply.
+    /// Non-empty only between a deferral and its resume; the drain discharges
+    /// it before advancing to the next player.
+    #[serde(default)]
+    pub owed_life_loss: VecDeque<PendingEmptyPoolLifeLoss>,
     /// The phase the turn is leaving, paired with `next_phase` to identify the
     /// boundary being crossed. Replaces a derived `in_combat: bool`, which
     /// carried strictly less information than the phase it was computed from
@@ -21188,6 +21219,7 @@ mod phase_transition_progress_serde_tests {
             remaining_players: VecDeque::from([PlayerId(1)]),
             next_phase: Phase::Upkeep,
             previous_phase: Some(Phase::Untap),
+            owed_life_loss: VecDeque::new(),
             entering_cleanup: false,
             drain_state: PhaseTransitionDrainState::AwaitingPostReplacementContinuation,
         };

--- a/crates/engine/src/types/mana.rs
+++ b/crates/engine/src/types/mana.rs
@@ -11,6 +11,7 @@ use super::events::GameEvent;
 use super::game_state::ProductionOverride;
 use super::identifiers::{ObjectId, ObjectIncarnationRef};
 use super::keywords::{Keyword, KeywordKind};
+use super::phase::Phase;
 use super::player::PlayerId;
 use super::zones::Zone;
 
@@ -1531,6 +1532,18 @@ pub enum ManaExpiry {
     /// Mana persists through combat steps but drains at EndCombat → PostCombatMain.
     /// Used by Firebending and similar "mana lasts within combat" mechanics.
     EndOfCombat,
+    /// Mana persists through the steps of whichever of CR 500.1's five phases is
+    /// active, and drains only when the turn crosses into a different one.
+    ///
+    /// The pre-M10 mana-burn rule, which emptied pools at end of PHASE rather
+    /// than end of step (see the "Mana Burn (Obsolete)" glossary entry), and is
+    /// opted into per format by `LegacyRuleSet.mana_burn`.
+    ///
+    /// Generalizes [`ManaExpiry::EndOfCombat`], which is this same "survive my
+    /// phase's internal steps, drain at the real boundary" shape hardcoded to
+    /// one phase. Like its two siblings this variant names no specific phase —
+    /// it resolves against whichever group is active when it is checked.
+    EndOfPhaseGroup,
 }
 
 /// CR 205.4g: Supertype carried by produced mana (Snow today; extensible).
@@ -2316,12 +2329,67 @@ impl ManaPool {
     /// effect may still apply.
     ///
     /// - `EndOfCombat`: marker clears when leaving combat (CR 500.5a).
+    /// - `EndOfPhaseGroup`: marker clears when the turn crosses from one of
+    ///   CR 500.1's five phases into another.
     /// - `EndOfTurn`: marker remains until the cleanup action (CR 514.2).
     /// - `None`: already eligible for the ordinary empty-pool event.
-    pub fn clear_expired_end_of_combat_retention_markers(&mut self, in_combat: bool) {
+    ///
+    /// `from` is the PRE-transition phase and is `None` only for a `GameState`
+    /// saved before it was recorded. A phase-group crossing cannot be computed
+    /// without it, so such a resume leaves `EndOfPhaseGroup` units retained —
+    /// the conservative direction, since the alternative would burn a player
+    /// for mana at a boundary the engine cannot confirm they crossed.
+    ///
+    /// `EndOfCombat` deliberately still keys off the DESTINATION alone rather
+    /// than the crossing, preserving its existing behavior exactly: a stray
+    /// combat-retained unit drains at the next non-combat step whether or not
+    /// that step is a phase-group boundary.
+    pub fn clear_expired_retention_markers(&mut self, from: Option<Phase>, to: Phase) {
+        let leaving_phase_group = from.is_some_and(|from| from.group() != to.group());
         for unit in &mut self.mana {
-            if matches!(unit.expiry, Some(ManaExpiry::EndOfCombat)) && !in_combat {
+            let expired = match unit.expiry {
+                // CR 500.5a
+                Some(ManaExpiry::EndOfCombat) => !to.is_combat(),
+                // CR 500.1
+                Some(ManaExpiry::EndOfPhaseGroup) => leaving_phase_group,
+                // CR 514.2: cleared by the cleanup action, not here.
+                Some(ManaExpiry::EndOfTurn) => false,
+                None => false,
+            };
+            if expired {
                 unit.expiry = None;
+            }
+        }
+    }
+
+    /// Mana burn: hold unspent mana across the steps INSIDE one of CR 500.1's
+    /// five phases, so it empties only at the phase boundary — where the
+    /// emptied count is the life the player loses.
+    ///
+    /// Marks ordinary units with [`ManaExpiry::EndOfPhaseGroup`], reusing the
+    /// same retention mechanism Firebending's `EndOfCombat` already rides on,
+    /// rather than suppressing the drain: retention is what keeps a unit out of
+    /// the `Drop` set, and a second way to do that could disagree with the
+    /// first.
+    ///
+    /// **Marks here, not at each `ManaUnit` construction.** A unit cannot know
+    /// the format it was produced under — `ManaUnit::new` takes no state, and
+    /// there are well over a hundred construction sites, most of them tests.
+    /// The phase transition is the one place that has both the pool and the
+    /// resolved rules, and it is also the only place the mark is ever read.
+    ///
+    /// At a real crossing this deliberately does nothing, leaving the units
+    /// ordinary so [`Self::clear_expired_retention_markers`] and the
+    /// empty-pool pipeline treat them exactly as they treat any other unspent
+    /// mana. That is what makes the burn amount fall out of the existing drop
+    /// count instead of needing a second, separately-computed tally.
+    pub fn retain_across_phase_group_steps(&mut self, from: Option<Phase>, to: Phase) {
+        if from.is_some_and(|from| from.group() != to.group()) {
+            return;
+        }
+        for unit in &mut self.mana {
+            if unit.expiry.is_none() {
+                unit.expiry = Some(ManaExpiry::EndOfPhaseGroup);
             }
         }
     }
@@ -2777,7 +2845,7 @@ mod tests {
 
         // Non-cleanup transition: EndOfTurn unit survives; non-expiry unit
         // is left in place (the pipeline drives Drop disposition elsewhere).
-        pool.clear_expired_end_of_combat_retention_markers(false);
+        pool.clear_expired_retention_markers(Some(Phase::Upkeep), Phase::Draw);
         assert_eq!(pool.count_color(ManaType::Green), 1);
         assert_eq!(pool.count_color(ManaType::Red), 1);
         assert_eq!(pool.mana[0].expiry, Some(ManaExpiry::EndOfTurn));
@@ -2799,13 +2867,51 @@ mod tests {
 
         // In-combat transition (e.g., DeclareAttackers → DeclareBlockers):
         // EndOfCombat unit survives.
-        pool.clear_expired_end_of_combat_retention_markers(true);
+        pool.clear_expired_retention_markers(Some(Phase::DeclareAttackers), Phase::DeclareBlockers);
         assert_eq!(pool.count_color(ManaType::Red), 1);
         assert_eq!(pool.mana[0].expiry, Some(ManaExpiry::EndOfCombat));
 
         // Leaving combat ends the retention duration; ordinary empty-pool
         // processing decides the unit's final disposition.
-        pool.clear_expired_end_of_combat_retention_markers(false);
+        pool.clear_expired_retention_markers(Some(Phase::EndCombat), Phase::PostCombatMain);
+        assert_eq!(pool.total(), 1);
+        assert_eq!(pool.mana[0].expiry, None);
+    }
+
+    /// CR 500.1: the pre-M10 boundary is the PHASE, not the step. A unit must
+    /// survive every intra-phase step and clear only on a real crossing.
+    #[test]
+    fn mana_pool_clears_end_of_phase_group_marker_only_when_crossing_phases() {
+        let mut pool = ManaPool::default();
+        let mut burn_mana = make_unit(ManaType::Red);
+        burn_mana.expiry = Some(ManaExpiry::EndOfPhaseGroup);
+        pool.add(burn_mana);
+
+        // Intra-group steps, across three different groups, all retain. The
+        // combat pair is the one the old `EndOfCombat` rule already handled;
+        // the beginning-phase pair is the one it never could.
+        for (from, to) in [
+            (Phase::Untap, Phase::Upkeep),
+            (Phase::Upkeep, Phase::Draw),
+            (Phase::DeclareAttackers, Phase::DeclareBlockers),
+            (Phase::End, Phase::Cleanup),
+        ] {
+            pool.clear_expired_retention_markers(Some(from), to);
+            assert_eq!(
+                pool.mana[0].expiry,
+                Some(ManaExpiry::EndOfPhaseGroup),
+                "{from:?} -> {to:?} stays inside one phase and must retain"
+            );
+        }
+
+        // An unknown pre-transition phase (a save predating the field) also
+        // retains — the crossing cannot be confirmed, so it is not assumed.
+        pool.clear_expired_retention_markers(None, Phase::PreCombatMain);
+        assert_eq!(pool.mana[0].expiry, Some(ManaExpiry::EndOfPhaseGroup));
+
+        // A real crossing clears the marker, handing the unit to the ordinary
+        // empty-pool pipeline.
+        pool.clear_expired_retention_markers(Some(Phase::Draw), Phase::PreCombatMain);
         assert_eq!(pool.total(), 1);
         assert_eq!(pool.mana[0].expiry, None);
     }

--- a/crates/engine/src/types/phase.rs
+++ b/crates/engine/src/types/phase.rs
@@ -62,18 +62,61 @@ pub enum TurnDirection {
     Reversed,
 }
 
+/// CR 500.1: "A turn consists of five phases, in this order: beginning,
+/// precombat main, combat, postcombat main, and ending."
+///
+/// [`Phase`] flattens MTG's phases AND steps into one list — `DeclareAttackers`
+/// and `CombatDamage` are separate `Phase` variants inside the single real
+/// combat phase — because almost everything the engine does happens per step.
+/// This type recovers the distinction CR 500.1 draws, for the rules that are
+/// about the PHASE rather than the step within it.
+///
+/// Deliberately not parameterized by anything: it is a total, closed
+/// classification of `Phase`, so `Phase::group` is exhaustive and a future
+/// `Phase` variant cannot be added without the compiler demanding a group for
+/// it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum PhaseGroup {
+    /// CR 501.1: untap, upkeep, draw.
+    Beginning,
+    /// CR 505.1: the first main phase.
+    PrecombatMain,
+    /// CR 506.1: the five combat steps.
+    Combat,
+    /// CR 505.1: the second main phase.
+    PostcombatMain,
+    /// CR 512.1: end and cleanup.
+    Ending,
+}
+
 impl Phase {
     /// CR 506.1: The combat phase has five steps: beginning of combat, declare
     /// attackers, declare blockers, combat damage, and end of combat.
     pub fn is_combat(self) -> bool {
-        matches!(
-            self,
+        matches!(self.group(), PhaseGroup::Combat)
+    }
+
+    /// CR 500.1: which of the turn's five phases this step belongs to.
+    ///
+    /// Exhaustive by construction — no wildcard arm — so adding a `Phase`
+    /// variant is a compile error here rather than a silent mis-grouping.
+    pub fn group(self) -> PhaseGroup {
+        match self {
+            // CR 501.1
+            Phase::Untap | Phase::Upkeep | Phase::Draw => PhaseGroup::Beginning,
+            // CR 505.1
+            Phase::PreCombatMain => PhaseGroup::PrecombatMain,
+            // CR 506.1
             Phase::BeginCombat
-                | Phase::DeclareAttackers
-                | Phase::DeclareBlockers
-                | Phase::CombatDamage
-                | Phase::EndCombat
-        )
+            | Phase::DeclareAttackers
+            | Phase::DeclareBlockers
+            | Phase::CombatDamage
+            | Phase::EndCombat => PhaseGroup::Combat,
+            // CR 505.1
+            Phase::PostCombatMain => PhaseGroup::PostcombatMain,
+            // CR 512.1
+            Phase::End | Phase::Cleanup => PhaseGroup::Ending,
+        }
     }
 }
 

--- a/crates/engine/tests/integration/custom_format_schema.rs
+++ b/crates/engine/tests/integration/custom_format_schema.rs
@@ -162,9 +162,22 @@ fn validate_custom_rules_consistency_accepts_every_builtin_default() {
 
 #[test]
 fn legacy_axis_gate_rejects_undeclared_axis() {
+    // Uses damage timing, not mana burn: Phase 2b implemented mana burn, so it
+    // is no longer an example of an UNimplemented axis. The gate's job is
+    // unchanged — the set it checks against simply grew.
+    let mut def = sample_def(1);
+    def.rules.legality.legacy.damage_timing = CombatDamageTiming::OnStack;
+    assert!(!passes_legacy_axis_gate(&def.rules.legality.legacy));
+}
+
+/// The other side of that change: an axis the engine now DOES implement must
+/// pass. Without this, `IMPLEMENTED_LEGACY_AXES` could be emptied again and
+/// only the EC presets' registry test would notice.
+#[test]
+fn legacy_axis_gate_accepts_the_implemented_mana_burn_axis() {
     let mut def = sample_def(1);
     def.rules.legality.legacy.mana_burn = ManaBurnPolicy::Obsolete;
-    assert!(!passes_legacy_axis_gate(&def.rules.legality.legacy));
+    assert!(passes_legacy_axis_gate(&def.rules.legality.legacy));
 }
 
 #[test]
@@ -380,16 +393,16 @@ fn old_school_95_extends_93_94_by_exactly_its_declared_deltas() {
     assert_ne!(extended.short_label, base.short_label);
 }
 
-/// The legacy-axis gate, exercised against real entries for the first time.
-/// Both EC presets declare `mana_burn: Obsolete`, which the engine does not
-/// implement, so `custom_format_registry()` must list and then reject them.
+/// Phase 2b's payoff: the two EC presets are now SELECTABLE. They were listed
+/// in `bundled_presets()` and rejected by the legacy-axis gate from the moment
+/// they existed; implementing mana burn released them without either
+/// constructor changing.
 #[test]
-fn the_eternal_central_presets_are_listed_but_withheld_by_the_legacy_axis_gate() {
-    // "Listed but withheld" is a claim about `bundled_presets()`, so assert it
-    // there. Checking only that the registry is empty would keep passing if
-    // both presets were quietly dropped from the list — the registry would
-    // still be empty, and independently-constructed presets would still fail
-    // the gate, so nothing would catch it.
+fn the_eternal_central_presets_are_registered_once_mana_burn_is_implemented() {
+    // Still asserted against the pre-gate list, for the same reason as before:
+    // "registered" is only meaningful if they were considered in the first
+    // place, and a registry assertion alone cannot tell a listed-and-passing
+    // preset from one that was never listed.
     let listed: BTreeSet<u16> = bundled_presets().iter().map(|def| def.rules.id.0).collect();
     assert!(
         listed.contains(&old_school_93_94().rules.id.0)
@@ -403,18 +416,20 @@ fn the_eternal_central_presets_are_listed_but_withheld_by_the_legacy_axis_gate()
     for preset in bundled_presets() {
         let label = preset.label.clone();
         assert!(
-            !passes_legacy_axis_gate(&preset.rules.legality.legacy),
-            "{label} declares mana burn, which IMPLEMENTED_LEGACY_AXES does not cover yet"
+            passes_legacy_axis_gate(&preset.rules.legality.legacy),
+            "{label} declares only mana burn, which IMPLEMENTED_LEGACY_AXES now covers"
         );
-        // The OTHER gate must pass, so the rejection above is attributable to
-        // the unimplemented axis and not to mismatched reprint metadata.
         assert!(passes_reprint_fidelity_gate(&preset), "{label}");
         assert_no_lobby_save_sentinel_collision(&[preset]);
     }
 
-    assert!(
-        engine::types::custom_format::custom_format_registry().is_empty(),
-        "neither EC preset is selectable until mana burn lands (Phase 2b)"
+    let registry = engine::types::custom_format::custom_format_registry();
+    let registered: BTreeSet<u16> = registry.iter().map(|def| def.rules.id.0).collect();
+    assert_eq!(
+        registered,
+        BTreeSet::from([old_school_93_94().rules.id.0, old_school_95().rules.id.0]),
+        "exactly the two EC presets are selectable; got {:?}",
+        registry.iter().map(|def| &def.label).collect::<Vec<_>>()
     );
 }
 
@@ -490,9 +505,13 @@ fn custom_format_registry_withholds_swedish_old_school_on_open_item_6() {
         "Swedish passes both gates, so listing it in bundled_presets() would register it"
     );
 
+    // The registry is no longer empty as of Phase 2b, so absence has to be
+    // asserted by identity rather than by emptiness — which is the stronger
+    // assertion anyway, and would have caught a Swedish entry appearing
+    // alongside the EC ones.
     let registry = engine::types::custom_format::custom_format_registry();
     assert!(
-        registry.is_empty(),
+        !registry.iter().any(|def| def.rules.id == preset.rules.id),
         "swedish_old_school() must not be selectable while Open item 6 is unresolved; got {:?}",
         registry.iter().map(|def| &def.label).collect::<Vec<_>>()
     );
@@ -1262,12 +1281,16 @@ fn format_config_deserialization_rejects_a_custom_payload_forging_a_looser_copy_
 fn format_config_deserialization_rejects_a_custom_payload_declaring_an_unimplemented_legacy_axis() {
     // Hostile fixture: structurally self-consistent (the resolver check
     // would pass), but custom_rules.legality.legacy declares
-    // ManaBurnPolicy::Obsolete — a LegacyAxis not in IMPLEMENTED_LEGACY_AXES.
-    // Accepting it would promise mana-burn behavior no engine code enforces.
-    // The registry gate alone does not cover this: a deserialized Custom
-    // config never passes through custom_format_registry().
+    // CombatDamageTiming::OnStack — a LegacyAxis not in
+    // IMPLEMENTED_LEGACY_AXES. Accepting it would promise damage-on-the-stack
+    // behavior no engine code enforces. The registry gate alone does not cover
+    // this: a deserialized Custom config never passes through
+    // custom_format_registry().
+    //
+    // Was mana burn until Phase 2b implemented it; the axis had to change for
+    // the fixture to stay hostile, which is the gate auto-narrowing as designed.
     let mut rules = sample_rules(5);
-    rules.legality.legacy.mana_burn = ManaBurnPolicy::Obsolete;
+    rules.legality.legacy.damage_timing = CombatDamageTiming::OnStack;
     let config = FormatConfig::for_custom_rules(&rules);
     let json = serde_json::to_value(&config).unwrap();
     let error = serde_json::from_value::<FormatConfig>(json)
@@ -2503,6 +2526,8 @@ fn a_preset_claiming_the_lobby_save_sentinel_id_trips_the_registration_assert() 
 fn presets_with_ordinary_ids_pass_the_sentinel_guard() {
     // Paired positive control: the guard must not reject every preset.
     assert_no_lobby_save_sentinel_collision(&[sample_def(1), sample_def(2)]);
-    // And the real registry construction path still runs it without firing.
-    assert!(engine::types::custom_format::custom_format_registry().is_empty());
+    // And the real registry construction path still runs it without firing —
+    // now over real entries rather than an empty vector, which is what makes
+    // this a live check on the shipped presets.
+    assert!(!engine::types::custom_format::custom_format_registry().is_empty());
 }

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -933,6 +933,7 @@ mod magus_of_the_abyss_scoped_chooser;
 mod make_an_example_pile_separation;
 mod make_your_move_pt_suffix_binds_creature_leg;
 mod mana_autotap_preference;
+mod mana_burn;
 mod mana_cost_reducers_issue_141;
 mod mana_display_self_sacrifice_clone_gate;
 mod mana_drain_refund;

--- a/crates/engine/tests/integration/mana_burn.rs
+++ b/crates/engine/tests/integration/mana_burn.rs
@@ -154,3 +154,70 @@ fn a_custom_format_without_the_axis_does_not_burn() {
     );
     assert_eq!(runner.life(P0), life_before);
 }
+
+/// Diagnostic: is the missing cleanup-exit drain pre-existing, or introduced by
+/// mana burn? `EndOfTurn` retention (Klauth) has nothing to do with this PR —
+/// its marker is cleared by the cleanup action itself, leaving an ordinary
+/// unspent unit that the ending phase should empty. Under a MODERN format.
+#[test]
+fn diagnostic_end_of_turn_mana_does_not_survive_into_the_next_turn() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::End);
+    scenario.with_library_top(P0, &["Mountain", "Mountain", "Mountain"]);
+    let mut retained = ManaUnit::new(ManaType::Red, ObjectId(9_002), false, vec![]);
+    retained.expiry = Some(engine::types::mana::ManaExpiry::EndOfTurn);
+    scenario.with_mana_pool(P0, vec![retained]);
+    let mut runner = scenario.build();
+    runner.state_mut().format_config = FormatConfig::standard();
+
+    let turn_before = runner.state().turn_number;
+    runner.advance_to_phase(Phase::Untap);
+    assert_ne!(
+        runner.state().turn_number,
+        turn_before,
+        "the turn must actually roll over; halted on {:?}",
+        runner.state().waiting_for
+    );
+    assert_eq!(
+        unspent(&runner),
+        0,
+        "CR 106.4: the ending phase must empty the pool before the next turn"
+    );
+}
+
+/// The review's HIGH finding, tested directly: mana produced during the END
+/// step is retained across End -> Cleanup (both inside CR 512.1's ending
+/// phase), so the ending phase's own boundary — Cleanup -> Untap — is the one
+/// that must empty it and charge the burn.
+#[test]
+fn mana_held_through_the_ending_phase_burns_before_the_next_turn() {
+    let format = FormatConfig::for_custom_rules(&old_school_93_94().rules);
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::End);
+    scenario.with_library_top(P0, &["Mountain", "Mountain", "Mountain"]);
+    scenario.with_mana_pool(P0, pool(POOL));
+    let mut runner = scenario.build();
+    runner.state_mut().format_config = format;
+
+    let life_before = runner.life(P0);
+    let turn_before = runner.state().turn_number;
+    assert_eq!(unspent(&runner), POOL);
+
+    runner.advance_to_phase(Phase::Untap);
+    assert_ne!(
+        runner.state().turn_number,
+        turn_before,
+        "the turn must roll over; halted on {:?}",
+        runner.state().waiting_for
+    );
+    assert_eq!(
+        unspent(&runner),
+        0,
+        "mana must not survive the ending phase into the next turn"
+    );
+    assert_eq!(
+        runner.life(P0),
+        life_before - POOL as i32,
+        "the ending phase's boundary charges the burn like any other"
+    );
+}

--- a/crates/engine/tests/integration/mana_burn.rs
+++ b/crates/engine/tests/integration/mana_burn.rs
@@ -1,0 +1,156 @@
+//! Mana burn — the pre-M10 rule a custom format can opt back into.
+//!
+//! The current rules have no such rule; the glossary entry "Mana Burn
+//! (Obsolete)" records that "unspent mana caused a player to lose life."
+//! Two things separate it from the modern behavior, and both are asserted
+//! here against a real phase advance rather than against the helpers:
+//!
+//! 1. **Pools empty at the end of a PHASE (CR 500.1's five), not every step.**
+//!    Modern CR 106.4 / CR 500.5 empty at the end of each step AND phase.
+//! 2. **Emptying costs life** equal to the mana lost.
+//!
+//! Every assertion is paired against the same scenario under a modern format,
+//! so a failure to burn and a failure to set the scenario up are
+//! distinguishable.
+
+use engine::game::scenario::{GameRunner, GameScenario, P0};
+use engine::types::custom_format::{old_school_93_94, swedish_old_school};
+use engine::types::format::FormatConfig;
+use engine::types::identifiers::ObjectId;
+use engine::types::mana::{ManaType, ManaUnit};
+use engine::types::phase::Phase;
+
+const POOL: usize = 2;
+
+fn pool(count: usize) -> Vec<ManaUnit> {
+    vec![ManaUnit::new(ManaType::Red, ObjectId(9_001), false, vec![]); count]
+}
+
+/// A game sitting in the upkeep step with `POOL` unspent mana, under `format`.
+///
+/// Upkeep is chosen deliberately: it is inside the beginning phase (CR 501.1)
+/// alongside untap and draw, so the untap → upkeep → draw run exercises steps
+/// the OLD `EndOfCombat` retention could never have covered. A combat-only
+/// implementation would pass a combat-based test while failing this one.
+fn game_in_upkeep_with_mana(format: FormatConfig) -> GameRunner {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::Upkeep);
+    // CR 704.5b: the draw step draws a card, and an empty library loses the
+    // game — which ends the turn before any phase boundary is reached. Stocking
+    // the library keeps the game alive long enough to observe the boundary.
+    scenario.with_library_top(P0, &["Mountain", "Mountain", "Mountain"]);
+    scenario.with_mana_pool(P0, pool(POOL));
+    let mut runner = scenario.build();
+    runner.state_mut().format_config = format;
+    runner
+}
+
+fn unspent(runner: &GameRunner) -> usize {
+    runner
+        .state()
+        .players
+        .iter()
+        .find(|p| p.id == P0)
+        .expect("player 0 exists")
+        .mana_pool
+        .total()
+}
+
+/// Old School 93/94 declares `mana_burn: Obsolete`, so this is the shipped
+/// preset's own behavior, not a synthetic config.
+#[test]
+fn mana_survives_steps_inside_a_phase_and_burns_when_the_phase_ends() {
+    let format = FormatConfig::for_custom_rules(&old_school_93_94().rules);
+    let mut runner = game_in_upkeep_with_mana(format);
+    let life_before = runner.life(P0);
+    assert_eq!(unspent(&runner), POOL, "scenario starts with unspent mana");
+
+    // Upkeep -> Draw: a step boundary INSIDE the beginning phase (CR 501.1).
+    // Modern rules would empty the pool here; the pre-M10 rule does not.
+    runner.advance_to_phase(Phase::Draw);
+    assert_eq!(runner.state().phase, Phase::Draw);
+    assert_eq!(
+        unspent(&runner),
+        POOL,
+        "mana must survive a step boundary within one phase"
+    );
+    assert_eq!(
+        runner.life(P0),
+        life_before,
+        "no life is lost until the phase itself ends"
+    );
+
+    // Draw -> PreCombatMain: a real CR 500.1 phase crossing. The pool empties
+    // and the emptied count is the life lost.
+    runner.advance_to_phase(Phase::PreCombatMain);
+    assert_eq!(
+        runner.state().phase,
+        Phase::PreCombatMain,
+        "did not reach the phase boundary; halted waiting on {:?}",
+        runner.state().waiting_for
+    );
+    assert_eq!(
+        unspent(&runner),
+        0,
+        "the pool empties at the phase boundary"
+    );
+    assert_eq!(
+        runner.life(P0),
+        life_before - POOL as i32,
+        "mana burn costs one life per unspent mana"
+    );
+
+    // NOTE: the `GameEvent::ManaBurn` narration is deliberately NOT asserted
+    // here. `advance_to_phase` discards the events it drives, and the log is
+    // carried on `ActionResult` rather than `GameState`, so there is no honest
+    // way to observe it from this harness — asserting something weaker and
+    // calling it event coverage would be worse than saying so. Life total and
+    // pool contents below are the player-visible behavior either way.
+}
+
+/// The paired control: the same scenario under a modern format. Without this,
+/// every assertion above would still pass against an engine that emptied pools
+/// at the wrong time or never emptied them at all.
+#[test]
+fn a_modern_format_empties_every_step_and_costs_no_life() {
+    let mut runner = game_in_upkeep_with_mana(FormatConfig::standard());
+    let life_before = runner.life(P0);
+
+    runner.advance_to_phase(Phase::Draw);
+    assert_eq!(
+        unspent(&runner),
+        0,
+        "CR 106.4 / CR 500.5: modern pools empty at the end of every step"
+    );
+    assert_eq!(runner.life(P0), life_before, "emptying costs nothing");
+
+    // The same second advance the mana-burn test makes. If the harness cannot
+    // cross this boundary even with an empty pool, that is a scenario-driver
+    // limitation and not a mana-burn defect — this is what tells them apart.
+    runner.advance_to_phase(Phase::PreCombatMain);
+    assert_eq!(
+        runner.state().phase,
+        Phase::PreCombatMain,
+        "halted waiting on {:?}",
+        runner.state().waiting_for
+    );
+    assert_eq!(runner.life(P0), life_before);
+}
+
+/// A custom format that does NOT declare the axis behaves like a built-in.
+/// Swedish Old School is the shipped preset that proves it: an old card pool
+/// played under fully modern rules, which is exactly what its source says.
+#[test]
+fn a_custom_format_without_the_axis_does_not_burn() {
+    let format = FormatConfig::for_custom_rules(&swedish_old_school().rules);
+    let mut runner = game_in_upkeep_with_mana(format);
+    let life_before = runner.life(P0);
+
+    runner.advance_to_phase(Phase::Draw);
+    assert_eq!(
+        unspent(&runner),
+        0,
+        "a custom format is not automatically an old-rules format"
+    );
+    assert_eq!(runner.life(P0), life_before);
+}

--- a/crates/engine/tests/integration/mana_burn.rs
+++ b/crates/engine/tests/integration/mana_burn.rs
@@ -13,12 +13,21 @@
 //! so a failure to burn and a failure to set the scenario up are
 //! distinguishable.
 
-use engine::game::scenario::{GameRunner, GameScenario, P0};
+use engine::game::scenario::{GameRunner, GameScenario, P0, P1};
+use engine::types::ability::{
+    AbilityDefinition, AbilityKind, Effect, PlayerFilter, QuantityExpr, QuantityModification,
+    ReplacementDefinition, ReplacementPlayerScope, TargetFilter,
+};
+use engine::types::actions::GameAction;
 use engine::types::custom_format::{old_school_93_94, swedish_old_school};
+use engine::types::events::GameEvent;
 use engine::types::format::FormatConfig;
+use engine::types::game_state::WaitingFor;
 use engine::types::identifiers::ObjectId;
 use engine::types::mana::{ManaType, ManaUnit};
 use engine::types::phase::Phase;
+use engine::types::player::PlayerId;
+use engine::types::replacements::ReplacementEvent;
 
 const POOL: usize = 2;
 
@@ -220,4 +229,181 @@ fn mana_held_through_the_ending_phase_burns_before_the_next_turn() {
         life_before - POOL as i32,
         "the ending phase's boundary charges the burn like any other"
     );
+}
+
+// ---------------------------------------------------------------------------
+// Provenance through the CR 616.1 replacement pipeline.
+//
+// A mana burn is a life loss like any other, so it can be doubled, prevented
+// or substituted. Whatever survives that pipeline, the log still has to say
+// mana burn is WHY — and it must never say so about a loss that is not one.
+// These two are the paired halves of that: the burn that happens must be
+// narrated, and the burn that does not happen must not leave its name behind.
+// ---------------------------------------------------------------------------
+
+/// Every `ManaBurn` event in `events`, as `(player, amount)`.
+fn burns(events: &[GameEvent]) -> Vec<(PlayerId, u32)> {
+    events
+        .iter()
+        .filter_map(|event| match event {
+            GameEvent::ManaBurn { player_id, amount } => Some((*player_id, *amount)),
+            _ => None,
+        })
+        .collect()
+}
+
+/// A branch prompt, used as the substitute effect so the CR 614.6 continuation
+/// pauses on real player input instead of completing synchronously.
+fn gain_branches() -> Effect {
+    let gain = |amount| {
+        AbilityDefinition::new(
+            AbilityKind::Spell,
+            Effect::GainLife {
+                amount: QuantityExpr::Fixed { value: amount },
+                player: TargetFilter::Controller,
+            },
+        )
+    };
+    Effect::ChooseOneOf {
+        chooser: PlayerFilter::Controller,
+        branches: vec![gain(1), gain(2)],
+    }
+}
+
+/// A two-player game in the precombat main phase under Old School 93/94, with
+/// `P1` holding `POOL` unspent mana. `P0` hosts the replacement effects, so
+/// `ReplacementPlayerScope::Opponent` names `P1` and nothing else.
+fn burner_facing_replacements(defs: Vec<ReplacementDefinition>) -> GameRunner {
+    let mut scenario = GameScenario::new_n_player(2, 51);
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.with_mana_pool(P1, pool(POOL));
+    let mut creature = scenario.add_creature(P0, "Burn Replacements", 1, 1);
+    for def in defs {
+        creature.with_replacement_definition(def);
+    }
+    let mut runner = scenario.build();
+    runner.state_mut().format_config = FormatConfig::for_custom_rules(&old_school_93_94().rules);
+    runner
+}
+
+/// CR 614.6: the burn RESOLVED and then its substitute paused, so the loss is
+/// already final — the log must name its cause even though the transition has
+/// not finished.
+///
+/// Reverts to red by dropping the amount from
+/// `ReplacementDeferred::SubstitutionContinuation`: the drain then has no
+/// figure to narrate at the point the pause happens, the root's provenance is
+/// parked instead, and no later resume ever claims it — `LifeChanged` lands
+/// with no `ManaBurn` beside it.
+#[test]
+fn a_burn_whose_substitute_pauses_still_names_itself() {
+    let mut doubled_with_substitute = ReplacementDefinition::new(ReplacementEvent::LoseLife)
+        .quantity_modification(QuantityModification::DOUBLE)
+        .execute(AbilityDefinition::new(AbilityKind::Spell, gain_branches()))
+        .description("Double, then choose a gain".to_string());
+    doubled_with_substitute.valid_player = Some(ReplacementPlayerScope::Opponent);
+    let mut runner = burner_facing_replacements(vec![doubled_with_substitute]);
+    let life_before = runner.state().players[1].life;
+
+    let mut events = Vec::new();
+    engine::game::turns::advance_phase(runner.state_mut(), &mut events);
+
+    assert!(
+        matches!(
+            runner.state().waiting_for,
+            WaitingFor::ChooseOneOfBranch { .. }
+        ),
+        "the substitute must pause, or this exercises the synchronous path; \
+         got {:?}",
+        runner.state().waiting_for
+    );
+    // The REAL figure, not the pool count: the replacement doubled it.
+    let burned = POOL as i32 * 2;
+    assert_eq!(runner.state().players[1].life, life_before - burned);
+    assert_eq!(
+        burns(&events),
+        vec![(P1, burned as u32)],
+        "the resolved burn is narrated once, with what was actually lost"
+    );
+
+    // Answering the prompt finishes the transition and adds no second burn.
+    let resumed = runner
+        .act(GameAction::ChooseBranch { index: 1 })
+        .expect("answering the substitute resumes the drain");
+    assert!(
+        burns(&resumed.events).is_empty(),
+        "the burn is emitted once"
+    );
+    assert_eq!(runner.state().phase, Phase::BeginCombat);
+    assert!(runner.state().pending_phase_transition_progress.is_none());
+}
+
+/// CR 614.1a: a PREVENTED burn is not a burn. Its parked provenance has to be
+/// consumed at that terminal outcome, or it outlives its own event and the next
+/// same-player life loss to resume through the pipeline inherits it.
+///
+/// The interactive substitute is what makes the leak observable: it holds the
+/// phase transition open past the prevented choice, so the record can be read
+/// at the one moment it would still be there.
+#[test]
+fn a_prevented_burn_leaves_no_provenance_behind() {
+    let mut double = ReplacementDefinition::new(ReplacementEvent::LoseLife)
+        .quantity_modification(QuantityModification::DOUBLE)
+        .description("Double".to_string());
+    double.valid_player = Some(ReplacementPlayerScope::Opponent);
+    let mut substitute = ReplacementDefinition::new(ReplacementEvent::LoseLife)
+        .execute(AbilityDefinition::new(AbilityKind::Spell, gain_branches()))
+        .description("Choose gain instead".to_string());
+    substitute.valid_player = Some(ReplacementPlayerScope::Opponent);
+    let mut runner = burner_facing_replacements(vec![double, substitute]);
+    let life_before = runner.state().players[1].life;
+
+    let mut events = Vec::new();
+    engine::game::turns::advance_phase(runner.state_mut(), &mut events);
+
+    let substitute_index = match &runner.state().waiting_for {
+        WaitingFor::ReplacementChoice { candidates, .. } => candidates
+            .iter()
+            .position(|candidate| candidate.description == "Choose gain instead")
+            .expect("the substituting candidate is offered"),
+        waiting => panic!("expected a life-loss replacement choice, got {waiting:?}"),
+    };
+    let chosen = runner
+        .act(GameAction::ChooseReplacement {
+            index: substitute_index,
+        })
+        .expect("the prevented choice surfaces the substitute's own prompt");
+    events.extend(chosen.events);
+
+    // The transition is still open, which is the whole point — the parked
+    // record would still be readable here if it were not consumed.
+    let progress = runner
+        .state()
+        .pending_phase_transition_progress
+        .as_ref()
+        .expect("the phase cursor stays owned while the substitute waits");
+    assert!(
+        progress.in_flight_life_loss.is_none(),
+        "a prevented burn must not leave provenance parked, or the next \
+         same-player loss to resume is logged as mana burn: {:?}",
+        progress.in_flight_life_loss
+    );
+
+    let resumed = runner
+        .act(GameAction::ChooseBranch { index: 1 })
+        .expect("answering the substitute resumes the drain");
+    events.extend(resumed.events);
+
+    assert_eq!(
+        runner.state().players[1].life,
+        life_before,
+        "CR 614.1a: the prevented burn took no life"
+    );
+    assert!(
+        burns(&events).is_empty(),
+        "nothing may be narrated as mana burn when no burn resolved: {:?}",
+        burns(&events)
+    );
+    assert!(runner.state().players[1].mana_pool.mana.is_empty());
+    assert_eq!(runner.state().phase, Phase::BeginCombat);
 }


### PR DESCRIPTION
Phase 2b of the custom-format-engine charter, following #8736 (Phase 1d) and #8765 (Phase 2a).

**The first `LegacyRuleSet` axis with real runtime behavior** — and the change that makes the Eternal Central Old School presets selectable. They were listed in `custom_format_registry()` and rejected by the legacy-axis gate from the moment they existed; adding `LegacyAxis::ManaBurn` to `IMPLEMENTED_LEGACY_AXES` is the whole of what released them. **Neither constructor was touched**, which is what listing-then-filtering was for.

## What mana burn is

The current rules have none. The glossary entry "Mana Burn (Obsolete)" records it: *"unspent mana caused a player to lose life."* **Life loss, not damage** — the two differ here (damage can be prevented or redirected and triggers "dealt damage" abilities; life loss does neither).

It differs from modern behavior on two axes, and both are implemented:

1. **When pools empty.** CR 106.4 / CR 500.5 empty at the end of every step *and* phase. The pre-M10 rule emptied at the end of each **phase** — CR 500.1's five — so mana survived the steps within one.
2. **What emptying costs.** Modern emptying is free; here the emptied count is life lost.

## `PhaseGroup`

`Phase` flattens MTG's phases and steps into one enum — `DeclareAttackers` and `CombatDamage` are separate variants inside the single real combat phase — so "which phase are we in" isn't recoverable from it. `PhaseGroup` (CR 500.1's five) plus `Phase::group()` restores it, **exhaustively**: a new `Phase` variant is a compile error rather than a silent mis-grouping. `Phase::is_combat` now derives from it instead of re-listing the combat steps, and `turns.rs` no longer keeps a third copy of that list.

## Reusing retention, not inventing suppression

`ManaExpiry::EndOfPhaseGroup` generalizes `EndOfCombat`, which is *already* "survive my phase's internal steps, drain at the real boundary" — just hardcoded to one phase. Retention is what keeps a unit out of the `Drop` set, so a second mechanism for the same job could disagree with the first.

Two signature changes fall out of that, both narrowing what can diverge:

- `clear_expired_end_of_combat_retention_markers(in_combat)` → `clear_expired_retention_markers(from, to)`. A crossing is a property of the **pair**; the old `bool` carried strictly less information than the phase it was computed from. `EndOfCombat` still keys off the destination alone, so its behavior is unchanged.
- `PhaseTransitionProgress.in_combat` → `previous_phase`, for the same reason. It had exactly one reader — this one.

**The mark is applied at the transition, not at each `ManaUnit` construction** as PLAN.md §4 sketched. A unit cannot know its format: `ManaUnit::new` takes no state, and there are 119 construction sites, mostly tests. The transition is the only place holding both the pool and the resolved rules, and the only place the mark is ever read. Flagging the deviation since the plan is specific.

Because tagged units reach the Drop path only at a real crossing, **the drop count IS the burn amount** — no second tally, and no "was this a boundary" branch at the life-loss point.

## Independence from Yurlok

`GameEvent::ManaBurn` is deliberately distinct from the Yurlok-class life loss at the same seam: one is the format's rules being older, the other is a card doing something, and a log that conflated them would tell a player the wrong reason they're at 14 life.

Both applying to one event is **unreachable** today — Old School's card pool predates every Yurlok-class card by decades, and a lobby save can't declare the axis. The code says so explicitly rather than relying on the coincidence, and notes that making both reachable would need a continuation, not a reordering.

## Tests

Three integration tests, each **paired** against the same scenario under a modern format *and* under a custom format that does not declare the axis — so "failed to burn" and "failed to set the scenario up" are distinguishable.

They use the **beginning phase** (untap/upkeep/draw) deliberately: those are steps the old `EndOfCombat` retention could never have covered, so a combat-only implementation would pass a combat-based test and fail these.

One thing the tests do **not** assert, stated rather than papered over: the `GameEvent::ManaBurn` narration. `advance_to_phase` discards the events it drives and the log rides on `ActionResult` rather than `GameState`, so there's no honest way to observe it from that harness. Life total and pool contents are the player-visible behavior either way, and the test says why.

| Check | Result |
|---|---|
| `--test integration mana_burn` | 5 passed |
| `--test integration custom_format` | 97 passed |
| `--test integration turn` / `mana` / `phase` / `rules::combat` | 548 / 491 / 73 / 49 passed |
| `--lib deck_validation::tests` / `types::mana` | 150 / 68 passed |
| `cargo check -p phase-engine --all-targets`, `cargo fmt --all` | clean |

9285 lib tests passed before an unrelated environment kill on my machine; no failures in anything that ran. Full-suite and `clippy` runs keep getting OOM-killed here, so CI's workspace clippy + nextest remains the gate for the remainder — same standing caveat as the last two PRs.

Two incidental notes for reviewers: `PhaseTransitionProgress.entering_cleanup` is written and never read, which predates this PR and I left alone; and running the test binaries directly (outside `cargo test`) makes insta snapshot tests fail on `cargo metadata` — those failures are harness artifacts, and every one of them passes under `cargo test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013h1rTnbzGpibH8sbszunhs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the pre-M10 mana burn rule in eligible legacy and custom formats.
  * Unspent mana can carry across steps within a phase and cause life loss when the phase ends.
  * Old School 93/94 and 95 formats are now available for selection.
  * Mana burn events appear in game logs and public game state updates.

* **Bug Fixes**
  * Improved phase-transition handling for mana retention and expiration.
  * Deferred life-loss effects now resume correctly, report final amounts, and avoid reporting prevented mana burn.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->