### PR TITLE
Fix Corpse Appraiser

### DIFF
--- a/crates/engine/src/parser/oracle_effect/conditions.rs
+++ b/crates/engine/src/parser/oracle_effect/conditions.rs
@@ -902,7 +902,8 @@ pub(super) fn strip_if_you_do_conditional(text: &str) -> (Option<AbilityConditio
     // `parse_zone_changed_this_way_clause` combinator in `oracle_nom::condition`.
     // The combinator covers past + present tense, single-word imperatives
     // (destroyed/exiled/sacrificed/returned/discarded/milled/countered) AND
-    // the multi-word "put onto the battlefield" verb, with subtype filters
+    // the multi-word destination-bound "put onto the battlefield" /
+    // "put into a graveyard" / "put into exile" verbs, with subtype filters
     // (Aura/Equipment/...) via `parse_type_phrase_folding`. Replaces the prior
     // hand-rolled past-tense / single-word / top-level-type-only matcher.
     if let Ok((rest, _)) =

--- a/crates/engine/src/parser/oracle_nom/condition.rs
+++ b/crates/engine/src/parser/oracle_nom/condition.rs
@@ -9737,7 +9737,8 @@ pub(crate) fn parse_unless_condition(input: &str) -> OracleResult<'_, StaticCond
 /// CR 400.7 + CR 608.2c: Parse "a[n] [type] (is|was) [verb-phrase] this way"
 /// — the noun-anaphoric clause that gates a sub-ability on the LKI of an
 /// object the parent effect just operated on (destroyed, exiled, sacrificed,
-/// returned, discarded, milled, countered, or "put onto the battlefield").
+/// returned, discarded, milled, countered, "put onto the battlefield",
+/// "put into a graveyard", or "put into exile").
 ///
 /// CR 303.4f / CR 301.5b are the host-rules that motivate the present-tense
 /// "is put onto the battlefield this way" variant — Aura/Equipment ETB
@@ -9757,9 +9758,9 @@ pub(crate) fn parse_unless_condition(input: &str) -> OracleResult<'_, StaticCond
 /// `remainder` is the input after the consumed " this way" suffix (caller is
 /// responsible for stripping any trailing punctuation like ", " or ".").
 /// `destination` is `Some(zone)` for wording that names an arrival zone
-/// ("enters", "put onto the battlefield", "dies", or "put into a graveyard")
-/// and `None` for cause-bound verbs. On `wasn't`/`was not` the negation is
-/// exposed via `negated`.
+/// ("enters", "put onto the battlefield", "dies", "put into a graveyard",
+/// or "put into exile") and `None` for cause-bound verbs. On `wasn't`/`was not`
+/// the negation is exposed via `negated`.
 pub fn parse_zone_changed_this_way_clause(
     input: &str,
 ) -> OracleResult<'_, (TargetFilter, bool, Option<crate::types::zones::Zone>)> {
@@ -9774,8 +9775,9 @@ pub fn parse_zone_changed_this_way_clause(
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ThisWayVerbScope {
     /// Every verb the rider grammar covers: the present-tense "enters"/"enter"
-    /// branch plus "put onto the battlefield", "destroyed", "exiled",
-    /// "sacrificed", "returned", "discarded", "milled", "countered".
+    /// branch plus "put onto the battlefield", "put into a graveyard",
+    /// "put into exile", "destroyed", "exiled", "sacrificed", "returned",
+    /// "discarded", "milled", "countered".
     AnyZoneChange,
     /// Battlefield-entry verbs only: the present-tense "enters"/"enter" branch
     /// plus "put onto the battlefield". CR 614.1c replacement classification is
@@ -9876,8 +9878,8 @@ pub fn parse_zone_changed_this_way_clause_scoped(
     ))
     .parse(after_filter)?;
 
-    // verb-phrase: single-word imperatives + the multi-word
-    // "put onto the battlefield". The verb itself is value-discarded; the
+    // verb-phrase: single-word imperatives + the multi-word destination-bound
+    // "put onto/into …" family. The verb itself is value-discarded; the
     // " this way" suffix is the discriminator. Under
     // `ThisWayVerbScope::BattlefieldEntry` only the battlefield-entry verb is
     // offered; the non-entry zone-change verbs are withheld.
@@ -9904,6 +9906,15 @@ pub fn parse_zone_changed_this_way_clause_scoped(
             value(
                 Some(crate::types::zones::Zone::Graveyard),
                 tag("put into a graveyard"),
+            ),
+            // CR 608.2c + CR 701.13a + CR 614.6: "put into exile" names the
+            // arrival (Corpse Appraiser: "If a card is put into exile this
+            // way, …"). Distinct from cause-bound "exiled this way": a
+            // replacement that redirects the move away from exile defeats
+            // this clause, because the replaced event never happened.
+            value(
+                Some(crate::types::zones::Zone::Exile),
+                tag("put into exile"),
             ),
         ))
         .parse(rest)?,
@@ -20659,6 +20670,22 @@ mod tests {
         assert_eq!(rest, ", draw a card");
         assert!(!negated);
         assert_eq!(destination, Some(Zone::Graveyard));
+
+        // CR 608.2c + CR 701.13a + CR 614.6: destination-bound exile wording
+        // (Corpse Appraiser) is the exile sibling of "put into a graveyard".
+        let (rest, (filter, negated, destination)) = parse_zone_changed_this_way_clause(
+            "a card is put into exile this way, look at the top three cards",
+        )
+        .unwrap();
+        assert_eq!(rest, ", look at the top three cards");
+        assert!(!negated);
+        assert_eq!(destination, Some(Zone::Exile));
+        match filter {
+            TargetFilter::Typed(TypedFilter { type_filters, .. }) => {
+                assert_eq!(type_filters, vec![TypeFilter::Card]);
+            }
+            other => panic!("expected Typed Card, got {other:?}"),
+        }
     }
 
     /// Every imperative verb in the `alt` chain must round-trip; this guards

--- a/crates/engine/tests/integration/corpse_appraiser.rs
+++ b/crates/engine/tests/integration/corpse_appraiser.rs
@@ -1,0 +1,157 @@
+//! Corpse Appraiser — ETB exile from a graveyard, then dig if a card was
+//! put into exile this way.
+//!
+//! Oracle: "When this creature enters, exile up to one target creature card
+//! from a graveyard. If a card is put into exile this way, look at the top
+//! three cards of your library, then put one of those cards into your hand
+//! and the rest into your graveyard."
+
+use engine::game::scenario::{GameScenario, P0, P1};
+use engine::parser::oracle::parse_oracle_text;
+use engine::types::ability::{AbilityCondition, Effect, QuantityExpr, TypeFilter};
+use engine::types::actions::GameAction;
+use engine::types::game_state::WaitingFor;
+use engine::types::identifiers::ObjectId;
+use engine::types::mana::{ManaType, ManaUnit};
+use engine::types::phase::Phase;
+use engine::types::triggers::TriggerMode;
+use engine::types::zones::Zone;
+
+const CORPSE_APPRAISER: &str = "When this creature enters, exile up to one target creature card from a graveyard. If a card is put into exile this way, look at the top three cards of your library, then put one of those cards into your hand and the rest into your graveyard.";
+
+fn floating_ubr() -> Vec<ManaUnit> {
+    vec![
+        ManaUnit::new(ManaType::Blue, ObjectId(0), false, vec![]),
+        ManaUnit::new(ManaType::Black, ObjectId(0), false, vec![]),
+        ManaUnit::new(ManaType::Red, ObjectId(0), false, vec![]),
+    ]
+}
+
+/// SHAPE: the leading-if "put into exile this way" peels so the look-at +
+/// put-one-keep-rest chain can assemble as a `Dig` gated by
+/// `ZoneChangedThisWay { destination: Exile }`.
+#[test]
+fn corpse_appraiser_etb_parses_exile_then_conditional_dig() {
+    let parsed = parse_oracle_text(CORPSE_APPRAISER, "Corpse Appraiser", &[], &[], &[]);
+    let etb = parsed
+        .triggers
+        .iter()
+        .find(|t| t.mode == TriggerMode::ChangesZone)
+        .expect("ETB trigger");
+    let execute = etb.execute.as_ref().expect("execute");
+    assert!(
+        matches!(
+            execute.effect.as_ref(),
+            Effect::ChangeZone {
+                origin: Some(Zone::Graveyard),
+                destination: Zone::Exile,
+                ..
+            }
+        ),
+        "first instruction is exile from a graveyard, got {:?}",
+        execute.effect
+    );
+    let dig = execute.sub_ability.as_ref().expect("dig sub_ability");
+    let Effect::Dig {
+        count,
+        keep_count,
+        destination,
+        rest_destination,
+        ..
+    } = &*dig.effect
+    else {
+        panic!("expected Dig follow-up, got {:?}", dig.effect);
+    };
+    assert_eq!(*count, QuantityExpr::Fixed { value: 3 });
+    assert_eq!(*keep_count, Some(1));
+    assert_eq!(*destination, Some(Zone::Hand));
+    assert_eq!(*rest_destination, Some(Zone::Graveyard));
+    let Some(AbilityCondition::ZoneChangedThisWay {
+        filter,
+        destination: this_way_dest,
+    }) = &dig.condition
+    else {
+        panic!(
+            "Dig must be gated by ZoneChangedThisWay, got {:?}",
+            dig.condition
+        );
+    };
+    assert_eq!(*this_way_dest, Some(Zone::Exile));
+    match filter {
+        engine::types::ability::TargetFilter::Typed(typed) => {
+            assert_eq!(typed.type_filters, vec![TypeFilter::Card]);
+        }
+        other => panic!("expected Typed Card this-way filter, got {other:?}"),
+    }
+}
+
+/// CR 608.2c + CR 701.13a + CR 701.20e: exiling a graveyard creature card
+/// makes the "put into exile this way" gate true, so the look-at-three
+/// instruction surfaces a DigChoice (keep one, rest to graveyard).
+#[test]
+fn corpse_appraiser_etb_exile_surfaces_dig_choice() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let appraiser = scenario
+        .add_creature_to_hand_from_oracle(P0, "Corpse Appraiser", 3, 3, CORPSE_APPRAISER)
+        .id();
+    let gy_creature = scenario
+        .add_creature_to_graveyard(P1, "Doomed Bear", 2, 2)
+        .id();
+    let mill_two = scenario.add_card_to_library_top(P0, "Mill Two");
+    let mill_one = scenario.add_card_to_library_top(P0, "Mill One");
+    let keep = scenario.add_card_to_library_top(P0, "Keep Me");
+    scenario.with_mana_pool(P0, floating_ubr());
+
+    let mut runner = scenario.build();
+    let outcome = runner.cast(appraiser).target_object(gy_creature).resolve();
+
+    assert_eq!(
+        outcome.zone_of(gy_creature),
+        Zone::Exile,
+        "the targeted graveyard creature card must be exiled"
+    );
+
+    let WaitingFor::DigChoice {
+        cards,
+        keep_count,
+        rest_destination,
+        kept_destination,
+        ..
+    } = outcome.final_waiting_for()
+    else {
+        panic!(
+            "expected DigChoice after a card is put into exile this way, got {:?}",
+            outcome.final_waiting_for()
+        );
+    };
+    assert_eq!(*keep_count, 1);
+    assert_eq!(*kept_destination, Some(Zone::Hand));
+    assert_eq!(*rest_destination, Some(Zone::Graveyard));
+    assert_eq!(cards.len(), 3, "look at the top three cards");
+    assert!(
+        cards.contains(&keep) && cards.contains(&mill_one) && cards.contains(&mill_two),
+        "DigChoice must offer the three looked-at library cards, got {cards:?}"
+    );
+
+    runner
+        .act(GameAction::SelectCards { cards: vec![keep] })
+        .expect("DigChoice SelectCards must succeed");
+
+    let state = runner.state();
+    assert_eq!(
+        state.objects[&keep].zone,
+        Zone::Hand,
+        "the chosen looked-at card goes to hand"
+    );
+    assert_eq!(
+        state.objects[&mill_one].zone,
+        Zone::Graveyard,
+        "the rest of the looked-at cards go to the graveyard"
+    );
+    assert_eq!(
+        state.objects[&mill_two].zone,
+        Zone::Graveyard,
+        "the rest of the looked-at cards go to the graveyard"
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -143,6 +143,7 @@ mod copied_ability_transform_generation;
 mod copy_gy_creature_mana_value_x;
 mod copy_retarget_past_rider;
 mod copy_token_except_keyword_and_quoted_ability;
+mod corpse_appraiser;
 mod cosmic_intervention_graveyard_redirect;
 mod cost_x_carrier_runtime;
 mod cost_zone_pipeline;

--- a/docs/parser-misparse-backlog.md
+++ b/docs/parser-misparse-backlog.md
@@ -1884,7 +1884,6 @@ This is the prioritized "fix N root causes → unlock M cards" backlog: the top 
 - Conductive Current
 - Conundrum Sphinx
 - Convenient Target
-- Corpse Appraiser
 - Corruption of Towashi
 - Cosmic Horror
 - Covenant of Minds


### PR DESCRIPTION
## Summary

Recognize destination-bound "put into exile this way" so Corpse Appraiser's ETB peels the If-gate and the existing look-at-three / keep-one / rest-to-graveyard Dig chain assembles.

## Files changed

- `crates/engine/src/parser/oracle_nom/condition.rs` — add `tag("put into exile")` arm on the this-way verb `alt()`, plus combinator unit coverage
- `crates/engine/src/parser/oracle_effect/conditions.rs` — comment lockstep with the new destination-bound verb
- `crates/engine/tests/integration/corpse_appraiser.rs` — SHAPE parse + GameRunner ETB DigChoice test
- `crates/engine/tests/integration/main.rs` — register the integration module
- `docs/parser-misparse-backlog.md` — remove Corpse Appraiser

## Track

Developer

## LLM

Model: grok-4.6
Tier: Frontier
Thinking: high

## Implementation method (required)

Method: /engine-implementer

> [!NOTE]
> Combinator subset of `/engine-implementer`: in-thread implement + one `/review-impl`. Did not spawn the plan-review loop.

## CR references

- CR 608.2c — later text on the same effect refers to objects moved by the prior instruction; instructions are followed in written order
- CR 701.13a — to exile an object, move it to the exile zone
- CR 614.6 — a replaced event never happens, so destination-bound "put into exile this way" is defeated by a redirect away from exile
- CR 701.20e — look at the top N cards (private Dig)

## Verification

- [x] Required checks ran clean, or the exact CI-owned alternative is stated below.
- [x] Gate A output below is for the current committed head.
- [x] Final review-impl below is clean for the current committed head.
- [x] Both anchors cite existing analogous code at the same seam.

- `cargo fmt --all` — clean
- `cargo test -p phase-engine --lib -- test_zone_changed_this_way_destination_bound` — 1 passed
- `cargo test -p phase-engine --test integration corpse_appraiser` — 2 passed
- `cargo clippy -p phase-engine --lib -- -D warnings` — clean

Did not run `cargo test -p phase-engine` (whole package), `gen-card-data`, `cargo coverage`, `cargo semantic-audit`, or repo pre-push. CI owns those.

## Gate A

Gate A PASS head=527b9d72e7fc3d37f88735a7e11befd419442fea base=aa6948a4f7970661e700bb653f218b542763b32d

## Anchored on

- crates/engine/src/parser/oracle_nom/condition.rs:9893 — destination-bound `tag("put onto the battlefield")` in the same `ThisWayVerbScope::AnyZoneChange` verb `alt()`
- crates/engine/src/parser/oracle_nom/condition.rs:9908 — destination-bound `tag("put into a graveyard")` sibling in that same `alt()`

## Final review-impl

Final review-impl PASS head=527b9d72e7fc3d37f88735a7e11befd419442fea

## Claimed parse impact

Corpse Appraiser

## Scope Expansion

None.

## Validation Failures

None.

## CI Failures

None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved rules-text parsing for effects that put cards into exile.
  - Added support for correctly interpreting “put into exile this way” conditions, including card-type filters.
  - Added complete parsing and gameplay support for Corpse Appraiser, including exiling a creature from a graveyard and resolving its “look at three” choice.

- **Bug Fixes**
  - Corrected handling of chained effects and exile-related zone changes for Corpse Appraiser.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->