### PR TITLE
feat(client): move tournament bearer credentials off localStorage (sessionStorage)

### DIFF
--- a/client/src/stores/__tests__/multiplayerStore.test.ts
+++ b/client/src/stores/__tests__/multiplayerStore.test.ts
@@ -43,6 +43,8 @@ import {
   normalizeDisabledDirectorySources,
   normalizeRememberedHostConfig,
   normalizeUserLobbySources,
+  hydrateSessionTournamentCredentials,
+  rememberTournamentCredential,
   userLobbySource,
   type AmbientLobbyFrame,
   type HostingSettings,
@@ -671,6 +673,39 @@ describe("multiplayerStore", () => {
       ],
     };
     expect(migratePersistedMultiplayerState(blob, 6)).toEqual(blob);
+  });
+
+  // v6 -> v7: tournament bearer credentials leave localStorage. A pre-v7 blob
+  // that persisted them has them stripped; every other field is preserved.
+  it("strips tournament credentials from a pre-v7 store (v6 -> v7)", () => {
+    const migrated = migratePersistedMultiplayerState(
+      {
+        hostingServer: "wss://play.example.com/ws",
+        userLobbySources: [],
+        tournamentCredentials: {
+          TOUR01: { organizerToken: "secret", updatedAt: 1 },
+        },
+      },
+      6,
+    ) as Record<string, unknown>;
+
+    expect(migrated.tournamentCredentials).toBeUndefined();
+    expect(migrated.hostingServer).toBe("wss://play.example.com/ws");
+  });
+
+  // The strip must survive the early return the `version < 6` serverAddress arm
+  // takes — a pre-v6 blob carrying BOTH a legacy address and credentials.
+  it("strips credentials even when the legacy serverAddress arm runs (v5 -> v7)", () => {
+    const migrated = migratePersistedMultiplayerState(
+      {
+        serverAddress: "wss://play.example.com/ws",
+        tournamentCredentials: { TOUR01: { playerToken: "secret", updatedAt: 1 } },
+      },
+      5,
+    ) as Record<string, unknown>;
+
+    expect(migrated.tournamentCredentials).toBeUndefined();
+    expect(migrated.hostingServer).toBe("wss://play.example.com/ws");
   });
 
   it("drops malformed persisted user sources on hydration", () => {
@@ -2657,6 +2692,70 @@ describe("multiplayerStore", () => {
     detach = await dial({ directorySources: belowFloor(PRESET_URL) });
     expect(openPhaseSocket).toHaveBeenCalledWith(PRESET_URL, { surface: "lobby" });
     detach?.();
+  });
+});
+
+describe("tournament credential storage (sessionStorage, not localStorage)", () => {
+  const SESSION_KEY = "phase-tournament-credentials";
+
+  beforeEach(() => {
+    sessionStorage.clear();
+    localStorageItems.clear();
+    useMultiplayerStore.setState({ tournamentCredentials: {} });
+  });
+
+  it("writes credentials to sessionStorage and NOT to the localStorage persist blob", () => {
+    act(() => {
+      useMultiplayerStore.setState((state) => ({
+        tournamentCredentials: rememberTournamentCredential(
+          state.tournamentCredentials,
+          "TOUR01",
+          { organizerToken: "secret" },
+        ),
+      }));
+    });
+
+    // Present in sessionStorage.
+    const session = JSON.parse(sessionStorage.getItem(SESSION_KEY) ?? "null");
+    expect(session?.TOUR01?.organizerToken).toBe("secret");
+
+    // Absent from the localStorage persist blob — the whole point of the move.
+    const persisted = JSON.parse(localStorageItems.get("phase-multiplayer") ?? "null");
+    expect(persisted?.state?.tournamentCredentials).toBeUndefined();
+  });
+
+  it("hydrates credentials from sessionStorage into the store", () => {
+    // The store is already empty from `beforeEach`; seed sessionStorage with no
+    // intervening `setState`, or the change subscription would wipe the seed
+    // (an emptied map removes the key).
+    sessionStorage.setItem(
+      SESSION_KEY,
+      JSON.stringify({ TOUR01: { playerToken: "secret", updatedAt: 5 } }),
+    );
+
+    hydrateSessionTournamentCredentials();
+
+    expect(
+      useMultiplayerStore.getState().tournamentCredentials.TOUR01?.playerToken,
+    ).toBe("secret");
+  });
+
+  it("removes the sessionStorage key when the credential map empties", () => {
+    act(() => {
+      useMultiplayerStore.setState((state) => ({
+        tournamentCredentials: rememberTournamentCredential(
+          state.tournamentCredentials,
+          "TOUR01",
+          { organizerToken: "secret" },
+        ),
+      }));
+    });
+    expect(sessionStorage.getItem(SESSION_KEY)).not.toBeNull();
+
+    act(() => {
+      useMultiplayerStore.setState({ tournamentCredentials: {} });
+    });
+    expect(sessionStorage.getItem(SESSION_KEY)).toBeNull();
   });
 });
 

--- a/client/src/stores/__tests__/multiplayerStore.tournament.test.ts
+++ b/client/src/stores/__tests__/multiplayerStore.tournament.test.ts
@@ -27,6 +27,7 @@ const localStorageMock = vi.hoisted(() => {
 
 import {
   MAX_TOURNAMENT_CREDENTIALS,
+  hydrateSessionTournamentCredentials,
   rememberTournamentCredential,
   useMultiplayerStore,
   findLobbyGameByCode,
@@ -277,35 +278,38 @@ afterEach(() => {
 // ── A. tournament credentials (R1, R2, R6, R10, R11, R11b) ───────────────
 
 describe("tournament credentials", () => {
-  it("persists tournament credentials across a rehydrate", async () => {
-    useMultiplayerStore.setState({
-      tournamentCredentials: {
-        AAA: { organizerToken: "org-a", updatedAt: 10 },
-        BBB: { playerToken: "ply-b", playerKey: "key-b", updatedAt: 20 },
-      },
-    });
+  it("persists tournament credentials to sessionStorage, not the localStorage blob", () => {
+    const CREDS = {
+      AAA: { organizerToken: "org-a", updatedAt: 10 },
+      BBB: { playerToken: "ply-b", playerKey: "key-b", updatedAt: 20 },
+    };
+    useMultiplayerStore.setState({ tournamentCredentials: CREDS });
 
+    // The bearer secrets must NOT ride the localStorage persist blob.
     const raw = localStorage.getItem("phase-multiplayer");
     expect(raw).not.toBeNull();
     const blob = JSON.parse(raw as string) as { state: Record<string, unknown> };
-    expect(blob.state.tournamentCredentials).toEqual({
-      AAA: { organizerToken: "org-a", updatedAt: 10 },
-      BBB: { playerToken: "ply-b", playerKey: "key-b", updatedAt: 20 },
-    });
-    // Positive reach-guard: the credentials rode the SAME partition as the
-    // other persisted keys, so this is not a coincidentally-present blob.
+    expect(blob.state.tournamentCredentials).toBeUndefined();
+    // Positive reach-guard: the blob IS being written (other keys ride it), so
+    // the absence above is a real exclusion, not a coincidentally-absent blob.
     expect(blob.state.playerId).toBe(store().playerId);
 
-    // Wipe in memory, restore the blob (the wipe re-persisted an empty map),
-    // and hydrate through `merge` + the normalizer.
-    useMultiplayerStore.setState({ tournamentCredentials: {} });
-    localStorage.setItem("phase-multiplayer", raw as string);
-    await useMultiplayerStore.persist.rehydrate();
+    // They live in sessionStorage instead.
+    const session = JSON.parse(
+      sessionStorage.getItem("phase-tournament-credentials") ?? "null",
+    );
+    expect(session).toEqual(CREDS);
 
-    expect(store().tournamentCredentials).toEqual({
-      AAA: { organizerToken: "org-a", updatedAt: 10 },
-      BBB: { playerToken: "ply-b", playerKey: "key-b", updatedAt: 20 },
-    });
+    // Hydrate them back. Reseed sessionStorage right before hydrating: a
+    // `setState` wipe would fire the change subscription and clear the key.
+    useMultiplayerStore.setState({ tournamentCredentials: {} });
+    sessionStorage.setItem(
+      "phase-tournament-credentials",
+      JSON.stringify(CREDS),
+    );
+    hydrateSessionTournamentCredentials();
+
+    expect(store().tournamentCredentials).toEqual(CREDS);
   });
 
   it("hydrates a pre-phase-2 blob with an empty credential map", async () => {
@@ -330,26 +334,22 @@ describe("tournament credentials", () => {
     expect(store().displayName).toBe("Legacy");
   });
 
-  it("drops malformed persisted credentials and enforces the cap on hydrate", async () => {
-    const hydrateWith = async (credentials: unknown) => {
-      localStorage.setItem(
-        "phase-multiplayer",
-        JSON.stringify({
-          state: {
-            playerId: "p",
-            serverAddress: "ws://localhost:8787",
-            tournamentCredentials: credentials,
-          },
-          version: 5,
-        }),
+  it("drops malformed persisted credentials and enforces the cap on hydrate", () => {
+    const hydrateWith = (credentials: unknown) => {
+      // Credentials hydrate from sessionStorage now; seed it directly (a
+      // `setState` wipe would fire the change subscription and clear the key)
+      // and hydrate through the same normalizer + cap.
+      sessionStorage.setItem(
+        "phase-tournament-credentials",
+        JSON.stringify(credentials),
       );
-      await useMultiplayerStore.persist.rehydrate();
+      hydrateSessionTournamentCredentials();
       return store().tournamentCredentials;
     };
 
     // Part 1 — malformed entries, well under the cap so eviction cannot be
     // confused with rejection.
-    const cleaned = await hydrateWith({
+    const cleaned = hydrateWith({
       AAA: { organizerToken: "t", updatedAt: 5 },
       BBB: { playerToken: 42 }, // non-string token, no other authority
       CCC: "not-an-object",
@@ -373,7 +373,7 @@ describe("tournament credentials", () => {
     paddedCodes(1, 40).forEach((code, index) => {
       overflowing[code] = { organizerToken: `org-${code}`, updatedAt: 1000 + index };
     });
-    const capped = await hydrateWith(overflowing);
+    const capped = hydrateWith(overflowing);
 
     expect(Object.keys(capped)).toHaveLength(MAX_TOURNAMENT_CREDENTIALS);
     expect("T40" in capped).toBe(true); // newest survives

--- a/client/src/stores/multiplayerStore.ts
+++ b/client/src/stores/multiplayerStore.ts
@@ -2061,6 +2061,17 @@ export function migratePersistedMultiplayerState(
 ): unknown {
   if (!persisted || typeof persisted !== "object") return persisted;
   const migrated = persisted as Record<string, unknown>;
+  // v6 → v7: tournament bearer credentials moved OFF localStorage. They are
+  // secrets that must not sit at rest in localStorage (readable by any
+  // same-origin script for the life of the profile); a dedicated sessionStorage
+  // sync owns them going forward and `partialize` no longer writes them here.
+  // Strip any a pre-v7 build persisted.
+  //
+  // Placed BEFORE the `version < 6` arm below, which returns early when a legacy
+  // `serverAddress` is present — a strip that ran after it could be skipped.
+  if (version < 7 && "tournamentCredentials" in migrated) {
+    delete migrated.tournamentCredentials;
+  }
   if (version < 3) {
     migrated.serverAddress = migrateOfficialServerAddress(
       migrated.serverAddress,
@@ -3459,7 +3470,7 @@ export const useMultiplayerStore = create<MultiplayerState & MultiplayerActions>
     }),
     {
       name: "phase-multiplayer",
-      version: 6,
+      version: 7,
       // v0/v1 → v2: official hosted lobby addresses are deployment defaults,
       // not user intent. A self-hosted build must move returning browsers from
       // the official lobby to its configured default while preserving explicit
@@ -3490,6 +3501,12 @@ export const useMultiplayerStore = create<MultiplayerState & MultiplayerActions>
       // authorities it browses). A hand-typed address becomes both; an
       // official or build-default address is already derived as a preset, so
       // it becomes the hosting server only.
+      //
+      // v6 → v7: tournament bearer credentials leave this localStorage-backed
+      // persist for sessionStorage (secrets must not sit at rest in
+      // localStorage). The migration strips any a pre-v7 build wrote here;
+      // `partialize` no longer emits them and a dedicated sessionStorage sync
+      // (below the store) owns them.
       migrate: migratePersistedMultiplayerState,
       // Persisted state is external input. Migration only runs when the schema
       // version changes, so hydrate current-version blobs through the same
@@ -3502,9 +3519,13 @@ export const useMultiplayerStore = create<MultiplayerState & MultiplayerActions>
           ...current,
           ...saved,
           lastHostConfig: normalizeRememberedHostConfig(saved.lastHostConfig),
-          tournamentCredentials: normalizeTournamentCredentials(
-            saved.tournamentCredentials,
-          ),
+          // Tournament credentials are NEVER hydrated from this localStorage
+          // blob (v7): they live in sessionStorage now. Forcing the in-memory
+          // initial here — after `...saved` — guarantees a stray or
+          // pre-migration localStorage copy cannot win;
+          // `hydrateSessionTournamentCredentials` (below the store) fills the
+          // real value right after creation.
+          tournamentCredentials: current.tournamentCredentials,
           userLobbySources: normalizeUserLobbySources(saved.userLobbySources),
           disabledDirectorySources: normalizeDisabledDirectorySources(
             saved.disabledDirectorySources,
@@ -3541,11 +3562,84 @@ export const useMultiplayerStore = create<MultiplayerState & MultiplayerActions>
         // projection is rebuilt each session, never persisted.
         disabledDirectorySources: state.disabledDirectorySources,
         lastHostConfig: state.lastHostConfig,
-        tournamentCredentials: state.tournamentCredentials,
+        // `tournamentCredentials` is deliberately ABSENT: these are bearer
+        // secrets and must not be written to localStorage. They persist to
+        // sessionStorage instead — see `hydrateSessionTournamentCredentials`
+        // and the subscription just below the store.
       }),
     },
   ),
 );
+
+// ── Tournament credentials: sessionStorage, not localStorage ───────────────
+//
+// Bearer secrets (`organizer_token` / `player_token`) must not sit at rest in
+// localStorage, where any same-origin script can read them for the life of the
+// browser profile. They live in sessionStorage instead: preserved across a
+// refresh (an organizer keeps authority), cleared when the tab closes. This is
+// a separate persistence from the localStorage-backed `persist` above — the
+// store's `partialize` omits the credentials and its `merge` never hydrates
+// them from localStorage.
+
+const TOURNAMENT_CREDENTIALS_SESSION_KEY = "phase-tournament-credentials";
+
+/** Reads and validates the credential map from sessionStorage. Any failure
+ *  (absent, quota, disabled, malformed) yields an empty map — credentials then
+ *  simply do not survive, exactly as a fresh tab. */
+function readSessionTournamentCredentials(): Record<string, TournamentCredential> {
+  try {
+    const raw = sessionStorage.getItem(TOURNAMENT_CREDENTIALS_SESSION_KEY);
+    if (raw === null) return {};
+    return normalizeTournamentCredentials(JSON.parse(raw));
+  } catch {
+    return {};
+  }
+}
+
+/** Writes the credential map to sessionStorage, removing the key entirely when
+ *  the map is empty so a cleared session leaves nothing behind. */
+function writeSessionTournamentCredentials(
+  credentials: Record<string, TournamentCredential>,
+): void {
+  try {
+    if (Object.keys(credentials).length === 0) {
+      sessionStorage.removeItem(TOURNAMENT_CREDENTIALS_SESSION_KEY);
+      return;
+    }
+    sessionStorage.setItem(
+      TOURNAMENT_CREDENTIALS_SESSION_KEY,
+      JSON.stringify(credentials),
+    );
+  } catch {
+    // Non-fatal: with no sessionStorage the credentials just do not survive a
+    // refresh, which is a strictly safer failure than persisting them anyway.
+  }
+}
+
+/**
+ * Loads sessionStorage-persisted credentials into the store. Runs once at
+ * module load, after `create` has finished localStorage hydration, so it is the
+ * final word on the initial `tournamentCredentials` value. Idempotent and
+ * exported so a test can drive it against a seeded sessionStorage.
+ */
+export function hydrateSessionTournamentCredentials(): void {
+  const hydrated = readSessionTournamentCredentials();
+  if (Object.keys(hydrated).length > 0) {
+    useMultiplayerStore.setState({ tournamentCredentials: hydrated });
+  }
+}
+
+hydrateSessionTournamentCredentials();
+
+// Mirror every later change to the credential map back to sessionStorage. Keyed
+// on identity: `rememberTournamentCredential` and the fan-out both return a new
+// object only when the map actually changed, so unrelated store updates do not
+// touch storage.
+useMultiplayerStore.subscribe((state, prev) => {
+  if (state.tournamentCredentials !== prev.tournamentCredentials) {
+    writeSessionTournamentCredentials(state.tournamentCredentials);
+  }
+});
 
 export function getPlayerDisplayName(playerId: number, myId?: number): string {
   if (playerId === myId) return "You";

--- a/docs/proposals/tournament-organizer/PR7-CREDENTIAL-ROTATION.md
+++ b/docs/proposals/tournament-organizer/PR7-CREDENTIAL-ROTATION.md
@@ -1,0 +1,77 @@
+# PR 7 — Move tournament bearer credentials off localStorage (+ deferred rotation)
+
+**As-of base:** `upstream/main` (includes #8673). Frontend-only: no Rust, no protocol bump.
+
+This PR ships the **safe half** of the original credential-rotation plan — moving the bearer
+secrets off `localStorage` — and **defers credential rotation** to a follow-up, because rotation
+cannot be made safe on the current server protocol without a server-side change (see §3).
+
+---
+
+## 1. What this PR does
+
+Tournament bearer secrets (`organizer_token` / `player_token`) were persisted to **localStorage**
+via the `phase-multiplayer` Zustand `persist` (`partialize` included `tournamentCredentials`, and
+`merge` rehydrated them). Secrets at rest in localStorage are readable by any same-origin script
+for the life of the browser profile.
+
+They now live in **sessionStorage** instead:
+- Dropped from the localStorage persist `partialize`; `merge` no longer hydrates them from
+  localStorage (it forces the in-memory initial so a stray/pre-migration copy can't win).
+- Owned by a dedicated sessionStorage sync: `hydrateSessionTournamentCredentials()` (runs once at
+  module load, after localStorage hydration) + a store-change subscription that mirrors the map to
+  sessionStorage (removing the key when the map empties). Reads go through the existing
+  `normalizeTournamentCredentials` validator/cap.
+- Store persist **v6 → v7** migration strips any credentials a pre-v7 build wrote to localStorage,
+  placed before the early-returning legacy-`serverAddress` arm so it always runs.
+
+**Trade-off (accepted, per maintainer decision):** sessionStorage survives a refresh (an organizer
+keeps authority) but is cleared when the tab closes — a narrower lifetime than localStorage, which
+is the point. A credential lost this way is re-earned by re-create/re-join, which the model already
+treats as possible.
+
+Tests: sessionStorage-not-localStorage persistence, hydrate round-trip, empty-map key removal,
+malformed-drop + cap on hydrate, and v6→v7 (and v5→v7) credential strip.
+
+---
+
+## 2. What is DEFERRED (rotation) and why
+
+The original plan also added the `RenewTournamentCredential` client sender + a proactive
+near-expiry rotation trigger. That was implemented and reviewed on #8782, and a **[HIGH]** review
+finding (matthewevans, corroborated by CodeRabbit) showed it is **unsafe on the current server
+protocol** — so it is removed from this PR and deferred.
+
+---
+
+## 3. The blocking finding: rotation is destructive and non-idempotent
+
+`renew_credential` (`crates/lobby-broker/src/tournament.rs:2055-2102`) **replaces the stored token
+before replying**, and the reply (`broker.rs:1377-1389`) carries **only** the freshly minted
+secret. So a timeout / abort / connection loss *after the server commit but before the reply is
+delivered* leaves the client holding a credential the broker has already invalidated — and an
+expired/rotated credential is **unrenewable**, so the authority is **permanently stranded**. The
+uncertain-failure results are indistinguishable at the client (`tournamentClient.ts` `requestOver`).
+
+This is **not safe to solve in the client alone** (a client that reuses the old secret after an
+uncertain result races the server commit either way). A safe rotation needs one of:
+- **Idempotent rotation** — the request carries a client-minted correlation id/nonce; replaying it
+  returns the *already-minted* replacement instead of rotating again, so a lost reply is
+  recoverable by retry.
+- **Bounded old-token overlap** — the broker keeps the previous secret valid for a short grace
+  window after rotation, so a lost reply doesn't immediately strand the holder.
+
+Either is a **server-side (`lobby-broker` + mirror crates) change with a lobby-protocol bump** —
+no longer frontend-only. The follow-up PR does that first, then adds the client half (sender +
+proactive near-expiry trigger driven off the stored `expires_at_ms`) on top, with a production-path
+regression that drives server rotation, drops the reply, and proves the authority survives.
+
+The full client-side rotation design (sender shape, `shouldRenewCredential`, `maybeRenewNearExpiry`,
+7-day TTL sizing) is preserved on the `pr8782-fullrotation` tag / #8782 history for that follow-up.
+
+---
+
+## 4. Relationship to #8673
+#8673 (v6 client-consumption) merged; this PR is rebased onto that `main`. Independent feature;
+file overlap was only in the (now-deferred) rotation code — the storage move touches
+`multiplayerStore.ts` and its tests only.


### PR DESCRIPTION
**Rescoped** from the original "rotation + storage" PR to just the **safe half**: move tournament bearer credentials off `localStorage`. Credential **rotation is deferred** — it can't be made safe on the current server protocol (see the [HIGH] resolution below). Frontend-only: no Rust, no protocol bump. Design record: `docs/proposals/tournament-organizer/PR7-CREDENTIAL-ROTATION.md`.

## What changed
Bearer secrets (`organizer_token` / `player_token`) were persisted to **`localStorage`** via the `phase-multiplayer` Zustand `persist`, where any same-origin script can read them for the life of the browser profile. They move to **`sessionStorage`**: preserved across a refresh (an organizer keeps authority), cleared when the tab closes.

- Dropped `tournamentCredentials` from the localStorage persist `partialize`; `merge` no longer hydrates them from localStorage (forces the in-memory initial so a stray/pre-migration copy can't win).
- Dedicated sessionStorage sync: `hydrateSessionTournamentCredentials()` runs once at module load (after localStorage hydration) and a store-change subscription mirrors the map to sessionStorage, removing the key when the map empties. Reads go through the existing `normalizeTournamentCredentials` validator + cap.
- Store persist **v6 → v7** migration strips any credentials a pre-v7 build wrote to localStorage, placed before the early-returning legacy-`serverAddress` arm so it always runs.

**Trade-off (intentional):** sessionStorage has a narrower lifetime than localStorage — that's the security win. A credential lost on tab-close is re-earned by re-create/re-join, which the model already treats as possible.

## Tests
sessionStorage-not-localStorage persistence, hydrate round-trip, empty-map key removal, malformed-drop + cap on hydrate, and v6→v7 (and v5→v7) credential strip. Verified: `pnpm type-check` (incl. `protocol:check`), `eslint`, and the tournament/store suites. (A flaky, order-dependent set of unrelated UI/`scryfall` specs fails in my *local* env on current `main` too — confirmed against a clean `upstream/main` baseline — so it's pre-existing environmental noise, not from this change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security Improvements**
  - Tournament credentials are now stored in session storage instead of persistent local storage.
  - Existing persisted credentials are removed during migration.
  - Invalid session credentials are cleaned up, and credential limits are enforced.

- **Documentation**
  - Updated tournament credential documentation to describe the new storage behavior and defer credential rotation until server support is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->