### PR TITLE
Add a portable stack high-water instrument for the Commander resolution path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1957,6 +1957,7 @@ dependencies = [
  "im",
  "indexmap",
  "insta",
+ "libc",
  "nom",
  "petgraph",
  "phase-engine",

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -119,6 +119,11 @@ serde_json = "1"
 
 [dev-dependencies]
 flate2 = "1"
+# Test-only. `game_state_stack_high_water.rs` queries the running thread's real
+# stack bounds (`pthread_getattr_np` / `pthread_get_stackaddr_np`) instead of
+# inferring them from a local address. Already in Cargo.lock transitively, so
+# this vendors nothing new.
+libc = "0.2"
 engine = { path = ".", package = "phase-engine", features = ["test-support"] }
 tempfile = "3"
 insta = { version = "1", features = ["json"] }

--- a/crates/engine/tests/integration/game_state_stack_budget.rs
+++ b/crates/engine/tests/integration/game_state_stack_budget.rs
@@ -127,20 +127,28 @@
 //! `BOUNDED_STACK_BYTES` from the *intersection* of all measured windows.
 //! Cross-compiling is not enough — the bisection has to execute.
 //!
-//! # A better instrument exists — this gate is not the only option
+//! # A better instrument exists, and now sits next to this one
 //!
-//! Recorded as a follow-up, deliberately not built here: **stack-painting
-//! high-water measurement**. Spawn a thread with a known large stack, fill it
-//! with a sentinel pattern, run the fixture, then scan for the deepest
-//! disturbed byte. That yields a *number* rather than the survive/abort bit
-//! this test produces, which means it (a) fails politely with "high-water
-//! 2,410 KiB exceeds budget 3,072 KiB" instead of a bare SIGABRT, (b) runs on
-//! every target, because the assertion is on the measured value rather than on
-//! a target-calibrated bound, and (c) makes the 1.36x-vs-2.42x ratio above
-//! *trackable over time* instead of something that has to be re-bisected by
-//! hand. It is materially more work and needs care around what the OS actually
-//! commits versus reserves. Do not read the `cfg` below as a claim that
+//! **Stack-painting high-water measurement**, recorded here as a follow-up and
+//! since built as `game_state_stack_high_water.rs`. Spawn a thread with a known
+//! large stack, fill it with a sentinel pattern, run the fixture, then scan for
+//! the deepest disturbed byte. That yields a *number* rather than the
+//! survive/abort bit this test produces, which means it (a) fails politely with
+//! "high-water 2,410 KiB exceeds budget 3,072 KiB" instead of a bare SIGABRT,
+//! (b) runs on every target, because the assertion is on the measured value
+//! rather than on a target-calibrated bound, and (c) makes the
+//! 1.36x-vs-2.42x ratio above *trackable over time* instead of something that
+//! has to be re-bisected by hand. Do not read the `cfg` below as a claim that
 //! target-gating was the only available design.
+//!
+//! **It does not replace this file, and the two are not redundant.** That one
+//! runs the same fixture on a 64 MiB stack and asserts a loose, portable
+//! ceiling, so it can run in CI on every target — which this file, gated to a
+//! target this repository has no runner for, has never done. What it gives up
+//! is exactly what the calibration above buys: the 3 MiB bound below is a
+//! *discrimination* dial, sharp enough that reverting the boxing flips it red,
+//! and no portable assertion can be that sharp. Keep both: this one for
+//! sensitivity where it is calibrated, that one for coverage everywhere else.
 #![cfg(all(target_arch = "aarch64", target_os = "macos"))]
 
 use engine::game::scenario::{GameScenario, P0, P1};

--- a/crates/engine/tests/integration/game_state_stack_budget.rs
+++ b/crates/engine/tests/integration/game_state_stack_budget.rs
@@ -133,18 +133,25 @@
 //! since built as `game_state_stack_high_water.rs`. Spawn a thread with a known
 //! large stack, fill it with a sentinel pattern, run the fixture, then scan for
 //! the deepest disturbed byte. That yields a *number* rather than the
-//! survive/abort bit this test produces, which means it (a) fails politely with
-//! "high-water 2,410 KiB exceeds budget 3,072 KiB" instead of a bare SIGABRT,
-//! (b) runs on every target, because the assertion is on the measured value
-//! rather than on a target-calibrated bound, and (c) makes the
-//! 1.36x-vs-2.42x ratio above *trackable over time* instead of something that
-//! has to be re-bisected by hand. Do not read the `cfg` below as a claim that
-//! target-gating was the only available design.
+//! survive/abort bit this test produces, which means it (a) fails politely,
+//! naming the measured high-water against its 8 MiB portable ceiling, instead
+//! of a bare SIGABRT, (b) runs on 64-bit Linux, Android and macOS, because the
+//! assertion is on the measured value rather than on a target-calibrated bound,
+//! and (c) makes the 1.36x-vs-2.42x ratio above *trackable over time* instead
+//! of something that has to be re-bisected by hand. Do not read the `cfg` below
+//! as a claim that target-gating was the only available design.
+//!
+//! Its target list is worth reading carefully, because it is **not** the same
+//! kind of gate as the one below. That file needs a platform call to learn
+//! where the running thread's stack is; nothing in it is calibrated to a
+//! target, and adding one means adding a stack-bounds query rather than
+//! re-running a bisection. CI's `ubuntu-latest` x86_64 is covered, which is the
+//! point — this file is not.
 //!
 //! **It does not replace this file, and the two are not redundant.** That one
 //! runs the same fixture on a 64 MiB stack and asserts a loose, portable
-//! ceiling, so it can run in CI on every target — which this file, gated to a
-//! target this repository has no runner for, has never done. What it gives up
+//! ceiling, so it can run in CI on the targets it supports — which this file,
+//! gated to a target this repository has no runner for, has never done. What it gives up
 //! is exactly what the calibration above buys: the 3 MiB bound below is a
 //! *discrimination* dial, sharp enough that reverting the boxing flips it red,
 //! and no portable assertion can be that sharp. Keep both: this one for

--- a/crates/engine/tests/integration/game_state_stack_budget.rs
+++ b/crates/engine/tests/integration/game_state_stack_budget.rs
@@ -135,16 +135,17 @@
 //! the deepest disturbed byte. That yields a *number* rather than the
 //! survive/abort bit this test produces, which means it (a) fails politely,
 //! naming the measured high-water against its 8 MiB portable ceiling, instead
-//! of a bare SIGABRT, (b) runs on 64-bit Linux, Android and macOS, because the
-//! assertion is on the measured value rather than on a target-calibrated bound,
+//! of a bare SIGABRT, (b) runs on 64-bit Linux — including CI's x86_64, which
+//! this file has never run on — because the assertion is on the measured value
+//! rather than on a target-calibrated bound,
 //! and (c) makes the 1.36x-vs-2.42x ratio above *trackable over time* instead
 //! of something that has to be re-bisected by hand. Do not read the `cfg` below
 //! as a claim that target-gating was the only available design.
 //!
-//! Its target list is worth reading carefully, because it is **not** the same
-//! kind of gate as the one below. That file needs a platform call to learn
-//! where the running thread's stack is; nothing in it is calibrated to a
-//! target, and adding one means adding a stack-bounds query rather than
+//! Its target gate is worth reading carefully, because it is **not** the same
+//! kind of gate as the one below. Nothing in that file is calibrated to a
+//! target: it is gated to where its stack-bounds query has actually been run,
+//! so widening it means adding a query and executing the test there, not
 //! re-running a bisection. CI's `ubuntu-latest` x86_64 is covered, which is the
 //! point — this file is not.
 //!

--- a/crates/engine/tests/integration/game_state_stack_high_water.rs
+++ b/crates/engine/tests/integration/game_state_stack_high_water.rs
@@ -1,5 +1,5 @@
-//! Portable stack **high-water measurement** for the four-player Commander
-//! fixture that `game_state_stack_budget.rs` guards with a survive/abort bit.
+//! Stack **high-water measurement** for the four-player Commander fixture that
+//! `game_state_stack_budget.rs` guards with a survive/abort bit.
 //!
 //! This is the instrument that file's module docs record as the better
 //! available design and deliberately do not build:
@@ -12,25 +12,64 @@
 //! `#![cfg(all(target_arch = "aarch64", target_os = "macos"))]`, and this
 //! repository's CI has no macOS runner — every workflow in `.github/workflows/`
 //! is `ubuntu-latest` or an Android cross-build — so that guard has **never
-//! executed in CI**. It compiles out on every job. A measurement asserts on a
-//! value rather than on a target-calibrated bound, so it runs everywhere the
-//! engine builds, this repository's CI included.
+//! executed in CI**. It compiles out on every job. This file's assertion is on
+//! a measured value rather than on a target-calibrated bound, so it runs on
+//! every target it supports, CI's `ubuntu-latest` x86_64 included.
+//!
+//! # Which targets, and why not all of them
+//!
+//! 64-bit Linux, Android and macOS — see the `cfg` below. The gate is **not**
+//! a calibration gate like the sibling file's; nothing here is tuned to a
+//! target. It is a gate on [`stack_bounds`], which needs a platform call to
+//! learn where the running thread's stack actually is. Adding a target means
+//! adding its query to that function, not re-running a bisection.
 //!
 //! # Method
 //!
 //! 1. Spawn a thread with an explicit `MEASURE_STACK_BYTES` stack.
-//! 2. Take `anchor`, the address of a local in the measuring frame. The stack
-//!    grows down, so every frame the fixture pushes lies below it.
-//! 3. Paint `[low, anchor - FRAME_GAP)` with `SENTINEL`. `FRAME_GAP` keeps the
-//!    measuring frame's own live locals out of the painted region; `low` keeps
-//!    `GUARD_MARGIN` of clearance above the guard page.
+//! 2. Ask the platform for that thread's real stack bounds, and check the
+//!    answer against a local of the asking frame before trusting it.
+//! 3. Descend one frame into [`measure`], leaving the fixture's `GameRunner` in
+//!    the caller's frame, and paint `[low, hi)` with `SENTINEL`.
 //! 4. Run the fixture.
 //! 5. Scan up from `low` for the deepest byte that is no longer `SENTINEL`.
 //!
+//! # Why the paint cannot corrupt live state
+//!
+//! Painting a span of the running thread's own stack earns its safety
+//! argument, so here it is in full. Three claims, each checked at runtime
+//! rather than assumed:
+//!
+//! - **The span is inside the mapping.** `low` comes from
+//!   `pthread_getattr_np` / `pthread_get_stackaddr_np` — the thread's real
+//!   bounds — not from `anchor` arithmetic against the requested
+//!   `Builder::stack_size`, which is a *request* and tells you nothing about
+//!   where the allocation landed or how the guard page was carved out of it.
+//!   [`stack_bounds`] then refuses to return a range that does not contain a
+//!   local of its caller's frame, so a platform whose query describes some
+//!   other stack fails loudly instead of handing back an address to write to.
+//!
+//! - **Only values live at paint time can be damaged.** This is the load-bearing
+//!   one. Everything the fixture allocates *after* the paint — every frame it
+//!   pushes, every temporary in the `cast(..).resolve()` chain — is written into
+//!   the painted region on purpose. That is the measurement. So the exclusion
+//!   set is not "every local in this test", it is exactly "the values alive at
+//!   the instant `paint` runs", which is a short enumerable list.
+//!
+//! - **That list is enumerated and asserted.** In [`measure`] it is `probe`,
+//!   the `&mut GameRunner` and its pointee, `murder` and `victim`. Each is
+//!   checked to lie above the painted region before anything is written. The
+//!   `GameRunner` itself — by far the largest — is held by reference from a
+//!   *shallower* frame precisely so that it cannot be in range: whether a
+//!   captured value lands in the closure's frame or its caller's is the
+//!   compiler's choice, and this design removes the choice instead of betting
+//!   on it.
+//!
 //! # What the number is, and is not
 //!
-//! It is the deepest byte the fixture **wrote**, relative to `anchor`. Two
-//! honest caveats, neither of which affects its use as a regression signal:
+//! It is the deepest byte the fixture **wrote**, relative to the painting
+//! frame. Two honest caveats, neither of which affects its use as a regression
+//! signal:
 //!
 //! - **It is a lower bound.** A frame that reserves space without writing every
 //!   byte of it leaves sentinel behind, so the true reserved depth can exceed
@@ -45,6 +84,21 @@
 //! decisions) and `[profile.test]` inherits `dev`, so nothing is optimized
 //! away. Compare numbers **within** a target, never across targets.
 //!
+//! # Reading the number
+//!
+//! It is printed, and both harnesses hide stdout for a test that passes — which
+//! this one normally does. To actually see it:
+//!
+//! ```text
+//! cargo test -p phase-engine --test integration -- --nocapture \
+//!     --exact game_state_stack_high_water::four_player_commander_action_stack_high_water
+//! cargo nextest run -p phase-engine --success-output immediate -E 'test(stack_high_water)'
+//! ```
+//!
+//! So a default CI run asserts the ceiling but does not surface the value.
+//! Surfacing it per-run — and ratcheting on it — is the follow-up this file is
+//! the prerequisite for, not something it claims to have done.
+//!
 //! # Why the assertion is loose, and what it is for
 //!
 //! The number is the product; [`HIGH_WATER_CEILING_BYTES`] only stops the run
@@ -57,11 +111,9 @@
 //! target, where CI never runs it.
 //!
 //! So the split is deliberate: **assert** the thing that is true on every
-//! target (a single un-nested `apply()` must not approach the production stack
-//! budget), and **print** the thing that is only comparable within a target.
-//! Tightening the printed number into a per-target ratchet is the follow-up
-//! once it has a run history in CI to set rows from — see the drift figures in
-//! <https://github.com/phase-rs/phase/issues/8376>.
+//! supported target (a single un-nested `apply()` must not approach the
+//! production stack budget), and **print** the thing that is only comparable
+//! within a target.
 //!
 //! # A note on severity, so nobody reads this test as a fire alarm
 //!
@@ -73,23 +125,22 @@
 //! `phase-server/src/main.rs`: **32 MiB**, on the runtime owner thread and on
 //! every Tokio worker and blocking thread.
 //!
-//! That distinction is why this file's ceiling is nowhere near 3 MiB. Crossing
-//! 3 MiB means the *discriminating gate* has lost its calibration, which is
-//! worth knowing and is what issue #8376 reports. Crossing this file's ceiling
-//! would mean something much worse.
-//!
 //! The 32 MiB figure is also not headroom to spend: the server docs record
 //! that AI search keeps one live `Option<GameState>` per ply and that search
 //! depth is data-driven, so production depth is this fixture's number times a
 //! multiplier no static bound covers. The risk that matters is the multiplier,
-//! not the linear drift.
+//! not the linear drift — and the drift is not even monotonic. See
+//! <https://github.com/phase-rs/phase/issues/8376>.
 
-#![cfg(target_pointer_width = "64")]
+#![cfg(all(
+    target_pointer_width = "64",
+    any(target_os = "linux", target_os = "android", target_os = "macos")
+))]
 
 use std::ptr;
 use std::sync::atomic::{compiler_fence, Ordering};
 
-use engine::game::scenario::{GameScenario, P0, P1};
+use engine::game::scenario::{GameRunner, GameScenario, P0, P1};
 use engine::types::format::FormatConfig;
 use engine::types::identifiers::ObjectId;
 use engine::types::mana::{ManaType, ManaUnit};
@@ -105,8 +156,8 @@ use engine::types::{PlayerId, WaitingFor};
 /// from "recurses without bound" only if this stack is not itself the bound.
 const MEASURE_STACK_BYTES: usize = 64 << 20;
 
-/// Ceiling for the measured high-water. Fails the test, portably, on every
-/// target the engine builds for.
+/// Ceiling for the measured high-water. Fails the test on every supported
+/// target, without being tuned to any of them.
 ///
 /// **Derivation, so this is a stated policy and not a magic number.**
 /// Production runs the engine on 32 MiB threads (`RUNTIME_THREAD_STACK_BYTES`,
@@ -126,14 +177,15 @@ const MEASURE_STACK_BYTES: usize = 64 << 20;
 /// nearly 3x — both are findings, not calibration errors.
 const HIGH_WATER_CEILING_BYTES: usize = 8 << 20;
 
-/// Clearance kept above the low end of the thread stack. Covers the guard page
-/// and whatever std's thread-entry frames sit below `anchor`, so the paint
-/// never writes outside the mapping.
-const GUARD_MARGIN: usize = 256 << 10;
-
-/// Clearance kept below `anchor`. The measuring frame's own locals live in
-/// here and must survive the paint; the cost is that depths shallower than
-/// this are indistinguishable.
+/// Clearance kept below [`measure`]'s own locals.
+///
+/// This bounds one small frame — [`measure`] holds a reference, two ids and a
+/// few `usize`s — not a frame carrying a `GameRunner`, which is why it can be
+/// this generous. Every value alive in that frame at paint time is asserted to
+/// sit above the painted region anyway, so the constant is slack on a checked
+/// invariant rather than the invariant itself. The cost is that depths
+/// shallower than this are indistinguishable, which the saturation assertion
+/// turns into a loud failure rather than a small number.
 const FRAME_GAP: usize = 32 << 10;
 
 const SENTINEL: u8 = 0xAB;
@@ -146,30 +198,93 @@ const MURDER_ORACLE: &str = "Destroy target creature.";
 const DEATH_TRIGGER_ORACLE: &str =
     "Whenever this creature or another creature dies, you gain 1 life.";
 
-/// What the measuring thread hands back.
-struct Measurement<R> {
-    runner: R,
-    /// Deepest written byte, as a depth below `anchor`.
+/// What [`measure`] hands back.
+struct Measurement {
+    /// Deepest written byte, as a depth below the painting frame.
     high_water: usize,
+    /// The validated `[low, high)` from [`stack_bounds`]. Reported so that a
+    /// run on a newly enabled target shows what its query actually returned,
+    /// rather than only that the run agreed with it.
+    bounds: (usize, usize),
     /// The depth the scan saturates at, i.e. what `high_water` equals when
     /// nothing in the painted region was disturbed. Derived from the *aligned*
-    /// `hi`, not from `FRAME_GAP`, because rounding moves it by up to 7 bytes
+    /// `hi`, not from [`FRAME_GAP`], because rounding moves it by up to 7 bytes
     /// and a saturation check against the unrounded constant would miss.
     saturation_floor: usize,
 }
 
-/// Paints `[low, hi)` with `SENTINEL`.
+/// The running thread's usable stack as `[low, high)`, from the platform.
+///
+/// `probe` must be the address of a local in the caller's frame. It is not used
+/// to *derive* the bounds — that is the whole point — but to **validate** them:
+/// a query that does not describe the stack this code is running on panics here
+/// rather than returning a range the caller will write into.
+///
+/// Only ever called on a thread this file spawned. That matters on Linux, where
+/// the main thread's stack is reported from `RLIMIT_STACK` and is not fully
+/// mapped; a spawned thread's is a single mapping, so every byte in `[low,
+/// high)` is writable.
+fn stack_bounds(probe: *const u8) -> (usize, usize) {
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    let (low, high) = unsafe {
+        let mut attr: libc::pthread_attr_t = std::mem::zeroed();
+        let rc = libc::pthread_getattr_np(libc::pthread_self(), &mut attr);
+        assert_eq!(rc, 0, "pthread_getattr_np failed with {rc}");
+
+        let mut base: *mut libc::c_void = ptr::null_mut();
+        let mut size: libc::size_t = 0;
+        let rc = libc::pthread_attr_getstack(&attr, &mut base, &mut size);
+        assert_eq!(rc, 0, "pthread_attr_getstack failed with {rc}");
+
+        let mut guard: libc::size_t = 0;
+        let rc = libc::pthread_attr_getguardsize(&attr, &mut guard);
+        assert_eq!(rc, 0, "pthread_attr_getguardsize failed with {rc}");
+
+        libc::pthread_attr_destroy(&mut attr);
+
+        // Skipping `guard` bytes above the reported base is correct when the
+        // guard is carved out of the reported block, and merely costs one guard
+        // page of range when the platform already excluded it. Both directions
+        // are safe; only the other rounding would not be.
+        (base as usize + guard, base as usize + size)
+    };
+
+    #[cfg(target_os = "macos")]
+    let (low, high) = unsafe {
+        let this = libc::pthread_self();
+        // Returns the *high* end on Darwin, unlike the POSIX call above.
+        let top = libc::pthread_get_stackaddr_np(this) as usize;
+        let size = libc::pthread_get_stacksize_np(this);
+        (top - size, top)
+    };
+
+    assert!(
+        low < high,
+        "platform reported an empty stack range [{low:#x}, {high:#x})"
+    );
+    let probe = probe as usize;
+    assert!(
+        probe >= low && probe < high,
+        "the platform stack query does not contain this frame's own local \
+         ({probe:#x} is outside [{low:#x}, {high:#x})), so the bounds are wrong \
+         for this target — refusing to paint"
+    );
+    (low, high)
+}
+
+/// Paints `[low, hi)` with [`SENTINEL`].
 ///
 /// # Safety
 ///
-/// `[low, hi)` must lie inside the current thread's stack mapping, strictly
-/// below every live local of the caller's frame and strictly above the guard
-/// page. The caller derives both bounds from `anchor` for exactly that reason.
+/// `[low, hi)` must lie inside the current thread's stack mapping and hold no
+/// value that is live at the moment of the call. [`measure`] establishes both:
+/// the first from [`stack_bounds`], the second by asserting every value alive
+/// in its frame lies above `hi`.
 unsafe fn paint(low: usize, hi: usize) {
     ptr::write_bytes(low as *mut u8, SENTINEL, hi - low);
 }
 
-/// Lowest address in `[low, hi)` whose byte is no longer `SENTINEL`, or `hi`
+/// Lowest address in `[low, hi)` whose byte is no longer [`SENTINEL`], or `hi`
 /// if the whole region survived.
 ///
 /// Word-scans first so 64 MiB is cheap, then narrows to the byte. Volatile
@@ -200,6 +315,75 @@ unsafe fn deepest_disturbed(low: usize, hi: usize) -> usize {
     hi
 }
 
+/// Paint, run the measured action, scan.
+///
+/// `#[inline(never)]` and taking `runner` by reference are both load-bearing,
+/// not style: they keep the `GameRunner` in a shallower frame than the painted
+/// region, so the largest live value in the test provably cannot be in range.
+/// See the safety argument in the module docs.
+#[inline(never)]
+fn measure(runner: &mut GameRunner, murder: ObjectId, victim: ObjectId) -> Measurement {
+    let probe = 0u8;
+    let probe_addr = &probe as *const u8 as usize;
+    let bounds = stack_bounds(&probe);
+    let (stack_low, _stack_high) = bounds;
+
+    // Word-align both ends: `deepest_disturbed` scans `u64`s.
+    let low = stack_low.next_multiple_of(8);
+    let hi = (probe_addr - FRAME_GAP) & !7;
+    assert!(
+        low < hi,
+        "no room to paint between the stack floor ({low:#x}) and this frame \
+         ({hi:#x})"
+    );
+
+    // The enumerated live set, checked before anything is written. Everything
+    // the fixture creates *after* the paint is what we are measuring; only what
+    // is alive right now could be corrupted, and this is all of it.
+    let runner_lo = runner as *mut GameRunner as usize;
+    let live: [(&str, usize, usize); 4] = [
+        ("probe", probe_addr, probe_addr + size_of::<u8>()),
+        (
+            "&mut GameRunner",
+            &runner as *const _ as usize,
+            &runner as *const _ as usize + size_of::<&mut GameRunner>(),
+        ),
+        ("GameRunner", runner_lo, runner_lo + size_of::<GameRunner>()),
+        (
+            "murder/victim",
+            &murder as *const _ as usize,
+            &victim as *const _ as usize + size_of::<ObjectId>(),
+        ),
+    ];
+    for (name, value_lo, value_hi) in live {
+        assert!(
+            value_hi <= low || value_lo >= hi,
+            "{name} ({value_lo:#x}..{value_hi:#x}) overlaps the paint region \
+             ({low:#x}..{hi:#x}); raise FRAME_GAP rather than painting over \
+             live state"
+        );
+    }
+
+    // SAFETY: `[low, hi)` is inside the mapping `stack_bounds` reported and
+    // validated against this frame, and the loop above has just established
+    // that nothing live occupies it.
+    unsafe { paint(low, hi) };
+    compiler_fence(Ordering::SeqCst);
+
+    runner.cast(murder).target_objects(&[victim]).resolve();
+    runner.advance_until_stack_empty();
+
+    compiler_fence(Ordering::SeqCst);
+    // SAFETY: same region just painted, still owned by this thread.
+    let deepest = unsafe { deepest_disturbed(low, hi) };
+
+    Measurement {
+        high_water: probe_addr - deepest,
+        bounds,
+        saturation_floor: probe_addr - hi,
+    }
+}
+
 #[test]
 fn four_player_commander_action_stack_high_water() {
     let mut scenario = GameScenario::new_with_format(FormatConfig::commander(), 4, 42);
@@ -221,7 +405,7 @@ fn four_player_commander_action_stack_high_water() {
             .collect(),
     );
 
-    let mut runner = scenario.build();
+    let runner = scenario.build();
 
     // Reach-guards: without these, a fixture that never reached the cast would
     // measure a no-op and report a flatteringly small high-water.
@@ -244,62 +428,21 @@ fn four_player_commander_action_stack_high_water() {
     let handle = std::thread::Builder::new()
         .stack_size(MEASURE_STACK_BYTES)
         .spawn(move || {
-            let anchor_local = 0u8;
-            let anchor = &anchor_local as *const u8 as usize;
-            // Word-align both ends: `deepest_disturbed` scans `u64`s, and
-            // `anchor` is the address of a `u8` so it carries no alignment.
-            let low = (anchor + GUARD_MARGIN - MEASURE_STACK_BYTES).next_multiple_of(8);
-            let hi = (anchor - FRAME_GAP) & !7;
-
-            // The paint's safety contract says `[low, hi)` holds nothing live.
-            // `runner` is the one capture large enough to reach past FRAME_GAP
-            // if it were laid out below `anchor`, and painting over it would
-            // corrupt the fixture silently rather than fail. Check rather than
-            // reason about a layout no rule pins: whether a captured value
-            // lands in this frame or in the caller's is the compiler's choice.
-            let runner_lo = ptr::addr_of!(runner) as usize;
-            let runner_hi = runner_lo + std::mem::size_of_val(&runner);
-            assert!(
-                runner_hi <= low || runner_lo >= hi,
-                "the fixture ({runner_lo:#x}..{runner_hi:#x}) overlaps the paint \
-                 region ({low:#x}..{hi:#x}); raise FRAME_GAP rather than \
-                 painting over live state"
-            );
-
-            // SAFETY: `anchor` is a local of this frame, so the stack mapping
-            // runs from below it down to `anchor - MEASURE_STACK_BYTES` plus
-            // whatever std's entry frames occupy above `anchor`. `low` sits
-            // `GUARD_MARGIN` above that floor and `hi` sits `FRAME_GAP` below
-            // this frame's locals, so `[low, hi)` is stack this thread owns and
-            // nothing live occupies — the assertion above checks the one
-            // capture big enough to make that last clause false.
-            unsafe { paint(low, hi) };
-            compiler_fence(Ordering::SeqCst);
-
-            runner.cast(murder).target_objects(&[victim]).resolve();
-            runner.advance_until_stack_empty();
-
-            compiler_fence(Ordering::SeqCst);
-            // SAFETY: same region just painted, still owned by this thread.
-            let deepest = unsafe { deepest_disturbed(low, hi) };
-
-            Measurement {
-                runner,
-                high_water: anchor - deepest,
-                saturation_floor: anchor - hi,
-            }
+            let mut runner = runner;
+            let measurement = measure(&mut runner, murder, victim);
+            (runner, measurement)
         })
         .expect("spawn measuring thread");
 
-    let measurement = handle.join().expect(
+    let (runner, measurement) = handle.join().expect(
         "the measured action panicked. Unlike game_state_stack_budget.rs this \
          thread has 64 MiB — more than production's 32 MiB — so an overflow \
          here would mean genuinely unbounded recursion rather than a budget \
          overrun.",
     );
     let Measurement {
-        runner,
         high_water,
+        bounds: (stack_low, stack_high),
         saturation_floor,
     } = measurement;
 
@@ -343,10 +486,16 @@ fn four_player_commander_action_stack_high_water() {
         HIGH_WATER_CEILING_BYTES / 1024
     );
 
-    // The product. Stable, greppable, and the only line here that is worth
-    // comparing across commits — within a target.
+    // The product, and the only line here worth comparing across commits —
+    // within a target. Both harnesses capture stdout for a passing test, so
+    // reading it needs `cargo test -- --nocapture` or
+    // `cargo nextest run --success-output immediate`; see the module docs.
     println!(
         "STACK_HIGH_WATER_BYTES={high_water} ({} KiB)",
         high_water / 1024
+    );
+    println!(
+        "STACK_BOUNDS_VALIDATED=[{stack_low:#x}, {stack_high:#x}) ({} MiB requested)",
+        MEASURE_STACK_BYTES >> 20
     );
 }

--- a/crates/engine/tests/integration/game_state_stack_high_water.rs
+++ b/crates/engine/tests/integration/game_state_stack_high_water.rs
@@ -1,0 +1,352 @@
+//! Portable stack **high-water measurement** for the four-player Commander
+//! fixture that `game_state_stack_budget.rs` guards with a survive/abort bit.
+//!
+//! This is the instrument that file's module docs record as the better
+//! available design and deliberately do not build:
+//!
+//! > Spawn a thread with a known large stack, fill it with a sentinel pattern,
+//! > run the fixture, then scan for the deepest disturbed byte. That yields a
+//! > *number* rather than the survive/abort bit this test produces.
+//!
+//! Why it matters here: `game_state_stack_budget.rs` is
+//! `#![cfg(all(target_arch = "aarch64", target_os = "macos"))]`, and this
+//! repository's CI has no macOS runner — every workflow in `.github/workflows/`
+//! is `ubuntu-latest` or an Android cross-build — so that guard has **never
+//! executed in CI**. It compiles out on every job. A measurement asserts on a
+//! value rather than on a target-calibrated bound, so it runs everywhere the
+//! engine builds, this repository's CI included.
+//!
+//! # Method
+//!
+//! 1. Spawn a thread with an explicit `MEASURE_STACK_BYTES` stack.
+//! 2. Take `anchor`, the address of a local in the measuring frame. The stack
+//!    grows down, so every frame the fixture pushes lies below it.
+//! 3. Paint `[low, anchor - FRAME_GAP)` with `SENTINEL`. `FRAME_GAP` keeps the
+//!    measuring frame's own live locals out of the painted region; `low` keeps
+//!    `GUARD_MARGIN` of clearance above the guard page.
+//! 4. Run the fixture.
+//! 5. Scan up from `low` for the deepest byte that is no longer `SENTINEL`.
+//!
+//! # What the number is, and is not
+//!
+//! It is the deepest byte the fixture **wrote**, relative to `anchor`. Two
+//! honest caveats, neither of which affects its use as a regression signal:
+//!
+//! - **It is a lower bound.** A frame that reserves space without writing every
+//!   byte of it leaves sentinel behind, so the true reserved depth can exceed
+//!   the measured one.
+//! - **It cannot see shallower than `FRAME_GAP`.** If the fixture never got
+//!   below that, the scan finds nothing disturbed and the result saturates.
+//!   The reach-guards below, plus an explicit saturation assertion, exist so
+//!   that case reports "the paint or the scan is broken", not "the path is
+//!   cheap".
+//!
+//! Absolute values are target-dependent (ABI, register pressure, spill
+//! decisions) and `[profile.test]` inherits `dev`, so nothing is optimized
+//! away. Compare numbers **within** a target, never across targets.
+//!
+//! # Why the assertion is loose, and what it is for
+//!
+//! The number is the product; [`HIGH_WATER_CEILING_BYTES`] only stops the run
+//! from being decoration. A *tight* ratchet — assert within a few percent of a
+//! recorded value — is what would actually catch drift, and it is deliberately
+//! not what this file does, because a recorded value is a per-target constant
+//! and one portable assertion cannot carry a table of them. That is the same
+//! trap `game_state_stack_budget.rs` fell into: it took a number measured on
+//! one target, and to stay honest about it had to `cfg` itself down to that
+//! target, where CI never runs it.
+//!
+//! So the split is deliberate: **assert** the thing that is true on every
+//! target (a single un-nested `apply()` must not approach the production stack
+//! budget), and **print** the thing that is only comparable within a target.
+//! Tightening the printed number into a per-target ratchet is the follow-up
+//! once it has a run history in CI to set rows from — see the drift figures in
+//! <https://github.com/phase-rs/phase/issues/8376>.
+//!
+//! # A note on severity, so nobody reads this test as a fire alarm
+//!
+//! `game_state_stack_budget.rs`'s 3 MiB bound is **not** the production stack
+//! budget. Its module docs are explicit that 3 MiB was chosen to sit inside a
+//! `[2,560 KiB, 3,328 KiB]` window so that reverting the `ResolvedAbility`
+//! boxing would flip the test red — a discrimination dial, not a safety
+//! margin. The production budget is `RUNTIME_THREAD_STACK_BYTES` in
+//! `phase-server/src/main.rs`: **32 MiB**, on the runtime owner thread and on
+//! every Tokio worker and blocking thread.
+//!
+//! That distinction is why this file's ceiling is nowhere near 3 MiB. Crossing
+//! 3 MiB means the *discriminating gate* has lost its calibration, which is
+//! worth knowing and is what issue #8376 reports. Crossing this file's ceiling
+//! would mean something much worse.
+//!
+//! The 32 MiB figure is also not headroom to spend: the server docs record
+//! that AI search keeps one live `Option<GameState>` per ply and that search
+//! depth is data-driven, so production depth is this fixture's number times a
+//! multiplier no static bound covers. The risk that matters is the multiplier,
+//! not the linear drift.
+
+#![cfg(target_pointer_width = "64")]
+
+use std::ptr;
+use std::sync::atomic::{compiler_fence, Ordering};
+
+use engine::game::scenario::{GameScenario, P0, P1};
+use engine::types::format::FormatConfig;
+use engine::types::identifiers::ObjectId;
+use engine::types::mana::{ManaType, ManaUnit};
+use engine::types::phase::Phase;
+use engine::types::zones::Zone;
+use engine::types::{PlayerId, WaitingFor};
+
+/// Large enough that the fixture cannot reach the guard page, so the run
+/// produces a number instead of the SIGABRT this instrument exists to replace.
+///
+/// Deliberately **larger** than production's 32 MiB: a measurement that aborts
+/// has measured nothing, and the join below distinguishes "overran a budget"
+/// from "recurses without bound" only if this stack is not itself the bound.
+const MEASURE_STACK_BYTES: usize = 64 << 20;
+
+/// Ceiling for the measured high-water. Fails the test, portably, on every
+/// target the engine builds for.
+///
+/// **Derivation, so this is a stated policy and not a magic number.**
+/// Production runs the engine on 32 MiB threads (`RUNTIME_THREAD_STACK_BYTES`,
+/// `phase-server/src/main.rs`). This fixture measures **one** `apply()` with no
+/// AI search above it, while production nests several live `GameState` slots
+/// and one more per AI ply on the same frame chain. A quarter of the production
+/// stack for the un-nested case leaves the nesting somewhere to go.
+///
+/// Headroom at the time of writing: 2,493 KiB measured on
+/// `x86_64-unknown-linux-gnu` debug, so this fires at ~3.3x the current value.
+/// It will not flake on a target that runs a couple of hundred KiB deeper —
+/// and the slack is deliberate, because this number moves. The same fixture
+/// measured 2,915 KiB fifteen commits earlier.
+///
+/// **If this fires**, do not raise it as the first move. It means either a new
+/// recursion on the resolution path or a per-frame cost that has grown by
+/// nearly 3x — both are findings, not calibration errors.
+const HIGH_WATER_CEILING_BYTES: usize = 8 << 20;
+
+/// Clearance kept above the low end of the thread stack. Covers the guard page
+/// and whatever std's thread-entry frames sit below `anchor`, so the paint
+/// never writes outside the mapping.
+const GUARD_MARGIN: usize = 256 << 10;
+
+/// Clearance kept below `anchor`. The measuring frame's own locals live in
+/// here and must survive the paint; the cost is that depths shallower than
+/// this are indistinguishable.
+const FRAME_GAP: usize = 32 << 10;
+
+const SENTINEL: u8 = 0xAB;
+const SENTINEL_WORD: u64 = u64::from_ne_bytes([SENTINEL; 8]);
+
+// Fixture text copied verbatim from `game_state_stack_budget.rs` so the two
+// measure the same path. A death trigger on every seat makes the measured
+// resolution a real trigger cascade rather than a bare removal.
+const MURDER_ORACLE: &str = "Destroy target creature.";
+const DEATH_TRIGGER_ORACLE: &str =
+    "Whenever this creature or another creature dies, you gain 1 life.";
+
+/// What the measuring thread hands back.
+struct Measurement<R> {
+    runner: R,
+    /// Deepest written byte, as a depth below `anchor`.
+    high_water: usize,
+    /// The depth the scan saturates at, i.e. what `high_water` equals when
+    /// nothing in the painted region was disturbed. Derived from the *aligned*
+    /// `hi`, not from `FRAME_GAP`, because rounding moves it by up to 7 bytes
+    /// and a saturation check against the unrounded constant would miss.
+    saturation_floor: usize,
+}
+
+/// Paints `[low, hi)` with `SENTINEL`.
+///
+/// # Safety
+///
+/// `[low, hi)` must lie inside the current thread's stack mapping, strictly
+/// below every live local of the caller's frame and strictly above the guard
+/// page. The caller derives both bounds from `anchor` for exactly that reason.
+unsafe fn paint(low: usize, hi: usize) {
+    ptr::write_bytes(low as *mut u8, SENTINEL, hi - low);
+}
+
+/// Lowest address in `[low, hi)` whose byte is no longer `SENTINEL`, or `hi`
+/// if the whole region survived.
+///
+/// Word-scans first so 64 MiB is cheap, then narrows to the byte. Volatile
+/// reads because the writes it is looking for happened through frames the
+/// compiler has every right to believe are dead.
+///
+/// # Safety
+///
+/// Same contract as [`paint`]: `[low, hi)` must be the region just painted.
+unsafe fn deepest_disturbed(low: usize, hi: usize) -> usize {
+    let mut addr = low;
+    while addr + 8 <= hi {
+        if ptr::read_volatile(addr as *const u64) != SENTINEL_WORD {
+            for byte in addr..addr + 8 {
+                if ptr::read_volatile(byte as *const u8) != SENTINEL {
+                    return byte;
+                }
+            }
+        }
+        addr += 8;
+    }
+    while addr < hi {
+        if ptr::read_volatile(addr as *const u8) != SENTINEL {
+            return addr;
+        }
+        addr += 1;
+    }
+    hi
+}
+
+#[test]
+fn four_player_commander_action_stack_high_water() {
+    let mut scenario = GameScenario::new_with_format(FormatConfig::commander(), 4, 42);
+    scenario.at_phase(Phase::PreCombatMain);
+
+    for seat in [P0, P1, PlayerId(2), PlayerId(3)] {
+        scenario.add_creature_from_oracle(seat, "Zulaport Cutthroat", 0, 1, DEATH_TRIGGER_ORACLE);
+        scenario.add_vanilla(seat, 2, 2);
+        scenario.add_vanilla(seat, 3, 3);
+    }
+    let victim = scenario.add_creature(P1, "Doomed Bystander", 4, 4).id();
+    let murder = scenario
+        .add_spell_to_hand_from_oracle(P0, "Murder", false, MURDER_ORACLE)
+        .id();
+    scenario.with_mana_pool(
+        P0,
+        (0..3)
+            .map(|_| ManaUnit::new(ManaType::Black, ObjectId(0), false, vec![]))
+            .collect(),
+    );
+
+    let mut runner = scenario.build();
+
+    // Reach-guards: without these, a fixture that never reached the cast would
+    // measure a no-op and report a flatteringly small high-water.
+    assert!(
+        matches!(runner.state().waiting_for, WaitingFor::Priority { player } if player == P0),
+        "reach-guard: P0 holds priority before the measured action, got {:?}",
+        runner.state().waiting_for
+    );
+    assert_eq!(
+        runner
+            .state()
+            .objects
+            .get(&victim)
+            .map(|object| object.zone),
+        Some(Zone::Battlefield),
+        "reach-guard: the removal target is on the battlefield before the action"
+    );
+    let life_before = runner.life(P0);
+
+    let handle = std::thread::Builder::new()
+        .stack_size(MEASURE_STACK_BYTES)
+        .spawn(move || {
+            let anchor_local = 0u8;
+            let anchor = &anchor_local as *const u8 as usize;
+            // Word-align both ends: `deepest_disturbed` scans `u64`s, and
+            // `anchor` is the address of a `u8` so it carries no alignment.
+            let low = (anchor + GUARD_MARGIN - MEASURE_STACK_BYTES).next_multiple_of(8);
+            let hi = (anchor - FRAME_GAP) & !7;
+
+            // The paint's safety contract says `[low, hi)` holds nothing live.
+            // `runner` is the one capture large enough to reach past FRAME_GAP
+            // if it were laid out below `anchor`, and painting over it would
+            // corrupt the fixture silently rather than fail. Check rather than
+            // reason about a layout no rule pins: whether a captured value
+            // lands in this frame or in the caller's is the compiler's choice.
+            let runner_lo = ptr::addr_of!(runner) as usize;
+            let runner_hi = runner_lo + std::mem::size_of_val(&runner);
+            assert!(
+                runner_hi <= low || runner_lo >= hi,
+                "the fixture ({runner_lo:#x}..{runner_hi:#x}) overlaps the paint \
+                 region ({low:#x}..{hi:#x}); raise FRAME_GAP rather than \
+                 painting over live state"
+            );
+
+            // SAFETY: `anchor` is a local of this frame, so the stack mapping
+            // runs from below it down to `anchor - MEASURE_STACK_BYTES` plus
+            // whatever std's entry frames occupy above `anchor`. `low` sits
+            // `GUARD_MARGIN` above that floor and `hi` sits `FRAME_GAP` below
+            // this frame's locals, so `[low, hi)` is stack this thread owns and
+            // nothing live occupies — the assertion above checks the one
+            // capture big enough to make that last clause false.
+            unsafe { paint(low, hi) };
+            compiler_fence(Ordering::SeqCst);
+
+            runner.cast(murder).target_objects(&[victim]).resolve();
+            runner.advance_until_stack_empty();
+
+            compiler_fence(Ordering::SeqCst);
+            // SAFETY: same region just painted, still owned by this thread.
+            let deepest = unsafe { deepest_disturbed(low, hi) };
+
+            Measurement {
+                runner,
+                high_water: anchor - deepest,
+                saturation_floor: anchor - hi,
+            }
+        })
+        .expect("spawn measuring thread");
+
+    let measurement = handle.join().expect(
+        "the measured action panicked. Unlike game_state_stack_budget.rs this \
+         thread has 64 MiB — more than production's 32 MiB — so an overflow \
+         here would mean genuinely unbounded recursion rather than a budget \
+         overrun.",
+    );
+    let Measurement {
+        runner,
+        high_water,
+        saturation_floor,
+    } = measurement;
+
+    // Positive outcome assertions: the measured action really did resolve.
+    assert_eq!(
+        runner
+            .state()
+            .objects
+            .get(&victim)
+            .map(|object| object.zone),
+        Some(Zone::Graveyard),
+        "Murder resolved and put the target in the graveyard"
+    );
+    assert!(
+        runner.life(P0) > life_before,
+        "the death triggers resolved and gained P0 life (before {life_before}, after {})",
+        runner.life(P0)
+    );
+
+    // Saturation guard: a result pinned at the floor means the scan found
+    // nothing disturbed, which the reach-guards above say cannot be "the
+    // fixture was cheap". It would mean the paint or the scan is wrong.
+    assert!(
+        high_water > saturation_floor,
+        "measurement did not discriminate: high-water saturated at its floor \
+         ({saturation_floor} B), so the paint/scan is broken rather than the \
+         path cheap"
+    );
+
+    // The portable assertion. See HIGH_WATER_CEILING_BYTES for the derivation
+    // and for why raising it is the wrong first response.
+    assert!(
+        high_water <= HIGH_WATER_CEILING_BYTES,
+        "four-player Commander cast + resolve used {high_water} B ({} KiB) of \
+         stack, over the {HIGH_WATER_CEILING_BYTES} B ({} KiB) ceiling — a \
+         quarter of phase-server's 32 MiB RUNTIME_THREAD_STACK_BYTES. \
+         Production nests several live GameState slots and one per AI ply on \
+         this same chain, so this is a finding about the resolution path, not \
+         a stale bound.",
+        high_water / 1024,
+        HIGH_WATER_CEILING_BYTES / 1024
+    );
+
+    // The product. Stable, greppable, and the only line here that is worth
+    // comparing across commits — within a target.
+    println!(
+        "STACK_HIGH_WATER_BYTES={high_water} ({} KiB)",
+        high_water / 1024
+    );
+}

--- a/crates/engine/tests/integration/game_state_stack_high_water.rs
+++ b/crates/engine/tests/integration/game_state_stack_high_water.rs
@@ -13,16 +13,32 @@
 //! repository's CI has no macOS runner — every workflow in `.github/workflows/`
 //! is `ubuntu-latest` or an Android cross-build — so that guard has **never
 //! executed in CI**. It compiles out on every job. This file's assertion is on
-//! a measured value rather than on a target-calibrated bound, so it runs on
-//! every target it supports, CI's `ubuntu-latest` x86_64 included.
+//! a measured value rather than on a target-calibrated bound, so it runs
+//! wherever its stack-bounds query is known good — CI's `ubuntu-latest` x86_64
+//! included, which is what the sibling guard never managed.
 //!
-//! # Which targets, and why not all of them
+//! # Which targets, and why only one
 //!
-//! 64-bit Linux, Android and macOS — see the `cfg` below. The gate is **not**
-//! a calibration gate like the sibling file's; nothing here is tuned to a
-//! target. It is a gate on [`stack_bounds`], which needs a platform call to
-//! learn where the running thread's stack actually is. Adding a target means
-//! adding its query to that function, not re-running a bisection.
+//! 64-bit Linux — see the `cfg` below. Two things this gate is *not*:
+//!
+//! It is not a calibration gate like the sibling file's. Nothing here is tuned
+//! to a target; the assertion is on a measured value and the safety argument is
+//! on the ABI, so neither needs a bisection to move.
+//!
+//! It is not a claim that other platforms cannot work. `pthread_getattr_np` is
+//! in Bionic, and Darwin has `pthread_get_stackaddr_np` /
+//! `pthread_get_stacksize_np` with the opposite convention — it returns the
+//! high end. An earlier revision of this file enabled Android and macOS on that
+//! basis. They came back out because nobody has *run* it there, and a
+//! stack-bounds query that is merely plausible is the same species of claim
+//! this file exists to replace.
+//!
+//! **To add a target:** add its arm to [`stack_bounds`], widen the `cfg`, and
+//! run the test on that target — not a cross-build, an execution. The runtime
+//! checks in [`stack_bounds`] and [`paint_below_this_frame`] are designed to
+//! fail loudly on a target whose assumptions do not hold, so the cost of trying
+//! is a red test rather than a corrupted one. CI's `ubuntu-latest` x86_64 is
+//! covered, which is the gap this file was written to close.
 //!
 //! # Method
 //!
@@ -49,21 +65,31 @@
 //!   local of its caller's frame, so a platform whose query describes some
 //!   other stack fails loudly instead of handing back an address to write to.
 //!
-//! - **Only values live at paint time can be damaged.** This is the load-bearing
-//!   one. Everything the fixture allocates *after* the paint — every frame it
-//!   pushes, every temporary in the `cast(..).resolve()` chain — is written into
-//!   the painted region on purpose. That is the measurement. So the exclusion
-//!   set is not "every local in this test", it is exactly "the values alive at
-//!   the instant `paint` runs", which is a short enumerable list.
+//! - **Only values live at paint time can be damaged.** Everything the fixture
+//!   allocates *after* the paint — every frame it pushes, every temporary in
+//!   the `cast(..).resolve()` chain — is written into the painted region on
+//!   purpose. That is the measurement. So the question is only ever "where do
+//!   the values alive at this instant sit".
 //!
-//! - **That list is enumerated and asserted.** In [`measure`] it is `probe`,
-//!   the `&mut GameRunner` and its pointee, `murder` and `victim`. Each is
-//!   checked to lie above the painted region before anything is written. The
-//!   `GameRunner` itself — by far the largest — is held by reference from a
-//!   *shallower* frame precisely so that it cannot be in range: whether a
-//!   captured value lands in the closure's frame or its caller's is the
-//!   compiler's choice, and this design removes the choice instead of betting
-//!   on it.
+//! - **The ceiling is a frame boundary, so that question has a structural
+//!   answer.** `hi` is computed inside [`paint_below_this_frame`], one call
+//!   *below* [`measure`]. The stack grows down, so every frame above that one —
+//!   [`measure`]'s locals and spill slots, the closure's, the thread entry's —
+//!   is at a higher address than `hi` by the calling convention. Nothing has to
+//!   be enumerated, which is the point: an enumeration can only list values
+//!   that have names in the source, and the ones easiest to miss are compiler
+//!   temporaries and spill slots, which do not. Stack-growth direction is an
+//!   ABI property rather than a Rust guarantee, so it is asserted at runtime
+//!   too, against a local of the calling frame.
+//!
+//! Two things do not follow from the frame boundary and are therefore checked
+//! separately: [`PAINT_CLEARANCE`] covers the painting function's own frame and
+//! the `memset` frame `write_bytes` pushes *below* it, and the `GameRunner` is
+//! reached through a `&mut`, so its pointee is asserted outside the region —
+//! the reference proves nothing about where the referent lives. Holding it by
+//! reference from a shallower frame is deliberate: whether a captured value
+//! lands in the closure's frame or its caller's is the compiler's choice, and
+//! this removes the choice instead of betting on it.
 //!
 //! # What the number is, and is not
 //!
@@ -74,7 +100,7 @@
 //! - **It is a lower bound.** A frame that reserves space without writing every
 //!   byte of it leaves sentinel behind, so the true reserved depth can exceed
 //!   the measured one.
-//! - **It cannot see shallower than `FRAME_GAP`.** If the fixture never got
+//! - **It cannot see shallower than [`PAINT_CLEARANCE`].** If the fixture never got
 //!   below that, the scan finds nothing disturbed and the result saturates.
 //!   The reach-guards below, plus an explicit saturation assertion, exist so
 //!   that case reports "the paint or the scan is broken", not "the path is
@@ -132,10 +158,7 @@
 //! not the linear drift — and the drift is not even monotonic. See
 //! <https://github.com/phase-rs/phase/issues/8376>.
 
-#![cfg(all(
-    target_pointer_width = "64",
-    any(target_os = "linux", target_os = "android", target_os = "macos")
-))]
+#![cfg(all(target_pointer_width = "64", target_os = "linux"))]
 
 use std::ptr;
 use std::sync::atomic::{compiler_fence, Ordering};
@@ -177,16 +200,19 @@ const MEASURE_STACK_BYTES: usize = 64 << 20;
 /// nearly 3x — both are findings, not calibration errors.
 const HIGH_WATER_CEILING_BYTES: usize = 8 << 20;
 
-/// Clearance kept below [`measure`]'s own locals.
+/// Clearance kept below [`paint_below_this_frame`]'s own locals.
 ///
-/// This bounds one small frame — [`measure`] holds a reference, two ids and a
-/// few `usize`s — not a frame carrying a `GameRunner`, which is why it can be
-/// this generous. Every value alive in that frame at paint time is asserted to
-/// sit above the painted region anyway, so the constant is slack on a checked
-/// invariant rather than the invariant itself. The cost is that depths
-/// shallower than this are indistinguishable, which the saturation assertion
-/// turns into a loud failure rather than a small number.
-const FRAME_GAP: usize = 32 << 10;
+/// This does **not** have to cover [`measure`]'s frame, let alone the test's:
+/// `hi` is derived inside a function one call deeper, so every frame above it
+/// is out of range by the calling convention rather than by this constant. What
+/// it has to cover is that one leaf-ish function's own locals, the `memset`
+/// frame `write_bytes` pushes *below* it while painting, and the ABI red zone
+/// (128 B on x86-64 SysV; zero on AArch64). Those total a few hundred bytes at
+/// `opt-level = 0`, so 16 KiB is roughly two orders of magnitude of slack.
+///
+/// The cost is that depths shallower than this are indistinguishable, which the
+/// saturation assertion turns into a loud failure rather than a small number.
+const PAINT_CLEARANCE: usize = 16 << 10;
 
 const SENTINEL: u8 = 0xAB;
 const SENTINEL_WORD: u64 = u64::from_ne_bytes([SENTINEL; 8]);
@@ -208,7 +234,7 @@ struct Measurement {
     bounds: (usize, usize),
     /// The depth the scan saturates at, i.e. what `high_water` equals when
     /// nothing in the painted region was disturbed. Derived from the *aligned*
-    /// `hi`, not from [`FRAME_GAP`], because rounding moves it by up to 7 bytes
+    /// `hi`, not from [`PAINT_CLEARANCE`], because rounding moves it by up to 7 bytes
     /// and a saturation check against the unrounded constant would miss.
     saturation_floor: usize,
 }
@@ -225,7 +251,6 @@ struct Measurement {
 /// mapped; a spawned thread's is a single mapping, so every byte in `[low,
 /// high)` is writable.
 fn stack_bounds(probe: *const u8) -> (usize, usize) {
-    #[cfg(any(target_os = "linux", target_os = "android"))]
     let (low, high) = unsafe {
         let mut attr: libc::pthread_attr_t = std::mem::zeroed();
         let rc = libc::pthread_getattr_np(libc::pthread_self(), &mut attr);
@@ -249,15 +274,6 @@ fn stack_bounds(probe: *const u8) -> (usize, usize) {
         (base as usize + guard, base as usize + size)
     };
 
-    #[cfg(target_os = "macos")]
-    let (low, high) = unsafe {
-        let this = libc::pthread_self();
-        // Returns the *high* end on Darwin, unlike the POSIX call above.
-        let top = libc::pthread_get_stackaddr_np(this) as usize;
-        let size = libc::pthread_get_stacksize_np(this);
-        (top - size, top)
-    };
-
     assert!(
         low < high,
         "platform reported an empty stack range [{low:#x}, {high:#x})"
@@ -272,16 +288,63 @@ fn stack_bounds(probe: *const u8) -> (usize, usize) {
     (low, high)
 }
 
-/// Paints `[low, hi)` with [`SENTINEL`].
+/// Paints from `low` up to a ceiling derived from **this** function's frame,
+/// and returns that ceiling.
+///
+/// Deriving `hi` here rather than in [`measure`] is what makes the exclusion a
+/// proof instead of a checklist. The stack grows down, so every frame above
+/// this one — [`measure`]'s locals, its spill slots, its caller's, the whole
+/// chain up to the thread entry — lies at a higher address than this frame's
+/// locals, and therefore above `hi`. Nothing needs enumerating, which matters
+/// because the things easiest to forget are the ones with no name in the source:
+/// compiler temporaries and spill slots.
+///
+/// `caller_probe` is the address of a local in [`measure`]'s frame, used only to
+/// check the direction of stack growth at runtime rather than trust it.
 ///
 /// # Safety
 ///
-/// `[low, hi)` must lie inside the current thread's stack mapping and hold no
-/// value that is live at the moment of the call. [`measure`] establishes both:
-/// the first from [`stack_bounds`], the second by asserting every value alive
-/// in its frame lies above `hi`.
-unsafe fn paint(low: usize, hi: usize) {
+/// `low` must be the lowest writable byte of the current thread's stack, as
+/// returned and validated by [`stack_bounds`].
+#[inline(never)]
+unsafe fn paint_below_this_frame(low: usize, caller_probe: usize) -> usize {
+    let floor = 0u8;
+    let floor_addr = &floor as *const u8 as usize;
+
+    assert!(
+        floor_addr < caller_probe,
+        "this callee's frame ({floor_addr:#x}) is not below its caller's          ({caller_probe:#x}), so the stack does not grow down here and the          whole exclusion argument fails — refusing to paint"
+    );
+
+    let hi = (floor_addr - PAINT_CLEARANCE) & !7;
+    assert!(
+        low < hi,
+        "no room to paint between the validated stack floor ({low:#x}) and          this frame ({hi:#x})"
+    );
+
     ptr::write_bytes(low as *mut u8, SENTINEL, hi - low);
+
+    // Tripwire, not a proof — and the difference was measured, not assumed.
+    // `floor` is a zero-initialised local of this frame, so reading `SENTINEL`
+    // back means the write ran past `hi` into live storage.
+    //
+    // What it does **not** do is catch a large overrun. Planting `hi =
+    // floor_addr + 64` as a deliberate negative control does not trip this
+    // assertion: it produces `SIGSEGV`, because `floor_addr` is itself a local
+    // in the painted frame, so by the time the check runs it is reading through
+    // an address made of sentinel bytes. A checker whose own storage is inside
+    // the region it checks cannot be relied on. The guarantee here is the frame
+    // boundary plus [`PAINT_CLEARANCE`]; this only narrows the window where a
+    // marginal overrun would otherwise pass quietly.
+    assert_eq!(
+        ptr::read_volatile(floor_addr as *const u8),
+        0,
+        "the paint reached this frame's own local at {floor_addr:#x}: \
+         PAINT_CLEARANCE ({PAINT_CLEARANCE} B) is too small for this target's \
+         frame layout"
+    );
+
+    hi
 }
 
 /// Lowest address in `[low, hi)` whose byte is no longer [`SENTINEL`], or `hi`
@@ -328,46 +391,39 @@ fn measure(runner: &mut GameRunner, murder: ObjectId, victim: ObjectId) -> Measu
     let bounds = stack_bounds(&probe);
     let (stack_low, _stack_high) = bounds;
 
-    // Word-align both ends: `deepest_disturbed` scans `u64`s.
+    // Word-align the floor: `deepest_disturbed` scans `u64`s.
     let low = stack_low.next_multiple_of(8);
-    let hi = (probe_addr - FRAME_GAP) & !7;
-    assert!(
-        low < hi,
-        "no room to paint between the stack floor ({low:#x}) and this frame \
-         ({hi:#x})"
+
+    // The one live value whose placement is not settled by the calling
+    // convention. Everything in this frame and above it is excluded by
+    // construction — see `paint_below_this_frame` — but `runner` is a
+    // reference, and its *pointee* lives wherever the caller put it. In
+    // practice that is a shallower frame or the heap, both outside the region;
+    // this asserts it rather than reasoning about it.
+    let runner_lo = runner as *mut GameRunner as usize;
+    let runner_hi = runner_lo + size_of::<GameRunner>();
+
+    // SAFETY: `low` is the validated floor from `stack_bounds`, and the ceiling
+    // is derived inside the callee from its own frame, so every frame above it
+    // — this one included — is out of range by the calling convention.
+    let hi = unsafe { paint_below_this_frame(low, probe_addr) };
+
+    // Checked here rather than inside the painter: this frame is above the
+    // painted region and above the painter's frame, so it is still intact for
+    // any overrun that stopped short of it — which is exactly the case the
+    // painter's own tripwire cannot report.
+    assert_eq!(
+        probe, 0,
+        "the paint reached this frame's local at {probe_addr:#x}; the frame \
+         boundary in paint_below_this_frame did not hold on this target"
     );
 
-    // The enumerated live set, checked before anything is written. Everything
-    // the fixture creates *after* the paint is what we are measuring; only what
-    // is alive right now could be corrupted, and this is all of it.
-    let runner_lo = runner as *mut GameRunner as usize;
-    let live: [(&str, usize, usize); 4] = [
-        ("probe", probe_addr, probe_addr + size_of::<u8>()),
-        (
-            "&mut GameRunner",
-            &runner as *const _ as usize,
-            &runner as *const _ as usize + size_of::<&mut GameRunner>(),
-        ),
-        ("GameRunner", runner_lo, runner_lo + size_of::<GameRunner>()),
-        (
-            "murder/victim",
-            &murder as *const _ as usize,
-            &victim as *const _ as usize + size_of::<ObjectId>(),
-        ),
-    ];
-    for (name, value_lo, value_hi) in live {
-        assert!(
-            value_hi <= low || value_lo >= hi,
-            "{name} ({value_lo:#x}..{value_hi:#x}) overlaps the paint region \
-             ({low:#x}..{hi:#x}); raise FRAME_GAP rather than painting over \
-             live state"
-        );
-    }
-
-    // SAFETY: `[low, hi)` is inside the mapping `stack_bounds` reported and
-    // validated against this frame, and the loop above has just established
-    // that nothing live occupies it.
-    unsafe { paint(low, hi) };
+    assert!(
+        runner_hi <= low || runner_lo >= hi,
+        "the GameRunner ({runner_lo:#x}..{runner_hi:#x}) overlaps the paint \
+         region ({low:#x}..{hi:#x}); it must live in a shallower frame or the \
+         heap"
+    );
     compiler_fence(Ordering::SeqCst);
 
     runner.cast(murder).target_objects(&[victim]).resolve();

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -317,6 +317,7 @@ mod galactus_forced_attack_most_life;
 mod galion_elvenkings_butler_attack_pt_set;
 mod game_state_boxed_ability_serde;
 mod game_state_stack_budget;
+mod game_state_stack_high_water;
 mod gather_the_townsfolk_fateful_hour;
 mod gatta_and_luzzu_regression;
 mod gemstone_caverns_begin_game;


### PR DESCRIPTION
## Summary

Adds a portable stack **high-water measurement** for the four-player Commander resolution path that `game_state_stack_budget.rs` guards, so the budget is measured on every target instead of only on one this repository has no CI runner for. Refs #8376.

`game_state_stack_budget.rs` is `#![cfg(all(target_arch = "aarch64", target_os = "macos"))]` and every workflow in `.github/workflows/` is `ubuntu-latest` or an Android cross-build, so it compiles out on every CI job — the guard has never executed in CI. Confirmed directly on x86_64 rather than read off the source:

```
$ cargo test -p phase-engine --test integration -- --list | grep -E 'high_water|stack_budget'
game_state_stack_high_water::four_player_commander_action_stack_high_water: test
```

The new file is the instrument the sibling file's own module docs record as the better available design and deliberately do not build: spawn a thread with a known large stack, paint a sentinel below the measuring frame, run the fixture, scan up for the deepest disturbed byte. Same fixture text, same reach-guards, on a 64 MiB stack.

**Targets:** `#![cfg(all(target_pointer_width = "64", target_os = "linux"))]`. An earlier revision of this description said "not target-gated"; that was wrong, and thanks to @matthewevans and CodeRabbit for catching it from two directions. The gate is where the stack-bounds query has actually been *executed*, not a calibration boundary — widening it means adding a query arm, widening the `cfg`, and running the test on that target. CI's `ubuntu-latest` x86_64 is covered, which is the point: the sibling guard has never executed in CI at all.

**Safety of the paint**, after two rounds of review (`1f83654`, `6910b43`):

1. **Bounds are queried, not inferred.** `stack_bounds()` calls `pthread_getattr_np` + `pthread_attr_getstack`/`getguardsize`, and refuses to return a range that does not contain a local of the asking frame. Not ceremony — the run reports `STACK_BOUNDS_VALIDATED=[0x7fb7c8001000, 0x7fb7cc000000)` against a 64 MiB request, `67,104,768` vs `67,108,864` bytes, **exactly 4096 short**. The guard page is carved out of the requested size, so `Builder::stack_size` does not hand back what it was asked for.
2. **The ceiling is a frame boundary, not an enumeration.** `hi` is computed inside `paint_below_this_frame`, one call below `measure`, so every frame above it is out of range by the calling convention — locals, spill slots and compiler temporaries alike. Growth direction is an ABI property rather than a Rust guarantee, so it is asserted at runtime.
3. **Only values live at paint time can be damaged**, because everything allocated afterwards is written into the region on purpose. That is the measurement.

The one check that is *not* load-bearing is documented as such. A post-paint tripwire inside the painter does not survive its own failure mode: planting `hi = floor_addr + 64` as a negative control produces `SIGSEGV` rather than tripping it, because `floor_addr` is a local in the frame being painted. A checker whose storage is inside the region it checks cannot be relied on, so the caller-side probe carries the weight and the file says so.

**The assertion is deliberately loose, and that is the design.** A tight ratchet needs a per-target recorded value, and carrying a table of those is exactly what forced the sibling file's `cfg` down to a target CI does not run. So this file splits the two: it **asserts** what holds on every target — one un-nested `apply()` stays under a quarter of `phase-server`'s 32 MiB `RUNTIME_THREAD_STACK_BYTES` — and **prints** the number, which is only comparable within a target. Tightening the printed number into a per-target ratchet is the follow-up, once it has a CI run history to set rows from.

**It does not replace the sibling gate.** That file's 3 MiB bound is a *discrimination* dial, calibrated so reverting the `ResolvedAbility` boxing flips it red; no portable assertion can be that sharp. Its module docs are updated to say so, rather than to keep claiming the instrument is unbuilt.

## Files changed

- `crates/engine/tests/integration/game_state_stack_high_water.rs` — new
- `crates/engine/tests/integration/main.rs` — `mod` registration
- `crates/engine/tests/integration/game_state_stack_budget.rs` — module docs only; no code change
- `crates/engine/Cargo.toml` — `libc` into `[dev-dependencies]`, for the stack-bounds query
- `Cargo.lock` — one dependency edge; `libc` was already present transitively at 0.2.186, so nothing new is vendored

## Track

Developer

## LLM

Model: claude-opus-5
Tier: Frontier
Thinking: high

## Implementation method (required)

Method: not-applicable — test-only instrumentation. No `crates/engine/` game logic is touched: the diff adds one test file, one `mod` line, and a doc-comment edit. `git diff --stat origin/main...HEAD` shows nothing under `crates/engine/src/`.

## CR references

None. No rules behavior is involved and the diff adds no `CR XXX.Y` citations.

## Verification

- [x] Required checks ran clean, or the exact CI-owned alternative is stated below.
- [x] Gate A output below is for the current committed head.
- [ ] Final review-impl below is clean for the current committed head. — **not applicable**: `Method: not-applicable`, so `/engine-implementer` did not run. Stated rather than checked.
- [x] Both anchors cite existing analogous code at the same seam.

- `cargo test -p phase-engine --test integration -- --nocapture game_state_stack_high_water no_top_level_test_binaries` — **3 passed; 0 failed**, `STACK_HIGH_WATER_BYTES=2553199 (2493 KiB)`, `STACK_BOUNDS_VALIDATED=[0x7fb7c8001000, 0x7fb7cc000000)`
- `cargo test -p phase-engine --test integration -- --list | grep -E 'high_water|stack_budget'` — lists `game_state_stack_high_water::four_player_commander_action_stack_high_water` and **nothing** for `game_state_stack_budget`, which is the aarch64/macOS gate compiling out

All results above are at head `6910b43`. The raw byte count moved between `2553199` and `2553279` across this PR's revisions — the measuring frame reshaped by the review fixes, an 80 B spread at 0.003%; the KiB figure has not moved.
- `cargo fmt --all -- --check` — clean, exit 0
- `cargo clippy -p phase-engine --all-targets --features engine/proptest -- -D warnings` — clean, exit 0, no warnings
- `bash scripts/check-parser-combinators.sh origin/main` — `Gate A SKIPPED (no files under crates/engine/src/parser changed)`, then `Gate A PASS`
- `bash scripts/check-prelowered-ratchet.sh` — `Gate P PASS (PreLowered ratchet: no producer count increased)`
- `bash scripts/check-cr-citation-anchors.sh` — **walk PASS** (`walked 2450 source files, read 68648 lines that cite a rule, matched 0`). Its outer status-reading self-check leg could **not** execute here: this checkout is on a CIFS mount with `file_mode=0644`, so the copy the leg makes at `scripts/anchors.sh` is never executable and the child exits 126. Environment limitation, not a tree finding; the walk itself is reported above and the diff adds no CR citations.

**Determinism, measured two ways.** Three consecutive runs give the same byte at a given head. Stronger: the same file measured at `f1f074a91` gives `2985223` on *two independent builds* — separate target-dir states, incremental cache cleared between them — byte-for-byte identical. So the number is a property of the engine path, not of the build.

**And it is sensitive to real change.** Between `f1f074a91` and this PR's base `011409107` — 15 commits, `50 files changed, 8293 insertions(+)` under `crates/engine/src` — the same fixture moved **2,985,223 B -> ~2,553,2xx B, i.e. about -432,000 B (-422 KiB, -14.5%)**. Both endpoints are reproduced measurements, not estimates. That is the instrument doing the job the survive/abort bit cannot: the whole move is invisible to a test that only reports whether it aborted.

**Not run**, as irrelevant to a test-only diff: the pre-push hook's `oracle-gen` / `card-data-validate` / `coverage-report` / `coverage-regression-check` card legs and its `client` lint + type-check legs. No `data/`, `client/`, or card-data path is touched.

## Gate A

Gate A PASS head=6910b431214e65b89616f8b883b073d551a0ae0e base=0114091076646a5de6771ca47b3ef6a74ae316dd

## Anchored on

- `crates/engine/tests/integration/game_state_stack_budget.rs:152` — the fixture, the reach-guard shape, and the `thread::Builder` + explicit `stack_size` pattern this file copies verbatim so the two measure the same path
- `crates/engine/tests/integration/combo_infinite_pile.rs:218` — the in-tree precedent that pattern was itself adopted from: positive reach-guards asserting the measured action actually happened, so a fixture that no-ops cannot report a flattering result

## Final review-impl

not-applicable — `Method: not-applicable` (test-only; no engine game logic in the diff).

## Claimed parse impact

None.

## Scope Expansion

None. The instrument only; issue #8376's third open question — the drift itself — is deliberately left for a separate PR, since this one has to land first to measure it against.

Worth flagging for that follow-up, because it revises what #8376 currently says: the -422 KiB above means the drift is **not monotonic**. #8376's second comment reports "+625 KiB (+27.3%) in 44 days ... Monotonic — every interval positive, no step anywhere," and concludes x86_64 sat "~157 KiB from the bound ... about eleven days." Both endpoints here are reproduced measurements and they show the series moving sharply the other way in a single day. x86_64 is now ~579 KiB below the 3,072 KiB dial, not ~157 KiB under it. The sampling in that comment was one point per ~8 days, which cannot see a step of this size; nothing about the earlier numbers was wrong, but "monotonic" was an artifact of the sample spacing. I will post the correction on the issue.

## Validation Failures

None.

## CI Failures

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GVgJDj9cX1g1Csfqz7Cp2U
