### PR TITLE
fix(engine): treat a Class with no stored level as level 1 (CR 716.2d)

### DIFF
--- a/crates/engine/src/game/conditions.rs
+++ b/crates/engine/src/game/conditions.rs
@@ -75,14 +75,15 @@ pub(crate) fn eval_chosen_label_is(state: &GameState, source_id: ObjectId, label
 }
 
 /// CR 716.2a: True when the source Class enchantment is at or above the given level.
+/// CR 716.2d: a source with no stored level reads as level 1 (`GameObject::level`),
+/// so a Class copy is gated by its actual level rather than failing every gate.
 /// Does NOT include a battlefield zone guard — callers that require the source to be
 /// on the battlefield (e.g. `replacement.rs`) must apply the guard before calling.
 pub(crate) fn eval_class_level_ge(state: &GameState, source_id: ObjectId, level: u8) -> bool {
     state
         .objects
         .get(&source_id)
-        .and_then(|obj| obj.class_level)
-        .is_some_and(|current| current >= level)
+        .is_some_and(|obj| obj.level() >= level)
 }
 
 /// CR 113.6b: True when the source object is in the specified zone.

--- a/crates/engine/src/game/effects/set_class_level.rs
+++ b/crates/engine/src/game/effects/set_class_level.rs
@@ -112,7 +112,7 @@ mod tests {
 
     #[test]
     fn class_level_is_restriction_permits_correct_level() {
-        // CR 716.4: ClassLevelIs restriction permits at exactly the specified level.
+        // CR 716.2a: ClassLevelIs restriction permits at exactly the specified level.
         let restriction_level_1 = ActivationRestriction::ClassLevelIs { level: 1 };
         let restriction_level_2 = ActivationRestriction::ClassLevelIs { level: 2 };
 

--- a/crates/engine/src/game/game_object.rs
+++ b/crates/engine/src/game/game_object.rs
@@ -3297,6 +3297,30 @@ impl GameObject {
             .collect()
     }
 
+    /// CR 716.2d: This permanent's level — the single authority every class-level
+    /// gate reads. A permanent that doesn't have a level is treated as though its
+    /// level is 1, so an object that carries Class abilities without a stored level
+    /// (a copy effect grants the `Class` subtype and its level bars through the
+    /// layer system, while CR 716.2b keeps the level itself off the copiable
+    /// characteristics) still answers every level question, and answers it with 1
+    /// rather than the original's level.
+    ///
+    /// Contract: this answers "what is this permanent's level", which is the only
+    /// question CR 716.2d normalizes. It deliberately does NOT answer "does this
+    /// object store a level of its own" — read `class_level` directly for that.
+    /// CR 716.4: level counters on leveler cards are a separate designation and are
+    /// never read here.
+    pub fn level(&self) -> u8 {
+        Self::level_from_stored(self.class_level)
+    }
+
+    /// CR 716.2d: [`Self::level`] for callers that hold a latched level snapshot
+    /// instead of a live object (`TriggerSourceRead::Latched`). The default lives
+    /// here alone so no read site restates it.
+    pub fn level_from_stored(class_level: Option<u8>) -> u8 {
+        class_level.unwrap_or(1)
+    }
+
     /// CR 614.12c + CR 607.2d: Look up the persisted anchor-word label chosen
     /// as this permanent entered the battlefield (e.g. "Jeskai" / "Temur" on
     /// Frostcliff Siege, "Khans" / "Dragons" on a Khans of Tarkir Siege).

--- a/crates/engine/src/game/replacement.rs
+++ b/crates/engine/src/game/replacement.rs
@@ -6563,17 +6563,20 @@ fn evaluate_replacement_condition(
                 .count();
             matching_count >= *minimum as usize
         }
-        // CR 611.3b + CR 716.2a + CR 614.1b: A Class-level static replacement applies
+        // CR 611.3b + CR 716.2a + CR 614.1: A Class-level static replacement applies
         // only while the source Class enchantment is on the battlefield and at the gated
         // level or higher. Unlike the shared `eval_class_level_ge` (used by
         // StaticCondition/TriggerCondition, where the functioning-abilities path already
         // constrains source availability), replacement effects can persist in lookup
         // tables beyond a source's zone change — so the battlefield zone guard here is
-        // load-bearing and must NOT be factored out into the shared helper.
+        // load-bearing and must NOT be factored out into the shared helper. The level
+        // itself still comes from the shared CR 716.2d accessor (`GameObject::level`):
+        // reading `class_level` raw made an absent level sort BELOW `Some(1)`, which
+        // silenced every level gate on a Class copy.
         ReplacementCondition::ClassLevelGE { level } => state
             .objects
             .get(&source_id)
-            .is_some_and(|obj| obj.zone == Zone::Battlefield && obj.class_level >= Some(*level)),
+            .is_some_and(|obj| obj.zone == Zone::Battlefield && obj.level() >= *level),
         // CR 611.2b: "for as long as you control [source]" — the replacement
         // applies only while the captured source object is on the battlefield AND
         // still controlled by the captured installing player. Either departure

--- a/crates/engine/src/game/restrictions.rs
+++ b/crates/engine/src/game/restrictions.rs
@@ -1142,12 +1142,13 @@ fn activation_restriction_applies(
             .objects
             .get(&source_id)
             .is_some_and(|obj| obj.harnessed),
-        // CR 716.4: Level N+1 ability can only activate when Class is at level N.
+        // CR 716.2a: "[Cost]: Level N" activates only while the Class is level N-1.
+        // CR 716.2d: a source with no stored level is level 1, so a Class copy
+        // (Mirrormade) can gain its first level like any printed Class.
         ActivationRestriction::ClassLevelIs { level } => state
             .objects
             .get(&source_id)
-            .and_then(|obj| obj.class_level)
-            .is_some_and(|current| current == *level),
+            .is_some_and(|obj| obj.level() == *level),
         // CR 711.2a + CR 711.2b: Leveler counter range — activatable when source has
         // level counters in the specified range [minimum, maximum] (or >= minimum if unbounded).
         ActivationRestriction::LevelCounterRange { minimum, maximum } => {

--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -13466,9 +13466,10 @@ fn check_trigger_constraint_with_ref(
             nth_in_turn == *n
         }
         // CR 716.2a: "When this Class becomes level N" — fire only at the specified level.
-        TriggerConstraint::AtClassLevel { level } => source_context
-            .and_then(|source| source.source_read(state).class_level())
-            .is_some_and(|current| current == *level),
+        // CR 716.2d: an absent stored level reads as 1 (`GameObject::level`).
+        TriggerConstraint::AtClassLevel { level } => {
+            source_context.is_some_and(|source| source.source_read(state).level() == *level)
+        }
         // CR 603.4: "This ability triggers only the first N times each turn."
         TriggerConstraint::MaxTimesPerTurn { max } => definition_ref.is_none_or(|key| {
             state
@@ -14028,9 +14029,10 @@ fn evaluate_trigger_condition_with_source(
                 })
         }),
         // CR 716.2a: True when the source Class is at or above the specified level.
-        TriggerCondition::ClassLevelGE { level } => source_context
-            .and_then(|source| source.source_read(state).class_level())
-            .is_some_and(|current| current >= *level),
+        // CR 716.2d: an absent stored level reads as 1 (`GameObject::level`).
+        TriggerCondition::ClassLevelGE { level } => {
+            source_context.is_some_and(|source| source.source_read(state).level() >= *level)
+        }
         // CR 701.64b + CR 702.186b: True when the source permanent is harnessed.
         // Gates an ∞ (Infinity) triggered ability so it only fires while
         // harnessed (the ∞ ability word maps to this condition).

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -23315,7 +23315,9 @@ pub enum ActivationRestriction {
     /// Read from `GameObject::harnessed`. Sibling of `IsSolved` (CR 719.3c) — a
     /// per-object designation activation gate, not a parameterization of it.
     SourceIsHarnessed,
-    /// CR 716.4: Level N+1 ability can only activate when the source Class is at exactly this level.
+    /// CR 716.2a: "[Cost]: Level N" activates only while the source Class is at
+    /// exactly this level (N-1). CR 716.4 is the disjoint leveler-card rule and
+    /// explicitly does not interact with Class levels.
     ClassLevelIs {
         level: u8,
     },

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -21171,6 +21171,58 @@ pub struct PhaseTransitionProgress {
 }
 
 #[cfg(test)]
+mod trigger_source_read_level_tests {
+    use super::*;
+    use crate::game::game_object::GameObject;
+
+    fn class_object(class_level: Option<u8>) -> GameObject {
+        let mut object = GameObject::new(
+            ObjectId(1),
+            CardId(1),
+            PlayerId(0),
+            "Stormchaser's Talent".to_string(),
+            Zone::Battlefield,
+        );
+        object.class_level = class_level;
+        object
+    }
+
+    fn latched(object: &GameObject) -> TriggerSourceContext {
+        object
+            .snapshot_for_zone_change(object.id, Some(Zone::Battlefield), object.zone)
+            .trigger_source_context
+            .expect("snapshot always carries trigger context")
+    }
+
+    /// CR 716.2d: a source with no stored level reads as level 1, on BOTH
+    /// `TriggerSourceRead` arms. No printed card reaches this through a trigger —
+    /// zero cards say "becomes level 1", and `oracle_class.rs` only wraps a
+    /// trigger in `ClassLevelGE` when `section.level > 1` — so the guarantee is
+    /// asserted directly here rather than through a card scenario the parser
+    /// cannot emit. Without it, a `None` level fails every `== N` / `>= N` gate,
+    /// which is the shape of issue #8773.
+    #[test]
+    fn absent_stored_level_reads_as_one_on_both_arms() {
+        let object = class_object(None);
+        let context = latched(&object);
+
+        assert_eq!(TriggerSourceRead::ExactLive(&object).level(), 1);
+        assert_eq!(TriggerSourceRead::Latched(&context).level(), 1);
+    }
+
+    /// A stored level is reported verbatim, so normalization cannot mask a real
+    /// level, and the two arms agree.
+    #[test]
+    fn stored_level_is_reported_verbatim_on_both_arms() {
+        let object = class_object(Some(3));
+        let context = latched(&object);
+
+        assert_eq!(TriggerSourceRead::ExactLive(&object).level(), 3);
+        assert_eq!(TriggerSourceRead::Latched(&context).level(), 3);
+    }
+}
+
+#[cfg(test)]
 mod phase_transition_progress_serde_tests {
     use super::*;
 

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -931,10 +931,13 @@ impl<'context, 'state> TriggerSourceRead<'context, 'state> {
         }
     }
 
-    pub fn class_level(self) -> Option<u8> {
+    /// CR 716.2d: the source's level, normalized through the shared
+    /// [`GameObject::level`] authority so a latched snapshot and a live object
+    /// answer identically, and so a source with no stored level reads as 1.
+    pub fn level(self) -> u8 {
         match self {
-            Self::ExactLive(object) => object.class_level,
-            Self::Latched(context) => context.class_level,
+            Self::ExactLive(object) => object.level(),
+            Self::Latched(context) => GameObject::level_from_stored(context.class_level),
         }
     }
 

--- a/crates/engine/tests/integration/issue_8773_class_copy_enters_at_level_one.rs
+++ b/crates/engine/tests/integration/issue_8773_class_copy_enters_at_level_one.rs
@@ -1,0 +1,329 @@
+//! Issue #8773: a copy of a Class (Mirrormade on a Class enchantment) could
+//! never gain a level, and every level-gated static and replacement on it was
+//! inert forever.
+//!
+//! `GameObject::class_level` is seeded only when an object's own printed face
+//! carries the `Class` subtype. A copy gets the subtype and the level bars from
+//! the layer system, so its stored level stays absent, and every read site used
+//! to fail closed on that absence: the `{Cost}: Level N` gate wanted
+//! `Some(N-1)`, so no level was ever reachable.
+//!
+//! CR 716.2d: "If a rule or effect refers to a permanent's level and that
+//! permanent doesn't have a level, it is treated as though its level is 1."
+//! CR 716.2b: "Levels are not a copiable characteristic." — so a copy of a
+//! level-3 Class is level 1, not level 3.
+//! CR 716.2a: "[Cost]: Level N" means "Activate only if this Class is level N-1
+//! and only as a sorcery."
+//!
+//! The fixture puts the ORIGINAL under the opponent and the COPY under P0 so
+//! every gated ability under test is discriminating: Innkeeper's Talent's
+//! level-2 static ("Permanents *you control* …") and level-3 replacement ("If
+//! *you* would put …") are both controller-scoped (CR 109.5), so the opponent's
+//! level-3 original can never be the source of an effect observed on P0's side.
+
+use engine::game::layers::evaluate_layers;
+use engine::game::scenario::{GameRunner, GameScenario, P0, P1};
+use engine::types::ability::{Effect, StaticCondition};
+use engine::types::actions::GameAction;
+use engine::types::counter::CounterType;
+use engine::types::keywords::Keyword;
+use engine::types::mana::{ManaType, ManaUnit};
+use engine::types::phase::Phase;
+use engine::types::ObjectId;
+
+/// Innkeeper's Talent (BLB), verbatim Oracle text. One card covers all three
+/// gated read paths: the level bars (activation restriction), a level-2 static,
+/// and a level-3 replacement.
+const INNKEEPERS_TALENT: &str = "(Gain the next level as a sorcery to add its ability.)\n\
+At the beginning of combat on your turn, put a +1/+1 counter on target creature you control.\n\
+{G}: Level 2\n\
+Permanents you control with counters on them have ward {1}.\n\
+{3}{G}: Level 3\n\
+If you would put one or more counters on a permanent or player, put twice that many of each of those kinds of counters on that permanent or player instead.";
+
+/// Mirrormade (ELD), verbatim Oracle text.
+const MIRRORMADE: &str =
+    "You may have this enchantment enter as a copy of any artifact or enchantment on the battlefield.";
+
+/// "Put a +1/+1 counter on target creature." — the probe the level-3
+/// counter-doubling replacement must modify.
+const COUNTER_SPELL_TEXT: &str = "Put a +1/+1 counter on target creature.";
+
+/// Green mana is enough for every cost in this file: Mirrormade is staged
+/// cost-free, and both level bars ({G} and {3}{G}) are payable in green.
+fn green_pool(count: usize) -> Vec<ManaUnit> {
+    (0..count)
+        .map(|_| ManaUnit::new(ManaType::Green, ObjectId(0), false, vec![]))
+        .collect()
+}
+
+/// Index of the level bar that sets `level` on `source`.
+fn level_bar_index(runner: &GameRunner, source: ObjectId, level: u8) -> usize {
+    runner.state().objects[&source]
+        .abilities
+        .iter()
+        .position(
+            |a| matches!(a.effect.as_ref(), Effect::SetClassLevel { level: l } if *l == level),
+        )
+        .unwrap_or_else(|| {
+            panic!(
+                "the copy must carry the Level {level} bar it copied: {:?}",
+                runner.state().objects[&source].abilities
+            )
+        })
+}
+
+/// P1 controls a level-3 Innkeeper's Talent; P0 casts Mirrormade copying it.
+/// Returns the runner plus the original and the copy (Mirrormade's own object).
+fn copy_of_level_three_talent() -> (GameRunner, ObjectId, ObjectId) {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.with_mana_pool(P0, green_pool(8));
+
+    // The `Class` subtype must be set BEFORE the Oracle text is parsed:
+    // `from_oracle_text` is the call that routes through
+    // `parse_class_oracle_text`, and it snapshots the subtypes at call time.
+    let original = scenario
+        .add_creature(P1, "Innkeeper's Talent", 0, 0)
+        .as_enchantment()
+        .with_subtypes(vec!["Class"])
+        .from_oracle_text(INNKEEPERS_TALENT)
+        .id();
+
+    let mirrormade = scenario
+        .add_creature_to_hand(P0, "Mirrormade", 0, 0)
+        .as_enchantment()
+        .from_oracle_text(MIRRORMADE)
+        .id();
+
+    let mut runner = scenario.build();
+
+    // CR 716.2b is only testable against an original that is NOT level 1.
+    runner
+        .state_mut()
+        .objects
+        .get_mut(&original)
+        .unwrap()
+        .class_level = Some(3);
+
+    let outcome = runner
+        .cast(mirrormade)
+        .accept_optional()
+        .replacement_choice(0)
+        .copy_target(original)
+        .resolve();
+
+    let copy = &outcome.state().objects[&mirrormade];
+    assert!(
+        copy.card_types.subtypes.iter().any(|s| s == "Class"),
+        "reach-guard: Mirrormade must have entered as a copy of the Class \
+         (subtypes {:?})",
+        copy.card_types.subtypes
+    );
+
+    (runner, original, mirrormade)
+}
+
+/// CR 716.2d + CR 716.2b: the copy of a level-3 Class is level 1 — it can gain
+/// its Level 2, and it cannot skip to Level 3. Before the fix the absent stored
+/// level failed the `ClassLevelIs` gate outright, so neither bar was ever legal.
+#[test]
+fn copy_of_a_level_three_class_enters_at_level_one_and_can_level_up() {
+    let (mut runner, original, copy) = copy_of_level_three_talent();
+
+    let level_2 = level_bar_index(&runner, copy, 2);
+    let level_3 = level_bar_index(&runner, copy, 3);
+
+    // CR 716.2b: the level is not copied, so the Level 3 bar (gated at level 2)
+    // is illegal on a copy of a level-3 Class. Mana is staged well above
+    // {3}{G}, so the refusal can only come from the level gate — the paired
+    // positive below proves exactly that by activating the SAME bar once the
+    // copy has reached level 2.
+    assert!(
+        runner
+            .act(GameAction::ActivateAbility {
+                source_id: copy,
+                ability_index: level_3,
+            })
+            .is_err(),
+        "CR 716.2b: a copy of a level-3 Class must not start at level 3"
+    );
+
+    // CR 716.2d + CR 716.2a: absent level reads as 1, so the Level 2 bar is live.
+    runner.activate(copy, level_2).resolve();
+    assert_eq!(
+        runner.state().objects[&copy].class_level,
+        Some(2),
+        "activating the Level 2 bar must set the copy's level to 2"
+    );
+
+    // Paired positive: the same Level 3 bar that was refused above is now legal.
+    runner.activate(copy, level_3).resolve();
+    assert_eq!(
+        runner.state().objects[&copy].class_level,
+        Some(3),
+        "CR 716.2a: at level 2 the Level 3 bar must be activatable"
+    );
+
+    assert_eq!(
+        runner.state().objects[&original].class_level,
+        Some(3),
+        "the original Class must be untouched by the copy's own leveling"
+    );
+}
+
+/// CR 716.2a + CR 611.3a: the copy's level-2 static ("Permanents you control
+/// with counters on them have ward {1}") is off while the copy is level 1 and
+/// live once the copy reaches level 2. The opponent's level-3 original controls
+/// the same static, but it is scoped to ITS controller (CR 109.5), so ward on
+/// P0's creature can only have come from P0's copy.
+#[test]
+fn copy_level_two_static_applies_once_the_copy_levels_up() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.with_mana_pool(P0, green_pool(8));
+
+    let original = scenario
+        .add_creature(P1, "Innkeeper's Talent", 0, 0)
+        .as_enchantment()
+        .with_subtypes(vec!["Class"])
+        .from_oracle_text(INNKEEPERS_TALENT)
+        .id();
+    let mirrormade = scenario
+        .add_creature_to_hand(P0, "Mirrormade", 0, 0)
+        .as_enchantment()
+        .from_oracle_text(MIRRORMADE)
+        .id();
+    let countered_creature = scenario
+        .add_creature(P0, "Countered Bear", 2, 2)
+        .with_plus_counters(1)
+        .id();
+
+    let mut runner = scenario.build();
+    runner
+        .state_mut()
+        .objects
+        .get_mut(&original)
+        .unwrap()
+        .class_level = Some(3);
+    runner
+        .cast(mirrormade)
+        .accept_optional()
+        .replacement_choice(0)
+        .copy_target(original)
+        .resolve();
+
+    // Reach-guard: the copied static really is the level-2-gated ward grant.
+    // Without this a silent parse failure would make the negative below vacuous.
+    assert!(
+        runner.state().objects[&mirrormade]
+            .static_definitions
+            .iter_unchecked()
+            .any(|s| s.condition == Some(StaticCondition::ClassLevelGE { level: 2 })),
+        "reach-guard: the copy must carry the level-2-gated static: {:?}",
+        runner.state().objects[&mirrormade].static_definitions
+    );
+
+    let has_ward = |runner: &mut GameRunner| {
+        runner.state_mut().layers_dirty.mark_full();
+        evaluate_layers(runner.state_mut());
+        runner.state().objects[&countered_creature]
+            .keywords
+            .iter()
+            .any(|k| matches!(k, Keyword::Ward(_)))
+    };
+
+    assert!(
+        !has_ward(&mut runner),
+        "CR 716.2a: the copy is level 1, so its level-2 ward grant must be off \
+         (and the opponent's level-3 original grants ward only to ITS controller's \
+         permanents, CR 109.5)"
+    );
+
+    let level_2 = level_bar_index(&runner, mirrormade, 2);
+    runner.activate(mirrormade, level_2).resolve();
+
+    assert!(
+        has_ward(&mut runner),
+        "CR 716.2a: once the copy is level 2 its static must grant ward {{1}} to \
+         its controller's permanents with counters"
+    );
+}
+
+/// CR 716.2a + CR 614.1a: the copy's level-3 replacement ("If you would put one
+/// or more counters … put twice that many … instead") is off below level 3 and
+/// live at level 3. Same controller-scoping argument as the static test: the
+/// opponent's level-3 original doubles only ITS controller's counter placements.
+#[test]
+fn copy_level_three_replacement_applies_once_the_copy_levels_up() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.with_mana_pool(P0, green_pool(8));
+
+    let original = scenario
+        .add_creature(P1, "Innkeeper's Talent", 0, 0)
+        .as_enchantment()
+        .with_subtypes(vec!["Class"])
+        .from_oracle_text(INNKEEPERS_TALENT)
+        .id();
+    let mirrormade = scenario
+        .add_creature_to_hand(P0, "Mirrormade", 0, 0)
+        .as_enchantment()
+        .from_oracle_text(MIRRORMADE)
+        .id();
+    let bear = scenario.add_creature(P0, "Plain Bear", 2, 2).id();
+    let probe_before = scenario
+        .add_spell_to_hand_from_oracle(P0, "Counter Probe One", false, COUNTER_SPELL_TEXT)
+        .id();
+    let probe_after = scenario
+        .add_spell_to_hand_from_oracle(P0, "Counter Probe Two", false, COUNTER_SPELL_TEXT)
+        .id();
+
+    let mut runner = scenario.build();
+    runner
+        .state_mut()
+        .objects
+        .get_mut(&original)
+        .unwrap()
+        .class_level = Some(3);
+    runner
+        .cast(mirrormade)
+        .accept_optional()
+        .replacement_choice(0)
+        .copy_target(original)
+        .resolve();
+
+    // CR 122.1: read the typed +1/+1 counter entry, never a stringly-typed probe.
+    let plus_counters = |runner: &GameRunner| {
+        runner.state().objects[&bear]
+            .counters
+            .get(&CounterType::Plus1Plus1)
+            .copied()
+            .unwrap_or(0)
+    };
+
+    runner.cast(probe_before).target_objects(&[bear]).resolve();
+    assert_eq!(
+        plus_counters(&runner),
+        1,
+        "CR 716.2a: below level 3 the copy must not double counter placement"
+    );
+
+    for level in [2u8, 3] {
+        let index = level_bar_index(&runner, mirrormade, level);
+        runner.activate(mirrormade, index).resolve();
+    }
+    assert_eq!(
+        runner.state().objects[&mirrormade].class_level,
+        Some(3),
+        "reach-guard: the copy must actually have reached level 3"
+    );
+
+    runner.cast(probe_after).target_objects(&[bear]).resolve();
+    assert_eq!(
+        plus_counters(&runner),
+        3,
+        "CR 716.2a: at level 3 the copy's replacement must double the second \
+         placement (1 + 2), not add a single counter"
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -852,6 +852,7 @@ mod issue_861_tree_of_perdition;
 mod issue_864_phyrexian_dreadnought;
 mod issue_868_szarekh_attack_trigger;
 mod issue_874_nadiers_nightblade_token_leaves;
+mod issue_8773_class_copy_enters_at_level_one;
 mod issue_879_obsessive_pursuit;
 mod issue_924_offspring;
 mod issue_927_tireless_provisioner;


### PR DESCRIPTION
Fixes #8773.

## The bug

Cast Stormchaser's Talent, level it to 2, then Mirrormade copying it. The original levels normally; **the copy can never activate any level ability**, with mana available. Reported from phase-rs.dev.

## Root cause

`GameObject::class_level` is `Option<u8>`, seeded only when an object's own printed face carries the `Class` subtype (`printed_cards.rs:225`). Mirrormade's face is a plain Enchantment, so the field stays `None`; the copy effect grants the `Class` subtype and its level bars through the layer system, but nothing back-fills the stored level, and no copy site writes `class_level` anywhere in the engine.

Every read then failed closed on `None`, including `obj.class_level >= Some(*level)` in `replacement.rs`, where `None` sorts below `Some(1)`. The Level 2 gate wants `class_level == Some(1)`, so the copy sat permanently below level 1: no level abilities, and its level-gated statics and replacements inert too.

That contradicts **CR 716.2d**: "If a rule or effect refers to a permanent's level and that permanent doesn't have a level, it is treated as though its level is 1."

## The fix

One shared authority in `GameObject`, with every level gate routed through it:

```rust
pub fn level(&self) -> u8 { Self::level_from_stored(self.class_level) }
pub fn level_from_stored(class_level: Option<u8>) -> u8 { class_level.unwrap_or(1) }
```

Its doc comment states the contract: it answers "what is this permanent's level", the only question CR 716.2d normalizes, and deliberately does not answer "does this object store a level of its own" — read `class_level` directly for that. `engine_debug.rs` asks the latter and correctly still reads the field.

Five read sites routed, so no raw-`Option` level read survives: `ActivationRestriction::ClassLevelIs`, `eval_class_level_ge`, `ReplacementCondition::ClassLevelGE` (its battlefield zone guard kept), and `TriggerConstraint::AtClassLevel` / `TriggerCondition::ClassLevelGE` via `TriggerSourceRead::class_level() -> level()`, whose `Latched` arm delegates to `level_from_stored` so the default lives in one place. The two trigger sites are behaviourally inert for real cards, but leaving them on the raw `Option` would preserve the exact shape of this bug.

Normalization is unconditional, with no "is this a Class" guard. CR 716.2b says a level is a designation any permanent can have, so scoping to Class-subtyped objects would contradict the rule, and it is unnecessary: `oracle_class.rs` only wraps abilities in a level condition when `section.level > 1`, so `ClassLevelGE { level: 1 }` is never produced. A permanent carrying no level-gated ability cannot satisfy a gate it does not have.

Seeding `class_level` on subtype gain was rejected: CR 716.2b keeps the level off copiable characteristics, so a write at copy time would be a second authority disagreeing with the rule.

## Corrected citations

`restrictions.rs`, `types/ability.rs` and a `set_class_level.rs` test comment all cited **CR 716.4** for the level-bar gate. CR 716.4 is the leveler-card rule and states level counters and class levels do not interact. Now **CR 716.2a**. The replacement block also cited **CR 614.1b** (the "skip" rule) for a Class-level gate; now **CR 614.1**.

Every CR number was verified by grepping `docs/MagicCompRules.txt`, and every card's Oracle text against the Scryfall API.

## Tests

`crates/engine/tests/integration/issue_8773_class_copy_enters_at_level_one.rs`, three tests. P1 controls a level-3 Innkeeper's Talent; P0 casts Mirrormade copying it. The original sits under the opponent deliberately — Innkeeper's level-2 static and level-3 replacement are controller-scoped per CR 109.5, so nothing observed on P0's side can come from the opponent's original.

1. The Level 3 bar is refused on a fresh copy (CR 716.2b), the Level 2 bar activates, then the **same** Level 3 bar activates — a paired positive proving the refusal was the level gate rather than mana; the original stays at 3.
2. The level-2 static (ward {1}) is absent at copy level 1 and present at level 2, with a reach-guard asserting the copy really carries the `ClassLevelGE { level: 2 }` static so the negative is not vacuous.
3. The level-3 replacement adds 1 counter below level 3 and 2 at level 3, with a reach-guard on the copy actually reaching level 3.

Revert probe: with `level_from_stored` temporarily returning `unwrap_or(0)`, all three fail with the reported error, `ActionNotAllowed("Activation restriction not satisfied: ClassLevelIs { level: 1 }")`.

## Verification

Tilt was unavailable, so cargo ran directly.

- `cargo fmt --all` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — exit 0, no warnings
- `cargo test -p phase-engine --test integration` — **6716 passed, 0 failed**, 3 ignored
- `cargo test -p phase-engine --lib` — 21045 passed, 0 failed, across parallel and `--test-threads=1` runs

**One flake to be aware of, believed pre-existing.** `game::mana_abilities::tests::bulk_treasure_activation_is_linear_not_factorial` failed on two early runs ("readiness calls must be linear in N"). It reads a process-global counter and its own comment documents that concurrent tests pollute it. It passes in isolation, at `--test-threads=1`, and 3/3 on later parallel runs; `upstream/main` was green 4/4 in the same environment. Nothing here touches the mana path.

## Known follow-up, not in this PR

`CardPreview.tsx`, `PermanentCard.tsx` and `DebugCardContextMenu.tsx` render the level badge only when `class_level != null`, so a Class copy shows no "Lv I" badge until it levels up. Display-only; the right fix is exposing the normalized level in the serialized view, which is a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013pPDjptpG7r95MocbYGDqj

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Class copies without a stored level now correctly enter at level 1.
  * Level-based abilities, restrictions, triggers, and replacement effects now evaluate these copies correctly.
  * Class copies can gain levels normally, with level-gated effects activating at the appropriate level.

* **Tests**
  * Added integration coverage for copied Class cards entering at level 1 and progressing through higher levels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->