### PR TITLE
Fix Burning-Eye Zubera

### DIFF
--- a/crates/engine/src/game/filter.rs
+++ b/crates/engine/src/game/filter.rs
@@ -5212,11 +5212,19 @@ fn object_matches_trigger_source(
     source_id: ObjectId,
     trigger_source: Option<&TriggerSourceContext>,
 ) -> bool {
+    // CR 608.2h + CR 603.4: a dies intervening-if that names the source
+    // ("damage was dealt to it this turn") is checked after the source has
+    // left the battlefield. `ExactLive` is gone; the latched identity is the
+    // same object the damage record targeted.
     trigger_source.map_or(object_id == source_id, |context| {
-        matches!(
-            context.source_read(state),
-            crate::types::game_state::TriggerSourceRead::ExactLive(object) if object.id == object_id
-        )
+        match context.source_read(state) {
+            crate::types::game_state::TriggerSourceRead::ExactLive(object) => {
+                object.id == object_id
+            }
+            crate::types::game_state::TriggerSourceRead::Latched(latched) => {
+                latched.identity.reference.object_id == object_id
+            }
+        }
     })
 }
 

--- a/crates/engine/src/parser/oracle_nom/condition.rs
+++ b/crates/engine/src/parser/oracle_nom/condition.rs
@@ -485,6 +485,10 @@ fn parse_damage_dealt_this_turn_conditions(input: &str) -> OracleResult<'_, Stat
         // "was dealt excess damage this turn" wins over the shorter "was dealt
         // damage this turn" prefix in `parse_source_was_dealt_damage_this_turn`.
         parse_subject_was_dealt_excess_damage_this_turn,
+        // Quantity-first passive ("N or more damage was dealt to it this turn")
+        // must precede the subject-first player threshold so a leading numeral
+        // is not left for a later Fail.
+        parse_n_or_more_damage_was_dealt_to_source_this_turn,
         parse_player_was_dealt_damage_threshold_this_turn,
         parse_player_dealt_combat_damage_by_source_this_turn,
         parse_source_dealt_damage_this_turn,
@@ -570,6 +574,44 @@ fn parse_subject_was_dealt_excess_damage_this_turn(
 /// CR 603.4 + CR 120.3: "you were/an opponent was dealt N or more damage this
 /// turn" — Boarded Window and Phoenix Chick-style end-step intervening-if
 /// predicates. Any-source damage to the matching player set.
+/// CR 107.1 + CR 120.1 + CR 603.4: "N or more damage was dealt to
+/// it/this creature/~ this turn" — Zubera-class dies intervening-if.
+///
+/// Quantity-first passive, distinct from
+/// `parse_player_was_dealt_damage_threshold_this_turn` (subject-first
+/// "you were dealt N or more damage this turn") and from
+/// `parse_source_was_dealt_damage_this_turn` (existential "this creature
+/// was dealt damage this turn"). Reuses `parse_ge_threshold` and
+/// `DamageDealtThisTurn` (target `SelfRef`); no new variant.
+fn parse_n_or_more_damage_was_dealt_to_source_this_turn(
+    input: &str,
+) -> OracleResult<'_, StaticCondition> {
+    let (rest, amount) = parse_ge_threshold(input)?;
+    let (rest, _) = tag("damage was dealt to ").parse(rest)?;
+    let (rest, _) = alt((
+        tag("this creature"),
+        tag("this permanent"),
+        tag("~"),
+        tag("it"),
+    ))
+    .parse(rest)?;
+    let (rest, _) = tag(" this turn").parse(rest)?;
+    Ok((
+        rest,
+        make_quantity_ge(
+            QuantityRef::DamageDealtThisTurn {
+                source: Box::new(TargetFilter::Any),
+                target: Box::new(TargetFilter::SelfRef),
+                aggregate: AggregateFunction::Sum,
+                group_by: None,
+                damage_kind: DamageKindFilter::Any,
+                channel: DamageChannel::Total,
+            },
+            amount,
+        ),
+    ))
+}
+
 fn parse_player_was_dealt_damage_threshold_this_turn(
     input: &str,
 ) -> OracleResult<'_, StaticCondition> {
@@ -22300,6 +22342,74 @@ mod tests {
             !matches!(target.as_ref(), TargetFilter::Any),
             "target filter must be non-Any, got: {target:?}"
         );
+    }
+
+    /// CR 107.1 + CR 120.1 + CR 603.4: quantity-first "N or more damage was
+    /// dealt to it this turn" (Burning-Eye Zubera / Rushing-Tide Zubera).
+    #[test]
+    fn parse_inner_condition_n_or_more_damage_was_dealt_to_it_this_turn() {
+        let (rest, cond) =
+            parse_inner_condition("4 or more damage was dealt to it this turn").unwrap();
+        assert_eq!(rest, "");
+        let StaticCondition::QuantityComparison {
+            lhs:
+                QuantityExpr::Ref {
+                    qty:
+                        QuantityRef::DamageDealtThisTurn {
+                            ref source,
+                            ref target,
+                            channel,
+                            damage_kind,
+                            ..
+                        },
+                },
+            comparator: Comparator::GE,
+            rhs: QuantityExpr::Fixed { value: 4 },
+        } = cond
+        else {
+            panic!("expected DamageDealtThisTurn GE 4, got: {cond:?}");
+        };
+        assert_eq!(source.as_ref(), &TargetFilter::Any);
+        assert_eq!(target.as_ref(), &TargetFilter::SelfRef);
+        assert_eq!(channel, DamageChannel::Total);
+        assert_eq!(damage_kind, DamageKindFilter::Any);
+    }
+
+    /// English numeral + `this creature` self-ref, same encoding.
+    #[test]
+    fn parse_inner_condition_four_or_more_damage_was_dealt_to_this_creature() {
+        let (rest, cond) =
+            parse_inner_condition("four or more damage was dealt to this creature this turn")
+                .unwrap();
+        assert_eq!(rest, "");
+        let StaticCondition::QuantityComparison {
+            lhs:
+                QuantityExpr::Ref {
+                    qty: QuantityRef::DamageDealtThisTurn { ref target, .. },
+                },
+            comparator: Comparator::GE,
+            rhs: QuantityExpr::Fixed { value: 4 },
+        } = cond
+        else {
+            panic!("expected DamageDealtThisTurn GE 4, got: {cond:?}");
+        };
+        assert_eq!(target.as_ref(), &TargetFilter::SelfRef);
+    }
+
+    /// Existential "was dealt damage this turn" must not swallow the
+    /// quantity-first form (reach-guard for alt order).
+    #[test]
+    fn parse_inner_condition_n_or_more_damage_was_dealt_does_not_collapse_to_ge_1() {
+        let (_, cond) =
+            parse_inner_condition("4 or more damage was dealt to it this turn").unwrap();
+        let StaticCondition::QuantityComparison {
+            rhs: QuantityExpr::Fixed { value },
+            ..
+        } = cond
+        else {
+            panic!("expected QuantityComparison, got: {cond:?}");
+        };
+        assert_eq!(value, 4, "must not collapse to existential GE 1");
     }
 }
 

--- a/crates/engine/src/parser/oracle_trigger_tests.rs
+++ b/crates/engine/src/parser/oracle_trigger_tests.rs
@@ -1613,6 +1613,59 @@ fn while_saddled_fold_refused_for_non_attacks_trigger_is_strictly_unsupported() 
 }
 
 #[test]
+fn intervening_if_n_or_more_damage_was_dealt_to_it_this_turn() {
+    // CR 107.1 + CR 120.1 + CR 603.4: quantity-first "if N or more damage was
+    // dealt to it this turn" on a dies trigger (Burning-Eye Zubera).
+    let def = parse_trigger_line(
+        "When this creature dies, if 4 or more damage was dealt to it this turn, \
+         this creature deals 3 damage to any target.",
+        "Burning-Eye Zubera",
+    );
+    match &def.condition {
+        Some(TriggerCondition::QuantityComparison {
+            lhs:
+                QuantityExpr::Ref {
+                    qty:
+                        QuantityRef::DamageDealtThisTurn {
+                            target, channel, ..
+                        },
+                },
+            comparator: Comparator::GE,
+            rhs: QuantityExpr::Fixed { value: 4 },
+        }) => {
+            assert_eq!(target.as_ref(), &TargetFilter::SelfRef);
+            assert_eq!(*channel, DamageChannel::Total);
+        }
+        other => panic!("expected DamageDealtThisTurn GE 4, got {other:?}"),
+    }
+    let exec = def.execute.as_deref().expect("execute");
+    assert!(matches!(exec.effect.as_ref(), Effect::DealDamage { .. }));
+    assert!(exec.condition.is_none());
+    assert_no_unimplemented(exec);
+
+    let tide = parse_trigger_line(
+        "When this creature dies, if 4 or more damage was dealt to it this turn, draw three cards.",
+        "Rushing-Tide Zubera",
+    );
+    match &tide.condition {
+        Some(TriggerCondition::QuantityComparison {
+            lhs:
+                QuantityExpr::Ref {
+                    qty: QuantityRef::DamageDealtThisTurn { target, .. },
+                },
+            comparator: Comparator::GE,
+            rhs: QuantityExpr::Fixed { value: 4 },
+        }) => {
+            assert_eq!(target.as_ref(), &TargetFilter::SelfRef);
+        }
+        other => panic!("expected DamageDealtThisTurn GE 4, got {other:?}"),
+    }
+    let tide_exec = tide.execute.as_deref().expect("execute");
+    assert!(matches!(tide_exec.effect.as_ref(), Effect::Draw { .. }));
+    assert_no_unimplemented(tide_exec);
+}
+
+#[test]
 fn intervening_if_source_has_counters_on_it_populates_condition() {
     // CR 603.4 + CR 122: source-scoped "if ~ has counters on it" gates the
     // trigger on the source permanent currently having at least one counter of

--- a/crates/engine/tests/integration/burning_eye_zubera_damage_threshold.rs
+++ b/crates/engine/tests/integration/burning_eye_zubera_damage_threshold.rs
@@ -1,0 +1,105 @@
+//! Runtime tests for Burning-Eye Zubera's intervening-if
+//! "if 4 or more damage was dealt to it this turn" (CR 603.4 + CR 107.1 +
+//! CR 120.1).
+//!
+//! Revert discriminator: drop the quantity-first combinator arm → trigger
+//! `condition` is `None` → a 3-damage lethal hit still deals 3 to P1.
+
+use engine::game::scenario::{CastOutcome, GameScenario, P0, P1};
+use engine::types::ability::{Comparator, QuantityExpr, QuantityRef, TriggerCondition};
+use engine::types::game_state::WaitingFor;
+use engine::types::identifiers::ObjectId;
+use engine::types::mana::{ManaCost, ManaCostShard, ManaType, ManaUnit};
+use engine::types::phase::Phase;
+use engine::types::zones::Zone;
+
+const ZUBERA: &str =
+    "When this creature dies, if 4 or more damage was dealt to it this turn, this creature deals 3 damage to any target.";
+
+fn deal_n_to_zubera(n: i32) -> CastOutcome {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let zubera = scenario
+        .add_creature_from_oracle(P0, "Burning-Eye Zubera", 3, 3, ZUBERA)
+        .id();
+    let oracle = format!("Burn deals {n} damage to any target.");
+    let spell = scenario
+        .add_spell_to_hand_from_oracle(P0, "Burn", true, &oracle)
+        .with_mana_cost(ManaCost::Cost {
+            shards: vec![ManaCostShard::Red],
+            generic: 0,
+        })
+        .id();
+    scenario.with_mana_pool(
+        P0,
+        vec![ManaUnit::new(ManaType::Red, ObjectId(0), false, vec![])],
+    );
+    let mut runner = scenario.build();
+
+    let has_gate = runner.state().objects[&zubera]
+        .trigger_definitions
+        .iter_unchecked()
+        .any(|entry| {
+            matches!(
+                entry.definition.condition,
+                Some(TriggerCondition::QuantityComparison {
+                    lhs: QuantityExpr::Ref {
+                        qty: QuantityRef::DamageDealtThisTurn { .. },
+                    },
+                    comparator: Comparator::GE,
+                    rhs: QuantityExpr::Fixed { value: 4 },
+                })
+            )
+        });
+    assert!(
+        has_gate,
+        "Zubera must parse intervening-if DamageDealtThisTurn GE 4"
+    );
+
+    // Spell targets the Zubera. When the gate is true the dies trigger also
+    // needs an any-target (P1). When it is false that extra target is not asked.
+    let outcome = if n >= 4 {
+        runner
+            .cast(spell)
+            .target_object(zubera)
+            .target_player(P1)
+            .resolve()
+    } else {
+        runner.cast(spell).target_object(zubera).resolve()
+    };
+    assert_eq!(
+        outcome.state().objects[&zubera].zone,
+        Zone::Graveyard,
+        "reach-guard: {n} damage must kill the 3/3"
+    );
+    outcome
+}
+
+#[test]
+fn burning_eye_zubera_deals_three_when_four_damage_this_turn() {
+    // CR 603.4: 4 damage marked on a 3/3 is lethal and satisfies the
+    // intervening-if, so the dies trigger deals 3 to P1.
+    let outcome = deal_n_to_zubera(4);
+    assert!(
+        matches!(
+            outcome.state().waiting_for,
+            WaitingFor::Priority { .. } | WaitingFor::GameOver { .. }
+        ),
+        "expected Priority/GameOver, got {:?}",
+        outcome.state().waiting_for
+    );
+    outcome.assert_life_delta(P1, -3);
+}
+
+#[test]
+fn burning_eye_zubera_does_not_deal_when_three_damage_this_turn() {
+    // 3 damage is lethal for a 3/3 but fails GE 4. Reach-guard: P1 is not
+    // the spell's target, so life_delta 0 proves the trigger did not fire.
+    let outcome = deal_n_to_zubera(3);
+    assert!(
+        matches!(outcome.state().waiting_for, WaitingFor::Priority { .. }),
+        "expected Priority, got {:?}",
+        outcome.state().waiting_for
+    );
+    outcome.assert_life_delta(P1, 0);
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -95,6 +95,7 @@ mod brigid_mana_ability;
 mod bring_the_ending_corrupted_instead_branch_5683;
 mod bring_to_light_free_cast_2880;
 mod broken_bond_land_prompt;
+mod burning_eye_zubera_damage_threshold;
 mod calamity_of_the_titans_reveal_cost;
 mod call_damage_control_modal_return;
 mod call_forth_tempest_and_rootha;

--- a/docs/parser-misparse-backlog.md
+++ b/docs/parser-misparse-backlog.md
@@ -900,7 +900,6 @@ This is the prioritized "fix N root causes → unlock M cards" backlog: the top 
 - Bronze Horse
 - Bull-Rush Bruiser
 - Bulwark Ox
-- Burning-Eye Zubera
 - Cache Grab
 - Calamity of the Titans
 - Call to Arms
@@ -1263,7 +1262,6 @@ This is the prioritized "fix N root causes → unlock M cards" backlog: the top 
 - Rowdy Crew
 - Rubblebelt Braggart
 - Runaway Steam-Kin
-- Rushing-Tide Zubera
 - Rushwood Legate
 - Saffi Eriksdotter
 - Sahagin


### PR DESCRIPTION
## Summary

Fixes the dropped intervening-if misparse for **Burning-Eye Zubera**. `"N or more damage was dealt to it this turn"` now parses on the existing `DamageDealtThisTurn` quantity axis (CR 603.4), and dies LKI `SelfRef` matches a latched source (CR 608.2h). Backlog §2 entries removed: Burning-Eye Zubera, Rushing-Tide Zubera.

## Files changed

- `crates/engine/src/parser/oracle_nom/condition.rs`
- `crates/engine/src/parser/oracle_trigger_tests.rs`
- `crates/engine/src/game/filter.rs`
- `crates/engine/tests/integration/burning_eye_zubera_damage_threshold.rs`
- `crates/engine/tests/integration/main.rs`
- `docs/parser-misparse-backlog.md`

## Track

Developer

## LLM

Model: grok-4.6
Tier: Frontier
Thinking: high

## Implementation method (required)

Method: /engine-implementer

## CR references

- CR 107.1 — `"N or more"` is the integers `{N, N+1, …}`
- CR 120.1 — objects can be dealt damage; this turn's records are the look-back
- CR 603.4 — intervening-if checked on announcement and resolution
- CR 608.2h — source information uses LKI when the object has left its public zone

## Verification

- [x] Required checks ran clean, or the exact CI-owned alternative is stated below.
- [x] Gate A output below is for the current committed head.
- [x] Final review-impl below is clean for the current committed head.
- [x] Both anchors cite existing analogous code at the same seam.

- `cargo fmt --all` — PASS
- `./scripts/check-parser-combinators.sh` — Gate G PASS; Gate A PASS (see Gate A)
- `cargo test -p phase-engine --lib -- n_or_more_damage_was_dealt four_or_more_damage_was_dealt intervening_if_n_or_more_damage` — PASS
- `cargo test -p phase-engine --test integration burning_eye_zubera` — 2 passed
- `cargo clippy -p phase-engine --lib -- -D warnings` — PASS (isolated `CARGO_TARGET_DIR`)
- CI owns `gen-card-data` / coverage / semantic-audit

## Gate A

Gate A PASS head=3b36bddbd929d4ed22714f13972b6c0bd858876c base=aa6948a4f7970661e700bb653f218b542763b32d

## Anchored on

- `crates/engine/src/parser/oracle_nom/condition.rs:615` — `parse_player_was_dealt_damage_threshold_this_turn` (`"you were dealt N or more damage this turn"` → `DamageDealtThisTurn` GE N)
- `crates/engine/src/parser/oracle_nom/condition.rs:770` — `parse_source_was_dealt_damage_this_turn` (existential `"this creature was dealt damage this turn"` → `DamageDealtThisTurn` target `SelfRef`)

## Final review-impl

Final review-impl PASS head=3b36bddbd929d4ed22714f13972b6c0bd858876c

```text
Pipeline-reviewed head: 3b36bddbd929d4ed22714f13972b6c0bd858876c
Current branch head: 3b36bddbd929d4ed22714f13972b6c0bd858876c
Pipeline status: current
Current-head review: clean at 3b36bddbd929d4ed22714f13972b6c0bd858876c
```

## Claimed parse impact

- Burning-Eye Zubera
- Rushing-Tide Zubera

## Scope Expansion

None.

## Validation Failures

None.

## CI Failures

None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Dies-trigger conditions now continue to recognize their source after it leaves the battlefield.
  - Added support for conditions requiring a specified amount of damage dealt to a source this turn.
  - Corrected damage-threshold handling for Burning-Eye Zubera triggers, including qualifying and non-qualifying lethal damage.

- **Tests**
  - Added parser and integration coverage for numeric and written damage thresholds.

- **Documentation**
  - Updated the parser issue backlog to reflect resolved cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->