### PR TITLE
feat(telemetry): capture P2P disconnect causes and transport backlog

### DIFF
--- a/client/src/network/__tests__/peer.test.ts
+++ b/client/src/network/__tests__/peer.test.ts
@@ -1,10 +1,14 @@
-import { describe, it, expect, vi } from "vitest";
+import { beforeEach, describe, it, expect, vi } from "vitest";
 
+import { trackEvent } from "../../services/telemetry";
 import { buildGameState } from "../../test/factories/gameStateFactory";
 import { createPeerSession } from "../peer";
 import { validateMessage } from "../protocol";
 import type { P2PMessage } from "../protocol";
 import { FakeDataConnection } from "./fakeDataConnection";
+
+vi.mock("../../services/telemetry", () => ({ trackEvent: vi.fn() }));
+beforeEach(() => { vi.mocked(trackEvent).mockClear(); });
 
 function createTestSession(opts?: { onSessionEnd?: () => void }) {
   const conn = new FakeDataConnection();
@@ -190,6 +194,18 @@ describe("PeerSession", () => {
     session.close("manual"); // additional close attempt
 
     expect(onSessionEnd).toHaveBeenCalledTimes(1);
+    expect(trackEvent).toHaveBeenCalledExactlyOnceWith("p2p_disconnect", expect.objectContaining({
+      reason: "connection-close", channel_open: false,
+    }));
+  });
+
+  it("reports remote closure without collecting the remote's free-form reason", async () => {
+    const { conn } = createTestSession();
+    await conn.simulateData({ type: "disconnect", reason: "private room information" });
+    expect(trackEvent).toHaveBeenCalledExactlyOnceWith("p2p_disconnect", expect.objectContaining({
+      reason: "remote-disconnect", last_message_type: "disconnect",
+    }));
+    expect(JSON.stringify(vi.mocked(trackEvent).mock.calls)).not.toContain("private room information");
   });
 
   // Regression: a thrown handler MUST NOT poison the recvQueue. `.then()`
@@ -246,7 +262,7 @@ describe("PeerSession", () => {
   });
 
   // A wire-version skew must TRAVERSE the transport, not die inside it. This
-  // file mocks nothing, so the REAL `encodeWireMessage`/`decodeWireMessage`
+  // file mocks only telemetry, so the REAL `encodeWireMessage`/`decodeWireMessage`
   // and the real binary framing run end to end — the one place in the suite
   // where that is true. A `game_setup` stamped with a stale version used to
   // throw inside `decodeWireMessage` and be swallowed by the decode `catch`
@@ -380,6 +396,14 @@ describe("PeerSession keep-alive", () => {
       // so the silence is real evidence.
       await vi.advanceTimersByTimeAsync(5_000);
       expect(onDisconnect).toHaveBeenCalledWith("Ping timeout");
+      expect(trackEvent).toHaveBeenCalledExactlyOnceWith("p2p_disconnect", expect.objectContaining({
+        reason: "ping-timeout",
+        pong_age_ms: 10_000,
+        receive_age_ms: -1,
+        pending_sends: 0,
+        pending_decodes: 0,
+        channel_open: true,
+      }));
     } finally {
       vi.useRealTimers();
     }

--- a/client/src/network/peer.ts
+++ b/client/src/network/peer.ts
@@ -1,5 +1,6 @@
 import type { DataConnection } from "peerjs";
 
+import { trackEvent } from "../services/telemetry";
 import type { P2PMessage } from "./protocol";
 import { decodeWireMessage, encodeWireMessage } from "./protocol";
 
@@ -35,6 +36,9 @@ export interface PeerSessionOptions {
   onSessionEnd?: () => void;
 }
 
+type DisconnectCause = "ping-timeout" | "send-error" | "connection-close"
+  | "connection-error" | "remote-disconnect" | "local-close";
+
 export function createPeerSession(
   conn: DataConnection,
   options: PeerSessionOptions = {},
@@ -65,6 +69,10 @@ export function createPeerSession(
   // is deliberately NOT the reason stated here.
   let lastPongAt = 0;
   let lastTickAt = 0;
+  let lastReceivedAt: number | null = null;
+  let lastReceivedType: P2PMessage["type"] | "" = "";
+  let pendingSends = 0;
+  let pendingDecodes = 0;
 
   const clearKeepAlive = () => {
     if (pingInterval !== null) { clearInterval(pingInterval); pingInterval = null; }
@@ -81,6 +89,7 @@ export function createPeerSession(
   // `handleDisconnect` from inside the queue.
   const trySend = (msg: P2PMessage): Promise<boolean> => {
     if (closed || !conn.open) return Promise.resolve(false);
+    pendingSends += 1;
     const entry = sendQueue.then(async () => {
       // Only gate on `conn.open` here, NOT `closed`. `close()` flips `closed`
       // to true synchronously so subsequent NEW `trySend` calls bail (the
@@ -110,11 +119,11 @@ export function createPeerSession(
         return true;
       } catch (err) {
         console.warn("[PeerSession] send failed:", err);
-        handleDisconnect("Channel send failed");
+        handleDisconnect("Channel send failed", "send-error");
         return false;
       }
     });
-    sendQueue = entry.then(() => undefined);
+    sendQueue = entry.then(() => { pendingSends -= 1; });
     return entry;
   };
 
@@ -167,7 +176,7 @@ export function createPeerSession(
       if (sinceLastTick >= PONG_TIMEOUT_MS || sinceLastTick < 0) {
         lastPongAt = now;
       } else if (now - lastPongAt >= PONG_TIMEOUT_MS) {
-        handleDisconnect("Ping timeout");
+        handleDisconnect("Ping timeout", "ping-timeout");
         return;
       }
 
@@ -196,12 +205,28 @@ export function createPeerSession(
   //   disposeChannel — closes the RTCDataChannel. Called either directly
   //     (from `conn.on("close"/"error")` paths where there are no queued
   //     sends to flush) or chained off `sendQueue` (from `close()`).
-  const markDisconnected = (reason: string) => {
+  const markDisconnected = (reason: string, cause: DisconnectCause) => {
     if (closed) return;
     closed = true;
     disconnectReason = reason;
     tracePeerSession("disconnect", { reason, connOpen: conn.open });
     console.warn("[PeerSession] disconnected:", reason);
+    // Only bounded transport metadata: never upload peer IDs, room codes,
+    // message payloads, or the free-form reason supplied by a remote peer.
+    const now = Date.now();
+    trackEvent("p2p_disconnect", {
+      reason: cause,
+      connection_state: conn.peerConnection?.connectionState ?? "",
+      ice_state: conn.peerConnection?.iceConnectionState ?? "",
+      visibility: document.visibilityState,
+      last_message_type: lastReceivedType,
+      pong_age_ms: Math.max(0, now - lastPongAt),
+      receive_age_ms: lastReceivedAt === null ? -1 : Math.max(0, now - lastReceivedAt),
+      pending_sends: pendingSends,
+      pending_decodes: pendingDecodes,
+      buffered_bytes: conn.dataChannel?.bufferedAmount ?? 0,
+      channel_open: conn.open,
+    });
     clearKeepAlive();
     window.removeEventListener("beforeunload", beforeUnloadHandler);
     for (const handler of disconnectHandlers) {
@@ -224,9 +249,9 @@ export function createPeerSession(
 
   // Backwards-compatible bundled handler used by remote-close / error paths
   // where there is no queued-send-flush to await.
-  const handleDisconnect = (reason: string) => {
+  const handleDisconnect = (reason: string, cause: DisconnectCause) => {
     if (closed) return;
-    markDisconnected(reason);
+    markDisconnected(reason, cause);
     disposeChannel();
   };
 
@@ -241,6 +266,7 @@ export function createPeerSession(
   // full inbound chain.
   const onData = (data: unknown): Promise<void> => {
     let delivery: Promise<void> | undefined;
+    pendingDecodes += 1;
     recvQueue = recvQueue.then(async () => {
       if (closed) return;
       if (!(data instanceof Uint8Array || data instanceof ArrayBuffer)) {
@@ -258,6 +284,8 @@ export function createPeerSession(
         console.warn("Failed to decode message from peer:", e);
         return;
       }
+      lastReceivedAt = Date.now();
+      lastReceivedType = msg.type;
       // Skip ping/pong — they fire every 5s and drown the rest of the trace.
       if (msg.type !== "ping" && msg.type !== "pong") {
         tracePeerSession("data", { type: msg.type, queued: messageHandlers.size === 0 });
@@ -277,7 +305,7 @@ export function createPeerSession(
       delivery = dispatchQueue.then(async () => {
         if (closed) return;
         if (msg.type === "disconnect") {
-          handleDisconnect(msg.reason);
+          handleDisconnect(msg.reason, "remote-disconnect");
           return;
         }
 
@@ -299,15 +327,15 @@ export function createPeerSession(
         }
       });
       dispatchQueue = delivery;
-    });
+    }).finally(() => { pendingDecodes -= 1; });
     // Tests can await this message's full delivery without making the decode
     // queue itself wait for game work.
     return recvQueue.then(() => delivery);
   };
 
   conn.on("data", onData);
-  conn.on("close", () => handleDisconnect("Connection closed"));
-  conn.on("error", (err) => handleDisconnect(`Connection error: ${err.message}`));
+  conn.on("close", () => handleDisconnect("Connection closed", "connection-close"));
+  conn.on("error", (err) => handleDisconnect(`Connection error: ${err.message}`, "connection-error"));
 
   startKeepAlive();
 
@@ -366,7 +394,7 @@ export function createPeerSession(
       // immediately as the API contract requires), THEN dispose the channel
       // after the queue drains so the queued bytes actually flush.
       if (conn.open) trySend({ type: "disconnect", reason });
-      markDisconnected(reason);
+      markDisconnected(reason, "local-close");
       sendQueue = sendQueue.then(() => { disposeChannel(); });
     },
   };

--- a/client/src/services/telemetry.ts
+++ b/client/src/services/telemetry.ts
@@ -39,6 +39,7 @@ const PER_EVENT_CAPS: Record<string, number> = {
   js_error: 10,
   card_report: 10,
   route_view: 50,
+  p2p_disconnect: 10,
 };
 
 /** A queued event: the caller's fields plus the event name and a client

--- a/lobby-worker/src/telemetry.ts
+++ b/lobby-worker/src/telemetry.ts
@@ -46,6 +46,10 @@ export const EVENT_SCHEMAS: Record<string, { blobs: string[]; doubles: string[] 
   engine_panic: { blobs: ["reason", "panic", "game_mode"], doubles: ["fatal", "turn"] },
   stuck_decision: { blobs: ["waiting_for_kind", "game_mode", "phase"], doubles: [] },
   js_error: { blobs: ["name", "message", "top_frame", "source", "route"], doubles: [] },
+  p2p_disconnect: {
+    blobs: ["reason", "connection_state", "ice_state", "visibility", "last_message_type"],
+    doubles: ["pong_age_ms", "receive_age_ms", "pending_sends", "pending_decodes", "buffered_bytes", "channel_open"],
+  },
   // `probe_*` columns are appended (never inserted — AE columns are
   // positional) and populated only on `reason: "loop-abort"` events: the
   // client refetches the failing chunk and reports what it actually got.

--- a/lobby-worker/test/telemetry.test.mjs
+++ b/lobby-worker/test/telemetry.test.mjs
@@ -137,6 +137,21 @@ test("unknown events are dropped, not errors", () => {
   assert.equal(out[0].event, "stuck_decision");
 });
 
+test("P2P disconnect diagnostics preserve column order and discard payload fields", () => {
+  const [event] = sanitizeTelemetryBatch(batch([{
+    event: "p2p_disconnect", reason: "ping-timeout", connection_state: "connected",
+    ice_state: "connected", visibility: "visible", last_message_type: "state_update",
+    pong_age_ms: 10000, receive_age_ms: 50, pending_sends: 2, pending_decodes: 1,
+    buffered_bytes: 16300, channel_open: true,
+    peer_id: "private", room_code: "private", payload: "private",
+  }]));
+  assert.deepEqual(toDataPoint(event), {
+    indexes: ["p2p_disconnect"],
+    blobs: ["p2p_disconnect", "0.42.1", "02b26c3", "web", "ping-timeout", "connected", "connected", "visible", "state_update"],
+    doubles: [10000, 50, 2, 1, 16300, 1],
+  });
+});
+
 test("unknown fields are dropped from a known event", () => {
   const [e] = sanitizeTelemetryBatch(
     batch([{ event: "stuck_decision", waiting_for_kind: "Priority", game_mode: "ai", phase: "Draw", secret: "leak" }]),


### PR DESCRIPTION
Preview telemetry recorded `Game paused-disconnect` on build `6e70845` after the heartbeat/game-handler fix in #8826. Existing telemetry reports the resulting paused game but does not record why the P2P session ended, so it cannot distinguish heartbeat starvation, a transport failure, or an intentional close.

Record one bounded `p2p_disconnect` event per session with a typed disconnect cause, WebRTC/ICE state, page visibility, last decoded message type/age, pong age, pending send/decode counts, and data-channel buffered bytes. The existing opt-out, build gate, and session limits apply, with a dedicated ten-event cap. The Worker accepts the new event using an additive column layout. No peer identifiers, room codes, payloads, or free-form close reasons are collected.

This change adds diagnostics only; it does not claim to fix the remaining disconnect reports or change heartbeat timing, message ordering, or reconnection behavior. No wire protocol bump is needed.

Diagnostic interpretation: `pong_age_ms` follows the existing keepalive baseline, including its reset after a suspend or wall-clock discontinuity. `receive_age_ms` measures the last successfully decoded message and is -1 before the first one. Pending counts include in-flight work; `buffered_bytes` is the browser data-channel buffer, not PeerJS's separate internal frame queue.

Validation: Tilt frontend type-check/lint passed; frontend suite passed (6,667 tests, including 23 PeerSession tests). All 16 telemetry ingestion tests passed. Tests cover duplicate-close suppression, heartbeat-timeout metadata, and exclusion of remote free-form reasons/payload fields. `cargo fmt --all` and diff whitespace checks passed. The local whole-Worker type-check is blocked by pre-existing stale generated broker WASM exports in `lobby-do.ts`; CI must regenerate these and validate the Worker.

CI follow-up: All required checks passed, including frontend and repository-wide Rust checks. The Lobby Worker check passed. CodeRabbit reported no actionable findings; its generic docstring-coverage warning does not identify a transport or telemetry defect. Superagent passed.
