### PR TITLE
fix(engine): make tracked-set chain unification a set union (#8135)

### DIFF
--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -7194,16 +7194,41 @@ pub(crate) fn publish_tracked_set(state: &mut GameState, affected_ids: Vec<Objec
     // between exile and hand-fallback must not wipe the exiled card).
     // Storm Herald mid-pause empty publishes are skipped at the EffectZoneChoice
     // site; CreateDelayedTrigger also prefers a nonempty chain id.
+    // CR 608.2c: Chain unification is a set UNION, not a concatenation. Two
+    // producers in one chain legitimately publish the SAME object when both
+    // name the same population — Gifts Ungiven's "search your library for up to
+    // four cards ... and reveal them" both finds and reveals the identical four
+    // cards, so each was appended twice and every downstream consumer saw eight
+    // members (issue #8135: the opponent's chooser rendered each revealed card
+    // twice, and `QuantityRef::TrackedSetSize` would likewise have double-counted
+    // them). A tracked set holds objects, and an object cannot be in it twice.
+    //
+    // Membership is deduplicated in FIRST-PUBLISH order rather than by sorting:
+    // consumers read this population positionally (the chooser prompt renders it
+    // in order), so the sibling publisher's `sort_unstable_by_key` + `dedup`
+    // shape is deliberately NOT used here — it would reorder every existing
+    // chain set. Retaining the earliest occurrence keeps the producer order each
+    // consumer already observes.
     if let Some(chain_id) = state.chain_tracked_set_id {
-        state
-            .tracked_object_sets
-            .entry(chain_id)
-            .or_default()
-            .extend(affected_ids);
+        let members = state.tracked_object_sets.entry(chain_id).or_default();
+        for id in affected_ids {
+            if !members.contains(&id) {
+                members.push(id);
+            }
+        }
     } else {
         let set_id = TrackedSetId(state.next_tracked_set_id);
         state.next_tracked_set_id += 1;
-        state.tracked_object_sets.insert(set_id, affected_ids);
+        // A single publish can also repeat an id (a producer that reports the
+        // same object under two events); the invariant is the set's, not the
+        // caller's, so it is enforced on this path too.
+        let mut members: Vec<ObjectId> = Vec::with_capacity(affected_ids.len());
+        for id in affected_ids {
+            if !members.contains(&id) {
+                members.push(id);
+            }
+        }
+        state.tracked_object_sets.insert(set_id, members);
         state.chain_tracked_set_id = Some(set_id);
     }
 }

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -7194,7 +7194,15 @@ pub(crate) fn publish_tracked_set(state: &mut GameState, affected_ids: Vec<Objec
     // between exile and hand-fallback must not wipe the exiled card).
     // Storm Herald mid-pause empty publishes are skipped at the EffectZoneChoice
     // site; CreateDelayedTrigger also prefers a nonempty chain id.
-    // CR 608.2c: Chain unification is a set UNION, not a concatenation. Two
+    // Chain unification is a set UNION, not a concatenation. Deliberately
+    // carries no CR citation: set identity is an engine data-structure
+    // invariant, not a game rule. CR 608.2c governs the ORDER instructions are
+    // followed in during resolution and says nothing about membership identity,
+    // so citing it here would be a false verification signal (CLAUDE.md: a wrong
+    // CR number is worse than no CR number, and plumbing is not annotated).
+    // What the rules do supply is the anaphor this set serves — "those cards" /
+    // "<verb> this way" naming a population — and an object is in that
+    // population once or not at all. Two
     // producers in one chain legitimately publish the SAME object when both
     // name the same population — Gifts Ungiven's "search your library for up to
     // four cards ... and reveal them" both finds and reveals the identical four

--- a/crates/engine/tests/integration/gifts_ungiven_duplicate_candidates_8135.rs
+++ b/crates/engine/tests/integration/gifts_ungiven_duplicate_candidates_8135.rs
@@ -97,9 +97,15 @@ fn gifts_ungiven_offers_each_revealed_card_exactly_once() {
          click appears to select both while the submitted pick stays correct. \
          offered={offered:?}"
     );
+    // Identity, not cardinality. A payload of four DIFFERENT unique ids — the
+    // resolving Gifts Ungiven card itself, say, swapped in for a revealed one —
+    // has four unique members and would satisfy a count-only check while
+    // offering the opponent a card that was never revealed.
+    let mut expected = found.clone();
+    expected.sort();
     assert_eq!(
-        deduped.len(),
-        found.len(),
-        "exactly the four searched-and-revealed cards may be offered"
+        deduped, expected,
+        "exactly the searched-and-revealed cards may be offered, and nothing \
+         else; offered={offered:?} found={found:?}"
     );
 }

--- a/crates/engine/tests/integration/gifts_ungiven_duplicate_candidates_8135.rs
+++ b/crates/engine/tests/integration/gifts_ungiven_duplicate_candidates_8135.rs
@@ -1,0 +1,105 @@
+//! Issue #8135 — Gifts Ungiven's chooser prompt lists every revealed card twice.
+//!
+//! Oracle: "Search your library for up to four cards with different names and
+//! reveal them. Target opponent chooses two of those cards. Put the chosen cards
+//! into your graveyard and the rest into your hand. Then shuffle."
+//!
+//! Reported symptoms (Discord, plus a corroborating report): the opponent's
+//! chooser interface shows each revealed card twice; clicking one copy visually
+//! selects both; the submitted selection and the spell's resolution are correct.
+//!
+//! Those three together localize the defect precisely. `CardChoiceModal`'s
+//! `ChooseFromZoneModal` renders `data.cards.map(...)` with `key={id}` and holds
+//! selection in a `Set<ObjectId>`, so a `cards` payload containing the same
+//! ObjectId twice produces exactly this: two tiles, one shared selection
+//! identity, and a deduplicated `Array.from(set)` on confirm. The frontend is
+//! faithful to its input — so the duplication must be in the engine's
+//! `WaitingFor::ChooseFromZoneChoice { cards }`.
+//!
+//! This test asserts on that payload directly.
+
+use engine::game::scenario::{GameScenario, P0, P1};
+use engine::types::actions::GameAction;
+use engine::types::game_state::WaitingFor;
+use engine::types::mana::ManaCost;
+use engine::types::phase::Phase;
+
+/// Verbatim Scryfall Oracle text (verified 2026-09-09).
+const GIFTS_UNGIVEN: &str = "Search your library for up to four cards with \
+different names and reveal them. Target opponent chooses two of those cards. \
+Put the chosen cards into your graveyard and the rest into your hand. Then \
+shuffle.";
+
+/// Four distinct names, so the "with different names" selection constraint is
+/// satisfiable. Built from Oracle text rather than the shared card database:
+/// Gifts Ungiven is absent from the curated test fixture, and requiring the
+/// full export would silently skip this regression in ordinary CI.
+const LIBRARY: [&str; 4] = [
+    "Library card A",
+    "Library card B",
+    "Library card C",
+    "Library card D",
+];
+
+#[test]
+fn gifts_ungiven_offers_each_revealed_card_exactly_once() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.with_library_top(P0, &LIBRARY);
+    let gifts = scenario
+        .add_spell_to_hand_from_oracle(P0, "Gifts Ungiven", false, GIFTS_UNGIVEN)
+        .with_mana_cost(ManaCost::zero())
+        .id();
+    let mut runner = scenario.build();
+
+    runner.cast(gifts).target_player(P1).resolve();
+
+    // P0's search picks the four distinct-named cards Gifts reveals.
+    let WaitingFor::SearchChoice { cards, count, .. } = runner.state().waiting_for.clone() else {
+        panic!(
+            "reach guard: Gifts must first park P0's library search, got {:?}",
+            runner.state().waiting_for
+        );
+    };
+    assert_eq!(count, 4, "Gifts searches for up to four cards");
+    let found: Vec<_> = cards.into_iter().take(count).collect();
+    runner
+        .act(GameAction::SelectCards {
+            cards: found.clone(),
+        })
+        .expect("submitting the four searched cards must resume Gifts");
+
+    // Now the targeted opponent chooses two of those revealed cards.
+    let WaitingFor::ChooseFromZoneChoice {
+        cards: offered,
+        player,
+        count: pick,
+        ..
+    } = runner.state().waiting_for.clone()
+    else {
+        panic!(
+            "reach guard: the targeted opponent must be offered the revealed cards, got {:?}",
+            runner.state().waiting_for
+        );
+    };
+    assert_eq!(player, P1, "the TARGETED opponent chooses (CR 601.2c)");
+    assert_eq!(pick, 2, "Gifts has the opponent choose two");
+
+    let mut deduped = offered.clone();
+    deduped.sort();
+    deduped.dedup();
+    assert_eq!(
+        offered.len(),
+        deduped.len(),
+        "issue #8135: the chooser must offer each revealed card EXACTLY ONCE. A \
+         duplicated id renders two tiles that share one selection identity in \
+         ChooseFromZoneModal (`key={{id}}` + `Set<ObjectId>`), which is why one \
+         click appears to select both while the submitted pick stays correct. \
+         offered={offered:?}"
+    );
+    assert_eq!(
+        deduped.len(),
+        found.len(),
+        "exactly the four searched-and-revealed cards may be offered"
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -331,6 +331,7 @@ mod gideon_jura_forced_attack_planeswalker;
 mod gideon_trials_emblem;
 mod gift_delivery_draw_sequence_migration;
 mod gift_recipient_phased_out_opponent;
+mod gifts_ungiven_duplicate_candidates_8135;
 mod giggling_skitterspike_issue_890;
 mod gimbal_gremlin_prodigy;
 mod glen_elendras_answer_counter_all_conjunction;


### PR DESCRIPTION
Fixes #8135.

## Symptoms

Gifts Ungiven's chooser prompt listed every revealed card **twice**. Clicking one copy visually selected both, while the submitted selection and the spell's resolution stayed **correct**.

## Not a frontend bug

The issue is labelled `area:frontend`; it isn't. Those three symptoms together localize it precisely.

`ChooseFromZoneModal` renders `data.cards.map(...)` with `key={id}` and holds selection in a `Set<ObjectId>`. A payload carrying the same `ObjectId` twice therefore yields exactly the reported behavior:

| symptom | mechanism |
|---|---|
| two tiles per card | duplicate ids in `data.cards` |
| one click selects both | `selectedSet.has(id)` — shared selection identity |
| selection/resolution correct | `Array.from(selectedSet)` deduplicates on confirm |

The client was faithful to its input. Measured payload before the fix:

```
offered=[ObjectId(4), ObjectId(3), ObjectId(2), ObjectId(1),
         ObjectId(4), ObjectId(3), ObjectId(2), ObjectId(1)]
```

Four cards, eight entries — the same ordered sequence appended twice.

**Suggest relabelling `area:frontend` → `area:engine`.** Anyone picking this up from the label would search React and find nothing wrong there.

## Root cause

`publish_tracked_set` (`crates/engine/src/game/effects/mod.rs`) chain-unified by `extend` with no dedup. Two producers in one resolution chain legitimately publish the **same** object when both name the same population — Gifts' *"search your library for up to four cards with different names and reveal them"* both finds and reveals the identical four cards — so each landed twice.

## Wider than the prompt

`QuantityRef::TrackedSetSize` reads the same population, so **any** "for each card &lt;verb&gt; this way" on a chain with two producers over shared objects would likewise have double-counted. A tracked set holds objects; an object cannot be in it twice.

Fixed at that invariant rather than at the Gifts chain, so the whole class is covered rather than the one card.

## Two deliberate choices

- **First-publish order, not sorted.** Consumers read this population positionally (the chooser renders it in order), so the sibling publisher's `sort_unstable_by_key` + `dedup` shape is deliberately *not* reused — it would reorder every existing chain set.
- **The single-publish path is deduplicated too.** The invariant belongs to the set, not to each caller.

## Verification

- **21,057** lib tests pass, 0 failures
- **6,720** integration tests pass, 0 failures

The integration run is the load-bearing one: every "this way" consumer (Living Death, Kathril, Storm Herald, the exile/sacrifice chains) exercises merged tracked sets end-to-end, and none were disturbed by the ordering change.

The regression test builds Gifts from verified Scryfall Oracle text rather than the shared card database — Gifts Ungiven is absent from the curated fixture, so a db-backed test would have silently skipped in ordinary CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TJ4SDW7uZMSdKXtinzFuHe

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed duplicate cards appearing when an effect reports the same cards multiple times.
  * Card selection prompts now show each revealed card only once, preserving the original discovery order.
  * Gifts Ungiven selection prompts now consistently offer the four cards searched and revealed, without duplicate entries.

* **Tests**
  * Added integration coverage verifying that Gifts Ungiven presents exactly four unique cards for selection and that each matches the searched cards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->