### PR TITLE
Avoid staggered animation for long choice lists

### DIFF
--- a/client/src/components/modal/NamedChoiceModal.tsx
+++ b/client/src/components/modal/NamedChoiceModal.tsx
@@ -362,9 +362,11 @@ function ButtonGrid({ data, typeKey }: { data: OptionChoice["data"]; typeKey: st
                   ? "border-emerald-400 bg-emerald-500/30 text-white"
                   : "border-gray-600 bg-gray-800/80 text-gray-300 hover:border-gray-400 hover:text-white"
               }`}
-              initial={{ opacity: 0, y: 20, scale: 0.95 }}
+              initial={showFilter ? false : { opacity: 0, y: 20, scale: 0.95 }}
               animate={{ opacity: 1, y: 0, scale: 1 }}
-              transition={{ delay: 0.05 + index * 0.03, duration: 0.25 }}
+              transition={
+                showFilter ? undefined : { delay: 0.05 + index * 0.03, duration: 0.25 }
+              }
               whileHover={{ scale: 1.05 }}
               onClick={onClick}
             >

--- a/client/src/components/modal/__tests__/NamedChoiceModal.test.tsx
+++ b/client/src/components/modal/__tests__/NamedChoiceModal.test.tsx
@@ -39,6 +39,20 @@ describe("NamedChoiceModal", () => {
     });
   });
 
+  it("does not fade in every option in a searchable long list", () => {
+    const data: NamedChoiceData = {
+      player: 0,
+      choice_type: { CreatureType: { options: [] } },
+      options: Array.from({ length: 13 }, (_, index) => `Creature type ${index}`),
+    };
+
+    render(<NamedChoiceModal data={data} />);
+
+    expect(screen.getByRole("button", { name: "Creature type 12" })).not.toHaveStyle({
+      opacity: "0",
+    });
+  });
+
   // CR 107.1a/b. The engine publishes `free_entry` for a choice whose answer is
   // typed rather than picked, and enforces exactly those bounds. These pin that
   // the modal RENDERS the contract rather than re-deriving one: the numeric form


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved searchable choice lists so all options remain visible instead of being hidden by entrance animations.
  * Preserved the existing staggered animation when no filter is displayed.

* **Tests**
  * Added coverage ensuring the final option in a long searchable list is visible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->