### PR TITLE
fix(parser): read the color axis of "no colored mana was spent" (#8807)

### DIFF
--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -7612,10 +7612,27 @@ fn parse_no_spent_mana_metric(i: &str) -> OracleResult<'_, CastManaSpentMetric> 
     .parse(i)
 }
 
-/// CR 400.7d + CR 601.2h: which object's payment record the anaphor names.
-/// "it"/"that spell"/"this spell"/"them" is the object carried by the trigger
-/// event (the spell just cast, or the permanent that just entered); "~" is the
-/// ability's own source.
+/// CR 400.7d + CR 601.2h + CR 603.4: which object's payment record the anaphor
+/// names, IN A TRIGGER'S INTERVENING-IF. "it"/"that spell"/"this spell"/"them"
+/// is the object carried by the trigger event (the spell just cast, or the
+/// permanent that just entered); "~" is the ability's own source.
+///
+/// Deliberately NOT `oracle_nom::quantity::parse_mana_spent_self_subject`,
+/// which maps the same words the other way ("it"/"this spell"/"them" →
+/// `SelfObject`). That combinator is the authority for a RESOLVING spell
+/// referring to its own payment ("where X is the amount of mana spent to cast
+/// it" — Toph, Greatest Earthbender); there "it" IS the source. Here the clause
+/// sits on a trigger whose event carries a different object, so the same words
+/// resolve to the event's subject: Void Mirror's "if no colored mana was spent
+/// to cast it" asks about the spell a player just cast, never about Void Mirror.
+/// Reading `SelfObject` here would answer with the mirror's own {2} payment —
+/// always zero colored — and counter every spell, which is issue #8807 itself.
+///
+/// This matches the mapping the sibling intervening-if extractor in this file
+/// already uses (`try_extract_mana_spent_comparison_condition`: "in a
+/// spell-cast trigger's intervening-if clause, 'it'/'that spell'/'this spell'
+/// all refer to the spell object carried by the trigger event"). The two
+/// contracts are context-scoped, not contradictory.
 fn parse_cast_payment_subject_scope(i: &str) -> OracleResult<'_, CastManaObjectScope> {
     alt((
         value(CastManaObjectScope::TriggeringSpell, tag("it")),

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -2,7 +2,7 @@ use crate::parser::oracle_nom::error::OracleError;
 use nom::branch::alt;
 use nom::bytes::complete::{tag, take_until};
 use nom::character::complete::{alpha1, one_of, space1};
-use nom::combinator::{all_consuming, eof, map, not, opt, peek, recognize, rest, value};
+use nom::combinator::{all_consuming, consumed, eof, map, not, opt, peek, recognize, rest, value};
 use nom::multi::{many0, many1, separated_list1};
 use nom::sequence::{delimited, pair, preceded, terminated};
 use nom::Parser;
@@ -7530,11 +7530,23 @@ fn map_attachment_kind_filter_prop(input: &str) -> OracleResult<'_, FilterProp> 
     Ok((rest, attachment_kinds_filter_prop(kinds, None)))
 }
 
+/// CR 603.4 + CR 601.2h + CR 106.1a: Extract "if no [colored ]mana was spent to
+/// cast it/that spell/them/~" — the intervening-if that gates on the triggering
+/// spell having been paid for with nothing (Lavinia, Vexing Bauble) or with
+/// nothing *colored* (Void Mirror).
+///
+/// The two metrics take different condition shapes on purpose. The colorless
+/// axis (`Total`) keeps the pre-existing `ManaSpentCondition`, whose runtime arm
+/// carries a source-context fallback for the event-less ETB shapes
+/// ("if it wasn't cast or no mana was spent to cast it"). The color axis
+/// (`DistinctColors`) has no legacy encoding at all, so it goes straight onto
+/// the canonical `QuantityComparison { ManaSpentToCast, EQ, 0 }` path, which
+/// reads the per-color payment tally rather than a substring.
 fn try_extract_no_mana_spent_condition(
     lower: &str,
     text: &str,
 ) -> Option<(String, Option<TriggerCondition>)> {
-    let (before, clause_text, rest) = scan_preceded(lower, |i| {
+    let (before, (clause_text, metric, scope), rest) = scan_preceded(lower, |i| {
         preceded(tag("if "), parse_no_mana_spent_clause).parse(i)
     })?;
     let rest_trimmed = rest.trim_start();
@@ -7544,24 +7556,73 @@ fn try_extract_no_mana_spent_condition(
     }
     let clause_start = before.len();
     let clause_len = lower.len() - before.len() - rest.len();
+    let condition = match metric {
+        CastManaSpentMetric::Total => TriggerCondition::ManaSpentCondition {
+            text: clause_text.to_string(),
+        },
+        // CR 106.1a + CR 106.1b: colorless is a type of mana but not a color,
+        // so "no colored mana was spent" is satisfied when the count of distinct
+        // colors in the payment record is zero — a cost paid entirely with
+        // colorless mana (or with no mana at all). `== 0` is the right
+        // reading for every metric that names a KIND of mana rather than an
+        // amount, so widening `parse_no_spent_mana_metric` ("no red mana",
+        // "no mana from a Treasure") needs no change here; the arms are listed
+        // rather than wildcarded so a metric that is NOT a kind has to choose.
+        metric @ (CastManaSpentMetric::DistinctColors
+        | CastManaSpentMetric::OfColor { .. }
+        | CastManaSpentMetric::FromSource { .. }) => TriggerCondition::QuantityComparison {
+            lhs: QuantityExpr::Ref {
+                qty: QuantityRef::ManaSpentToCast { scope, metric },
+            },
+            comparator: Comparator::EQ,
+            rhs: QuantityExpr::Fixed { value: 0 },
+        },
+    };
     Some((
         strip_condition_clause(text, clause_start, clause_len),
-        Some(TriggerCondition::ManaSpentCondition {
-            text: clause_text.to_string(),
-        }),
+        Some(condition),
     ))
 }
 
-fn parse_no_mana_spent_clause(i: &str) -> OracleResult<'_, &str> {
-    recognize(pair(
-        tag("no mana was spent to cast "),
+/// Returns the recognized clause alongside the payment metric it measures and
+/// the object whose payment record answers it.
+fn parse_no_mana_spent_clause(
+    i: &str,
+) -> OracleResult<'_, (&str, CastManaSpentMetric, CastManaObjectScope)> {
+    let (rest, (clause, (metric, scope))) = consumed(pair(
+        terminated(parse_no_spent_mana_metric, tag(" was spent to cast ")),
+        parse_cast_payment_subject_scope,
+    ))
+    .parse(i)?;
+    Ok((rest, (clause, metric, scope)))
+}
+
+/// CR 106.1a + CR 601.2h: "no mana" / "no colored mana" — the aggregate over the
+/// payment record that the clause requires to be zero. The bare form must come
+/// last: "mana" is a suffix of "colored mana", so ordering it first would
+/// shadow the qualified reading.
+fn parse_no_spent_mana_metric(i: &str) -> OracleResult<'_, CastManaSpentMetric> {
+    preceded(
+        tag("no "),
         alt((
-            tag("it"),
-            tag("that spell"),
-            tag("this spell"),
-            tag("them"),
-            tag("~"),
+            value(CastManaSpentMetric::DistinctColors, tag("colored mana")),
+            value(CastManaSpentMetric::Total, tag("mana")),
         )),
+    )
+    .parse(i)
+}
+
+/// CR 400.7d + CR 601.2h: which object's payment record the anaphor names.
+/// "it"/"that spell"/"this spell"/"them" is the object carried by the trigger
+/// event (the spell just cast, or the permanent that just entered); "~" is the
+/// ability's own source.
+fn parse_cast_payment_subject_scope(i: &str) -> OracleResult<'_, CastManaObjectScope> {
+    alt((
+        value(CastManaObjectScope::TriggeringSpell, tag("it")),
+        value(CastManaObjectScope::TriggeringSpell, tag("that spell")),
+        value(CastManaObjectScope::TriggeringSpell, tag("this spell")),
+        value(CastManaObjectScope::TriggeringSpell, tag("them")),
+        value(CastManaObjectScope::SelfObject, tag("~")),
     ))
     .parse(i)
 }

--- a/crates/engine/src/parser/oracle_trigger_tests.rs
+++ b/crates/engine/src/parser/oracle_trigger_tests.rs
@@ -24126,6 +24126,55 @@ fn extract_no_colored_mana_spent_condition() {
     );
 }
 
+/// CR 400.7d: the anaphor names whose payment record answers the clause —
+/// "it"/"that spell"/"this spell"/"them" is the object carried by the trigger
+/// event, "~" is the ability's own source. Every arm must both be accepted and
+/// map to its own scope; an arm that failed to parse would drop the
+/// intervening-if entirely rather than fail loudly.
+#[test]
+fn colored_mana_clause_maps_each_anaphor_to_its_payment_subject() {
+    use crate::types::ability::CastManaObjectScope;
+
+    for (anaphor, expected_scope) in [
+        ("it", CastManaObjectScope::TriggeringSpell),
+        ("that spell", CastManaObjectScope::TriggeringSpell),
+        ("this spell", CastManaObjectScope::TriggeringSpell),
+        ("them", CastManaObjectScope::TriggeringSpell),
+        ("~", CastManaObjectScope::SelfObject),
+    ] {
+        let text = format!("if no colored mana was spent to cast {anaphor}, counter that spell");
+        let (cleaned, cond) = extract_if_condition(&text);
+        assert_eq!(
+            cleaned, "counter that spell",
+            "the clause must be stripped from the effect text for {anaphor:?}"
+        );
+        let scope = match &cond {
+            Some(TriggerCondition::QuantityComparison {
+                lhs:
+                    QuantityExpr::Ref {
+                        qty: QuantityRef::ManaSpentToCast { scope, metric },
+                    },
+                comparator: Comparator::EQ,
+                rhs: QuantityExpr::Fixed { value: 0 },
+            }) => {
+                assert_eq!(
+                    *metric,
+                    crate::types::ability::CastManaSpentMetric::DistinctColors,
+                    "the colored qualifier must select the distinct-colors metric for {anaphor:?}"
+                );
+                *scope
+            }
+            other => {
+                panic!("expected a DistinctColors == 0 comparison for {anaphor:?}, got {other:?}")
+            }
+        };
+        assert_eq!(
+            scope, expected_scope,
+            "wrong payment subject for {anaphor:?}"
+        );
+    }
+}
+
 /// The bare "no mana" reading must NOT be shadowed by the qualified one: the
 /// amount axis keeps its own condition shape (Vexing Bauble, Lavinia).
 #[test]

--- a/crates/engine/src/parser/oracle_trigger_tests.rs
+++ b/crates/engine/src/parser/oracle_trigger_tests.rs
@@ -24102,6 +24102,46 @@ fn extract_no_mana_spent_condition() {
     );
 }
 
+/// CR 603.4 + CR 106.1a + CR 601.2h, issue #8807: Void Mirror's intervening-if
+/// gates on the COLOR axis of the payment record, not the amount. Before this
+/// was parsed the clause was dropped entirely and the trigger degraded to an
+/// unconditional "whenever a player casts a spell, counter that spell".
+#[test]
+fn extract_no_colored_mana_spent_condition() {
+    let (cleaned, cond) =
+        extract_if_condition("if no colored mana was spent to cast it, counter that spell");
+    assert_eq!(cleaned, "counter that spell");
+    assert_eq!(
+        cond,
+        Some(TriggerCondition::QuantityComparison {
+            lhs: QuantityExpr::Ref {
+                qty: QuantityRef::ManaSpentToCast {
+                    scope: crate::types::ability::CastManaObjectScope::TriggeringSpell,
+                    metric: crate::types::ability::CastManaSpentMetric::DistinctColors,
+                },
+            },
+            comparator: Comparator::EQ,
+            rhs: QuantityExpr::Fixed { value: 0 },
+        })
+    );
+}
+
+/// The bare "no mana" reading must NOT be shadowed by the qualified one: the
+/// amount axis keeps its own condition shape (Vexing Bauble, Lavinia).
+#[test]
+fn no_colored_mana_qualifier_does_not_capture_the_bare_amount_clause() {
+    for clause in [
+        "if no mana was spent to cast that spell, counter that spell",
+        "if no mana was spent to cast them, draw a card",
+    ] {
+        let (_, cond) = extract_if_condition(clause);
+        assert!(
+            matches!(cond, Some(TriggerCondition::ManaSpentCondition { .. })),
+            "bare no-mana clause must stay on the amount axis, got {cond:?} for {clause:?}"
+        );
+    }
+}
+
 #[test]
 fn extract_mana_spent_comparison_condition_less_than() {
     let (cleaned, cond) = extract_if_condition(

--- a/crates/engine/tests/integration/issue_8807_void_mirror_colored_mana.rs
+++ b/crates/engine/tests/integration/issue_8807_void_mirror_colored_mana.rs
@@ -1,0 +1,80 @@
+//! CR 603.4 + CR 106.1a + CR 601.2h, issue #8807: Void Mirror's intervening-if
+//! reads the COLOR axis of the payment record, not the amount.
+//!
+//! > Whenever a player casts a spell, if no colored mana was spent to cast it,
+//! > counter that spell.
+//!
+//! The clause never parsed, so the trigger degraded to an unconditional
+//! "whenever a player casts a spell, counter that spell" and the mirror
+//! countered everything. Both branches below spend the SAME amount of mana on
+//! the SAME card for the SAME cost — only the color of the mana differs — so
+//! the pair discriminates the color axis from the amount axis (which is Vexing
+//! Bauble's clause, covered by `omniscience_free_cast_vexing_bauble`).
+
+use engine::game::scenario::{GameScenario, P0};
+use engine::types::mana::{ManaCost, ManaType, ManaUnit};
+use engine::types::phase::Phase;
+use engine::types::zones::Zone;
+
+// Verbatim MH2 Oracle text (Scryfall, 2026-09-11).
+const VOID_MIRROR: &str =
+    "Whenever a player casts a spell, if no colored mana was spent to cast it, counter that spell.";
+
+/// Casts a generic-cost `{2}` creature under Void Mirror, paying the whole cost
+/// with two mana of `mana_type`. CR 107.4b: generic mana in costs can be paid
+/// with any type of mana, so the card, the cost and the amount spent are
+/// identical across branches. Returns the creature's final zone.
+fn cast_generic_two_drop_paying_with(mana_type: ManaType) -> Zone {
+    let mut sc = GameScenario::new();
+    sc.at_phase(Phase::PreCombatMain);
+
+    sc.add_creature(P0, "Void Mirror", 0, 0)
+        .as_artifact()
+        .from_oracle_text(VOID_MIRROR);
+
+    let bear = sc
+        .add_creature_to_hand(P0, "Test Bear", 2, 2)
+        .with_mana_cost(ManaCost::Cost {
+            shards: Vec::new(),
+            generic: 2,
+        })
+        .id();
+
+    sc.with_mana_pool(
+        P0,
+        vec![
+            ManaUnit::new(mana_type, bear, false, Vec::new()),
+            ManaUnit::new(mana_type, bear, false, Vec::new()),
+        ],
+    );
+
+    let mut runner = sc.build();
+    runner.cast(bear).resolve().zone_of(bear)
+}
+
+#[test]
+fn colorless_payment_is_countered_by_void_mirror() {
+    // CR 106.1a + CR 106.1b: colorless is a type of mana but not a color, so a
+    // cost paid entirely with colorless mana spends no colored mana and the
+    // intervening-if holds.
+    assert_eq!(
+        cast_generic_two_drop_paying_with(ManaType::Colorless),
+        Zone::Graveyard,
+        "a cost paid entirely with colorless mana spends no colored mana, \
+         so Void Mirror must counter the spell"
+    );
+}
+
+#[test]
+fn colored_payment_dodges_void_mirror() {
+    // Discriminator for the reported bug: before the fix the clause was dropped
+    // and this spell was countered too. It is not a vacuous negative — the
+    // sibling test above proves the trigger still fires and still counters when
+    // the condition genuinely holds.
+    assert_eq!(
+        cast_generic_two_drop_paying_with(ManaType::Green),
+        Zone::Battlefield,
+        "paying the same generic cost with green mana spends colored mana, \
+         so Void Mirror's intervening-if must fail and the spell must resolve"
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -863,6 +863,7 @@ mod issue_868_szarekh_attack_trigger;
 mod issue_874_nadiers_nightblade_token_leaves;
 mod issue_8773_class_copy_enters_at_level_one;
 mod issue_879_obsessive_pursuit;
+mod issue_8807_void_mirror_colored_mana;
 mod issue_924_offspring;
 mod issue_927_tireless_provisioner;
 mod issue_934_ring_goes_south;


### PR DESCRIPTION
Closes #8807.

## The bug

**Void Mirror** (MH2) countered essentially every spell cast.

> Whenever a player casts a spell, if no colored mana was spent to cast it, counter that spell.

`parse_no_mana_spent_clause` (`parser/oracle_trigger.rs`) recognized exactly one literal shape, `"no mana was spent to cast "`. Void Mirror's clause does not match it and no other parser path claimed it, so the CR 603.4 intervening-`if` was dropped and the trigger degraded to an unconditional *"whenever a player casts a spell, counter that spell"*.

Nothing caught it: the phrase is on no coverage exemption list and `swallow_check` has no arm for it, so the card read as **fully supported** while a rules-bearing clause was silently discarded.

The reporter noted one survivor — a creature cast off Cavern of Souls. That is a red herring: Cavern produces colored mana *and* independently grants "can't be countered" (CR 701.6a), so it was the one spell that behaved correctly, for reasons unrelated to the condition.

## The fix

The clause parser is parameterized on the two axes it always had, rather than gaining a Void Mirror branch:

| axis | values | type |
|---|---|---|
| metric | `no mana` / `no colored mana` | `CastManaSpentMetric` |
| anaphor | `it` / `that spell` / `this spell` / `them` / `~` | `CastManaObjectScope` |

- **The amount axis is unchanged, byte-for-byte.** It keeps emitting `TriggerCondition::ManaSpentCondition { text }` with the identical recognized string, so Vexing Bauble, Lavinia and Boromir take exactly the path they took before. That arm's runtime evaluator carries a source-context fallback for the event-less ETB shapes, which the scope enum does not express; converting it is a separate refactor with real regression surface and zero behavioral gain.
- **The color axis has no legacy encoding**, so it goes straight onto the canonical typed path:
  ```rust
  QuantityComparison {
      lhs: ManaSpentToCast { scope, metric: DistinctColors },
      comparator: EQ,
      rhs: Fixed(0),
  }
  ```
  This is the same shape `parse_no_mana_spent_to_cast_target_condition` (Nix, `oracle_effect/conditions.rs:3597`) already emits for the `AbilityTarget` scope.

That second point also fixes the **second half** of the defect noted in the issue. The runtime `ManaSpentCondition` arm substring-dispatches on `"no mana was spent"` and defaults everything else to `false`; a colored clause routed through the legacy shape would have countered *nothing* — the opposite failure. The canonical path reads the per-color payment tally through `resolve_mana_spent_to_cast_metric` instead, at both the CR 603.4 detection-time and resolution-time checks (`resolve_event_scoped_ref` already handles `ManaSpentToCast { TriggeringSpell, .. }`).

**No new enum variants.** `CastManaSpentMetric::DistinctColors`, `CastManaObjectScope` and the `QuantityComparison` runtime are all pre-existing and already wired.

`== 0` is the correct reading for any metric naming a *kind* of mana, so a future "no red mana was spent" / "no mana from a Treasure was spent" is one `alt()` arm in `parse_no_spent_mana_metric` with no change to the condition builder.

## Tests

`crates/engine/tests/integration/issue_8807_void_mirror_colored_mana.rs` drives the real cast pipeline with **the same card, the same generic `{2}` cost, and the same amount of mana** — only the *color* of the mana differs (CR 107.4b: generic mana can be paid with any type):

| payment | expected | why |
|---|---|---|
| 2 × colorless | countered | CR 106.1a/b — colorless is a type of mana, not a color |
| 2 × green | resolves | colored mana was spent, so the intervening-`if` fails |

The pair is not a vacuous negative: the colorless branch proves the trigger still fires and still counters when the condition genuinely holds, and the green branch is the one the bug broke.

Plus parser arms for the new clause and for the bare clause still landing on the amount axis.

## Verification

- **Discrimination proved.** Reverting `oracle_trigger.rs` to `upstream/main` and re-running leaves `colorless_payment_is_countered_by_void_mirror` passing and flips `colored_payment_dodges_void_mirror` to:
  ```
  assertion `left == right` failed
    left: Graveyard
   right: Battlefield
  ```
  i.e. Void Mirror counters the green-paid spell too — exactly the reported bug.
- `cargo test -p phase-engine --lib` — **21092 passed, 0 failed** (8 ignored).
- `cargo test -p phase-engine --test integration` — **6781 passed, 0 failed** (3 ignored). Run in full because `parse_no_mana_spent_clause` is shared with the Lavinia / Vexing Bauble / Satoru family.
- `cargo fmt --all --check` clean.
- **Clippy was not run locally** — `--all-targets` does not fit this machine's build budget. Leaving it to CI's "Rust lint (fmt, clippy, parser gate)" job rather than claiming a green I did not observe.
- Oracle text verified against the Scryfall API (`cards/named?exact=Void+Mirror`), not from the issue's paraphrase. Every CR number was grepped from `docs/MagicCompRules.txt` before it was written: 106.1a, 106.1b, 107.4b, 400.7d, 601.2h, 603.4.

## Deliberately not changed

`parse_no_mana_spent_to_cast_target_condition` (Nix's `AbilityTarget` anaphor) does not accept the colored qualifier. No printed card says "counter target spell if no colored mana was spent to cast it"; when one prints, it is the same one-line `alt()` extension there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TJ4SDW7uZMSdKXtinzFuHe

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected handling of “no colored mana was spent” conditions, so effects such as Void Mirror distinguish colorless payments from colored mana payments.
  - Improved recognition of references to the triggering spell and the ability’s source in mana-payment conditions.
  - Preserved existing behavior for “no mana was spent” conditions, which continue to evaluate the total amount paid.

- **Tests**
  - Added coverage for colored-mana conditions, including identical generic costs paid with colorless or colored mana.
  - Added regression tests for payment references and existing no-mana behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->