### PR TITLE
test(engine): cover the summary dispatch's CR 407.3 check

### DIFF
--- a/crates/engine/src/game/deck_validation.rs
+++ b/crates/engine/src/game/deck_validation.rs
@@ -9514,6 +9514,73 @@ mod tests {
         );
     }
 
+    /// CR 407.3 must reach the SUMMARY dispatch too, not only the
+    /// authoritative one.
+    ///
+    /// `evaluate_selected_format_summary` carries its own copy of the check,
+    /// with a comment promising the UI hint cannot disagree with the
+    /// game-creation gate about an ante card. Nothing tested that promise:
+    /// every other ante test drives `validate_deck_for_format`, and
+    /// `summary_only` defaults to `false`, so deleting that block left the
+    /// whole suite green while the deck builder silently showed a deck as
+    /// legal that game creation would then refuse.
+    ///
+    /// Loops the flag rather than testing the summary path alone, matching
+    /// `commander_listed_by_composite_and_front_name_is_one_card` — the two
+    /// verdicts agreeing is the property worth pinning, and asserting the
+    /// summary result in isolation would not catch the two drifting apart.
+    #[test]
+    fn both_dispatches_agree_that_an_ante_card_is_illegal() {
+        let db = CardDatabase::from_json_str(&ante_db_json()).unwrap();
+        let config = FormatConfig::for_custom_rules(
+            &crate::types::custom_format::swedish_old_school().rules,
+        );
+
+        for summary_only in [false, true] {
+            // Paired control FIRST, on the same config and flag: a legal deck
+            // is accepted. The summary path answers `None` ("no opinion") for
+            // several shapes, and a `None` would satisfy neither assertion
+            // below — this proves the path is actually forming a verdict
+            // rather than declining to.
+            let legal = DeckCompatibilityRequest {
+                main_deck: expand("Plains", 60),
+                selected_format: Some(SelectedFormat::Resolved(Box::new(config.clone()))),
+                summary_only,
+                player_count: default_player_count(),
+                ..Default::default()
+            };
+            assert_eq!(
+                evaluate_deck_compatibility(&db, &legal).selected_format_compatible,
+                Some(true),
+                "summary_only={summary_only}: a clean deck must be accepted"
+            );
+
+            let with_ante = DeckCompatibilityRequest {
+                main_deck: legal_60_main("Jeweled Bird"),
+                selected_format: Some(SelectedFormat::Resolved(Box::new(config.clone()))),
+                summary_only,
+                player_count: default_player_count(),
+                ..Default::default()
+            };
+            let result = evaluate_deck_compatibility(&db, &with_ante);
+            assert_eq!(
+                result.selected_format_compatible,
+                Some(false),
+                "summary_only={summary_only}: CR 407.3 must reject the deck on BOTH dispatches, \
+                 got reasons {:?}",
+                result.selected_format_reasons
+            );
+            assert!(
+                result
+                    .selected_format_reasons
+                    .iter()
+                    .any(|reason| reason.contains("Jeweled Bird")),
+                "summary_only={summary_only}: the rejection must name the ante card, got {:?}",
+                result.selected_format_reasons
+            );
+        }
+    }
+
     /// CR 407.3 across the routes that decide deck admission by DIFFERENT
     /// authorities: permissive formats with no card-pool check at all
     /// (FreeForAll / TwoHeadedGiant answer `true` unconditionally) and a custom


### PR DESCRIPTION
Closes the follow-up CodeRabbit raised on #8736 and matthewevans marked non-blocking.

`evaluate_selected_format_summary` carries its own copy of the CR 407.3 ante check, with a comment promising the UI hint cannot disagree with the game-creation gate about an ante card. **Nothing tested that promise.** Every other ante test drives `validate_deck_for_format`, and `summary_only` defaults to `false`, so the block was unreachable from the suite entirely.

Not cosmetic: had it been deleted, the deck builder would have shown a deck as legal that game creation then refused — and the suite would have stayed green.

## The test

`both_dispatches_agree_that_an_ante_card_is_illegal` loops `summary_only` over `[false, true]`, following the module's existing `commander_listed_by_composite_and_front_name_is_one_card`.

Looping is the point rather than testing the summary path alone: **the two verdicts agreeing** is the property worth pinning, and asserting the summary result in isolation would not catch the two drifting apart.

Each iteration runs a paired legal-deck control first. The summary path answers `None` ("no opinion") for several shapes, and a `None` satisfies neither assertion below it — so the control proves the path is actually forming a verdict rather than declining to.

## Verified by mutation, not by argument

Since this PR exists *because* a test passed that should not have, I didn't want to assert the new one discriminates without showing it.

With the summary-path block removed:

```
test game::deck_validation::tests::both_dispatches_agree_that_an_ante_card_is_illegal ... FAILED
assertion `left == right` failed: summary_only=true: CR 407.3 must reject the deck on BOTH dispatches, got reasons []
test result: FAILED. 150 passed; 1 failed
```

Exactly one test fails — this one, on the `summary_only=true` iteration — while the other 150 still pass, reproducing the original blind spot precisely. Block restored:

```
test result: ok. 151 passed; 0 failed
```

The diff is purely additive (67 insertions, 0 deletions); the mutation was fully reverted before committing.

Test-only change, no production behavior touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013h1rTnbzGpibH8sbszunhs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage verifying that ante cards are rejected from decks across both compatibility-checking paths.
  * Confirmed that valid 60-card Plains decks continue to be accepted.
  * Verified that rejection details identify the specific illegal card.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->