### PR TITLE
Fix Descendants' Path

### DIFF
--- a/crates/engine/src/game/filter.rs
+++ b/crates/engine/src/game/filter.rs
@@ -7422,6 +7422,120 @@ fn source_context_from_spell_filter(context: SpellFilterContext<'_>) -> SourceCo
     }
 }
 
+/// CR 109.2: does this `TypedFilter` name a zone of its own? A bare descriptive
+/// reference ("a creature you control") names none; one that says "in your
+/// graveyard" / "on the battlefield" carries an `InZone`/`InAnyZone` prop that
+/// `filter_inner` already enforces.
+///
+/// Nearest neighbor: `layers.rs::target_filter_reads_zone` runs the identical
+/// `InZone`/`InAnyZone` prop scan and recurses `Or`/`And`/`Not`. A separate
+/// helper is correct here because it answers a DIFFERENT question — "does the
+/// filter name ANY zone at all?" (a boolean gate on emptiness of the zone
+/// axis) versus that function's "does the filter constrain to this SPECIFIC
+/// `zone`?" — and because `target_filter_reads_zone` is module-private to
+/// `layers.rs` (game must not reach across modules for a private predicate,
+/// and `layers.rs` is out of bounds for this change).
+fn typed_reference_names_zone(tf: &TypedFilter) -> bool {
+    tf.properties
+        .iter()
+        .any(|p| matches!(p, FilterProp::InZone { .. } | FilterProp::InAnyZone { .. }))
+}
+
+/// CR 109.2 + CR 109.2a/b: decide whether `reference_obj` is admitted as the
+/// referent of `reference_filter`, applying the zone default per leg.
+///
+/// * A bare descriptive `Typed` reference that names no zone means a permanent
+///   ON THE BATTLEFIELD (CR 109.2) — the half of the contract this scan
+///   previously left unimplemented (it only excluded the stack, CR 109.2b).
+/// * A `Typed` reference that names a zone keeps it; `filter_inner`'s
+///   `InZone`/`InAnyZone` props are the single authority for that zone (CR 109.2a).
+/// * `Or` recurses so a disjunctive reference ("a creature you control OR a
+///   creature card in your graveyard", Volo) binds the battlefield default to
+///   the zone-less leg only.
+/// * Any other (identity/anaphoric) reference — `SelfRef`, etc. — keeps the
+///   prior "anything but the stack" rule; CR 109.2 scopes only to descriptions
+///   that include a card type or subtype, which "it"/"~" do not.
+///
+/// CR 109.2 PRECONDITION: CR 109.2 applies only to descriptions that include a
+/// card type/subtype, and EXCLUDES descriptions containing the word
+/// "card"/"spell"/"source"/"scheme" (CR 109.2a/b/c). The `Typed` arm below
+/// honors the first half literally — an empty `type_filters` list carries no
+/// type word, so it is NOT given the battlefield default. A corpus census of
+/// `client/public/card-data.json` (measured: 112 `SharesQuality` nodes across 96
+/// cards) shows exactly one such reference: Tiamat's "Dragon cards not named
+/// Tiamat" → `Typed { type_filters: [], properties: [Named "tiamat"] }`, which
+/// therefore keeps the prior "anything but the stack" rule.
+///
+/// The second half — the "card"/"spell"/"source" word exclusion — cannot be
+/// honored literally, because the engine's `TargetFilter` has no representation
+/// for a zone-less "card" word. The census bounds that gap instead: every
+/// `Typed` reference that includes the word "card" (core type `Card`) already
+/// carries an explicit `InZone`, and the only such references (Frostpyre
+/// Arcanist, Pyromancer Ascension) all resolve `InZone Graveyard`, so
+/// `typed_reference_names_zone` keeps their zone rather than defaulting to the
+/// battlefield. Every remaining zone-less, type-bearing `Typed` reference is a
+/// bare permanent description ("a creature/land you control"), for which the
+/// battlefield default is exactly what CR 109.2 prescribes. Re-measure this
+/// census before widening the arm; a new printing is what would invalidate it.
+///
+/// COMPOUND SHAPES (`And` / `Not`) are deliberately left on the `_` arm's prior
+/// "anything but the stack" rule rather than given speculative recursion, and
+/// the bound on that is EMPIRICAL, not structural. `parse_shared_quality_reference`
+/// (`parser/oracle_target.rs`) is the sole producer of this `reference`; its own
+/// arms emit `Typed`, `Or { Typed, Typed }`, and the identity/anaphoric filters
+/// (`CostPaidObject`, `TriggeringSource`, `ParentTarget`, `TrackedSet`), but its
+/// final leg delegates to the general `parse_target`, which CAN build `And`/`Not`
+/// for other noun phrases — so reachability is bounded by which reference
+/// phrasings printed cards actually use, not by construction. The corpus census
+/// above measures that bound: across all 112 `SharesQuality` nodes the only
+/// reference shapes present are `Typed`, a single `Or` (Volo), and anaphors —
+/// zero `And`, zero `Not`. `Not` in particular has no grounded zone semantics
+/// here ("an object that is NOT a creature you control" does not inherit a
+/// battlefield default from the negated description), so inventing one against
+/// no card would be untested rule-making. If a printing ever makes an `And`/`Not`
+/// reference reachable, extend this match with that shape's real zone rule (for
+/// `And`, the natural reading is "apply the battlefield default unless SOME leg
+/// names a zone"; `layers.rs::target_filter_reads_zone` is the syntactic analog)
+/// and add a card-backed test — do not take this comment's parenthetical as the
+/// answer.
+fn reference_leg_admits(
+    state: &GameState,
+    reference_id: ObjectId,
+    reference_obj: &GameObject,
+    reference_filter: &TargetFilter,
+    ctx: &FilterContext<'_>,
+) -> bool {
+    match reference_filter {
+        TargetFilter::Or { filters } => filters
+            .iter()
+            .any(|leg| reference_leg_admits(state, reference_id, reference_obj, leg, ctx)),
+        TargetFilter::Typed(tf) => {
+            // CR 109.2's precondition is a description that INCLUDES A CARD TYPE
+            // OR SUBTYPE. An empty `type_filters` list carries no such type word
+            // — the reference is characteristic-only ("not named Tiamat" →
+            // `Typed { type_filters: [], properties: [Named] }`, the corpus's one
+            // instance) — so CR 109.2 does not reach it and it must NOT inherit
+            // the battlefield default. Those keep the prior "anything but the
+            // stack" rule, which is what sources Tiamat's own name for its
+            // "Dragon cards not named Tiamat" search in the CR 113.7a window
+            // where the triggered ability outlives its source — Tiamat having
+            // left the battlefield before its enters trigger resolves.
+            let zone_ok = if tf.type_filters.is_empty() {
+                reference_obj.zone != Zone::Stack
+            } else if typed_reference_names_zone(tf) {
+                true
+            } else {
+                reference_obj.zone == Zone::Battlefield
+            };
+            zone_ok && filter_inner(state, reference_id, reference_filter, ctx)
+        }
+        _ => {
+            reference_obj.zone != Zone::Stack
+                && filter_inner(state, reference_id, reference_filter, ctx)
+        }
+    }
+}
+
 fn object_shares_quality_with_reference_filter(
     state: &GameState,
     obj: &GameObject,
@@ -7473,26 +7587,32 @@ fn object_shares_quality_with_reference_filter(
         recipient_id: source.recipient_id,
         scoped_iteration_player: None,
     };
-    // CR 109.2 + CR 205.3m: a bare type reference such as "a creature you
-    // control" or "a creature card in your graveyard" denotes an object in the
-    // zone that reference implies — a permanent on the battlefield or a card in
-    // the named zone — never a spell on the stack. A creature spell being cast
-    // (Volo, Guide to Monsters; Menagerie Curator) is itself on the stack, and
-    // any sibling creature spell on the stack is likewise not a "creature you
-    // control" permanent. Excluding stack objects from the reference scan keeps
-    // any same-type spell (the one under test AND its siblings) from
-    // self-satisfying the "shares a creature type" test; stack-scoped references
-    // (TriggeringSource / ParentTarget) are resolved by the branches above, so
-    // this scan only ever backs bare permanent/card references. Battlefield- and
+    // CR 109.2 + CR 205.3m: resolve a bare descriptive reference such as "a
+    // creature you control" or "a creature card in your graveyard" to the zone
+    // that description implies, per leg. CR 109.2: a zone-less description that
+    // includes a card type/subtype means a permanent of that type ON THE
+    // BATTLEFIELD — the half of the contract this scan previously left
+    // unimplemented (it only excluded the stack). CR 109.2a: a description that
+    // names a zone keeps it, enforced by `filter_inner`'s `InZone`/`InAnyZone`
+    // props (the single authority for that zone). CR 109.2b: a spell being cast
+    // (Volo, Guide to Monsters; Menagerie Curator) is on the stack and is never
+    // a "creature you control" permanent, and any sibling creature spell on the
+    // stack is likewise excluded — so a same-type spell cannot self-satisfy the
+    // "shares a creature type" test. Stack-scoped references (TriggeringSource /
+    // ParentTarget) are resolved by the branches above, so this scan only ever
+    // backs bare permanent/card references. `Or` is evaluated per leg so a
+    // disjunctive reference (Volo's battlefield-or-graveyard) binds the
+    // battlefield default to the zone-less leg only. Battlefield- and
     // graveyard-to-object comparisons keep their existing self-inclusive
-    // semantics.
+    // semantics; only the previously-unguarded library/hand self-match (the
+    // Descendants' Path defect, where the revealed library card satisfied its
+    // own "a creature you control" reference) is closed.
     state.objects.keys().copied().any(|reference_id| {
         state
             .objects
             .get(&reference_id)
             .is_some_and(|reference_obj| {
-                reference_obj.zone != Zone::Stack
-                    && filter_inner(state, reference_id, reference_filter, &ctx)
+                reference_leg_admits(state, reference_id, reference_obj, reference_filter, &ctx)
                     && {
                         let values = object_shared_quality_values(
                             reference_obj,

--- a/crates/engine/src/parser/oracle_effect/conditions.rs
+++ b/crates/engine/src/parser/oracle_effect/conditions.rs
@@ -1502,6 +1502,18 @@ fn parse_if_exiled_card_type_conditional(text: &str) -> Option<(AbilityCondition
 /// `tag("with the ")`. Note the last two are NOT routed through
 /// `parse_suffix_subject_head` — enumerate all three heads when auditing this.
 ///
+/// The shared-quality relative-clause branch adds one more determiner head:
+/// `parse_shared_quality_clause` is fronted by `tag("that ")` (e.g. "that
+/// shares a creature type with a creature you control", Descendants' Path).
+/// It is additionally GUARDED on `reference: Some(_)` so a reference-less
+/// clause consumes nothing (a `None` reference is an unconditionally-true gate
+/// at runtime — see the branch's own comment below). The `tag("that ")` head
+/// is why it is safe between `tag(" card")` and `tag(" is revealed this way")`:
+/// the reveal-head slice trims to `"is revealed this way"`, which fails
+/// `tag("that ")` and is consumed by nothing. Any change to this branch, like
+/// the mana-value ones above, must re-run the card-data structural diff (no
+/// card carrying "is revealed this way" may move except by intent).
+///
 /// Consequently, for any input the reveal head accepted before the property
 /// slot existed, the slice handed here begins `" is revealed this way"`, which
 /// no branch above can consume: byte-identity for those cards is a PROOF, not a
@@ -1522,6 +1534,34 @@ fn parse_revealed_card_gate_suffix<'a>(
     {
         let leading_ws = after_type.len() - after_type.trim_start().len();
         return (&after_type[leading_ws + consumed..], Some(prop));
+    }
+    // CR 205.3m + CR 608.2c: postnominal shared-quality relative clause on a
+    // revealed/exiled card gate — "creature card that shares a creature type
+    // with a creature you control" (Descendants' Path). Delegates to the shared
+    // `parse_shared_quality_clause` building block, fronted by the determiner
+    // `tag("that ")` (consumes NOTHING on a non-match, preserving this helper's
+    // load-bearing invariant: the `is revealed this way` caller's post-`card`
+    // slice trims to "is revealed this way", which fails `tag("that ")`).
+    //
+    // The `reference: Some(_)` guard is REQUIRED, not cosmetic: the clause parses
+    // its reference with `opt(...)` and returns `Ok` with `reference: None` when
+    // the `" with <ref>"` phrase is absent OR present-but-unparseable. Runtime
+    // `evaluate_shares_quality` treats a `None` reference as UNCONDITIONALLY TRUE
+    // (`is_none_or`), so accepting a `None`-reference clause here would (a) re-emit
+    // the always-satisfied gate this fix exists to remove, and (b) in the
+    // `is revealed this way` caller, consume `that shares <quality>`, leave the
+    // mandatory anchor unmatchable, and drop that card's ENTIRE condition. Guarding
+    // on `Some(_)` makes the arm consume nothing in both degenerate cases, keeping
+    // the invariant intact for all callers; a genuinely unparseable reference then
+    // stays an honest unsupported gap rather than a false gate.
+    if let Ok((
+        rest,
+        prop @ FilterProp::SharesQuality {
+            reference: Some(_), ..
+        },
+    )) = crate::parser::oracle_target::parse_shared_quality_clause(after_type.trim_start(), ctx)
+    {
+        return (rest, Some(prop));
     }
     (after_type, None)
 }
@@ -7931,6 +7971,7 @@ mod tests {
     use crate::parser::parse_oracle_text;
     use crate::types::ability::{
         AggregateFunction, CardTypeSetSource, CommanderOwnership, PlayerFilter, SharedQuality,
+        SharedQualityRelation,
     };
     use crate::types::counter::{CounterMatch, CounterType};
 
@@ -11372,6 +11413,78 @@ mod tests {
         assert!(subtype_filter.is_none());
     }
 
+    /// CR 205.3m + CR 608.2c (Verification row 3): Descendants' Path —
+    /// "If it's a creature card that shares a creature type with a creature you
+    /// control, you may cast it …". The postnominal shared-quality clause must
+    /// be consumed by the revealed-card gate suffix and wired onto
+    /// `additional_filter` as a `SharesQuality{ CreatureType, Shares, Some(ref) }`,
+    /// leaving a CLEAN effect body. Reverting the new arm makes
+    /// `additional_filter` `None` and leaves the clause stranded in the body.
+    #[test]
+    fn strip_card_type_conditional_creature_that_shares_creature_type() {
+        let (cond, body) = strip_card_type_conditional(
+            "If it's a creature card that shares a creature type with a creature you control, \
+             you may cast it without paying its mana cost.",
+        );
+        assert_eq!(body, "you may cast it without paying its mana cost.");
+        let Some(AbilityCondition::RevealedHasCardType {
+            card_types,
+            additional_filter,
+            subtype_filter,
+        }) = cond
+        else {
+            panic!("expected RevealedHasCardType with SharesQuality filter, got {cond:?}");
+        };
+        assert_eq!(card_types, vec![CoreType::Creature]);
+        assert!(subtype_filter.is_none());
+        let Some(FilterProp::SharesQuality {
+            quality,
+            relation,
+            reference,
+        }) = additional_filter
+        else {
+            panic!("expected SharesQuality additional_filter, got {additional_filter:?}");
+        };
+        assert_eq!(quality, SharedQuality::CreatureType);
+        assert_eq!(relation, SharedQualityRelation::Shares);
+        // The load-bearing guard: the reference "a creature you control" must
+        // have resolved. A `None` here is the always-true gate this fix removes.
+        assert!(
+            reference.is_some(),
+            "reference 'a creature you control' must resolve to Some(_), got None"
+        );
+    }
+
+    /// CR 205.3m (Verification row 4, GUARD): a reference-less shares clause
+    /// ("that shares a creature type", with NO " with <ref>") must NOT be
+    /// consumed — `parse_shared_quality_clause` returns `reference: None`, which
+    /// `evaluate_shares_quality` treats as unconditionally true. The
+    /// `reference: Some(_)` guard rejects it, so the arm consumes NOTHING: the
+    /// gate carries no `additional_filter` and the clause stays in the body.
+    /// Removing the guard flips both assertions.
+    #[test]
+    fn strip_card_type_conditional_shares_clause_without_reference_is_unconsumed() {
+        let (cond, body) = strip_card_type_conditional(
+            "If it's a creature card that shares a creature type, \
+             you may cast it without paying its mana cost.",
+        );
+        let Some(AbilityCondition::RevealedHasCardType {
+            additional_filter, ..
+        }) = cond
+        else {
+            panic!("expected RevealedHasCardType, got {cond:?}");
+        };
+        assert!(
+            additional_filter.is_none(),
+            "reference-less shares clause must NOT be consumed (would emit an \
+             always-true gate), got {additional_filter:?}"
+        );
+        assert!(
+            // allow-noncombinator: test assertion on the leftover effect body, not parsing dispatch.
+            body.trim_start().starts_with("that shares"),
+            "the unconsumed clause must remain in the effect body, got {body:?}"
+        );
+    }
     /// CR 608.2c: Suffix-if peel (`strip_suffix_conditional`) must stay in lockstep
     /// with the leading-if `strip_card_type_conditional` mana-value gate.
     #[test]

--- a/crates/engine/tests/integration/descendants_path_shared_creature_type_gate.rs
+++ b/crates/engine/tests/integration/descendants_path_shared_creature_type_gate.rs
@@ -1,0 +1,388 @@
+//! Descendants' Path — Enchantment {2}{G}, verbatim Oracle:
+//!   "At the beginning of your upkeep, reveal the top card of your library. If
+//!    it's a creature card that shares a creature type with a creature you
+//!    control, you may cast it without paying its mana cost. If you don't cast
+//!    it, put it on the bottom of your library."
+//!
+//! TWO-LAYER DEFECT this file guards (both layers must be present to pass):
+//!
+//!  1. PARSER layer (`parser/oracle_effect/conditions.rs`): the postnominal
+//!     "that shares a creature type with a creature you control" clause folds
+//!     onto the free-cast leg's gate as `RevealedHasCardType { card_types:
+//!     [Creature], additional_filter: Some(SharesQuality{ CreatureType, Shares,
+//!     reference: "a creature you control" }) }`. Reverting it makes the gate
+//!     `RevealedHasCardType{[Creature]}` — unconditionally true for ANY revealed
+//!     creature.
+//!  2. RUNTIME layer (`game/filter.rs::object_shares_quality_with_reference_filter`,
+//!     via the new `reference_leg_admits`): CR 109.2 — a zone-less "a creature
+//!     you control" reference means a permanent ON THE BATTLEFIELD. Before the
+//!     fix the fallback scan admitted any non-stack object, so the revealed
+//!     LIBRARY card satisfied its own reference and shared a creature type with
+//!     itself ⇒ the gate was always true even on an empty battlefield.
+//!
+//! DISCRIMINATING ROWS:
+//!   * Row A (NEGATIVE, primary): battlefield creature subtype disjoint from the
+//!     library card's ⇒ never offered; card put on the bottom. Reverting EITHER
+//!     layer flips it (parser: gate becomes always-true; runtime: library card
+//!     self-matches).
+//!   * Row B (POSITIVE reach-guard): shared subtype ⇒ offered, answered, cast
+//!     onto the battlefield. Without it Rows A/C could pass vacuously.
+//!   * Row C (zone-rule-specific): ZERO battlefield creatures, but a same-type
+//!     "creature you control" sits in HAND ⇒ never offered. Flips ONLY on the
+//!     runtime zone rule (self-exclusion alone would still match the hand decoy).
+//!
+//! CR 109.2 verified verbatim in docs/MagicCompRules.txt: "a permanent … on the
+//! battlefield". CR 205.3m: creature types are the shared subtype list. CR
+//! 503.1 / 504.1: the drive stops inside the upkeep step, before the CR 504.1
+//! draw, so a negative row cannot deck P1 and read healthy while measuring
+//! nothing.
+
+use engine::game::scenario::{GameRunner, GameScenario, P1};
+use engine::game::zones::create_object;
+use engine::types::actions::GameAction;
+use engine::types::card_type::CoreType;
+use engine::types::game_state::{GameState, WaitingFor};
+use engine::types::identifiers::{CardId, ObjectId};
+use engine::types::mana::ManaCost;
+use engine::types::phase::Phase;
+use engine::types::player::PlayerId;
+use engine::types::zones::Zone;
+
+/// Verbatim Oracle text. The card NAME is irrelevant to the parse (the trigger
+/// is authored entirely from this text), but is kept exact for provenance.
+const DESCENDANTS_PATH_ORACLE: &str = "At the beginning of your upkeep, reveal the top card of your library. If it's a creature card that shares a creature type with a creature you control, you may cast it without paying its mana cost. If you don't cast it, put it on the bottom of your library.";
+
+/// Seed a CREATURE card on top of `player`'s library carrying real creature
+/// SUBTYPES on both `card_types` and `base_card_types`.
+///
+/// Distinct from `runo_stromkirk_reveal_transform_gate.rs::seed_library_top`,
+/// which seeds only `core_types`/`base_card_types.core_types`/`mana_cost` and NO
+/// subtypes. `SharesQuality{CreatureType}` compares SUBTYPES (CR 205.3m), so a
+/// subtype-less seed would make the positive row share nothing and pass
+/// vacuously. Both `card_types.subtypes` and `base_card_types.subtypes` are set
+/// because the gate's type leg and property leg read different fields.
+fn seed_library_top_creature(
+    state: &mut GameState,
+    player: PlayerId,
+    name: &str,
+    subtypes: &[&str],
+) -> ObjectId {
+    let id = create_object(
+        state,
+        CardId(state.next_object_id),
+        player,
+        name.to_string(),
+        Zone::Library,
+    );
+    let obj = state.objects.get_mut(&id).unwrap();
+    obj.card_types.core_types = vec![CoreType::Creature];
+    obj.base_card_types.core_types = vec![CoreType::Creature];
+    obj.card_types.subtypes = subtypes.iter().map(|s| (*s).to_string()).collect();
+    obj.base_card_types.subtypes = subtypes.iter().map(|s| (*s).to_string()).collect();
+    obj.mana_cost = ManaCost::generic(2);
+    let ps = state.players.iter_mut().find(|p| p.id == player).unwrap();
+    ps.library.retain(|&o| o != id);
+    ps.library.insert(0, id);
+    id
+}
+
+/// Drive P1's upkeep trigger to the end of ITS OWN resolution and stop there.
+///
+/// Returns whether the "you may cast it" optional was ever offered. Breaks the
+/// instant the revealed card reaches the battlefield (the positive path resolves
+/// the free cast) or when the stack empties with no pending optional (the
+/// negative path put the card on the bottom of the library). Never falls through
+/// to the CR 504.1 upkeep draw, so a negative row cannot deck P1 (CR 704.5b).
+fn drive_upkeep_free_cast(runner: &mut GameRunner, top: ObjectId) -> bool {
+    assert!(
+        !runner.state().stack.is_empty(),
+        "reach guard: the upkeep trigger must already be on the stack when the drive \
+         starts, or this loop returns immediately and the row measures nothing"
+    );
+    let mut offered = false;
+    for _ in 0..40 {
+        // Positive path: the free cast has resolved onto the battlefield.
+        if runner.state().objects.get(&top).map(|o| o.zone) == Some(Zone::Battlefield) {
+            break;
+        }
+        // Negative path: the trigger has left the stack and nothing is parked
+        // in a mid-resolution choice; the next PassPriority would leave the
+        // upkeep step (CR 503.1 -> CR 504.1). Stop before that draw.
+        if runner.state().stack.is_empty()
+            && !matches!(
+                runner.state().waiting_for,
+                WaitingFor::OptionalEffectChoice { .. }
+            )
+        {
+            break;
+        }
+        match &runner.state().waiting_for {
+            WaitingFor::OptionalEffectChoice { .. } => {
+                offered = true;
+                if runner
+                    .act(GameAction::DecideOptionalEffect { accept: true })
+                    .is_err()
+                {
+                    break;
+                }
+            }
+            WaitingFor::Priority { .. } => {
+                if runner.act(GameAction::PassPriority).is_err() {
+                    break;
+                }
+            }
+            _ => break,
+        }
+    }
+    offered
+}
+
+/// Number of creatures `player` controls on the battlefield.
+fn battlefield_creature_count(state: &GameState, player: PlayerId) -> usize {
+    state
+        .objects
+        .values()
+        .filter(|o| {
+            o.zone == Zone::Battlefield
+                && o.controller == player
+                && o.card_types.core_types.contains(&CoreType::Creature)
+        })
+        .count()
+}
+
+/// Build the shared board: Descendants' Path (an Enchantment, so it never
+/// self-satisfies "a creature you control") under P1, two noncreature filler
+/// cards beneath the seeded top so no incidental draw can deck P1, and the
+/// scenario advanced into P1's own upkeep (the trigger is OnlyDuringYourTurn).
+/// Shared tail: build the runner, seed the library top creature, advance into
+/// P1's upkeep, and assert the shared active-player reach guard.
+fn scenario_into_upkeep(scenario: GameScenario, top_subtypes: &[&str]) -> GameRunner {
+    let mut runner = scenario.build();
+    // CR 205.3m: `SharedQuality::CreatureType` counts only subtypes present in
+    // `all_creature_types`. The scenario builder does not derive it from
+    // inline-built cards, so seed the creature types this file uses — without
+    // this the SharesQuality comparison is empty-vs-empty and every row passes
+    // vacuously (measured: the positive row went RED, proving the guard).
+    runner.state_mut().all_creature_types = vec!["Goblin".to_string(), "Wall".to_string()];
+    seed_library_top_creature(runner.state_mut(), P1, "Revealed Creature", top_subtypes);
+    runner.advance_to_phase(Phase::Upkeep);
+    assert_eq!(
+        runner.state().active_player,
+        P1,
+        "reach guard: the trigger is OnlyDuringYourTurn, so this must be P1's own upkeep"
+    );
+    runner
+}
+
+/// Fetch the seeded library top by name (its `ObjectId` after `build()`).
+fn revealed_creature_id(state: &GameState) -> ObjectId {
+    state
+        .objects
+        .iter()
+        .find(|(_, o)| o.name == "Revealed Creature")
+        .map(|(id, _)| *id)
+        .expect("seeded 'Revealed Creature' must exist")
+}
+
+/// Shared SETUP guard for every row (asserted BEFORE driving): the seeded top
+/// carries the intended subtypes (so "shares"/"disjoint" is real, not two empty
+/// sets trivially sharing nothing). The reveal-ledger guard is asserted
+/// separately AFTER the drive (the reveal only happens during trigger
+/// resolution), via `assert_revealed_exactly_one`.
+fn assert_seeded_subtypes(runner: &GameRunner, top: ObjectId, expected_subtypes: &[&str]) {
+    let got: Vec<String> = runner.state().objects[&top].card_types.subtypes.clone();
+    let want: Vec<String> = expected_subtypes.iter().map(|s| (*s).to_string()).collect();
+    assert_eq!(
+        got, want,
+        "reach guard: the revealed creature must carry its seeded subtypes, or the \
+         SharesQuality comparison is vacuous"
+    );
+}
+
+/// Reveal-ledger reach guard, asserted AFTER the drive: exactly one card was
+/// revealed, so the gate had a real subject to read. A row where the trigger
+/// silently no-op'd (e.g. fired under the wrong player) would leave this empty.
+fn assert_revealed_exactly_one(runner: &GameRunner) {
+    assert_eq!(
+        runner.state().last_revealed_ids.len(),
+        1,
+        "reach guard: the reveal step must have produced exactly one card for the \
+         gate to read; got {:?}",
+        runner.state().last_revealed_ids
+    );
+}
+
+/// Row A — NEGATIVE (primary discriminator). One battlefield creature whose
+/// subtype (`Wall`) is DISJOINT from the revealed creature's (`Goblin`). The
+/// free cast must NEVER be offered; the revealed creature stays off the
+/// battlefield and is put on the bottom of the library. Reverting EITHER the
+/// parser arm (gate becomes always-true) OR the runtime zone rule (library card
+/// self-matches) flips this row.
+#[test]
+fn disjoint_battlefield_creature_type_never_offers_free_cast() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.add_enchantment_from_oracle(P1, "Descendants' Path", DESCENDANTS_PATH_ORACLE);
+    let wall = scenario
+        .add_creature(P1, "Wall Sentinel", 0, 4)
+        .with_subtypes(vec!["Wall"])
+        .id();
+    scenario.with_library_top(P1, &["Filler One", "Filler Two"]);
+    let mut runner = scenario_into_upkeep(scenario, &["Goblin"]);
+    let top = revealed_creature_id(runner.state());
+
+    assert_seeded_subtypes(&runner, top, &["Goblin"]);
+    assert_eq!(
+        runner.state().objects[&wall].card_types.subtypes,
+        vec!["Wall".to_string()],
+        "reach guard: the battlefield creature must carry its disjoint subtype"
+    );
+    assert_eq!(
+        battlefield_creature_count(runner.state(), P1),
+        1,
+        "reach guard: exactly the disjoint Wall is on P1's battlefield"
+    );
+
+    let offered = drive_upkeep_free_cast(&mut runner, top);
+
+    assert_revealed_exactly_one(&runner);
+    assert!(
+        !offered,
+        "a disjoint battlefield creature must NOT satisfy 'shares a creature type', \
+         so the free cast must never be offered"
+    );
+    assert_eq!(
+        runner.state().phase,
+        Phase::Upkeep,
+        "reach guard: the drive must stop inside the upkeep step it measures"
+    );
+    assert_ne!(
+        runner.state().objects[&top].zone,
+        Zone::Battlefield,
+        "the revealed creature must not have been cast onto the battlefield"
+    );
+    let library = &runner
+        .state()
+        .players
+        .iter()
+        .find(|p| p.id == P1)
+        .unwrap()
+        .library;
+    assert_eq!(
+        library.last().copied(),
+        Some(top),
+        "the un-cast creature must be put on the BOTTOM of P1's library"
+    );
+}
+
+/// Row B — POSITIVE reach-guard. A shared subtype (`Goblin`) on the battlefield
+/// makes the gate true; the free cast is offered, answered, and the revealed
+/// creature is cast onto P1's battlefield. This proves the harness CAN offer and
+/// resolve the free cast, so the negatives in Rows A/C are non-vacuous.
+#[test]
+fn shared_battlefield_creature_type_offers_and_casts() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.add_enchantment_from_oracle(P1, "Descendants' Path", DESCENDANTS_PATH_ORACLE);
+    let goblin = scenario
+        .add_creature(P1, "Goblin Piker", 2, 1)
+        .with_subtypes(vec!["Goblin"])
+        .id();
+    scenario.with_library_top(P1, &["Filler One", "Filler Two"]);
+    let mut runner = scenario_into_upkeep(scenario, &["Goblin"]);
+    let top = revealed_creature_id(runner.state());
+
+    assert_seeded_subtypes(&runner, top, &["Goblin"]);
+    assert_eq!(
+        runner.state().objects[&goblin].card_types.subtypes,
+        vec!["Goblin".to_string()],
+        "reach guard: the battlefield creature must carry the shared subtype"
+    );
+
+    let offered = drive_upkeep_free_cast(&mut runner, top);
+
+    assert_revealed_exactly_one(&runner);
+    assert!(
+        offered,
+        "a shared battlefield creature type must satisfy the gate and offer the \
+         free cast"
+    );
+    assert_eq!(
+        runner.state().objects[&top].zone,
+        Zone::Battlefield,
+        "the revealed creature must be cast onto the battlefield"
+    );
+    assert_eq!(
+        runner.state().objects[&top].controller,
+        P1,
+        "the cast creature must be controlled by P1"
+    );
+}
+
+/// Row C — zone-rule-specific discriminator. ZERO creatures on P1's battlefield,
+/// but a same-type ("Goblin") creature you control sits in P1's HAND. The gate
+/// must be false: CR 109.2 restricts "a creature you control" to the
+/// battlefield, so a hand creature does not satisfy it. Flips ONLY on the
+/// runtime zone rule — mere subject self-exclusion would still let the hand
+/// decoy match and the free cast would be offered.
+#[test]
+fn hand_creature_you_control_does_not_satisfy_battlefield_reference() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.add_enchantment_from_oracle(P1, "Descendants' Path", DESCENDANTS_PATH_ORACLE);
+    let hand_decoy = scenario
+        .add_creature_to_hand(P1, "Goblin In Hand", 2, 1)
+        .with_subtypes(vec!["Goblin"])
+        .id();
+    scenario.with_library_top(P1, &["Filler One", "Filler Two"]);
+    let mut runner = scenario_into_upkeep(scenario, &["Goblin"]);
+    let top = revealed_creature_id(runner.state());
+
+    assert_seeded_subtypes(&runner, top, &["Goblin"]);
+    assert_eq!(
+        battlefield_creature_count(runner.state(), P1),
+        0,
+        "reach guard: Row C must have ZERO creatures on P1's battlefield"
+    );
+    assert_eq!(
+        runner.state().objects[&hand_decoy].zone,
+        Zone::Hand,
+        "reach guard: the same-type decoy must be a creature you control in HAND"
+    );
+    assert_eq!(
+        runner.state().objects[&hand_decoy].card_types.subtypes,
+        vec!["Goblin".to_string()],
+        "reach guard: the hand decoy must carry the same subtype as the revealed card"
+    );
+
+    let offered = drive_upkeep_free_cast(&mut runner, top);
+
+    assert_revealed_exactly_one(&runner);
+    assert!(
+        !offered,
+        "a 'creature you control' in HAND must NOT satisfy a battlefield reference \
+         (CR 109.2), so the free cast must never be offered"
+    );
+    assert_eq!(
+        runner.state().phase,
+        Phase::Upkeep,
+        "reach guard: the drive must stop inside the upkeep step it measures"
+    );
+    assert_ne!(
+        runner.state().objects[&top].zone,
+        Zone::Battlefield,
+        "the revealed creature must not have been cast onto the battlefield"
+    );
+    let library = &runner
+        .state()
+        .players
+        .iter()
+        .find(|p| p.id == P1)
+        .unwrap()
+        .library;
+    assert_eq!(
+        library.last().copied(),
+        Some(top),
+        "the un-cast creature must be put on the BOTTOM of P1's library"
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -217,6 +217,7 @@ mod delayed_trigger_continuation;
 mod demilich_helbrute_graveyard_exile_cost;
 mod demon_of_fates_design;
 mod descendants_fury_sacrificed_referent_4795;
+mod descendants_path_shared_creature_type_gate;
 mod destroy_redirect_to_battlefield_delivery_tail;
 mod deterministic_blocker_prompt_order;
 mod deterministic_game_state_serde;


### PR DESCRIPTION
## Summary

Descendants' Path only lets you free-cast the revealed card if it is "a creature card that **shares a creature type with a creature you control**". Two defects made that restriction a no-op, so the engine free-cast *any* revealed creature. This fixes both layers and adds a discriminating runtime test.

## Files changed

- `crates/engine/src/game/filter.rs`
- `crates/engine/src/parser/oracle_effect/conditions.rs`
- `crates/engine/tests/integration/descendants_path_shared_creature_type_gate.rs` (new)
- `crates/engine/tests/integration/main.rs`

## Track

Developer

## LLM

Model: claude-opus-5
Tier: Frontier
Thinking: high

## Implementation method (required)

Method: /engine-implementer

## CR references

- `CR 109.2` — a description including a card type/subtype that names no zone means a permanent **on the battlefield** (the authorizing rule for the runtime fix)
- `CR 109.2a` — description with "card" + a named zone means a card in that zone
- `CR 109.2b` — description with "spell" means a spell on the stack
- `CR 109.2c` — description with "source" means any zone
- `CR 113.7a` — a triggered ability exists independently of its source (backs the name-only carve-out)
- `CR 205.3m` — creature types are subtypes
- `CR 608.2c` — read the whole text / later text modifies earlier

## What was wrong

**Parser.** The postnominal clause `" that shares a creature type with a creature you control"` was not consumed by the revealed-card gate suffix, so it stranded as `Effect::Unimplemented { name: "that" }` and the `CastFromZone { without_paying_mana_cost }` leg was gated on a bare `RevealedHasCardType { card_types: [Creature] }`.

**Runtime.** Even with the clause wired onto the gate, it stayed unconditionally true. `object_shares_quality_with_reference_filter`'s fallback scan excluded only `Zone::Stack`, and `filter_inner`'s `Typed` arm applies no zone default — so the revealed card sitting in `Zone::Library` (a real `GameObject` whose `controller == owner`) satisfied its **own** "a creature you control" reference and trivially shared a creature type with itself. Every shipped `SharesQuality { reference: "… you control" }` card so far has its subject on the **stack** (a creature *spell* being cast — Volo, Menagerie Curator), where the stack exclusion hid this; Descendants' Path is the first whose subject sits in a hidden zone.

Fixing the parser alone would have removed an `Effect::Unimplemented` and flipped the card to `supported` while the gate stayed always-true — a coverage-honesty regression. Both layers are required, and the test proves it (reverting *either* turns the negative rows red).

## What changed

**Parser** — one guarded arm in `parse_revealed_card_gate_suffix` delegating to the existing `parse_shared_quality_clause` building block. The `reference: Some(_)` guard is load-bearing, not cosmetic: the clause parses its reference with `opt(...)`, and `evaluate_shares_quality` treats a `None` reference as unconditionally true (`is_none_or`), so an unguarded arm would re-emit the always-satisfied gate *and* consume text ahead of the mandatory `tag(" is revealed this way")` anchor in a sibling caller, dropping that card's entire condition.

**Runtime** — completes the contract that scan's own comment already stated. A zone-less, type-bearing `Typed` reference now means a battlefield permanent (CR 109.2); explicit `InZone`/`InAnyZone` references keep their zone (CR 109.2a); `Or` recurses per leg so a disjunctive reference binds the default to its zone-less leg only (Volo); identity/anaphoric references keep the prior "anything but the stack" rule. Name-only references (`type_filters` empty — Tiamat's "not named Tiamat") also keep the prior rule, because CR 109.2's precondition is a description that *includes a card type or subtype*, which they do not.

No new enum variants. Two private helper predicates; everything else reuses existing building blocks.

## Verification

- [x] Required checks ran clean, or the exact CI-owned alternative is stated below.
- [x] Gate A output below is for the current committed head.
- [x] Final review-impl below is clean for the current committed head.
- [x] Both anchors cite existing analogous code at the same seam.

- `cargo fmt --all -- --check` — exit 0
- `cargo clippy-strict` — exit 0, no warnings
- `cargo test -p phase-engine` — **0 failed** (21084 + 6748 + 22 + 7 + 14 + 20 passed, 11 ignored). All three new integration rows green; every existing `game::filter::tests::shares_quality*` blast-radius test green and unmoved.
- `bash ./scripts/check-parser-combinators.sh` — Gate A PASS (below)
- `./scripts/gen-card-data.sh` + structural diff vs the pre-change corpus — exactly **1** card changed shape (`descendants' path`); **0** cards whose oracle text contains "is revealed this way" moved. The runtime change is parse-invisible by construction, so the engine test suite is its regression guard.
- `cargo coverage` — `Descendants' Path` `supported: false, gap_count: 1` → `supported: true, gap_count: 0`; 0 other cards regressed (31932 → 31933 supported of 35845).
- `cargo semantic-audit` — 32859 cards audited, 259 with findings; Descendants' Path not among them.
- **Revert-proof (empirical):** reverting only the runtime zone rule → Rows A and C RED; reverting only the parser arm → Rows A and C RED; Row B (positive reach-guard) green in both; both restored → 3 passed.
- **Manual play-test** in the running client: Bloom Tender (Elf Druid) revealed with no shared type → auto-bottomed, no cast offered; a Sliver revealed with a Sliver in play → free cast offered.

Tilt was not running in this environment, so all checks were invoked directly rather than via `tilt-wait.sh`.

## Gate A

Gate A PASS head=6967dec84e7e0ff52010f8e069f4fb7dda3f5c1c base=1cde7a25da3696766fcad6572269416ed4db1bfb

## Anchored on

- `crates/engine/src/parser/oracle_effect/conditions.rs:1528` — the existing `tag(" of the chosen type")` arm in `parse_revealed_card_gate_suffix`; the new arm is a third determiner-fronted arm in the same combinator returning `(rest, Some(FilterProp))` in the same shape.
- `crates/engine/src/parser/oracle_effect/conditions.rs:1533` — the existing `parse_mana_value_suffix(after_type.trim_start(), ctx)` arm in that same slot; the new arm follows it directly and mirrors its delegate-to-a-shared-combinator and `trim_start()` handling.
- `crates/engine/src/parser/oracle_target.rs:8191` — `parse_shared_quality_clause`, the existing `pub(crate)` nom combinator for "that shares a &lt;quality&gt; with &lt;reference&gt;", reused verbatim rather than re-implemented.
- `crates/engine/src/game/filter.rs:6296` — `FilterProp::DifferentNameFrom`, the pre-existing sibling prop that resolves a controller-scoped reference population by scanning `state.battlefield` rather than all objects. That is the established precedent for the CR 109.2 battlefield default this change applies to `SharesQuality` references.

## Final review-impl

Final review-impl PASS head=6967dec84e7e0ff52010f8e069f4fb7dda3f5c1c

## Claimed parse impact

Descendants' Path

## Scope Expansion

The approved plan was parser-only. Implementation measurement showed the runtime `SharesQuality` reference scan left the gate unconditionally true on its own, so scope was expanded to `crates/engine/src/game/filter.rs` and the plan re-reviewed before implementing. The card cannot be fixed by either layer alone — the integration test's negative rows go red on reverting either one.

The runtime rule is shared by every `SharesQuality`-with-reference card, so the blast radius was measured rather than assumed: a corpus census (112 `SharesQuality` nodes across 96 cards) found every zone-less type-bearing reference to be a battlefield-permanent description, every non-battlefield reference to carry an explicit `InZone`, and zero `And`/`Not` reference shapes. `And`/`Not` are consequently left on the prior rule with the bound documented as empirical rather than structural, since `parse_shared_quality_reference`'s final leg delegates to the general `parse_target`, which can build those shapes for other phrasings.

## Validation Failures

None.

## CI Failures

None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected shared-creature-type checks for Descendants’ Path so only creatures on the battlefield can satisfy “a creature you control.”
  - Fixed handling of zone-specific and compound references in shared-quality comparisons.
  - Improved recognition of shared-quality clauses such as “shares a creature type with a creature you control.”
  - Prevented cards in hand or other zones from incorrectly enabling the free-cast ability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->