### PR TITLE
fix(parser): bind "that creature" in damage triggers to the damage recipient

### DIFF
--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -36899,6 +36899,21 @@ pub(crate) fn parse_effect_chain_ir(
                         .flatten()
                 }),
             card_name: ctx.card_name.clone(),
+            // CR 608.2k: the DEMONSTRATIVE-scoped antecedent is a property of
+            // the whole trigger body (the Kashi-Tribe "tap that creature and it
+            // doesn't untap" tail lives in a sub-ability chunk), so it
+            // propagates like `plural_object_pronoun_ref`. It shares
+            // `object_pronoun_ref`'s first rung: CR 608.2k's nearest-antecedent
+            // rule means a typed referent introduced by an EARLIER chunk in this
+            // same chain outranks the outer trigger condition, and a
+            // demonstrative naming it binds that nearer choice.
+            //
+            // The `binds_source_counter_pronoun` rung is deliberately absent:
+            // that gate exists for the bare "it" pronoun's source-counter class
+            // (#8549), which is not a demonstrative grammar.
+            demonstrative_object_ref: prior_typed_referent
+                .then_some(TargetFilter::ParentTarget)
+                .or_else(|| ctx.demonstrative_object_ref.clone()),
             // CR 707.9a + CR 603.1: propagate the trigger index from the parent
             // ctx — `current_trigger_index` is a property of the whole trigger
             // body, not of an individual chunk, so all chunks inside a trigger

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -36899,14 +36899,12 @@ pub(crate) fn parse_effect_chain_ir(
                         .flatten()
                 }),
             card_name: ctx.card_name.clone(),
-            // CR 608.2k: the DEMONSTRATIVE-scoped antecedent is a property of
-            // the whole trigger body (the Kashi-Tribe "tap that creature and it
-            // doesn't untap" tail lives in a sub-ability chunk), so it
-            // propagates like `plural_object_pronoun_ref`. It shares
-            // `object_pronoun_ref`'s first rung: CR 608.2k's nearest-antecedent
-            // rule means a typed referent introduced by an EARLIER chunk in this
-            // same chain outranks the outer trigger condition, and a
-            // demonstrative naming it binds that nearer choice.
+            // The DEMONSTRATIVE-scoped antecedent is a property of the whole
+            // trigger body (the Kashi-Tribe "tap that creature and it doesn't
+            // untap" tail lives in a sub-ability chunk), so it propagates like
+            // `plural_object_pronoun_ref`. A typed referent introduced by an
+            // earlier chunk is more specific than the outer trigger-condition
+            // context, so a later demonstrative retains that chain-local binding.
             //
             // The `binds_source_counter_pronoun` rung is deliberately absent:
             // that gate exists for the bare "it" pronoun's source-counter class

--- a/crates/engine/src/parser/oracle_ir/context.rs
+++ b/crates/engine/src/parser/oracle_ir/context.rs
@@ -166,6 +166,20 @@ pub(crate) struct ParseContext {
     /// "choose one of them at random. You may cast IT" — "it" is the chosen card,
     /// not the pool).
     pub plural_object_pronoun_ref: Option<TargetFilter>,
+    /// CR 608.2k: Antecedent for a singular DEMONSTRATIVE ("that creature" /
+    /// "that permanent" / "that card" / "that token") in the current trigger
+    /// body. Deliberately separate from — and narrower than —
+    /// `object_pronoun_ref`, on the same principle that separates
+    /// `plural_object_pronoun_ref` from it: which references may capture a given
+    /// antecedent is a property of the surface grammar, not of the antecedent.
+    ///
+    /// Set only for the damage-RECIPIENT provenance (a demonstrative names an
+    /// object the condition acted upon), by
+    /// `oracle_trigger::trigger_demonstrative_object_ref_for_condition`. The
+    /// spell-cast provenance is excluded: "exile THAT CARD ... instead of putting
+    /// it into your graveyard as it resolves" is a replacement clause whose
+    /// demonstrative belongs to its own grammar.
+    pub demonstrative_object_ref: Option<TargetFilter>,
     /// Accumulated diagnostics for the current card parse (Phase 52, D-07).
     /// Replaces thread-local oracle_warnings accumulator.
     pub diagnostics: Vec<OracleDiagnostic>,

--- a/crates/engine/src/parser/oracle_target.rs
+++ b/crates/engine/src/parser/oracle_target.rs
@@ -982,6 +982,26 @@ pub fn parse_target_with_syntax<'a>(
             {
                 return (slot_filter, &text[lower.len() - slot_rest.len()..], syntax);
             }
+            // CR 608.2k: a pinned untargeted antecedent — "the specific
+            // untargeted object … previously referred to by that ability's …
+            // trigger condition" — outranks the generic `ParentTarget` lift
+            // below, exactly as it does for the bare-pronoun family in
+            // `resolve_pronoun_target` (which consults this same field before
+            // its own `ctx.subject` match). CR 608.2k draws no distinction
+            // between a demonstrative and a pronoun naming that object, so the
+            // two must not bind differently.
+            //
+            // This branch previously mirrored only `resolve_pronoun_target`'s
+            // `ctx.subject` consultation (the `CostPaidObject` arm below) and
+            // not its pin consultation, so one sentence could resolve the same
+            // referent two ways: the Kashi-Tribe cycle's "tap THAT CREATURE and
+            // IT doesn't untap during its controller's next untap step" bound
+            // "it" to the damaged creature and "that creature" to a parent
+            // target the untargeted trigger never had — leaving the tap with no
+            // subject at all. Completing the mirror unifies them.
+            if let Some(pinned) = ctx.object_pronoun_ref.clone() {
+                return (pinned, rem, syntax);
+            }
             // CR 608.2c + CR 701.21a: a gated "If you do," clause whose
             // antecedent is a resolution-time choice with no target concept
             // of its own (`Effect::Sacrifice`) seeds `ctx.subject` with

--- a/crates/engine/src/parser/oracle_target.rs
+++ b/crates/engine/src/parser/oracle_target.rs
@@ -986,10 +986,10 @@ pub fn parse_target_with_syntax<'a>(
             // untargeted object … previously referred to by that ability's …
             // trigger condition" — outranks the generic `ParentTarget` lift
             // below, exactly as it does for the bare-pronoun family in
-            // `resolve_pronoun_target` (which consults this same field before
-            // its own `ctx.subject` match). CR 608.2k draws no distinction
-            // between a demonstrative and a pronoun naming that object, so the
-            // two must not bind differently.
+            // `resolve_pronoun_target` (which consults its own pin before its
+            // `ctx.subject` match). CR 608.2k draws no distinction between a
+            // demonstrative and a pronoun naming that object, so where both may
+            // name it, the two must not bind differently.
             //
             // This branch previously mirrored only `resolve_pronoun_target`'s
             // `ctx.subject` consultation (the `CostPaidObject` arm below) and
@@ -999,7 +999,15 @@ pub fn parse_target_with_syntax<'a>(
             // "it" to the damaged creature and "that creature" to a parent
             // target the untargeted trigger never had — leaving the tap with no
             // subject at all. Completing the mirror unifies them.
-            if let Some(pinned) = ctx.object_pronoun_ref.clone() {
+            //
+            // Reads the DEMONSTRATIVE-scoped pin, not the wider bare-pronoun
+            // pin. The two provenances are not interchangeable here: a
+            // spell-cast body's "exile THAT CARD ... instead of putting it into
+            // your graveyard as it resolves" (Gandalf of the Secret Fire,
+            // Goliath Daydreamer) is a replacement clause whose demonstrative is
+            // consumed by its own grammar, and binding it to the cast spell
+            // reclassifies the clause into a silently swallowed replacement.
+            if let Some(pinned) = ctx.demonstrative_object_ref.clone() {
                 return (pinned, rem, syntax);
             }
             // CR 608.2c + CR 701.21a: a gated "If you do," clause whose

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -1515,6 +1515,10 @@ pub(crate) fn parse_trigger_line_with_index_ir(
         // otherwise bind "return it" to the cast spell instead of the Phoenix.
         object_pronoun_ref: trigger_object_pronoun_ref_for_intervening_if(&if_condition)
             .or_else(|| trigger_object_pronoun_ref_for_condition(condition_text, &trigger_subject)),
+        demonstrative_object_ref: trigger_demonstrative_object_ref_for_condition(
+            condition_text,
+            &trigger_subject,
+        ),
         plural_object_pronoun_ref: trigger_plural_object_pronoun_ref_for_intervening_if(
             &if_condition,
         ),
@@ -10892,8 +10896,30 @@ fn parse_passive_dealt_damage(input: &str) -> OracleResult<'_, ()> {
     Ok((input, ()))
 }
 
+/// CR 120.1: the ACTIVE-voice damage verb, both grammatical numbers.
+///
+/// Singular `"deals"` and plural `"deal"` (a `&`-joined subject, or a plural
+/// noun phrase such as "creatures you control") are the same verb on the same
+/// axis, so every consumer of the active-voice damage grammar must accept both
+/// or they drift apart. `try_parse_event`'s subject-led damage arm collapsed
+/// them from the start; this is that same alternative, factored so the
+/// antecedent scan below and the trigger parsers cannot diverge.
+///
+/// A scan that accepted only `"deals "` while the trigger parser accepted both
+/// is precisely how a plural condition ("Whenever creatures you control deal
+/// combat damage to a creature, destroy that creature") classifies as
+/// `DamageDone` yet leaves its recipient antecedent unset — the trigger fires
+/// and the effect resolves against nothing.
+fn parse_damage_verb(input: &str) -> OracleResult<'_, ()> {
+    alt((
+        value((), tag::<_, _, OracleError<'_>>("deals ")),
+        value((), tag("deal ")),
+    ))
+    .parse(input)
+}
+
 /// CR 120.1 + CR 120.3 + CR 608.2k: the ACTIVE-voice damage verb phrase that
-/// names an OBJECT recipient — "deals [combat|noncombat|excess] [N or more]
+/// names an OBJECT recipient — "deal[s] [combat|noncombat|excess] [N or more]
 /// damage to <object>".
 ///
 /// The voice dual of [`parse_passive_dealt_damage`]. In the active voice the
@@ -10904,12 +10930,13 @@ fn parse_passive_dealt_damage(input: &str) -> OracleResult<'_, ()> {
 /// Sliver deals combat damage to a creature, destroy THAT CREATURE" destroys the
 /// damaged creature, never the Sliver that dealt the damage.
 ///
-/// Composed entirely from the two combinators the `DamageDone` trigger grammar
-/// already uses for this exact tail — `parse_damage_predicate_tail` (damage
-/// class × amount threshold) and `parse_object_recipient_filter` (the recipient
-/// axis) — so the antecedent recognized here is by construction the same
-/// recipient `try_parse_source_deals_damage_trigger` stores in
-/// `TriggerDefinition::valid_target`, and both move together when either axis
+/// Composed entirely from the combinators the `DamageDone` trigger grammar
+/// already uses for this exact phrase — `parse_damage_verb` (grammatical
+/// number), `parse_damage_predicate_tail` (damage class × amount threshold) and
+/// `parse_object_recipient_filter` (the recipient axis) — so the antecedent
+/// recognized here is by construction the same recipient
+/// `try_parse_source_deals_damage_trigger` stores in
+/// `TriggerDefinition::valid_target`, and all three move together when any axis
 /// gains a form.
 ///
 /// `parse_object_recipient_filter` is what makes this OBJECT-only: it requires
@@ -10918,10 +10945,84 @@ fn parse_passive_dealt_damage(input: &str) -> OracleResult<'_, ()> {
 /// player-recipient trigger ("deals combat damage to a player") never reaches
 /// here and keeps its own `TriggeringPlayer` / `DefendingPlayer` antecedents.
 fn parse_active_deals_damage_to_object(input: &str) -> OracleResult<'_, ()> {
-    let (input, _) = tag("deals ").parse(input)?;
+    let (input, _) = parse_damage_verb(input)?;
     let (input, _) = parse_damage_predicate_tail(input)?;
     let (input, _) = parse_object_recipient_filter(input)?;
     Ok((input, ()))
+}
+
+/// CR 608.2k + CR 120.1 + CR 120.3: the damage RECIPIENT antecedent introduced
+/// by a damage trigger's condition, in either voice.
+///
+/// Single authority for "the trigger condition named an object that the damage
+/// was dealt TO". Both voices resolve to [`TargetFilter::EventTarget`], which
+/// reads `GameEvent::DamageDealt.target`:
+///
+///   * PASSIVE — "whenever `<subject>` is dealt damage": the grammatical subject
+///     IS the recipient. Gated on a non-self-referential subject, because on a
+///     self-scoped enrage trigger the recipient is the source itself and
+///     `SelfRef`/`ParentTarget` are the more precise antecedents — they resolve
+///     without consulting the trigger event at all.
+///   * ACTIVE — "whenever `<source>` deals damage to a creature": the subject is
+///     the SOURCE and the recipient is a different object, named by the
+///     `"to <object>"` tail. Deliberately NOT gated on a self-referential
+///     subject: voice is exactly what makes that gate unnecessary, and Phage the
+///     Untouchable ("Whenever Phage deals combat damage to a creature") has a
+///     self-referential subject while still meaning the damaged creature.
+///
+/// The subject phrase is arbitrarily long ("a creature or planeswalker an
+/// opponent controls with a bounty counter on it"), so each verb phrase is found
+/// by scanning the shared word-boundary primitive rather than by anchoring at a
+/// fixed offset.
+fn trigger_damage_recipient_ref_for_condition(
+    after_keyword: &str,
+    trigger_subject: &TargetFilter,
+) -> Option<TargetFilter> {
+    use crate::parser::oracle_nom::primitives::scan_at_word_boundaries;
+
+    // CR 608.2k + CR 120.1: a PASSIVE-voice damage trigger condition ("whenever
+    // <subject> is dealt damage") makes its grammatical subject the damage
+    // RECIPIENT, so the effect body's untargeted object anaphor ("destroy it",
+    // "put a +1/+1 counter on it") names the damaged permanent. The
+    // subject-derived `TargetFilter::TriggeringSource` fallback in
+    // `resolve_it_pronoun` reads `.source_id`, which on a passive-voice trigger
+    // is the damage DEALER — a different object entirely (Termination
+    // Facilitator destroyed the source of the damage instead of the bountied
+    // creature, issue #8379).
+    //
+    // Gated on the subject NOT being self-referential, mirroring the exclusion
+    // set both pronoun resolvers already apply (`resolve_it_pronoun`,
+    // `resolve_pronoun_target`).
+    let subject_is_self_referential = matches!(
+        trigger_subject,
+        TargetFilter::SelfRef | TargetFilter::Any | TargetFilter::CostPaidObject
+    );
+    if !subject_is_self_referential
+        && scan_at_word_boundaries(after_keyword, parse_passive_dealt_damage).is_some()
+    {
+        return Some(TargetFilter::EventTarget);
+    }
+
+    // CR 608.2k + CR 120.1 + CR 120.3: the ACTIVE-voice sibling. "Destroy that
+    // creature" / "exile that creature" / "tap that creature" / "put a -1/-1
+    // counter on that creature" all name the damaged permanent (Phage the
+    // Untouchable, Toxin Sliver, Stinkweed Imp, Pit Spawn, Sword of Kaldra,
+    // Kaldra Compleat, the Kashi-Tribe and basilisk cycles, Obelisk Spider).
+    //
+    // Without the pin, the reference fell through to the generic anaphor grammar
+    // and bound `ParentTarget`. An untargeted damage trigger has no chosen
+    // target, and the parentless-`ParentTarget` event fallback in
+    // `game/targeting.rs` carries no `DamageDealt` arm, so the referent resolved
+    // to NOTHING and every effect in the class silently did nothing. The
+    // subject-derived `TriggeringSource` fallback is equally wrong here and worse
+    // for being plausible: on an active-voice condition the event's `source_id`
+    // is the damage DEALER, so "destroy that creature" would destroy the
+    // blocking creature instead of the attacker.
+    if scan_at_word_boundaries(after_keyword, parse_active_deals_damage_to_object).is_some() {
+        return Some(TargetFilter::EventTarget);
+    }
+
+    None
 }
 
 fn trigger_object_pronoun_ref_for_condition(
@@ -10954,80 +11055,54 @@ fn trigger_object_pronoun_ref_for_condition(
         return Some(TargetFilter::TriggeringSource);
     }
 
-    // CR 608.2k + CR 120.1: a PASSIVE-voice damage trigger condition ("whenever
-    // <subject> is dealt damage") makes its grammatical subject the damage
-    // RECIPIENT, so the effect body's untargeted object anaphor ("destroy it",
-    // "put a +1/+1 counter on it") names the damaged permanent — CR 608.2k's
-    // "specific untargeted object … previously referred to by that ability's …
-    // trigger condition". `TargetFilter::EventTarget` reads
-    // `GameEvent::DamageDealt.target`; the subject-derived
-    // `TargetFilter::TriggeringSource` fallback in `resolve_it_pronoun` reads
-    // `.source_id`, which on a passive-voice trigger is the damage DEALER — a
-    // different object entirely (Termination Facilitator destroyed the source of
-    // the damage instead of the bountied creature, issue #8379).
-    //
-    // The subject phrase is arbitrarily long ("a creature or planeswalker an
-    // opponent controls with a bounty counter on it"), so the verb phrase is
-    // found by scanning the shared word-boundary primitive rather than by
-    // anchoring at a fixed offset.
-    //
-    // Gated on the subject NOT being self-referential, mirroring the exclusion
-    // set both pronoun resolvers already apply (`resolve_it_pronoun`,
-    // `resolve_pronoun_target`): on a self-scoped enrage trigger ("whenever this
-    // creature is dealt damage") the recipient IS the source, and `SelfRef` /
-    // `ParentTarget` remain the more precise antecedents — they resolve without
-    // consulting the trigger event at all.
-    let subject_is_self_referential = matches!(
-        trigger_subject,
-        TargetFilter::SelfRef | TargetFilter::Any | TargetFilter::CostPaidObject
-    );
-    if !subject_is_self_referential
-        && crate::parser::oracle_nom::primitives::scan_at_word_boundaries(
-            after_keyword,
-            parse_passive_dealt_damage,
-        )
-        .is_some()
+    // CR 608.2k + CR 120.1 + CR 120.3: a damage trigger condition names the
+    // damage RECIPIENT as the body's untargeted object antecedent, in either
+    // voice. Delegated to the single authority so the bare-pronoun pin and the
+    // demonstrative pin below can never recognize different condition shapes.
+    if let Some(recipient) =
+        trigger_damage_recipient_ref_for_condition(after_keyword, trigger_subject)
     {
-        return Some(TargetFilter::EventTarget);
-    }
-
-    // CR 608.2k + CR 120.1 + CR 120.3: an ACTIVE-voice damage trigger condition
-    // that names an OBJECT recipient ("whenever <source> deals combat damage to a
-    // creature") introduces that RECIPIENT as the effect body's untargeted object
-    // antecedent — CR 608.2k's "specific untargeted object … previously referred
-    // to by that ability's … trigger condition". "Destroy that creature" /
-    // "exile that creature" / "tap that creature" / "put a -1/-1 counter on that
-    // creature" all name the damaged permanent (Phage the Untouchable, Toxin
-    // Sliver, Stinkweed Imp, Pit Spawn, Sword of Kaldra, Kaldra Compleat, the
-    // Kashi-Tribe and basilisk cycles, Obelisk Spider, Sosuke).
-    //
-    // Without the pin, the demonstrative fell through to the generic anaphor
-    // grammar and bound `ParentTarget`. An untargeted damage trigger has no
-    // chosen target, and the parentless-`ParentTarget` event fallback in
-    // `game/targeting.rs` carries no `DamageDealt` arm, so the referent resolved
-    // to NOTHING and every effect in the class silently did nothing. The
-    // subject-derived `TriggeringSource` fallback is equally wrong here and worse
-    // for being plausible: on an active-voice condition the event's `source_id`
-    // is the damage DEALER, so "destroy that creature" would destroy the
-    // attacking creature's own controller's permanent.
-    //
-    // Unlike the passive-voice branch above, this one is NOT gated on the subject
-    // being non-self-referential. Voice is exactly what makes that gate
-    // unnecessary: in the passive voice the subject IS the recipient (so a
-    // self-scoped enrage trigger keeps the more precise `SelfRef`), while in the
-    // active voice the subject is the source and the recipient is a DIFFERENT
-    // object — Phage's "whenever Phage deals combat damage to a creature" has a
-    // self-referential subject and still means the damaged creature.
-    if crate::parser::oracle_nom::primitives::scan_at_word_boundaries(
-        after_keyword,
-        parse_active_deals_damage_to_object,
-    )
-    .is_some()
-    {
-        return Some(TargetFilter::EventTarget);
+        return Some(recipient);
     }
 
     None
+}
+
+/// CR 608.2k: the antecedent a singular DEMONSTRATIVE ("that creature" / "that
+/// permanent" / "that card" / "that token") in the current trigger body may
+/// bind, as opposed to the wider set a bare pronoun ("it") may bind.
+///
+/// Deliberately NARROWER than [`trigger_object_pronoun_ref_for_condition`], and
+/// separate for the same reason `plural_object_pronoun_ref` is separate from
+/// `object_pronoun_ref`: this codebase pins antecedents per surface form,
+/// because which references a given antecedent may capture is a property of the
+/// grammar, not of the antecedent alone.
+///
+/// Only the damage-RECIPIENT provenance qualifies. A demonstrative names an
+/// object the condition acted UPON, which is exactly what the `"to <object>"`
+/// tail (active voice) and the grammatical subject (passive voice) supply.
+///
+/// The spell-cast provenance deliberately does NOT qualify. "Whenever you cast
+/// an instant or sorcery spell from your hand, exile THAT CARD ... instead of
+/// putting it into your graveyard as it resolves" (Gandalf of the Secret Fire,
+/// Goliath Daydreamer) is a replacement clause whose demonstrative is consumed
+/// by its own grammar; routing it through the cast-spell pin reclassifies the
+/// clause and silently swallows the replacement. Bare pronouns in a spell-cast
+/// body keep their `TriggeringSource` pin — that binding is unchanged.
+fn trigger_demonstrative_object_ref_for_condition(
+    condition_text: &str,
+    trigger_subject: &TargetFilter,
+) -> Option<TargetFilter> {
+    let lower = condition_text.to_lowercase();
+    let after_keyword = alt((
+        value((), tag::<_, _, OracleError<'_>>("whenever ")),
+        value((), tag("when ")),
+    ))
+    .parse(lower.as_str())
+    .map(|(rest, _)| rest)
+    .unwrap_or(&lower);
+
+    trigger_damage_recipient_ref_for_condition(after_keyword, trigger_subject)
 }
 
 /// CR 603.4 + CR 406.6 + CR 607.2a: an intervening-if introduces the

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -10892,6 +10892,38 @@ fn parse_passive_dealt_damage(input: &str) -> OracleResult<'_, ()> {
     Ok((input, ()))
 }
 
+/// CR 120.1 + CR 120.3 + CR 608.2k: the ACTIVE-voice damage verb phrase that
+/// names an OBJECT recipient — "deals [combat|noncombat|excess] [N or more]
+/// damage to <object>".
+///
+/// The voice dual of [`parse_passive_dealt_damage`]. In the active voice the
+/// grammatical subject is the damage SOURCE (CR 120.1: "an object that deals
+/// damage is the source of that damage"), so the subject is *not* the object a
+/// later anaphor names. What the condition introduces as the nearest object
+/// antecedent is the RECIPIENT named by the `"to <object>"` tail — "Whenever a
+/// Sliver deals combat damage to a creature, destroy THAT CREATURE" destroys the
+/// damaged creature, never the Sliver that dealt the damage.
+///
+/// Composed entirely from the two combinators the `DamageDone` trigger grammar
+/// already uses for this exact tail — `parse_damage_predicate_tail` (damage
+/// class × amount threshold) and `parse_object_recipient_filter` (the recipient
+/// axis) — so the antecedent recognized here is by construction the same
+/// recipient `try_parse_source_deals_damage_trigger` stores in
+/// `TriggerDefinition::valid_target`, and both move together when either axis
+/// gains a form.
+///
+/// `parse_object_recipient_filter` is what makes this OBJECT-only: it requires
+/// an `"a "`/`"an "` article plus a type phrase and explicitly declines the
+/// `"creature or player"` / `"creature or opponent"` disjunctions, so a
+/// player-recipient trigger ("deals combat damage to a player") never reaches
+/// here and keeps its own `TriggeringPlayer` / `DefendingPlayer` antecedents.
+fn parse_active_deals_damage_to_object(input: &str) -> OracleResult<'_, ()> {
+    let (input, _) = tag("deals ").parse(input)?;
+    let (input, _) = parse_damage_predicate_tail(input)?;
+    let (input, _) = parse_object_recipient_filter(input)?;
+    Ok((input, ()))
+}
+
 fn trigger_object_pronoun_ref_for_condition(
     condition_text: &str,
     trigger_subject: &TargetFilter,
@@ -10955,6 +10987,42 @@ fn trigger_object_pronoun_ref_for_condition(
             parse_passive_dealt_damage,
         )
         .is_some()
+    {
+        return Some(TargetFilter::EventTarget);
+    }
+
+    // CR 608.2k + CR 120.1 + CR 120.3: an ACTIVE-voice damage trigger condition
+    // that names an OBJECT recipient ("whenever <source> deals combat damage to a
+    // creature") introduces that RECIPIENT as the effect body's untargeted object
+    // antecedent — CR 608.2k's "specific untargeted object … previously referred
+    // to by that ability's … trigger condition". "Destroy that creature" /
+    // "exile that creature" / "tap that creature" / "put a -1/-1 counter on that
+    // creature" all name the damaged permanent (Phage the Untouchable, Toxin
+    // Sliver, Stinkweed Imp, Pit Spawn, Sword of Kaldra, Kaldra Compleat, the
+    // Kashi-Tribe and basilisk cycles, Obelisk Spider, Sosuke).
+    //
+    // Without the pin, the demonstrative fell through to the generic anaphor
+    // grammar and bound `ParentTarget`. An untargeted damage trigger has no
+    // chosen target, and the parentless-`ParentTarget` event fallback in
+    // `game/targeting.rs` carries no `DamageDealt` arm, so the referent resolved
+    // to NOTHING and every effect in the class silently did nothing. The
+    // subject-derived `TriggeringSource` fallback is equally wrong here and worse
+    // for being plausible: on an active-voice condition the event's `source_id`
+    // is the damage DEALER, so "destroy that creature" would destroy the
+    // attacking creature's own controller's permanent.
+    //
+    // Unlike the passive-voice branch above, this one is NOT gated on the subject
+    // being non-self-referential. Voice is exactly what makes that gate
+    // unnecessary: in the passive voice the subject IS the recipient (so a
+    // self-scoped enrage trigger keeps the more precise `SelfRef`), while in the
+    // active voice the subject is the source and the recipient is a DIFFERENT
+    // object — Phage's "whenever Phage deals combat damage to a creature" has a
+    // self-referential subject and still means the damaged creature.
+    if crate::parser::oracle_nom::primitives::scan_at_word_boundaries(
+        after_keyword,
+        parse_active_deals_damage_to_object,
+    )
+    .is_some()
     {
         return Some(TargetFilter::EventTarget);
     }

--- a/crates/engine/tests/integration/active_damage_trigger_recipient_anaphor.rs
+++ b/crates/engine/tests/integration/active_damage_trigger_recipient_anaphor.rs
@@ -113,9 +113,163 @@ fn active_damage_trigger_demonstrative_binds_the_damage_recipient() {
     }
 }
 
-/// CR 120.1: the PLAYER-recipient sibling must be untouched — "deals combat
-/// damage to a player" names no object recipient, so the object anaphor pin must
-/// not fire and "that player" keeps its own player-scope binding.
+/// CR 120.1: the PLURAL active-voice verb ("creatures you control **deal**
+/// combat damage…") is the same grammar as the singular. The trigger parser has
+/// always collapsed `deal`/`deals` into one alternative, so an antecedent scan
+/// that recognized only `deals` would classify these as `DamageDone` while
+/// leaving the recipient unpinned — the trigger fires and the effect resolves
+/// against nothing, which is the exact failure this whole class is about.
+///
+/// Both articles are exercised: `parse_object_recipient_filter` requires an
+/// `"a "`/`"an "` article, and `an` is the rarer path.
+#[test]
+fn plural_active_damage_verb_binds_the_damage_recipient() {
+    for (label, oracle) in [
+        (
+            "plural + a",
+            "Whenever creatures you control deal combat damage to a creature, destroy that creature.",
+        ),
+        (
+            "plural + an",
+            "Whenever creatures you control deal combat damage to an artifact creature, destroy that creature.",
+        ),
+        (
+            "singular + an",
+            "Whenever this creature deals combat damage to an artifact creature, destroy that creature.",
+        ),
+        (
+            "plural, noncombat, exile",
+            "Whenever Elves you control deal damage to a creature, exile that creature.",
+        ),
+    ] {
+        let effect = trigger_body_effect(oracle, "Plural Damage Probe");
+        assert_eq!(
+            effect_subject(&effect),
+            &TargetFilter::EventTarget,
+            "{label}: the plural verb must pin the recipient exactly as the singular does"
+        );
+    }
+}
+
+/// CR 608.2k: the demonstrative pin is scoped to the damage-RECIPIENT
+/// provenance. A SPELL-CAST trigger pins the cast spell for BARE PRONOUNS, but
+/// its "that card" demonstrative belongs to the replacement clause's own
+/// grammar — "exile that card with N counters on it **instead of putting it into
+/// your graveyard as it resolves**" (Gandalf of the Secret Fire, Goliath
+/// Daydreamer).
+///
+/// Widening the demonstrative to every pin provenance reclassified that clause
+/// and silently swallowed the replacement, so this is a REGRESSION RATCHET: the
+/// replacement must keep parsing, and the clause must not degrade into a
+/// swallowed/unimplemented shape.
+#[test]
+fn spell_cast_trigger_demonstrative_is_not_captured_by_the_recipient_pin() {
+    for (card, oracle) in [
+        (
+            "Goliath Daydreamer",
+            "Whenever you cast an instant or sorcery spell from your hand, exile that card with a dream counter on it instead of putting it into your graveyard as it resolves.",
+        ),
+        (
+            "Gandalf of the Secret Fire",
+            "Whenever you cast an instant or sorcery spell from your hand during an opponent's turn, exile that card with three time counters on it instead of putting it into your graveyard as it resolves.",
+        ),
+    ] {
+        let effect = trigger_body_effect(oracle, card);
+        let Effect::ChangeZone {
+            target,
+            origin,
+            destination,
+            ..
+        } = &effect
+        else {
+            panic!("{card}: expected a ChangeZone body, got {effect:?}");
+        };
+        assert_eq!(
+            target,
+            &TargetFilter::ParentTarget,
+            "{card}: a spell-cast demonstrative keeps its parent-target binding"
+        );
+        // CR 614: "instead of putting it into your graveyard as it resolves" is
+        // the replacement, modelled as a Graveyard -> Exile redirect. If the
+        // demonstrative is rebound, the clause reclassifies and this origin is
+        // lost -- which is how it showed up as a newly swallowed replacement.
+        assert_eq!(
+            origin,
+            &Some(Zone::Graveyard),
+            "{card}: the replaced graveyard origin must survive"
+        );
+        assert_eq!(destination, &Zone::Exile, "{card}: exiled instead");
+    }
+}
+
+/// CR 120.1 + CR 510.4 + CR 701.8a: the PLURAL verb end to end, not just in the
+/// parser. An observer with "Whenever creatures you control **deal** combat
+/// damage to a creature, destroy that creature" must destroy the attacker that a
+/// *different* creature damaged.
+///
+/// The parser-level plural test above proves the pin is set; this proves the
+/// pinned referent actually resolves to an object at runtime. Both are needed:
+/// the original defect in this class parsed "correctly" by every AST assertion
+/// and still resolved against nothing.
+#[test]
+fn plural_active_damage_trigger_destroys_the_damaged_creature_at_runtime() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let observer = {
+        let mut b = scenario.add_creature(P0, "Plural Observer", 2, 2);
+        b.from_oracle_text(
+            "Whenever creatures you control deal combat damage to a creature, destroy that creature.",
+        );
+        b.id()
+    };
+    let blocker = {
+        let mut b = scenario.add_creature(P0, "First Striker", 1, 1);
+        b.first_strike();
+        b.id()
+    };
+    let attacker = scenario.add_creature(P1, "Grizzly Bears", 2, 2).id();
+
+    let mut runner = scenario.build();
+    runner.state_mut().active_player = P1;
+    runner.advance_to_combat();
+    runner
+        .declare_attackers(&[(attacker, AttackTarget::Player(P0))])
+        .expect("declare attackers");
+    for _ in 0..8 {
+        if runner.waiting_for_kind() == "DeclareBlockers" {
+            break;
+        }
+        runner
+            .act(GameAction::PassPriority)
+            .expect("pass priority into the declare-blockers step");
+    }
+    runner
+        .declare_blockers(&[(blocker, attacker)])
+        .expect("declare blockers");
+
+    let outcome = runner.combat_damage();
+
+    assert_eq!(
+        outcome.zone_of(attacker),
+        Zone::Graveyard,
+        "the plural-verb trigger must destroy the damaged attacker"
+    );
+    assert_eq!(
+        outcome.zone_of(blocker),
+        Zone::Battlefield,
+        "CR 510.4: the attacker dies in the first-strike step and never strikes back"
+    );
+    assert_eq!(
+        outcome.zone_of(observer),
+        Zone::Battlefield,
+        "the observer is not its own referent"
+    );
+}
+
+/// CR 120.1 + CR 120.3: the PLAYER-recipient sibling must be untouched — "deals
+/// combat damage to a player" names no object recipient, so the object anaphor
+/// pin must not fire and "that player" keeps its own player-scope binding.
 #[test]
 fn player_recipient_damage_trigger_keeps_its_player_anaphor() {
     let abilities = engine::parser::oracle::parse_oracle_text(

--- a/crates/engine/tests/integration/active_damage_trigger_recipient_anaphor.rs
+++ b/crates/engine/tests/integration/active_damage_trigger_recipient_anaphor.rs
@@ -1,0 +1,200 @@
+//! CR 120.1 + CR 120.3 + CR 608.2k: the ACTIVE-voice damage trigger with an
+//! OBJECT recipient — "Whenever <source> deals [combat] damage to a creature,
+//! <do something to> that creature".
+//!
+//! Reported from live play with a Sliver deck: a Striking Sliver (1/1, granting
+//! first strike) blocked a 2/2 attacker while a Toxin Sliver was on the
+//! battlefield. Toxin Sliver's trigger fired and put a Destroy on the stack, but
+//! the attacker survived the first-strike step and killed the blocker in the
+//! regular combat damage step.
+//!
+//! Cause: "that creature" bound to `TargetFilter::ParentTarget`. An untargeted
+//! damage trigger has no chosen target, and the parentless-`ParentTarget` event
+//! fallback in `game/targeting.rs` carries no `DamageDealt` arm, so the referent
+//! resolved to NO object and the effect silently did nothing. The
+//! subject-derived `TriggeringSource` fallback would have been just as wrong in
+//! the other direction: on an ACTIVE-voice condition the event's `source_id` is
+//! the damage DEALER (CR 120.1), so "destroy that creature" would have destroyed
+//! the blocking Sliver instead of the attacker.
+//!
+//! The referent is the damage RECIPIENT — `TargetFilter::EventTarget`.
+//!
+//! These are building-block tests: the parser assertions cover the whole printed
+//! class across four different effect verbs (destroy / exile / tap / put a
+//! counter) and three source-filter shapes (self-referential by name, a subtype
+//! filter, a controller-scoped filter), not one card's text.
+
+use super::rules::{GameScenario, Phase, P0, P1};
+use engine::game::combat::AttackTarget;
+use engine::types::ability::{Effect, TargetFilter};
+use engine::types::actions::GameAction;
+use engine::types::zones::Zone;
+
+const TOXIN_SLIVER: &str = "Whenever a Sliver deals combat damage to a creature, destroy that creature. It can't be regenerated.";
+const STRIKING_SLIVER: &str = "Sliver creatures you control have first strike.";
+
+/// Parse a single trigger line and return the top-level effect of its body.
+fn trigger_body_effect(oracle: &str, card_name: &str) -> Effect {
+    let abilities = engine::parser::oracle::parse_oracle_text(oracle, card_name, &[], &[], &[]);
+    let trigger = abilities
+        .triggers
+        .first()
+        .unwrap_or_else(|| panic!("{card_name}: expected a triggered ability"));
+    let execute = trigger
+        .execute
+        .as_deref()
+        .unwrap_or_else(|| panic!("{card_name}: trigger has no body"));
+    (*execute.effect).clone()
+}
+
+/// The primary object referent of an effect, for the four verbs this class uses.
+fn effect_subject(effect: &Effect) -> &TargetFilter {
+    match effect {
+        Effect::Destroy { target, .. }
+        | Effect::ChangeZone { target, .. }
+        | Effect::SetTapState { target, .. }
+        | Effect::PutCounter { target, .. } => target,
+        other => panic!("unexpected effect shape: {other:?}"),
+    }
+}
+
+/// CR 608.2k: "that creature" in an active-voice damage trigger names the damage
+/// RECIPIENT, across every effect verb and every source-filter shape in the
+/// class. Binding it to `ParentTarget` (no referent on an untargeted trigger) or
+/// to `TriggeringSource` (the damage dealer) are both wrong.
+#[test]
+fn active_damage_trigger_demonstrative_binds_the_damage_recipient() {
+    for (card, oracle) in [
+        // Subtype-filtered source.
+        ("Toxin Sliver", TOXIN_SLIVER),
+        // Self-referential source by name — the recipient is still a DIFFERENT
+        // object, so the self-referential subject must not suppress the binding
+        // the way it does for the passive-voice ("is dealt damage") class.
+        (
+            "Phage the Untouchable",
+            "Whenever Phage deals combat damage to a creature, destroy that creature. It can't be regenerated.",
+        ),
+        (
+            "Stinkweed Imp",
+            "Whenever this creature deals combat damage to a creature, destroy that creature.",
+        ),
+        // Noncombat-inclusive ("deals damage", no kind adjective) + exile verb.
+        (
+            "Pit Spawn",
+            "Whenever this creature deals damage to a creature, exile that creature.",
+        ),
+        // Attachment source subject.
+        (
+            "Sword of Kaldra",
+            "Whenever equipped creature deals damage to a creature, exile that creature.",
+        ),
+        // Tap verb.
+        (
+            "Kashi-Tribe Elite",
+            "Whenever this creature deals combat damage to a creature, tap that creature and it doesn't untap during its controller's next untap step.",
+        ),
+        // Counter verb.
+        (
+            "Obelisk Spider",
+            "Whenever this creature deals combat damage to a creature, put a -1/-1 counter on that creature.",
+        ),
+        // Controller-scoped source filter.
+        (
+            "Quest for the Gemblades class",
+            "Whenever a creature you control deals combat damage to a creature, exile that creature.",
+        ),
+    ] {
+        let effect = trigger_body_effect(oracle, card);
+        assert_eq!(
+            effect_subject(&effect),
+            &TargetFilter::EventTarget,
+            "{card}: \"that creature\" must bind the damage recipient"
+        );
+    }
+}
+
+/// CR 120.1: the PLAYER-recipient sibling must be untouched — "deals combat
+/// damage to a player" names no object recipient, so the object anaphor pin must
+/// not fire and "that player" keeps its own player-scope binding.
+#[test]
+fn player_recipient_damage_trigger_keeps_its_player_anaphor() {
+    let abilities = engine::parser::oracle::parse_oracle_text(
+        "Whenever this creature deals combat damage to a player, that player discards a card.",
+        "Player Recipient",
+        &[],
+        &[],
+        &[],
+    );
+    let trigger = abilities.triggers.first().expect("triggered ability");
+    let execute = trigger.execute.as_deref().expect("trigger body");
+    let Effect::Discard { target, .. } = &*execute.effect else {
+        panic!("expected a Discard body, got {:?}", execute.effect);
+    };
+    assert_eq!(
+        target,
+        &TargetFilter::TriggeringPlayer,
+        "a player recipient must not be captured by the object anaphor pin"
+    );
+}
+
+/// CR 510.4 + CR 702.7b + CR 701.8a: the reported board state end to end. A 1/1
+/// Striking Sliver blocks a 2/2 attacker while a Toxin Sliver watches. First
+/// strike means the Sliver's 1 damage lands in the first-strike combat damage
+/// step; Toxin Sliver's trigger resolves before the regular combat damage step,
+/// so the attacker is destroyed and never deals its damage back.
+#[test]
+fn toxin_sliver_destroys_a_creature_damaged_by_another_sliver() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let toxin = {
+        let mut b = scenario.add_creature(P0, "Toxin Sliver", 3, 3);
+        b.with_subtypes(vec!["Sliver"]);
+        b.from_oracle_text(TOXIN_SLIVER);
+        b.id()
+    };
+    let striking = {
+        let mut b = scenario.add_creature(P0, "Striking Sliver", 1, 1);
+        b.with_subtypes(vec!["Sliver"]);
+        b.from_oracle_text(STRIKING_SLIVER);
+        b.id()
+    };
+    let attacker = scenario.add_creature(P1, "Grizzly Bears", 2, 2).id();
+
+    let mut runner = scenario.build();
+    runner.state_mut().active_player = P1;
+    runner.advance_to_combat();
+    runner
+        .declare_attackers(&[(attacker, AttackTarget::Player(P0))])
+        .expect("declare attackers");
+    for _ in 0..8 {
+        if runner.waiting_for_kind() == "DeclareBlockers" {
+            break;
+        }
+        runner
+            .act(GameAction::PassPriority)
+            .expect("pass priority into the declare-blockers step");
+    }
+    runner
+        .declare_blockers(&[(striking, attacker)])
+        .expect("declare blockers");
+
+    let outcome = runner.combat_damage();
+
+    assert_eq!(
+        outcome.zone_of(attacker),
+        Zone::Graveyard,
+        "CR 701.8a: the creature dealt combat damage by a Sliver must be destroyed"
+    );
+    assert_eq!(
+        outcome.zone_of(striking),
+        Zone::Battlefield,
+        "CR 510.4: the attacker is destroyed in the first-strike step, so it never \
+         deals combat damage back to the 1/1 blocker"
+    );
+    assert_eq!(
+        outcome.zone_of(toxin),
+        Zone::Battlefield,
+        "the trigger source is not its own referent"
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -12,6 +12,7 @@ mod ability_block_display_clone_gate;
 mod ability_cost_block_readout;
 mod abundance_optional_draw_replacement;
 mod action_rejection;
+mod active_damage_trigger_recipient_anaphor;
 mod ad_nauseam_repeat;
 mod adamant_enters_with_leading_if_gate;
 mod adapter_contract_fixtures;


### PR DESCRIPTION
## What

"Whenever `<source>` deals combat damage to a creature, **destroy that creature**" did nothing at runtime. The trigger fired, went on the stack, and resolved as `EffectResolved { kind: Destroy, subject: None }`.

Reported from live play: a Striking Sliver (1/1, granting first strike) blocked a 2/2 attacker with a Toxin Sliver on the battlefield. The attacker survived the first-strike step and killed the blocker.

## Root cause

"That creature" bound to `TargetFilter::ParentTarget` — an anaphor to a *player-chosen* target. An untargeted damage trigger has no chosen target, and the parentless-`ParentTarget` event fallback in `game/targeting.rs` has arms for zone-change, mill, crew, saddle and station events but **none for `DamageDealt`**. The referent resolved to no object and the effect silently became a no-op.

CR 608.2k makes the recipient the antecedent — the "specific untargeted object … previously referred to by that ability's … trigger condition". That is `TargetFilter::EventTarget`.

The other plausible fallback, `TriggeringSource`, is wrong in the opposite direction and worse for being plausible: CR 120.1 makes the active-voice subject the damage **dealer**, so "destroy that creature" would have destroyed the blocking Sliver instead of the attacker.

## Changes

**`oracle_trigger.rs`** — adds `parse_active_deals_damage_to_object`, the voice dual of the existing `parse_passive_dealt_damage`. It is composed from the two combinators the `DamageDone` grammar already uses for this exact tail (`parse_damage_predicate_tail` × `parse_object_recipient_filter`), so the antecedent it recognizes is by construction the same recipient `try_parse_source_deals_damage_trigger` stores in `valid_target` — both move together when either axis gains a form.

`parse_object_recipient_filter` is what keeps this object-only: it requires an article plus a type phrase and declines the `"creature or player"` disjunctions, so player-recipient triggers never reach it and keep their own `TriggeringPlayer` binding.

Unlike the passive branch, this one is **not** gated on a non-self-referential subject. Voice is exactly what makes that gate unnecessary: in the passive voice the subject *is* the recipient, while in the active voice the subject is the source and the recipient is a different object — Phage's self-referential subject still means the damaged creature.

**`oracle_target.rs`** — completes a half-built mirror. The demonstrative branch in `parse_target_with_syntax` already mirrored `resolve_pronoun_target`'s `ctx.subject` consultation but skipped its `ctx.object_pronoun_ref` consultation, so one sentence could resolve the same referent two ways.

The Kashi-Tribe cycle is the proof case: *"tap **that creature** and **it** doesn't untap during its controller's next untap step"* bound "it" to the damaged creature and "that creature" to a parent target the untargeted trigger never had. CR 608.2k draws no distinction between a demonstrative and a pronoun naming that object.

## Impact

**31 cards** that were silently no-ops, **none of which had an issue filed**: Toxin Sliver, Phage the Untouchable, Stinkweed Imp, Voracious Cobra, Pit Spawn, Kaldra Compleat, Sword of Kaldra, Obelisk Spider, Creepy Doll, Dripping Dead, Grotesque Hybrid, Mephitic Ooze, Mercurial Kite, Neko-Te, Plague Fiend, Frostwalk Bastion, Hooded Blightfang, Queen of Ice, Red-Hot Hottie, Vraska Swarm's Eminence, Zagras, Cruel Deceiver, Overclocked Electromancer, and the Kashi-Tribe / Matsu-Tribe / Orochi cycles.

## Deliberately out of scope

Two adjacent classes share the wrong-antecedent shape but need different fixes, and are **not** addressed here:

1. **Delayed variant** — "destroy that creature **at end of combat**" (Ohran Viper #4229, Sosuke, and the basilisk cycle). Binds `EventTarget` correctly, but `EventTarget` reads `current_trigger_event`, which by end of combat is no longer the `DamageDealt` event. Needs a creation-time snapshot. Verified still failing.
2. **Possessive variant** — "that creature's **controller**" (Maarika #7764, Death Charmer, Flayed Nim, Greatbow Doyen, Soul Charmer). Binds `ParentTargetController`, which resolves via `extract_source_from_event` to the damage *dealer's* controller. This is why #7764's reporter saw *their own* Basilisk Collar sacrificed.

## Tests

New `active_damage_trigger_recipient_anaphor.rs`:
- 8 cards across 4 effect verbs (destroy / exile / tap / counter) and 3 source-filter shapes (name-self-referential, subtype, controller-scoped) — a building-block assertion, not one card's text.
- A guard that player-recipient triggers keep `TriggeringPlayer`, so the pin can't widen.
- The reported board state end to end, asserting both that the attacker dies and that the 1/1 blocker survives (i.e. the first-strike ordering is real, not incidental).

## Verification

- 21,168 lib tests pass; 6,886/6,887 integration. The single failure (`cr733_authority_matrix_covers_the_fresh_write_census`) is pre-existing and environmental — it shells out to Python, which isn't on PATH in this environment.
- `cargo clippy -p phase-engine --all-targets` clean.
- Regenerated `card-data.json` (35,858 cards) confirms the shipped export now carries `EventTarget` for the class, with Mirri the Cursed correctly still `SelfRef`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved parsing of damage-triggered abilities so phrases such as “that creature” correctly refer to the creature receiving damage.
  - Added consistent handling for singular and plural wording, including “deals” and “deal.”
  - Fixed demonstrative and pronoun resolution for untargeted triggers and spell-cast replacement effects.
  - Corrected interactions where damaged creatures are affected before dealing combat damage back.

- **Tests**
  - Added coverage for combat, noncombat, excess damage, creature and player recipients, and plural damage-trigger wording.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->