### PR TITLE
Fix P2P disconnects during slow game actions

### DIFF
--- a/client/src/network/__tests__/peer.test.ts
+++ b/client/src/network/__tests__/peer.test.ts
@@ -293,6 +293,77 @@ class SilentPeerConnection extends FakeDataConnection {
 // raw envelope path — no `CompressionStream`, which is what lets the real
 // protocol module run under fake timers here.
 describe("PeerSession keep-alive", () => {
+  it.each([false, true])("processes heartbeats during a slow game handler (buffered: %s)", async (buffered) => {
+    vi.useFakeTimers();
+    const { conn, session } = createTestSession();
+    let release!: () => void;
+    const blocked = new Promise<void>((resolve) => { release = resolve; });
+    try {
+      const onDisconnect = vi.fn();
+      session.onDisconnect(onDisconnect);
+      const received: string[] = [];
+      const action: P2PMessage = {
+        type: "action", senderPlayerId: 1, action: { type: "PassPriority" },
+      };
+      if (buffered) await conn.simulateData(action);
+      session.onMessage(async (msg) => {
+        received.push(msg.type);
+        if (msg.type === "action") await blocked;
+      });
+      const first = buffered ? Promise.resolve() : conn.simulateData(action);
+      await vi.advanceTimersByTimeAsync(0);
+      expect(received).toEqual(["action"]);
+      const second = conn.simulateData({ type: "concede" });
+
+      // Both directions of liveness must bypass game work. The fake answers
+      // our periodic pings; this inbound ping also requires us to answer it.
+      const inboundPing = conn.simulateData({ type: "ping", timestamp: 123 });
+      await vi.advanceTimersByTimeAsync(30_000);
+      expect(onDisconnect).not.toHaveBeenCalled();
+      expect(conn.open).toBe(true);
+      expect(await conn.getSentMessages()).toContainEqual({ type: "pong", timestamp: 123 });
+      expect(received).toEqual(["action"]);
+
+      release();
+      await Promise.all([first, second, inboundPing]);
+      expect(received).toEqual(["action", "concede"]);
+    } finally {
+      release();
+      session.close();
+      vi.useRealTimers();
+    }
+  });
+
+  it("still disconnects a silent peer during a slow game handler", async () => {
+    vi.useFakeTimers();
+    const conn = new SilentPeerConnection();
+    const session = createPeerSession(conn as never);
+    let release!: () => void;
+    const blocked = new Promise<void>((resolve) => { release = resolve; });
+    try {
+      const onDisconnect = vi.fn();
+      session.onDisconnect(onDisconnect);
+      const received: string[] = [];
+      session.onMessage(async (msg) => {
+        received.push(msg.type);
+        await blocked;
+      });
+      const first = conn.simulateData({ type: "concede" });
+      await vi.advanceTimersByTimeAsync(0);
+      const second = conn.simulateData({ type: "concede" });
+      await vi.advanceTimersByTimeAsync(10_000);
+      expect(onDisconnect).toHaveBeenCalledExactlyOnceWith("Ping timeout");
+
+      release();
+      await Promise.all([first, second]);
+      expect(received).toEqual(["concede"]);
+    } finally {
+      release();
+      session.close();
+      vi.useRealTimers();
+    }
+  });
+
   it("disconnects a peer that stops answering pings", async () => {
     vi.useFakeTimers();
     try {

--- a/client/src/network/peer.ts
+++ b/client/src/network/peer.ts
@@ -230,16 +230,19 @@ export function createPeerSession(
     disposeChannel();
   };
 
-  // FIFO receive queue mirrors the send queue. DecompressionStream is async,
-  // so concurrent onData invocations must be serialized to preserve the
-  // state_update N → state_update N+1 ordering invariant the engine depends on.
+  // Decode in wire order, but dispatch game messages on a separate FIFO.
+  // An async engine action must not strand an already-arrived ping/pong behind
+  // its handler: the keep-alive would otherwise close a healthy channel.
   let recvQueue: Promise<void> = Promise.resolve();
+  let dispatchQueue: Promise<void> = Promise.resolve();
 
-  // Returns the recvQueue entry's promise. Production callers (PeerJS event
+  // Returns this message's delivery promise. Production callers (PeerJS event
   // emitter) ignore it; the test fake uses it to deterministically await the
   // full inbound chain.
   const onData = (data: unknown): Promise<void> => {
+    let delivery: Promise<void> | undefined;
     recvQueue = recvQueue.then(async () => {
+      if (closed) return;
       if (!(data instanceof Uint8Array || data instanceof ArrayBuffer)) {
         // PeerJS "binary" mode can deliver either Uint8Array or ArrayBuffer
         // depending on msgpack unwrap path. Anything else means a version
@@ -271,36 +274,35 @@ export function createPeerSession(
         return;
       }
 
-      if (msg.type === "disconnect") {
-        handleDisconnect(msg.reason);
-        return;
-      }
-
-      if (messageHandlers.size === 0) {
-        pendingMessages.push(msg);
-        return;
-      }
-
-      // Await async handlers so the recvQueue chain reflects the full
-      // chain — handler-triggered sends complete before the next inbound
-      // message is dispatched. Sync handlers return undefined; awaiting
-      // it is a no-op microtask.
-      //
-      // Per-handler try/catch: a thrown handler must NOT reject the
-      // recvQueue promise. `.then(onFulfilled)` without `onRejected`
-      // propagates rejection forward, so the next onData would skip its
-      // body and silently freeze inbound dispatch for the rest of the
-      // session. Logging here is the same posture as decodeWireMessage's
-      // catch above — keep the channel alive, surface the error.
-      for (const handler of messageHandlers) {
-        try {
-          await handler(msg);
-        } catch (e) {
-          console.warn("[PeerSession] message handler threw:", e, msg.type);
+      delivery = dispatchQueue.then(async () => {
+        if (closed) return;
+        if (msg.type === "disconnect") {
+          handleDisconnect(msg.reason);
+          return;
         }
-      }
+
+        if (messageHandlers.size === 0) {
+          pendingMessages.push(msg);
+          return;
+        }
+
+        // Await each game handler to preserve action/state ordering. Catch
+        // failures per handler so a rejection cannot poison later deliveries.
+        for (const message of [...pendingMessages.splice(0), msg]) {
+          for (const handler of messageHandlers) {
+            try {
+              await handler(message);
+            } catch (e) {
+              console.warn("[PeerSession] message handler threw:", e, message.type);
+            }
+          }
+        }
+      });
+      dispatchQueue = delivery;
     });
-    return recvQueue;
+    // Tests can await this message's full delivery without making the decode
+    // queue itself wait for game work.
+    return recvQueue.then(() => delivery);
   };
 
   conn.on("data", onData);
@@ -317,20 +319,22 @@ export function createPeerSession(
       messageHandlers.add(handler);
 
       if (pendingMessages.length > 0) {
-        const queued = pendingMessages.splice(0);
-        // Flush buffered messages through the same serialized recvQueue used by
+        // Flush buffered messages through the same serialized dispatchQueue used by
         // onData, rather than dispatching them synchronously and un-awaited.
         // That keeps three guarantees the engine relies on:
         //  - async handlers are awaited, so a handler-triggered send completes
         //    before the next inbound message is dispatched (ordering invariant);
         //  - the buffered messages stay ordered relative to any inbound message
-        //    already queued on recvQueue;
+        //    already queued on dispatchQueue;
         //  - a throwing/rejecting handler is caught here instead of dropping an
         //    unhandled rejection or breaking the chain (matches onData).
-        recvQueue = recvQueue
+        dispatchQueue = dispatchQueue
           .catch(() => {})
           .then(async () => {
-            for (const msg of queued) {
+            // Drain at execution time: an earlier queued delivery may already
+            // have flushed these messages after this listener subscribed.
+            for (const msg of pendingMessages.splice(0)) {
+              if (closed) return;
               try {
                 await handler(msg);
               } catch (e) {


### PR DESCRIPTION
A slow P2P game-message handler prevented already-arrived ping/pong frames from being processed. Since the September 4 heartbeat fix (#8365), that could close a healthy connection after 10 seconds and pause the game.

Keep wire decoding ordered, but serialize game handlers on a separate queue so heartbeats can be processed while an engine action is pending. Preserve game-message and buffered-message order, and discard queued game work after the session closes.

Regression coverage holds both live and buffered handlers for 30 seconds while checking ping replies, pong reception, and subsequent game-message order. A silent-peer case verifies that the 10-second failure detector remains active and queued work is discarded after disconnect. A controlled before/after reproduction against the source confirms that the old implementation disconnects and the fix stays connected.

Validation: cargo fmt --all and pre-commit gates passed; the final Tilt check-frontend and test-frontend runs passed, including all 22 peer tests. CI runs the repository checks independently. Production telemetry contains disconnect-related errors, but does not record transport disconnect reasons, so attribution of the reported games remains unconfirmed.

Automated review finding disposition: the security scanner claims every decoded message enters dispatchQueue. This is a false positive: peer.ts lines 266–270 handle pong and return; lines 272–275 handle ping and return; dispatchQueue starts at line 277. The parameterized regression sends an inbound ping while the action handler remains blocked for 30 seconds and asserts the outgoing pong, continued connection, and game-message ordering. No code change is warranted for this finding.
