### PR TITLE
fix(parser): carry a scoped player subject into subjectless verbs

### DIFF
--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -24025,8 +24025,8 @@ fn apply_anchor_subject_to_clause(
 /// continuation of the anchored player's instruction ("…, then draws a card")
 /// rather than a bare IMPERATIVE addressed to the ability's controller ("Draw a
 /// card."). A conjugated verb ("draws") is not itself a clause starter but
-/// deconjugates to one, which is exactly the shared grammar distinction
-/// `inherits_carried_targeted_player_subject` uses for the same question.
+/// deconjugates to one — the same grammar distinction the chain loop's
+/// `CarriedPlayerSubject` inheritance asks.
 fn chunk_continues_anchored_subject(text_lower: &str) -> bool {
     !sequence::starts_clause_text(text_lower)
         && sequence::starts_clause_text_or_conjugated(text_lower)
@@ -24517,6 +24517,62 @@ fn target_filter_can_target_player(filter: &TargetFilter) -> bool {
         TargetFilter::Not { filter } => target_filter_can_target_player(filter),
         _ => false,
     }
+}
+
+/// CR 608.2c: A player subject stated once at the head of a same-sentence verb
+/// list governs every subjectless conjugated continuation after it ("target
+/// opponent sacrifices …, discards …, and loses 3 life"; "that player loses 2
+/// life and draws two cards"). The chain parser carries it chunk to chunk and
+/// re-supplies it to each continuation exactly as if it had been printed there.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CarriedPlayerSubject {
+    /// CR 601.2c: a declared player target is chosen once, at announcement, for
+    /// the whole verb list. Continuations inherit the leading verb's chosen
+    /// player (`ParentTarget`) rather than a fresh copy of the player filter,
+    /// which would surface a second target slot and prompt again (#2344).
+    Targeted,
+    /// CR 608.2c: the phase-scoped player ("at the beginning of each player's
+    /// upkeep, that player …") is not targeted; it is bound when the ability
+    /// resolves, so each continuation names the same `ScopedPlayer`.
+    Scoped,
+}
+
+impl CarriedPlayerSubject {
+    /// The carry a chunk's leading subject establishes, if it is a player
+    /// subject a following continuation can inherit.
+    fn from_leading_subject(application: &SubjectApplication) -> Option<Self> {
+        match &application.target {
+            Some(target) if target_filter_can_target_player(target) => Some(Self::Targeted),
+            None if application.affected == TargetFilter::ScopedPlayer => Some(Self::Scoped),
+            _ => None,
+        }
+    }
+
+    /// The subject phrase re-supplied to an inheriting continuation.
+    fn subject_phrase(self) -> SubjectPhraseAst {
+        let (player, target) = match self {
+            Self::Targeted => (TargetFilter::ParentTarget, Some(TargetFilter::ParentTarget)),
+            Self::Scoped => (TargetFilter::ScopedPlayer, None),
+        };
+        SubjectPhraseAst {
+            affected: Some(player),
+            target,
+            multi_target: None,
+            inherits_parent: self == Self::Targeted,
+            is_optional: false,
+        }
+    }
+}
+
+/// CR 608.2c: true when `head`'s leading subject establishes a
+/// `CarriedPlayerSubject`, i.e. the chain will re-supply it to a subjectless
+/// continuation split off after it. Probes a throwaway context because subject
+/// parsing may record target state on it.
+fn head_carries_player_subject(head: &str, ctx: &ParseContext) -> bool {
+    subject::parse_leading_subject_application(head, &mut ctx.clone_throwaway())
+        .as_ref()
+        .and_then(CarriedPlayerSubject::from_leading_subject)
+        .is_some()
 }
 
 /// CR 608.2c: true when `filter` is the resolution-scoped "that player"/"that
@@ -34655,16 +34711,10 @@ pub(crate) fn parse_effect_chain_ir(
     let (chain_zada_distinct_copy_targets, text) =
         lower::strip_each_copy_targets_distinct_member_suffix(text);
     let text = text.as_str();
-    let chunks = split_clause_sequence(text);
-    let chunks = if ctx.in_trigger
-        && matches!(
-            ctx.relative_player_scope.as_ref(),
-            Some(ControllerRef::ScopedPlayer)
-        ) {
-        sequence::split_subject_elided_control_continuations(chunks)
-    } else {
-        chunks
-    };
+    let chunks =
+        sequence::split_subject_elided_control_continuations(split_clause_sequence(text), |head| {
+            head_carries_player_subject(head, ctx)
+        });
     // CR 611.2a + CR 608.2c: expand any chunk whose leading duration governs conjuncts the
     // single-clause parse discarded. The expanded conjuncts become ORDINARY chunks of THIS
     // chain, which is the only construction under which chain-level anaphor state
@@ -34757,15 +34807,12 @@ pub(crate) fn parse_effect_chain_ir(
     // ScopedPlayer, "you" → OriginalController). Reset at the next `Sentence`
     // boundary, so a following independent instruction is unaffected.
     let mut decline_consequence_active = false;
-    // CR 608.2c: Within one sentence, English can state a targeted player
-    // subject once and then continue with conjugated predicates:
-    // "target opponent sacrifices ..., discards ..., and loses ...". Carry the
-    // targeted player subject so the bare conjugated continuations inherit the
-    // same player target rather than falling back to the ability controller.
-    let mut carried_targeted_player_subject: Option<SubjectApplication> = None;
-    // CR 608.2c: a scoped phase subject applies only to its immediate
-    // same-sentence conjugated continuation.
-    let mut carried_scoped_player_subject: Option<SubjectApplication> = None;
+    // CR 608.2c: Within one sentence, English can state a player subject once
+    // and then continue with conjugated predicates: "target opponent sacrifices
+    // ..., discards ..., and loses ..." / "that player loses 2 life and draws
+    // two cards". Carry the player subject so the bare conjugated continuations
+    // inherit it rather than falling back to the ability controller.
+    let mut carried_player_subject: Option<CarriedPlayerSubject> = None;
     // CR 608.2c + CR 109.4: Chain-spanning "its controller" antecedent. Armed
     // when a chunk's leading subject is "its/their controller may <act>"
     // (SubjectApplication { affected: ParentTargetController, is_optional: true });
@@ -36989,15 +37036,6 @@ pub(crate) fn parse_effect_chain_ir(
             ..Default::default()
         };
         let ctx = &mut chunk_ctx;
-        // Consume before every dispatch path so a non-continuation (including a
-        // special clause that exits early) cannot leak the subject farther down
-        // the sentence.
-        let consumed_scoped_player_subject = carried_scoped_player_subject.take();
-        let scoped_player_trigger_context = ctx.in_trigger
-            && matches!(
-                ctx.relative_player_scope.as_ref(),
-                Some(ControllerRef::ScopedPlayer)
-            );
         // CR 608.2c + CR 109.4 (issue #1670): Path-independent consumption-clear
         // of the single-shot "its controller" antecedent. The chunk consumed the
         // seeded scope above when `chunk_ctx.relative_player_scope` cloned
@@ -37030,24 +37068,35 @@ pub(crate) fn parse_effect_chain_ir(
                 leading_subject_application.as_ref().map(|s| &s.affected),
                 Some(TargetFilter::Controller)
             ) || (is_optional && opponent_may_scope.is_none() && player_scope.is_none());
-        let inherits_carried_targeted_player_subject = leading_subject_application.is_none()
+        // CR 608.2c: a subjectless conjugated verb ("draws", not the imperative
+        // "draw") continues the previous chunk's subject.
+        let continues_elided_subject = leading_subject_application.is_none()
             && player_scope.is_none()
-            && !sequence::starts_clause_text(&text)
-            && sequence::starts_clause_text_or_conjugated(&text);
-        let inherits_carried_scoped_player_subject = consumed_scoped_player_subject.filter(|_| {
-            leading_subject_application.is_none()
-                && player_scope.is_none()
-                && !sequence::starts_clause_text(&text)
-                && sequence::starts_clause_text_or_conjugated(&text)
-        });
-        // CR 608.2c: when a scoped phase player continues an immediately
-        // preceding self-targeted instruction, its bare object pronoun refers to
-        // that source rather than to an absent parent target.
-        if inherits_carried_scoped_player_subject.is_some()
+            && chunk_continues_anchored_subject(&text);
+        let inherited_player_subject = carried_player_subject.filter(|_| continues_elided_subject);
+        // CR 608.2c: the carry spans a run of inheriting continuations. A new
+        // leading subject replaces it, a chunk that neither states a subject nor
+        // continues one ends it, and it never crosses a sentence boundary.
+        // Updated here, before any later special-clause `continue`, so every
+        // chunk that consulted the carry also advances it (mirrors the #1670
+        // path-independent clear above).
+        if chunk.boundary_after == Some(ClauseBoundary::Sentence) {
+            carried_player_subject = None;
+        } else if let Some(application) = leading_subject_application.as_ref() {
+            carried_player_subject = CarriedPlayerSubject::from_leading_subject(application);
+        } else if !continues_elided_subject {
+            carried_player_subject = None;
+        }
+        // CR 608.2c: when a carried player subject continues an immediately
+        // preceding instruction that named the source (`~`), its bare object
+        // pronoun refers to that source rather than to an absent parent target
+        // ("that player untaps Karona and gains control of it"). Same antecedent
+        // test as the named-`~` pronoun rewrite below.
+        if inherited_player_subject.is_some()
             && builder
                 .clauses()
                 .last()
-                .is_some_and(|previous| effect_targets_self_ref(&deepest_clause_effect(previous)))
+                .is_some_and(|previous| parsed_clause_targets_self_ref(&previous.parsed))
         {
             ctx.object_pronoun_ref = Some(TargetFilter::SelfRef);
         }
@@ -37653,36 +37702,10 @@ pub(crate) fn parse_effect_chain_ir(
         if is_decline_consequence {
             rebind_clause_recipients_with(&mut clause, rebind_decline_body_recipient);
         }
-        if inherits_carried_targeted_player_subject {
-            if let Some(subject) = carried_targeted_player_subject.as_ref() {
-                // CR 601.2c: a single "target opponent" governs the whole verb
-                // list ("sacrifices …, discards …, and loses 3 life") — the
-                // target is chosen ONCE at announcement and every conjugated
-                // continuation applies to that same player. Inject
-                // `ParentTarget` (inherit the leading verb's chosen player) and
-                // NOT a fresh copy of the player filter, which would surface a
-                // second target slot and prompt the player again (#2344).
-                let subject = SubjectPhraseAst {
-                    affected: Some(TargetFilter::ParentTarget),
-                    target: Some(TargetFilter::ParentTarget),
-                    multi_target: None,
-                    inherits_parent: true,
-                    is_optional: subject.is_optional,
-                };
-                inject_subject_target(&mut clause.effect, &subject);
-            }
-        }
-        if let Some(subject) = inherits_carried_scoped_player_subject.as_ref() {
-            if matches!(clause.effect, Effect::GainControl { .. }) {
-                let subject = SubjectPhraseAst {
-                    affected: Some(subject.affected.clone()),
-                    target: None,
-                    multi_target: None,
-                    inherits_parent: subject.inherits_parent,
-                    is_optional: subject.is_optional,
-                };
-                inject_subject_target(&mut clause.effect, &subject);
-            }
+        // CR 608.2c: re-supply the elided player subject exactly as a printed
+        // subject would be applied (`inject_subject_target` is that authority).
+        if let Some(carried) = inherited_player_subject {
+            inject_subject_target(&mut clause.effect, &carried.subject_phrase());
         }
         if nom_primitives::scan_contains(&text.to_lowercase(), "villainous choice") {
             if let (Effect::ChooseOneOf { chooser, .. }, Some(scope)) =
@@ -38626,9 +38649,7 @@ pub(crate) fn parse_effect_chain_ir(
         // it runs on every iteration regardless of early `continue`; this block
         // only ARMS. The arming chunk (leading subject "its controller may
         // <act>") has `seeded == false` (the local was None at its start), so the
-        // hoisted clear was a no-op for it and this arm fires unimpeded. Read
-        // `leading_subject_application` via `.as_ref()` because it is MOVED
-        // below in the `carried_targeted_player_subject` update.
+        // hoisted clear was a no-op for it and this arm fires unimpeded.
         if matches!(
             leading_subject_application.as_ref(),
             Some(app) if app.is_optional && app.affected == TargetFilter::ParentTargetController
@@ -38641,31 +38662,6 @@ pub(crate) fn parse_effect_chain_ir(
         // "for each opponent who doesn't" body.
         if chunk.boundary_after == Some(ClauseBoundary::Sentence) {
             decline_consequence_active = false;
-        }
-        carried_scoped_player_subject = if scoped_player_trigger_context
-            && chunk.boundary_after != Some(ClauseBoundary::Sentence)
-            && chunks.get(chunk_idx + 1).is_some()
-        {
-            leading_subject_application
-                .as_ref()
-                .filter(|application| {
-                    application.affected == TargetFilter::ScopedPlayer
-                        && application.target.is_none()
-                })
-                .cloned()
-        } else {
-            None
-        };
-        if chunk.boundary_after == Some(ClauseBoundary::Sentence) {
-            carried_targeted_player_subject = None;
-        } else if let Some(application) = leading_subject_application {
-            carried_targeted_player_subject = application
-                .target
-                .as_ref()
-                .is_some_and(target_filter_can_target_player)
-                .then_some(application);
-        } else if !inherits_carried_targeted_player_subject {
-            carried_targeted_player_subject = None;
         }
     }
     // CR 601.2c + CR 608.2c: restore the caller's antecedent. Paired with the

--- a/crates/engine/src/parser/oracle_effect/sequence.rs
+++ b/crates/engine/src/parser/oracle_effect/sequence.rs
@@ -2,7 +2,7 @@ use crate::parser::oracle_nom::error::{OracleError, OracleResult};
 use nom::branch::alt;
 use nom::bytes::complete::{tag, tag_no_case, take_till, take_until};
 use nom::character::complete::multispace1;
-use nom::combinator::{all_consuming, eof, map, map_opt, not, opt, rest, value};
+use nom::combinator::{all_consuming, eof, map, map_opt, opt, rest, value};
 use nom::sequence::{preceded, terminated};
 use nom::Parser;
 
@@ -1528,31 +1528,22 @@ pub(super) fn split_clause_sequence(text: &str) -> Vec<ClauseChunk> {
     chunks
 }
 
-/// CR 608.2c: split a subject-elided control continuation only after the
-/// trigger parser has established a scoped phase-player provenance. The generic
-/// splitter cannot admit this conjugated form: outside that context, a clause
-/// such as Coveted Jewel's "that player draws three cards and gains control of
-/// this artifact" must remain a single instruction.
-fn starts_scoped_player_subject(lower: &str) -> bool {
-    alt((
-        value((), tag::<_, _, OracleError<'_>>("that player ")),
-        value((), (tag("the player "), not(tag("to ")))),
-        value((), tag("that opponent ")),
-    ))
-    .parse(lower)
-    .is_ok()
-}
-
+/// CR 608.2c: split a subject-elided "… and gains control of …" continuation
+/// off its head only when `head_carries_subject` confirms the head's subject
+/// will be carried into it; the split and the carry share one classifier. The
+/// probe sees the chain-entry context, so a per-chunk scope override (a chosen
+/// player or "its controller" re-seeding `relative_player_scope`) is not visible
+/// to it — no printed card reaches that case today. The generic splitter
+/// cannot admit this conjugated form: where no carry applies,
+/// a clause such as Coveted Jewel's "that player draws three cards and gains
+/// control of this artifact" must remain a single instruction.
 pub(super) fn split_subject_elided_control_continuations(
     chunks: Vec<ClauseChunk>,
+    head_carries_subject: impl Fn(&str) -> bool,
 ) -> Vec<ClauseChunk> {
     let mut split = Vec::with_capacity(chunks.len());
     for chunk in chunks {
         let lower = chunk.text.to_ascii_lowercase();
-        if !starts_scoped_player_subject(&lower) {
-            split.push(chunk);
-            continue;
-        }
         let Some(((), tail)) = nom_on_lower(&chunk.text, &lower, |input| {
             value(
                 (),
@@ -1579,7 +1570,7 @@ pub(super) fn split_subject_elided_control_continuations(
             split.push(chunk);
             continue;
         };
-        if head.trim().is_empty() || tail.trim().is_empty() {
+        if head.trim().is_empty() || tail.trim().is_empty() || !head_carries_subject(head.trim()) {
             split.push(chunk);
             continue;
         }
@@ -3335,7 +3326,7 @@ fn starts_bare_and_clause_lower(s: &str) -> bool {
     // abilities") on the un-split path: those are never followed by a player
     // action count such as "a card" or "1 life". Sibling-clause X-binding
     // (`compute_sentence_where_x`) and player-subject inheritance
-    // (`carried_targeted_player_subject`) handle the rest once both chunks
+    // (`CarriedPlayerSubject`) handle the rest once both chunks
     // reach the chain loop.
     if let Ok((rest, _)) = alt((
         tag::<_, _, OracleError<'_>>("draws "),
@@ -10005,10 +9996,11 @@ mod tests {
     }
 
     #[test]
-    fn scoped_subject_elided_control_continuation_splits() {
-        let chunks = split_subject_elided_control_continuations(split_clause_sequence(
-            "that player untaps Karona and gains control of it.",
-        ));
+    fn control_continuation_splits_when_its_head_carries_the_subject() {
+        let chunks = split_subject_elided_control_continuations(
+            split_clause_sequence("that player untaps Karona and gains control of it."),
+            |head| head == "that player untaps Karona",
+        );
         assert_eq!(chunks.len(), 2);
         assert_eq!(chunks[0].text, "that player untaps Karona");
         assert_eq!(chunks[0].boundary_after, Some(ClauseBoundary::Comma));
@@ -10017,27 +10009,15 @@ mod tests {
     }
 
     #[test]
-    fn non_anaphoric_player_subject_does_not_split_control_continuation() {
-        let chunks = split_subject_elided_control_continuations(split_clause_sequence(
-            "each player draws a card and gains control of it.",
-        ));
-        assert_eq!(chunks.len(), 1);
-        assert_eq!(
-            chunks[0].text,
-            "each player draws a card and gains control of it"
+    fn control_continuation_stays_whole_when_its_head_carries_no_subject() {
+        let chunks = split_subject_elided_control_continuations(
+            split_clause_sequence("that player untaps Karona and gains control of it."),
+            |_| false,
         );
-        assert_eq!(chunks[0].boundary_after, Some(ClauseBoundary::Sentence));
-    }
-
-    #[test]
-    fn neighbor_player_subject_does_not_split_control_continuation() {
-        let chunks = split_subject_elided_control_continuations(split_clause_sequence(
-            "the player to your right untaps Karona and gains control of it.",
-        ));
         assert_eq!(chunks.len(), 1);
         assert_eq!(
             chunks[0].text,
-            "the player to your right untaps Karona and gains control of it"
+            "that player untaps Karona and gains control of it"
         );
         assert_eq!(chunks[0].boundary_after, Some(ClauseBoundary::Sentence));
     }

--- a/crates/engine/src/parser/oracle_effect/sequence.rs
+++ b/crates/engine/src/parser/oracle_effect/sequence.rs
@@ -9999,6 +9999,7 @@ mod tests {
     fn control_continuation_splits_when_its_head_carries_the_subject() {
         let chunks = split_subject_elided_control_continuations(
             split_clause_sequence("that player untaps Karona and gains control of it."),
+            // allow-noncombinator: test stub classifier, not parser dispatch.
             |head| head == "that player untaps Karona",
         );
         assert_eq!(chunks.len(), 2);

--- a/crates/engine/src/parser/oracle_effect/tests.rs
+++ b/crates/engine/src/parser/oracle_effect/tests.rs
@@ -41121,6 +41121,28 @@ fn targeted_player_sacrifice_preserves_target_scope() {
     }
 }
 
+/// CR 608.2c: a subject-elided control continuation is split off only after a
+/// head whose subject the chain carries into it. The scoped "that player"
+/// anaphor carries; a non-anaphoric or seating-relative player subject does not,
+/// so its clause is never split into an orphaned subjectless continuation.
+#[test]
+fn control_continuation_split_uses_the_carried_subject_classification() {
+    let ctx = ParseContext {
+        relative_player_scope: Some(ControllerRef::ScopedPlayer),
+        ..Default::default()
+    };
+    assert!(head_carries_player_subject("that player untaps ~", &ctx));
+    for head in [
+        "each player draws a card",
+        "the player to your right untaps ~",
+    ] {
+        assert!(
+            !head_carries_player_subject(head, &ctx),
+            "must not split after: {head}"
+        );
+    }
+}
+
 /// CR 106.4 + CR 608.2c (issue #2900): Blinkmoth Urn — subject-predicate
 /// "that player adds {C} for each artifact they control" must stamp
 /// `Effect::Mana.target = ScopedPlayer` after imperative lowering.

--- a/crates/engine/src/parser/oracle_trigger_tests.rs
+++ b/crates/engine/src/parser/oracle_trigger_tests.rs
@@ -61,35 +61,124 @@ fn karona_false_god_upkeep_scoped_subject_gives_control() {
     assert_no_unimplemented(untap);
 }
 
-/// The scoped carry is restricted to the `each player's upkeep` context; a
-/// controller-scoped upkeep instruction must not fabricate a ScopedPlayer
-/// recipient merely because it also has a control clause.
+/// The trigger's effect chain, head first, following `sub_ability` links.
+fn trigger_chain_effects(trigger: &TriggerDefinition) -> Vec<&Effect> {
+    std::iter::successors(trigger.execute.as_deref(), |def| def.sub_ability.as_deref())
+        .map(|def| def.effect.as_ref())
+        .collect()
+}
+
+/// CR 608.2c: the scoped phase player stated once governs a same-sentence
+/// conjugated "and" continuation — Seizan, Perverter of Truth's upkeep player
+/// draws the two cards, not the ability's controller.
 #[test]
-fn controller_upkeep_subject_does_not_become_scoped_player_recipient() {
+fn scoped_phase_subject_carries_into_conjugated_and_continuation() {
     let trigger = parse_trigger_line(
-        "At the beginning of your upkeep, you untap Karona and gain control of it.",
-        "Karona, False God",
+        "At the beginning of each player's upkeep, that player loses 2 life and draws two cards.",
+        "Seizan, Perverter of Truth",
     );
-    let untap = trigger.execute.as_deref().expect("upkeep effect");
-    assert!(matches!(
-        untap.effect.as_ref(),
-        Effect::SetTapState {
-            target: TargetFilter::SelfRef,
-            scope: EffectScope::Single,
-            state: TapStateChange::Untap,
-        }
-    ));
-    let control = untap
-        .sub_ability
-        .as_deref()
-        .expect("control continuation must be reached");
-    assert!(matches!(
-        control.effect.as_ref(),
-        Effect::GainControl {
-            target: TargetFilter::ParentTarget,
-        }
-    ));
-    assert_no_unimplemented(untap);
+    let effects = trigger_chain_effects(&trigger);
+    assert!(
+        matches!(
+            effects.as_slice(),
+            [
+                Effect::LoseLife {
+                    target: Some(TargetFilter::ScopedPlayer),
+                    ..
+                },
+                Effect::Draw {
+                    target: TargetFilter::ScopedPlayer,
+                    ..
+                },
+            ]
+        ),
+        "{effects:?}"
+    );
+}
+
+/// CR 608.2c + CR 701.9a: the same carry across a ", then" continuation — Anvil
+/// of Bogardan's draw-step player discards, not the ability's controller.
+#[test]
+fn scoped_phase_subject_carries_into_conjugated_then_continuation() {
+    let trigger = parse_trigger_line(
+        "At the beginning of each player's draw step, that player draws an additional card, then discards a card.",
+        "Anvil of Bogardan",
+    );
+    let effects = trigger_chain_effects(&trigger);
+    assert!(
+        matches!(
+            effects.as_slice(),
+            [
+                Effect::Draw {
+                    target: TargetFilter::ScopedPlayer,
+                    ..
+                },
+                Effect::Discard {
+                    target: TargetFilter::ScopedPlayer,
+                    ..
+                },
+            ]
+        ),
+        "{effects:?}"
+    );
+}
+
+/// CR 608.2c + CR 701.23a + CR 701.24a: the carry spans the whole run of
+/// continuations — Maralen of the Mornsong's draw-step player searches and
+/// shuffles their own library.
+#[test]
+fn scoped_phase_subject_carries_across_a_run_of_continuations() {
+    let trigger = parse_trigger_line(
+        "At the beginning of each player's draw step, that player loses 3 life, searches their library for a card, puts it into their hand, then shuffles.",
+        "Maralen of the Mornsong",
+    );
+    let effects = trigger_chain_effects(&trigger);
+    assert!(
+        effects.iter().any(|effect| matches!(
+            effect,
+            Effect::SearchLibrary {
+                target_player: Some(TargetFilter::ScopedPlayer),
+                ..
+            }
+        )),
+        "that player searches their own library: {effects:?}"
+    );
+    assert!(
+        matches!(
+            effects.last(),
+            Some(Effect::Shuffle {
+                target: TargetFilter::ScopedPlayer
+            })
+        ),
+        "that player shuffles their own library: {effects:?}"
+    );
+}
+
+/// CR 608.2c: only an ELIDED subject is re-supplied. A continuation that
+/// prints its own subject keeps it, even inside a scoped-phase body.
+#[test]
+fn scoped_phase_subject_does_not_override_a_printed_continuation_subject() {
+    let trigger = parse_trigger_line(
+        "At the beginning of each player's upkeep, that player loses 2 life and you draw a card.",
+        "Scoped Probe",
+    );
+    let effects = trigger_chain_effects(&trigger);
+    assert!(
+        matches!(
+            effects.as_slice(),
+            [
+                Effect::LoseLife {
+                    target: Some(TargetFilter::ScopedPlayer),
+                    ..
+                },
+                Effect::Draw {
+                    target: TargetFilter::Controller,
+                    ..
+                },
+            ]
+        ),
+        "{effects:?}"
+    );
 }
 
 /// CR 603.4 + CR 601.2f: Liberator's intervening "if" survives the whole

--- a/crates/engine/tests/integration/karona_false_god.rs
+++ b/crates/engine/tests/integration/karona_false_god.rs
@@ -1,201 +1,16 @@
 //! Regression for Karona, False God's phase-triggered control handoff.
 
-use engine::game::scenario::{GameRunner, GameScenario};
-use engine::types::actions::GameAction;
-use engine::types::game_state::WaitingFor;
+use engine::game::scenario::{GameScenario, P0, P1};
 use engine::types::phase::Phase;
-use engine::types::player::PlayerId;
 use engine::types::triggers::TriggerMode;
-
-const P0: PlayerId = PlayerId(0);
-const P1: PlayerId = PlayerId(1);
 
 const KARONA_ORACLE: &str = "Haste\n\
     At the beginning of each player's upkeep, that player untaps Karona and gains control of it.\n\
     Whenever Karona attacks, creatures of the creature type of your choice get +3/+3 until end of turn.";
 
-/// Drive normal game actions until P1's upkeep trigger has resolved, while
-/// recording that the asserted handoff actually occurred during P1's upkeep.
-fn advance_until_karona_controlled_by_p1(
-    runner: &mut GameRunner,
-    karona: engine::types::identifiers::ObjectId,
-) -> bool {
-    let mut reached_p1_upkeep = false;
-    for _ in 0..240 {
-        reached_p1_upkeep |=
-            runner.state().active_player == P1 && runner.state().phase == Phase::Upkeep;
-        if reached_p1_upkeep && runner.state().objects[&karona].controller == P1 {
-            return true;
-        }
-        match &runner.state().waiting_for {
-            WaitingFor::Priority { .. } => {
-                if runner.act(GameAction::PassPriority).is_err() {
-                    return false;
-                }
-            }
-            WaitingFor::DeclareAttackers { .. } => {
-                if runner
-                    .act(GameAction::DeclareAttackers {
-                        attacks: vec![],
-                        bands: vec![],
-                    })
-                    .is_err()
-                {
-                    return false;
-                }
-            }
-            WaitingFor::DeclareBlockers { .. } => {
-                if runner
-                    .act(GameAction::DeclareBlockers {
-                        assignments: vec![],
-                    })
-                    .is_err()
-                {
-                    return false;
-                }
-            }
-            // Keep this exhaustive: adding a new interaction state must make
-            // this driver choose an action deliberately.
-            WaitingFor::ResolveAllConsent { .. }
-            | WaitingFor::ResolveAllReady { .. }
-            | WaitingFor::MeldPairChoice { .. }
-            | WaitingFor::MeldAttackTargetChoice { .. }
-            | WaitingFor::EntryAttackTargetChoice { .. }
-            | WaitingFor::MulliganDecision { .. }
-            | WaitingFor::OpeningHandBottomCards { .. }
-            | WaitingFor::ManaPayment { .. }
-            | WaitingFor::ManaSourceSelection { .. }
-            | WaitingFor::AssistChoosePlayer { .. }
-            | WaitingFor::AssistPayment { .. }
-            | WaitingFor::ChooseXValue { .. }
-            | WaitingFor::TargetSelection { .. }
-            | WaitingFor::UntapChoice { .. }
-            | WaitingFor::ChooseUntapSubset { .. }
-            | WaitingFor::ExertChoice { .. }
-            | WaitingFor::EnlistChoice { .. }
-            | WaitingFor::GameOver { .. }
-            | WaitingFor::ReplacementChoice { .. }
-            | WaitingFor::EntryControllerChoice { .. }
-            | WaitingFor::OrderTriggers { .. }
-            | WaitingFor::CopyTargetChoice { .. }
-            | WaitingFor::ExploreChoice { .. }
-            | WaitingFor::ReturnAsAuraTarget { .. }
-            | WaitingFor::EquipTarget { .. }
-            | WaitingFor::CrewVehicle { .. }
-            | WaitingFor::StationTarget { .. }
-            | WaitingFor::SaddleMount { .. }
-            | WaitingFor::ScryChoice { .. }
-            | WaitingFor::RippleRevealChoice { .. }
-            | WaitingFor::RippleBottomOrder { .. }
-            | WaitingFor::ArrangePlanarDeckTopChoice { .. }
-            | WaitingFor::RedistributeLifeTotals { .. }
-            | WaitingFor::CoinFlipKeepChoice { .. }
-            | WaitingFor::DieKeepChoice { .. }
-            | WaitingFor::DigChoice { .. }
-            | WaitingFor::SurveilChoice { .. }
-            | WaitingFor::RevealChoice { .. }
-            | WaitingFor::SearchChoice { .. }
-            | WaitingFor::SearchPartitionChoice { .. }
-            | WaitingFor::OutsideGameChoice { .. }
-            | WaitingFor::ChooseFromZoneChoice { .. }
-            | WaitingFor::BeholdChoice { .. }
-            | WaitingFor::ChooseOneOfBranch { .. }
-            | WaitingFor::ConniveDiscard { .. }
-            | WaitingFor::DiscardChoice { .. }
-            | WaitingFor::EffectZoneChoice { .. }
-            | WaitingFor::DrawnThisTurnTopdeckChoice { .. }
-            | WaitingFor::LearnChoice { .. }
-            | WaitingFor::ManifestDreadChoice { .. }
-            | WaitingFor::TriggerTargetSelection { .. }
-            | WaitingFor::BetweenGamesSideboard { .. }
-            | WaitingFor::BetweenGamesChoosePlayDraw { .. }
-            | WaitingFor::NamedChoice { .. }
-            | WaitingFor::OpponentGuess { .. }
-            | WaitingFor::SpellbookDraft { .. }
-            | WaitingFor::DamageSourceChoice { .. }
-            | WaitingFor::ModeChoice { .. }
-            | WaitingFor::DiscardToHandSize { .. }
-            | WaitingFor::OptionalCostChoice { .. }
-            | WaitingFor::ChooseGiftRecipient { .. }
-            | WaitingFor::SpliceOffer { .. }
-            | WaitingFor::DefilerPayment { .. }
-            | WaitingFor::CastOffer { .. }
-            | WaitingFor::ModalFaceChoice { .. }
-            | WaitingFor::AlternativeCastChoice { .. }
-            | WaitingFor::MutateMergeChoice { .. }
-            | WaitingFor::CipherEncodeChoice { .. }
-            | WaitingFor::CastingVariantChoice { .. }
-            | WaitingFor::ChoosePermanentTypeSlot { .. }
-            | WaitingFor::MultiTargetSelection { .. }
-            | WaitingFor::AbilityModeChoice { .. }
-            | WaitingFor::OptionalEffectChoice { .. }
-            | WaitingFor::ResolutionOptionalPaymentChoice { .. }
-            | WaitingFor::PairChoice { .. }
-            | WaitingFor::TributeChoice { .. }
-            | WaitingFor::MiracleReveal { .. }
-            | WaitingFor::OpponentMayChoice { .. }
-            | WaitingFor::LoopShortcut { .. }
-            | WaitingFor::RespondToShortcut { .. }
-            | WaitingFor::PrecastCopyShortcutOffer { .. }
-            | WaitingFor::RespondToPrecastCopyShortcut { .. }
-            | WaitingFor::UnlessPayment { .. }
-            | WaitingFor::UnlessPaymentChooseCost { .. }
-            | WaitingFor::WardDiscardChoice { .. }
-            | WaitingFor::WardSacrificeChoice { .. }
-            | WaitingFor::UnlessBounceChoice { .. }
-            | WaitingFor::ChooseRingBearer { .. }
-            | WaitingFor::ChooseRoomDoor { .. }
-            | WaitingFor::ChooseDungeon { .. }
-            | WaitingFor::ChooseDungeonRoom { .. }
-            | WaitingFor::SpecializeColor { .. }
-            | WaitingFor::PayCost { .. }
-            | WaitingFor::ActivationCostOneOfChoice { .. }
-            | WaitingFor::CostTypeChoice { .. }
-            | WaitingFor::BlightChoice { .. }
-            | WaitingFor::PayManaAbilityMana { .. }
-            | WaitingFor::ChooseManaColor { .. }
-            | WaitingFor::CollectEvidenceChoice { .. }
-            | WaitingFor::HarmonizeTapChoice { .. }
-            | WaitingFor::RevealUntilKeptChoice { .. }
-            | WaitingFor::RepeatDecision { .. }
-            | WaitingFor::TopOrBottomChoice { .. }
-            | WaitingFor::PopulateChoice { .. }
-            | WaitingFor::ClashChooseOpponent { .. }
-            | WaitingFor::ChooseFromZoneOpponentChooser { .. }
-            | WaitingFor::ChooseAnnouncingOpponent { .. }
-            | WaitingFor::ClashCardPlacement { .. }
-            | WaitingFor::VoteChoice { .. }
-            | WaitingFor::SeparatePilesChooseOpponent { .. }
-            | WaitingFor::SeparatePilesPartition { .. }
-            | WaitingFor::SeparatePilesChoice { .. }
-            | WaitingFor::CompanionReveal { .. }
-            | WaitingFor::ChooseLegend { .. }
-            | WaitingFor::CommanderZoneChoice { .. }
-            | WaitingFor::BattleProtectorChoice { .. }
-            | WaitingFor::ProliferateChoice { .. }
-            | WaitingFor::TimeTravelChoice { .. }
-            | WaitingFor::ChooseObjectsSelection { .. }
-            | WaitingFor::CategoryChoice { .. }
-            | WaitingFor::EachPlayerCopyChosenSelection { .. }
-            | WaitingFor::KeepWithinTotalPowerChoice { .. }
-            | WaitingFor::KeepExactPermanentsChoice { .. }
-            | WaitingFor::CopyRetarget { .. }
-            | WaitingFor::AssignCombatDamage { .. }
-            | WaitingFor::AssignBlockerDamage { .. }
-            | WaitingFor::DistributeAmong { .. }
-            | WaitingFor::MoveCountersDistribution { .. }
-            | WaitingFor::RemoveCountersChoice { .. }
-            | WaitingFor::PayAmountChoice { .. }
-            | WaitingFor::RetargetChoice { .. }
-            | WaitingFor::CombatTaxPayment { .. }
-            | WaitingFor::PhyrexianPayment { .. } => return false,
-        }
-    }
-    false
-}
-
 /// CR 608.2c: P1 is the scoped player on P1's upkeep, so Karona's printed
-/// untap and control instructions resolve for P1 in order.
+/// untap and control instructions resolve for P1 in order — even though P0,
+/// Karona's controller, controls the triggered ability.
 #[test]
 fn karona_upkeep_untaps_and_transfers_to_the_upkeep_player() {
     let mut scenario = GameScenario::new_n_player(2, 42);
@@ -219,22 +34,49 @@ fn karona_upkeep_untaps_and_transfers_to_the_upkeep_player() {
             }),
         "complete Karona Oracle text must provide its phase/upkeep trigger"
     );
+    // CR 502.3: P1's untap step untaps only permanents P1 controls, so a tapped
+    // Karona under P0 stays tapped until its own trigger untaps it.
+    // CR 508.1a: a tapped Karona also can't attack, so P0's combat declares no
+    // attackers and the turn rolls forward on priority passes alone.
     runner.state_mut().objects.get_mut(&karona).unwrap().tapped = true;
 
+    // The next upkeep after P0's precombat main is P1's.
+    runner.advance_to_upkeep();
     assert!(
-        advance_until_karona_controlled_by_p1(&mut runner, karona),
-        "must reach and resolve Karona's trigger during P1's upkeep"
-    );
-    assert_eq!(
-        runner.state().active_player,
-        P1,
-        "handoff must occur on P1's turn"
-    );
-    assert_eq!(
+        runner.state().active_player == P1 && runner.state().phase == Phase::Upkeep,
+        "must reach P1's upkeep; stopped at {:?} of {:?}'s turn on {:?}",
         runner.state().phase,
-        Phase::Upkeep,
-        "handoff must occur during upkeep"
+        runner.state().active_player,
+        runner.state().waiting_for
     );
+    // CR 503.1a: the upkeep trigger is on the stack before P1 gets priority,
+    // controlled by P0 — so the recipient below is not the ability controller.
+    assert!(
+        runner
+            .state()
+            .stack
+            .iter()
+            .any(|entry| entry.source_id == karona && entry.controller == P0),
+        "Karona's P0-controlled upkeep trigger must be on the stack at P1's upkeep; stack={:?}",
+        runner.state().stack
+    );
+    let before = &runner.state().objects[&karona];
+    assert_eq!(
+        before.controller, P0,
+        "reach-guard: P0 controls Karona pre-resolution"
+    );
+    assert!(
+        before.tapped,
+        "reach-guard: Karona is still tapped pre-resolution"
+    );
+
+    runner.advance_until_stack_empty();
+    assert!(
+        runner.state().stack.is_empty(),
+        "Karona's trigger must resolve; stopped on {:?}",
+        runner.state().waiting_for
+    );
+    assert_eq!(runner.state().phase, Phase::Upkeep);
     let object = &runner.state().objects[&karona];
     assert_eq!(object.controller, P1, "P1 must gain control of Karona");
     assert!(


### PR DESCRIPTION
Follow-up to #8808. That PR fixed Karona, False God by carrying the "each player's upkeep" scoped subject ("that player") into a subjectless "gains control of" continuation. It did this with a carry that only fired for `GainControl` and sat alongside the existing targeted-player carry. The same defect remains across the class: an elided conjugated verb after a scoped "that player" still resolves to the ability's controller, though each elided continuation belongs to the named player (CR 608.2c: the instructions are followed in the order written). This PR replaces both carries with a single `CarriedPlayerSubject { Targeted, Scoped }` and drops the `GainControl` filter. The carry persists across a run of continuations and is cleared at a sentence boundary. It is advanced before the loop's special-clause early exits, so those exits no longer leave it stale. The "… and gains control of …" pre-split now uses the same subject classifier as the carry (`head_carries_player_subject`, probing a `clone_throwaway` context), replacing a hand-maintained prefix list, so the split can no longer orphan a continuation the carry won't pick up.

### Expected parse-diff against main

| Card | main | this PR |
|---|---|---|
| Seizan, Perverter of Truth | `Draw` with no target (the controller draws) | `Draw { target: ScopedPlayer }` |
| Sycorax Commander | villainous-choice `Draw` with no target | `Draw { target: ScopedPlayer }` |
| Anvil of Bogardan | `Discard { target: Controller }` | `Discard { target: ScopedPlayer }` |
| Maralen of the Mornsong | `Shuffle { Controller }` | `Shuffle { ScopedPlayer }` |
| Mornsong Aria | `Shuffle { Controller }` | `Shuffle { ScopedPlayer }` |

The parse-diff at head `1286d2c1` changes exactly these five cards. For Maralen and Mornsong Aria, the search was already bound to the scoped player on main, because "their library" names it; only the trailing "then shuffles" was going to the controller. So the commit message's "the search and shuffle" overstates the search half.

**Karona, False God must not change.** Main already parses it as `SetTapState { SelfRef }` followed by `GiveControl { SelfRef → ScopedPlayer }`, and the unified carry produces the same AST:
- The split decision for its head ("that player untaps ~") is unchanged.
- The pronoun predicate now shared with the named-`~` rewrite (`parsed_clause_targets_self_ref`) agrees with the old one on its `SelfRef` untap clause.

If Karona appears in the parse-diff, treat it as a regression. Coveted Jewel, Illicit Auction and Alexios, Deimos of Kosmos are also expected unchanged.

Not covered: Gibbering Descent ("loses 1 life and discards a card"). Its discard never reaches the chain as a separate clause because the bare-"and" splitter has no conjugated `discards` arm. That needs a separate change.

### Tests

- `oracle_trigger_tests.rs`:
  - `scoped_phase_subject_carries_into_conjugated_and_continuation` (Seizan)
  - `scoped_phase_subject_carries_into_conjugated_then_continuation` (Anvil of Bogardan)
  - `scoped_phase_subject_carries_across_a_run_of_continuations` (Maralen of the Mornsong)
  - `scoped_phase_subject_does_not_override_a_printed_continuation_subject` (a printed "you draw" keeps the controller)
  - The existing `karona_false_god_upkeep_scoped_subject_gives_control` is kept.
  - `controller_upkeep_subject_does_not_become_scoped_player_recipient` is removed. It passed with the fix reverted and pinned an unbound `ParentTarget`.
- `oracle_effect/tests.rs`: `control_continuation_split_uses_the_carried_subject_classification`.
- `oracle_effect/sequence.rs`: `control_continuation_splits_when_its_head_carries_the_subject` and `control_continuation_stays_whole_when_its_head_carries_no_subject` replace the three prefix-list tests.
- `tests/integration/karona_false_god.rs`: `karona_upkeep_untaps_and_transfers_to_the_upkeep_player` is rewritten on `GameScenario`/`GameRunner` (`advance_to_upkeep`, `advance_until_stack_empty`) in place of the exhaustive `WaitingFor` driver. Before resolution it checks that Karona's P0-controlled trigger is on the stack at P1's upkeep and that Karona is still tapped under P0. After resolution it checks that P1 controls Karona and it is untapped.
