### PR TITLE
Fix Runaway Steam-Kin

### DIFF
--- a/crates/engine/src/parser/oracle_nom/condition.rs
+++ b/crates/engine/src/parser/oracle_nom/condition.rs
@@ -7,7 +7,7 @@ use nom::branch::alt;
 use nom::bytes::complete::tag;
 use nom::bytes::complete::take_until;
 use nom::character::complete::multispace1;
-use nom::combinator::{cut, eof, map, opt, peek, value, verify};
+use nom::combinator::{cut, eof, map, not, opt, peek, value, verify};
 use nom::multi::many0;
 use nom::sequence::{delimited, preceded, terminated};
 use nom::Parser;
@@ -2262,15 +2262,16 @@ fn parse_source_enchanted_by_aura_count(input: &str) -> OracleResult<'_, StaticC
 pub(crate) fn parse_source_has_counters(input: &str) -> OracleResult<'_, StaticCondition> {
     // The shared condition path (intervening-"if" triggers and static gates that
     // delegate to `parse_inner_condition`) reads the subject as
-    // source-referential: "whenever ~ attacks, if it has three +1/+1 counters on
-    // it" (Ayara's Oathsworn) means the triggering source itself. The
-    // recipient-bound "for as long as it has a counter" reading is the duration
-    // grammar's job — see `parse_recipient_has_counters`.
+    // source-referential: "whenever ~ deals combat damage to a player, if it has
+    // fewer than four +1/+1 counters on it" (Ayara's Oathsworn) means the
+    // triggering source itself. The recipient-bound "for as long as it has a
+    // counter" reading is the duration grammar's job — see
+    // `parse_recipient_has_counters`.
     let (rest, (subject, counters, minimum, maximum)) = parse_has_counters_axes(input)?;
     match subject {
         // "~"/"this creature" and the bound pronoun "it" are both
         // source-referential in this path (the intervening-"if" trigger /
-        // static-gate reading — #3084 Ayara's Oathsworn).
+        // static-gate reading — Ayara's Oathsworn "fewer than four").
         CounterConditionSubject::Source | CounterConditionSubject::RecipientPronoun => Ok((
             rest,
             StaticCondition::HasCounters {
@@ -2460,6 +2461,8 @@ fn parse_counter_condition_subject(input: &str) -> OracleResult<'_, CounterCondi
 /// - `"N or more"` → `(N, None)`
 /// - `"exactly N"` → `(N, Some(N))`
 /// - `"N or fewer"` → `(0, Some(N))`
+/// - `"fewer than N"` → `(0, Some(N-1))`
+/// - `"more than N"` → `(N+1, None)`
 fn parse_has_counters_quantity(input: &str) -> OracleResult<'_, (u32, Option<u32>)> {
     alt((
         value((1u32, None), tag("a ")),
@@ -2468,6 +2471,7 @@ fn parse_has_counters_quantity(input: &str) -> OracleResult<'_, (u32, Option<u32
         parse_exactly_n_counters,
         parse_n_or_more_counters,
         parse_n_or_fewer_counters,
+        parse_strict_n_counters,
         // CR 122.1: a bare "counter(s)" with no quantifier word means "at least
         // one" — "if ~ has counters on it" (The Ozolith, Denry Klin). `peek` so
         // the counter-type axis still consumes the noun, and gate on the bare
@@ -2498,6 +2502,38 @@ fn parse_exactly_n_counters(input: &str) -> OracleResult<'_, (u32, Option<u32>)>
     let (rest, n) = parse_number(rest)?;
     let (rest, _) = tag(" ").parse(rest)?;
     Ok((rest, (n, Some(n))))
+}
+
+/// CR 107.1 + CR 122.1: "fewer than N" / "more than N" are strict integer
+/// inequalities on the source's matching counters. Encoded as inclusive
+/// HasCounters bounds: LT N → (0, Some(N-1)); GT N → (N+1, None).
+/// CR 603.4: the resulting HasCounters is the intervening-if predicate.
+fn parse_strict_n_counters(input: &str) -> OracleResult<'_, (u32, Option<u32>)> {
+    let (rest, comparator) = parse_strict_comparator_prefix(input)?;
+    let (rest, n) = parse_number(rest)?;
+    let (rest, _) = tag(" ").parse(rest)?;
+    // Refuse mixed "fewer than N or more" (same refuse as parse_there_are_conditions).
+    let (rest, _) = peek(not(alt((
+        tag("or more "),
+        tag("or fewer "),
+        tag("at least "),
+    ))))
+    .parse(rest)?;
+    match comparator {
+        Comparator::LT => {
+            let Some(max) = n.checked_sub(1) else {
+                return Err(oracle_err(input));
+            };
+            Ok((rest, (0, Some(max))))
+        }
+        Comparator::GT => {
+            let Some(min) = n.checked_add(1) else {
+                return Err(oracle_err(input));
+            };
+            Ok((rest, (min, None)))
+        }
+        Comparator::GE | Comparator::LE | Comparator::EQ | Comparator::NE => Err(oracle_err(input)),
+    }
 }
 
 /// Consume `"<type> counter"` / `"<type> counters"` and return
@@ -4057,9 +4093,10 @@ fn parse_ge_threshold(input: &str) -> OracleResult<'_, u32> {
 /// are the strict-inequality prefix idioms (LT / GT), in contrast to the
 /// "N or more" (GE) / "N or fewer" (LE) suffix idioms. Single authority for
 /// the comparator-prefix family — shared by `parse_put_onto_battlefield_this_way`
-/// ("you put fewer than two lands onto the battlefield this way") and
+/// ("you put fewer than two lands onto the battlefield this way"),
 /// `parse_there_are_conditions` ("there are fewer than six creature cards in
-/// your graveyard").
+/// your graveyard"), and `parse_strict_n_counters` ("has fewer than three
+/// +1/+1 counters on it" / "has more than two +1/+1 counters on it").
 fn parse_strict_comparator_prefix(input: &str) -> OracleResult<'_, Comparator> {
     alt((
         value(Comparator::LT, tag("fewer than ")),
@@ -9032,7 +9069,8 @@ fn parse_zone_count_ref(input: &str) -> OracleResult<'_, ZoneRef> {
 ///
 /// Composes the same axes as `parse_source_has_counters`:
 /// - Quantity axis (`parse_has_counters_quantity`): "no" / "a" / "N or more"
-///   / "N or fewer" / "exactly N" / "one or more".
+///   / "N or fewer" / "exactly N" / "one or more" / "fewer than N"
+///   (`(0, Some(N-1))`) / "more than N" (`(N+1, None)`).
 /// - Counter type axis (`parse_typed_counter_noun` then `Any` fallback).
 /// - Source subject: any pronoun / `~` form accepted by
 ///   `parse_counter_on_source_subject`.
@@ -19872,12 +19910,12 @@ mod tests {
         );
     }
 
-    /// Regression for the coverage-honesty flip (#3084): the bare pronoun "it"
-    /// in an intervening-"if" trigger condition (Ayara's Oathsworn — "whenever ~
-    /// attacks, if it has three or more +1/+1 counters on it, …") is
-    /// source-referential. It must stay `HasCounters` (evaluated against the
-    /// triggering source), not `RecipientHasCounters`, which has no recipient at
-    /// trigger-evaluation time and is silently swallowed by the coverage gate.
+    /// Generic "N or more" sibling: the bare pronoun "it" in an intervening-"if"
+    /// trigger condition is source-referential. It must stay `HasCounters`
+    /// (evaluated against the triggering source), not `RecipientHasCounters`,
+    /// which has no recipient at trigger-evaluation time and is silently
+    /// swallowed by the coverage gate. Ayara's printed Oracle is "fewer than
+    /// four" — see `has_counters_fewer_than_four_pronoun_is_source`.
     #[test]
     fn parse_inner_condition_it_has_counters_is_source_referential() {
         let (rest, c) = parse_inner_condition("it has three or more +1/+1 counters on it").unwrap();
@@ -20163,6 +20201,130 @@ mod tests {
                 maximum: Some(2),
             }
         );
+    }
+
+    /// CR 107.1 + CR 122.1: "fewer than three" is the strict-LT integer band
+    /// {0,1,2}, encoded `(0, Some(2))` — the same AST as inclusive "two or fewer".
+    #[test]
+    fn has_counters_fewer_than_three_plus1() {
+        let expected = StaticCondition::HasCounters {
+            counters: CounterMatch::OfType(CounterType::Plus1Plus1),
+            minimum: 0,
+            maximum: Some(2),
+        };
+        for text in [
+            "~ has fewer than three +1/+1 counters on it",
+            "this creature has fewer than three +1/+1 counters on it",
+        ] {
+            let (rest, cond) = parse_source_has_counters(text)
+                .unwrap_or_else(|e| panic!("failed to parse {text:?}: {e:?}"));
+            assert_eq!(rest, "", "unconsumed remainder for {text:?}");
+            assert_eq!(cond, expected, "wrong condition for {text:?}");
+        }
+
+        let (_, or_fewer) = parse_source_has_counters("~ has two or fewer +1/+1 counters on it")
+            .expect("two or fewer sibling must still parse");
+        assert_eq!(or_fewer, expected);
+    }
+
+    /// Ayara's Oathsworn: intervening-if "if it has fewer than four +1/+1
+    /// counters on it" is source-referential `HasCounters`, not
+    /// `RecipientHasCounters`.
+    #[test]
+    fn has_counters_fewer_than_four_pronoun_is_source() {
+        let expected = StaticCondition::HasCounters {
+            counters: CounterMatch::OfType(CounterType::Plus1Plus1),
+            minimum: 0,
+            maximum: Some(3),
+        };
+        let (rest, inner) =
+            parse_inner_condition("it has fewer than four +1/+1 counters on it").unwrap();
+        assert_eq!(rest, "");
+        assert_eq!(inner, expected);
+
+        let (rest, source) =
+            parse_source_has_counters("it has fewer than four +1/+1 counters on it").unwrap();
+        assert_eq!(rest, "");
+        assert_eq!(source, expected);
+        assert!(
+            !matches!(inner, StaticCondition::RecipientHasCounters { .. }),
+            "source-referential `it` must not lower to RecipientHasCounters"
+        );
+    }
+
+    /// Adaptive Training Post: charge-counter type axis with the same LT bounds.
+    #[test]
+    fn has_counters_fewer_than_three_charge() {
+        let (rest, cond) =
+            parse_source_has_counters("this artifact has fewer than three charge counters on it")
+                .expect("ATP charge fewer-than form must parse");
+        assert_eq!(rest, "");
+        assert_eq!(
+            cond,
+            StaticCondition::HasCounters {
+                counters: CounterMatch::OfType(CounterType::Generic("charge".to_string())),
+                minimum: 0,
+                maximum: Some(2),
+            }
+        );
+    }
+
+    /// CR 107.1: "more than two" is the paired GT prefix → `(3, None)`, equal
+    /// to inclusive "three or more".
+    #[test]
+    fn has_counters_more_than_two_plus1() {
+        let expected = StaticCondition::HasCounters {
+            counters: CounterMatch::OfType(CounterType::Plus1Plus1),
+            minimum: 3,
+            maximum: None,
+        };
+        let (rest, more) =
+            parse_source_has_counters("~ has more than two +1/+1 counters on it").unwrap();
+        assert_eq!(rest, "");
+        assert_eq!(more, expected);
+
+        let (_, or_more) = parse_source_has_counters("~ has three or more +1/+1 counters on it")
+            .expect("three or more sibling must still parse");
+        assert_eq!(or_more, expected);
+    }
+
+    /// Mixed "fewer than N or more" is not English and must fail rather than
+    /// swallow "or more +1/+1" as a Generic counter type. Reach-guard: the
+    /// unmixed fewer-than form is Ok.
+    #[test]
+    fn has_counters_fewer_than_mixed_or_more_is_err() {
+        let (rest, ok) = parse_source_has_counters("~ has fewer than three +1/+1 counters on it")
+            .expect("unmixed fewer-than form is the reach-guard");
+        assert_eq!(rest, "");
+        assert!(matches!(
+            ok,
+            StaticCondition::HasCounters {
+                minimum: 0,
+                maximum: Some(2),
+                ..
+            }
+        ));
+
+        assert!(
+            parse_source_has_counters("~ has fewer than three or more +1/+1 counters on it")
+                .is_err(),
+            "mixed fewer-than N or more must fail"
+        );
+
+        // CR 107.1: "fewer than 0" is not an English integer band.
+        assert!(parse_source_has_counters("~ has fewer than 0 +1/+1 counters on it").is_err());
+
+        // Sibling: "exactly three" is unchanged EQ.
+        let (_, exact) = parse_source_has_counters("~ has exactly three +1/+1 counters on it")
+            .expect("exactly N sibling must still parse");
+        assert!(matches!(
+            exact,
+            StaticCondition::HasCounters {
+                minimum: 3,
+                maximum: Some(3),
+                ..
+            }
+        ));
     }
 
     /// "no" variant — zero counters (min 0, max 0).
@@ -22122,6 +22284,37 @@ mod tests {
             StaticCondition::HasCounters {
                 counters: CounterMatch::Any,
                 minimum: 1,
+                maximum: None,
+            }
+        );
+    }
+
+    /// Same quantity axis: existential "there are fewer than N [type] counters
+    /// on ~" shares the LT encoding. Reach-guard: Mazemind "four or more" still
+    /// `(4, None)`.
+    #[test]
+    fn parse_source_counters_exist_fewer_than() {
+        let (rest, cond) =
+            parse_source_counters_exist("there are fewer than three charge counters on ~")
+                .expect("existential fewer-than form must parse");
+        assert_eq!(rest, "");
+        assert_eq!(
+            cond,
+            StaticCondition::HasCounters {
+                counters: CounterMatch::OfType(CounterType::Generic("charge".to_string())),
+                minimum: 0,
+                maximum: Some(2),
+            }
+        );
+
+        let (_, mazemind) =
+            parse_source_counters_exist("there are four or more page counters on ~")
+                .expect("Mazemind four-or-more reach-guard must still parse");
+        assert_eq!(
+            mazemind,
+            StaticCondition::HasCounters {
+                counters: CounterMatch::OfType(CounterType::Generic("page".to_string())),
+                minimum: 4,
                 maximum: None,
             }
         );

--- a/crates/engine/src/parser/oracle_trigger_tests.rs
+++ b/crates/engine/src/parser/oracle_trigger_tests.rs
@@ -1649,6 +1649,110 @@ fn intervening_if_source_has_counters_on_it_populates_condition() {
     assert!(denry.execute.is_some());
 }
 
+/// Shared PutCounter + Unimplemented reach-guard for the fewer-than intervening-if
+/// SHAPE tests. Today's bug keeps PutCounter and drops only `condition`.
+fn assert_fewer_than_put_counter(
+    def: &TriggerDefinition,
+    counter_type: CounterType,
+    target: TargetFilter,
+) {
+    let execute = def.execute.as_deref().expect("trigger must have execute");
+    match execute.effect.as_ref() {
+        Effect::PutCounter {
+            counter_type: ct,
+            count,
+            target: tgt,
+        } => {
+            assert_eq!(ct, &counter_type, "PutCounter type");
+            assert_eq!(count, &QuantityExpr::Fixed { value: 1 }, "PutCounter count");
+            assert_eq!(tgt, &target, "PutCounter target");
+        }
+        other => panic!("expected PutCounter, got {other:?}"),
+    }
+    assert_no_unimplemented(execute);
+}
+
+/// CR 603.4 + CR 107.1 + CR 122.1: Runaway Steam-Kin's intervening-if
+/// "if this creature has fewer than three +1/+1 counters on it" populates
+/// `HasCounters { Plus1Plus1, 0, Some(2) }`. Revert the quantity arm →
+/// `condition == None`.
+#[test]
+fn intervening_if_fewer_than_three_plus1_steam_kin() {
+    let def = parse_trigger_line(
+        "Whenever you cast a red spell, if this creature has fewer than three +1/+1 counters on it, put a +1/+1 counter on this creature.",
+        "Runaway Steam-Kin",
+    );
+    assert_eq!(def.mode, TriggerMode::SpellCast);
+    assert_eq!(
+        def.condition,
+        Some(TriggerCondition::HasCounters {
+            counters: CounterMatch::OfType(CounterType::Plus1Plus1),
+            minimum: 0,
+            maximum: Some(2),
+        })
+    );
+    assert_fewer_than_put_counter(&def, CounterType::Plus1Plus1, TargetFilter::SelfRef);
+
+    let TargetFilter::Typed(tf) = def.valid_card.as_ref().expect("red spell filter") else {
+        panic!("expected Typed valid_card, got {:?}", def.valid_card);
+    };
+    assert_eq!(tf.type_filters, vec![TypeFilter::Card]);
+    assert!(
+        tf.properties.iter().any(|p| matches!(
+            p,
+            FilterProp::HasColor {
+                color: ManaColor::Red
+            }
+        )),
+        "expected HasColor Red, got {:?}",
+        tf.properties
+    );
+}
+
+/// Adaptive Training Post: charge counters, N=3, SpellCast. Execute `it` is
+/// `TriggeringSource` (existing SpellCast anaphor) — pin, do not retarget.
+#[test]
+fn intervening_if_fewer_than_three_charge_adaptive_training_post() {
+    let def = parse_trigger_line(
+        "Whenever you cast an instant or sorcery spell, if this artifact has fewer than three charge counters on it, put a charge counter on it.",
+        "Adaptive Training Post",
+    );
+    assert_eq!(def.mode, TriggerMode::SpellCast);
+    assert_eq!(
+        def.condition,
+        Some(TriggerCondition::HasCounters {
+            counters: CounterMatch::OfType(CounterType::Generic("charge".to_string())),
+            minimum: 0,
+            maximum: Some(2),
+        })
+    );
+    assert_fewer_than_put_counter(
+        &def,
+        CounterType::Generic("charge".to_string()),
+        TargetFilter::TriggeringSource,
+    );
+}
+
+/// Ayara's Oathsworn: bound `it`, N=4, combat-damage. First sentence only —
+/// the then-clause search is out of scope.
+#[test]
+fn intervening_if_fewer_than_four_plus1_ayara() {
+    let def = parse_trigger_line(
+        "Whenever this creature deals combat damage to a player, if it has fewer than four +1/+1 counters on it, put a +1/+1 counter on it.",
+        "Ayara's Oathsworn",
+    );
+    assert_eq!(def.mode, TriggerMode::DamageDone);
+    assert_eq!(
+        def.condition,
+        Some(TriggerCondition::HasCounters {
+            counters: CounterMatch::OfType(CounterType::Plus1Plus1),
+            minimum: 0,
+            maximum: Some(3),
+        })
+    );
+    assert_fewer_than_put_counter(&def, CounterType::Plus1Plus1, TargetFilter::SelfRef);
+}
+
 #[test]
 fn trigger_etb_self() {
     let def = parse_trigger_line(

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -1111,6 +1111,7 @@ mod roughshod_mentor_green_trample_grant;
 mod rules;
 mod run_for_your_life_escape;
 mod runadi_behemoth_caller_etb_counters;
+mod runaway_steam_kin_fewer_than_counters;
 mod runo_stromkirk_reveal_transform_gate;
 mod saddle_become_effect;
 mod saddle_state_model;

--- a/crates/engine/tests/integration/runaway_steam_kin_fewer_than_counters.rs
+++ b/crates/engine/tests/integration/runaway_steam_kin_fewer_than_counters.rs
@@ -1,0 +1,120 @@
+//! Runtime cast-pipeline tests for Runaway Steam-Kin's intervening-if
+//! "if this creature has fewer than three +1/+1 counters on it" (CR 603.4 +
+//! CR 107.1 + CR 122.1).
+//!
+//! Built via the `/card-test` recipe: `GameScenario` +
+//! `GameRunner::cast(..).resolve()` on verbatim Oracle text. The 2→3 positive
+//! is the PutCounter reach-guard for the 3-stays-3 negative. Both halves share
+//! a no-draw red instant (`"You gain 1 life."`) so CR 704.5b cannot SBA-end the
+//! game on `GameScenario::new()`'s empty library before PutCounter runs.
+//!
+//! Revert discriminator: drop the `parse_strict_n_counters` arm → `condition`
+//! is `None` → the 3-counter Steam-Kin gains a fourth.
+
+use engine::game::scenario::{CastOutcome, GameScenario, P0};
+use engine::types::ability::TriggerCondition;
+use engine::types::counter::{CounterMatch, CounterType};
+use engine::types::game_state::WaitingFor;
+use engine::types::identifiers::ObjectId;
+use engine::types::mana::{ManaCost, ManaCostShard, ManaType, ManaUnit};
+use engine::types::phase::Phase;
+
+/// Verbatim Oracle (Scryfall). The mana ability is out of scope and is not
+/// activated; it is kept so the card is not a paraphrase of the trigger line.
+const STEAM_KIN: &str = "Whenever you cast a red spell, if this creature has fewer than three +1/+1 counters on it, put a +1/+1 counter on this creature.\nRemove three +1/+1 counters from this creature: Add {R}{R}{R}.";
+
+/// Cast a no-draw red instant at Steam-Kin with `n` +1/+1 counters.
+///
+/// CR 704.5b: `GameScenario::new()` libraries are empty, so a `"Draw a card."`
+/// stimulus SBA-ends the game (`WaitingFor::GameOver`) and PutCounter never
+/// runs. `"You gain 1 life."` keeps `WaitingFor::Priority` so the counter
+/// gate is observable.
+fn run_with_plus1(n: u32) -> (CastOutcome, ObjectId) {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let kin = scenario
+        .add_creature_from_oracle(P0, "Runaway Steam-Kin", 1, 1, STEAM_KIN)
+        .with_plus_counters(n)
+        .id();
+    let spell = scenario
+        .add_spell_to_hand_from_oracle(P0, "Red Instant", true, "You gain 1 life.")
+        .with_mana_cost(ManaCost::Cost {
+            shards: vec![ManaCostShard::Red],
+            generic: 0,
+        })
+        .id();
+    scenario.with_mana_pool(
+        P0,
+        vec![ManaUnit::new(ManaType::Red, ObjectId(0), false, vec![])],
+    );
+    let mut runner = scenario.build();
+
+    // SHAPE reach-guard: if the combinator is reverted this is empty and both
+    // runtime tests are honestly red.
+    let has_gate = runner.state().objects[&kin]
+        .trigger_definitions
+        .iter_unchecked()
+        .any(|entry| {
+            matches!(
+                entry.definition.condition,
+                Some(TriggerCondition::HasCounters {
+                    counters: CounterMatch::OfType(CounterType::Plus1Plus1),
+                    minimum: 0,
+                    maximum: Some(2),
+                })
+            )
+        });
+    assert!(
+        has_gate,
+        "Steam-Kin must parse intervening-if HasCounters {{ Plus1Plus1, 0, Some(2) }}"
+    );
+
+    let outcome = runner.cast(spell).resolve();
+    (outcome, kin)
+}
+
+fn plus1_count(outcome: &CastOutcome, kin: ObjectId) -> u32 {
+    outcome.state().objects[&kin]
+        .counters
+        .get(&CounterType::Plus1Plus1)
+        .copied()
+        .unwrap_or(0)
+}
+
+fn assert_stimulus_resolved(outcome: &CastOutcome) {
+    // CR 704.5b: prove the red spell resolved and empty-library draw did not
+    // end the game, so PutCounter was actually on the pipeline.
+    outcome.assert_life_delta(P0, 1);
+    assert!(
+        matches!(outcome.final_waiting_for(), WaitingFor::Priority { .. }),
+        "expected Priority after resolve, got {:?}",
+        outcome.final_waiting_for()
+    );
+}
+
+/// CR 603.4 + CR 122.1 + CR 107.1: below the LT-3 band, PutCounter applies.
+/// `n=0` proves `unwrap_or(0)` on a missing counter map; `n=2` is the
+/// positive reach-guard for the 3-stays-3 negative.
+#[test]
+fn runaway_steam_kin_puts_counter_when_below_three() {
+    let (from_zero, kin_zero) = run_with_plus1(0);
+    assert_stimulus_resolved(&from_zero);
+    assert_eq!(plus1_count(&from_zero, kin_zero), 1, "0 counters → 1");
+
+    let (from_two, kin_two) = run_with_plus1(2);
+    assert_stimulus_resolved(&from_two);
+    assert_eq!(plus1_count(&from_two, kin_two), 3, "2 counters → 3");
+}
+
+/// CR 603.4 + CR 107.1: at three +1/+1 counters the intervening-if fails, so
+/// Steam-Kin does not gain a fourth. Discriminates LT from LE ("three or fewer"
+/// would put a fourth). The 2→3 sibling in
+/// `runaway_steam_kin_puts_counter_when_below_three` is the PutCounter
+/// reach-guard — without it, "stays at 3" could pass because PutCounter never
+/// ran.
+#[test]
+fn runaway_steam_kin_does_not_put_at_three() {
+    let (at_three, kin) = run_with_plus1(3);
+    assert_stimulus_resolved(&at_three);
+    assert_eq!(plus1_count(&at_three, kin), 3, "3 counters stays 3");
+}

--- a/docs/parser-misparse-backlog.md
+++ b/docs/parser-misparse-backlog.md
@@ -832,7 +832,6 @@ This is the prioritized "fix N root causes → unlock M cards" backlog: the top 
 <details><summary>Cards</summary>
 
 - A-Paragon of Modernity
-- Adaptive Training Post
 - Adrestia
 - Aether Revolt
 - Aether Rift
@@ -1262,7 +1261,6 @@ This is the prioritized "fix N root causes → unlock M cards" backlog: the top 
 - Routeway Moose
 - Rowdy Crew
 - Rubblebelt Braggart
-- Runaway Steam-Kin
 - Rushing-Tide Zubera
 - Rushwood Legate
 - Saffi Eriksdotter


### PR DESCRIPTION
## Summary

Fixes the dropped intervening-if / gating condition (`condition: null`) misparse for **Runaway Steam-Kin**. `"fewer than N"` (and paired `"more than N"`) now parse on the existing `HasCounters` quantity axis, so the CR 603.4 gate attaches. Backlog §2 entries removed: Runaway Steam-Kin, Adaptive Training Post.

## Files changed

- `crates/engine/src/parser/oracle_nom/condition.rs`
- `crates/engine/src/parser/oracle_trigger_tests.rs`
- `crates/engine/tests/integration/runaway_steam_kin_fewer_than_counters.rs`
- `crates/engine/tests/integration/main.rs`
- `docs/parser-misparse-backlog.md`

## Track

Developer

## LLM

Model: grok-4.6
Tier: Frontier
Thinking: high

## Implementation method (required)

Method: /engine-implementer

## CR references

- CR 107.1 — `"fewer than N"` is the integers `{0, …, N-1}`
- CR 122.1 — counters as typed markers (`CounterMatch::OfType`)
- CR 603.4 — intervening-if checked on announcement and resolution
- CR 704.5b — empty-library draw loses; runtime stimulus is a no-draw red instant

## Verification

- [x] Required checks ran clean, or the exact CI-owned alternative is stated below.
- [x] Gate A output below is for the current committed head.
- [x] Final review-impl below is clean for the current committed head.
- [x] Both anchors cite existing analogous code at the same seam.

- `cargo fmt --all` — PASS
- `./scripts/check-parser-combinators.sh` — Gate G PASS; Gate A PASS (see Gate A)
- `cargo test -p phase-engine --lib -- fewer_than has_counters_more_than` — 16 passed
- `cargo test -p phase-engine --test integration runaway_steam_kin` — 2 passed (`puts_counter_when_below_three`, `does_not_put_at_three`)
- `cargo clippy -p phase-engine --lib -- -D warnings` — PASS (isolated `CARGO_TARGET_DIR`)
- CI owns `gen-card-data` / coverage / semantic-audit

## Gate A

Gate A PASS head=cfcbc89498f90db81785dcdb08a461970809fd42 base=aa6948a4f7970661e700bb653f218b542763b32d

## Anchored on

- `crates/engine/src/parser/oracle_nom/condition.rs:2488` — `parse_n_or_more_counters` (`"N or more"` → `(N, None)`) on the same `parse_has_counters_quantity` axis
- `crates/engine/src/parser/oracle_nom/condition.rs:2494` — `parse_n_or_fewer_counters` (`"N or fewer"` → `(0, Some(N))`) on the same axis

## Final review-impl

Final review-impl PASS head=cfcbc89498f90db81785dcdb08a461970809fd42

```text
Pipeline-reviewed head: cfcbc89498f90db81785dcdb08a461970809fd42
Current branch head: cfcbc89498f90db81785dcdb08a461970809fd42
Pipeline status: current
Current-head review: clean at cfcbc89498f90db81785dcdb08a461970809fd42
```

Plan-review rounds: 2 (1 blocker round, then CLEAN). Surgical-fix mode: not used.
Implementation-review rounds: 1, CLEAN.

## Claimed parse impact

- Runaway Steam-Kin
- Adaptive Training Post
- Ayara's Oathsworn (first-sentence intervening-if only; Then-search remains out of scope)

## Scope Expansion

None.

## Validation Failures

None.

## CI Failures

None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for interpreting “fewer than N” and “more than N” counter conditions.
  - Counter-based triggered abilities now correctly handle strict thresholds, including +1/+1 and charge counters.
  - Added support for source-referential and existential wording such as “there are fewer than N.”

- **Bug Fixes**
  - Prevented invalid mixed comparison phrases from being accepted.
  - Added validation for impossible thresholds, such as “fewer than 0.”


<!-- end of auto-generated comment: release notes by coderabbit.ai -->