### PR TITLE
fix(p2p): preserve game connections through signaling outages

### DIFF
--- a/client/src/adapter/p2p-adapter.ts
+++ b/client/src/adapter/p2p-adapter.ts
@@ -616,9 +616,8 @@ const RECONNECT_STEADY_STATE_MS = 60_000;
  *
  * Reachability precondition: tab A's PeerJS SIGNALING socket must have dropped
  * (freeing the peer id) while its WebRTC DataConnections stay up. That state is
- * durable — no `peer.on("disconnected")` handler and no `.reconnect()` call
- * exists repo-wide — and is produced by sleep, a network change, or mobile
- * backgrounding. Opening a second tab does NOT reach it on its own: `hostRoom`
+ * possible while signaling recovery retries after sleep, a network change,
+ * or mobile backgrounding. Opening a second tab does NOT reach it on its own: `hostRoom`
  * opens the peer before the adapter is constructed, so tab B fails
  * `unavailable-id` and never reaches `claimP2PHostLease`. The lease flip must
  * land inside the `submitAction` → `broadcastStateUpdateInner` window, so

--- a/client/src/network/__tests__/connection.test.ts
+++ b/client/src/network/__tests__/connection.test.ts
@@ -5,24 +5,53 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 // factory cannot close over ordinary module scope.
 const peerState = vi.hoisted(() => ({
   peersCreated: 0,
-  peerHandlers: new Map<string, (arg?: unknown) => void>(),
+  peerHandlers: new Map<string, Set<(arg?: unknown) => void>>(),
   connHandlers: new Map<string, (arg?: unknown) => void>(),
   dials: [] as Array<{ peerId: string; options: unknown }>,
+  destroyCalls: 0,
+  reconnectCalls: 0,
+  emitPeer: (_event: string, _arg?: unknown): void => {},
 }));
 
 vi.mock("peerjs", () => {
   class FakePeer {
+    destroyed = false;
+    disconnected = false;
+    private onceHandlers = new Map<(arg?: unknown) => void, (arg?: unknown) => void>();
     constructor() {
       peerState.peersCreated += 1;
+      peerState.emitPeer = (event, arg) => {
+        if (event === "disconnected") this.disconnected = true;
+        if (event === "open") this.disconnected = false;
+        for (const handler of [...(peerState.peerHandlers.get(event) ?? [])]) handler(arg);
+      };
     }
     on(event: string, handler: (arg?: unknown) => void): void {
-      peerState.peerHandlers.set(event, handler);
+      const handlers = peerState.peerHandlers.get(event) ?? new Set();
+      handlers.add(handler);
+      peerState.peerHandlers.set(event, handlers);
     }
     once(event: string, handler: (arg?: unknown) => void): void {
-      peerState.peerHandlers.set(event, handler);
+      const once = (arg?: unknown) => {
+        this.off(event, handler);
+        handler(arg);
+      };
+      this.onceHandlers.set(handler, once);
+      this.on(event, once);
     }
-    off(): void {}
-    destroy(): void {}
+    off(event: string, handler: (arg?: unknown) => void): void {
+      peerState.peerHandlers.get(event)?.delete(this.onceHandlers.get(handler) ?? handler);
+      this.onceHandlers.delete(handler);
+    }
+    destroy(): void {
+      this.destroyed = true;
+      peerState.destroyCalls += 1;
+      peerState.emitPeer("close");
+    }
+    reconnect(): void {
+      this.disconnected = false;
+      peerState.reconnectCalls += 1;
+    }
     connect(peerId: string, options: unknown): unknown {
       peerState.dials.push({ peerId, options });
       return {
@@ -36,7 +65,7 @@ vi.mock("peerjs", () => {
   return { default: FakePeer };
 });
 
-import { PEER_CONNECT_OPTIONS, joinRoom, logSelectedIceCandidate } from "../connection";
+import { PEER_CONNECT_OPTIONS, hostRoom, joinRoom, logSelectedIceCandidate } from "../connection";
 
 // Fake RTCStatsReport: a Map<string, {type, ...}> with a forEach that matches
 // the browser API shape.
@@ -165,6 +194,8 @@ describe("joinRoom", () => {
     peerState.peerHandlers.clear();
     peerState.connHandlers.clear();
     peerState.dials.length = 0;
+    peerState.destroyCalls = 0;
+    peerState.reconnectCalls = 0;
     vi.spyOn(console, "log").mockImplementation(() => {});
     vi.spyOn(console, "warn").mockImplementation(() => {});
     vi.spyOn(console, "debug").mockImplementation(() => {});
@@ -175,6 +206,7 @@ describe("joinRoom", () => {
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     vi.unstubAllGlobals();
     vi.restoreAllMocks();
   });
@@ -188,7 +220,7 @@ describe("joinRoom", () => {
     await flush();
 
     expect(peerState.peersCreated).toBe(1);
-    peerState.peerHandlers.get("open")!();
+    peerState.emitPeer("open");
 
     expect(peerState.dials).toEqual([
       { peerId: "phase2-ABCDE", options: PEER_CONNECT_OPTIONS },
@@ -197,5 +229,71 @@ describe("joinRoom", () => {
 
     peerState.connHandlers.get("open")!();
     await expect(joined).resolves.toMatchObject({ conn: { open: false } });
+  });
+
+  it.each(["socket-error", "socket-closed", "server-error", "unavailable-id"])(
+    "keeps an established guest alive after signaling %s",
+    async (type) => {
+      const joining = joinRoom("ABCDE");
+      await flush();
+      peerState.emitPeer("open");
+      peerState.connHandlers.get("open")!();
+      const joined = await joining;
+      peerState.emitPeer("error", Object.assign(new Error("signaling interrupted"), { type }));
+      expect(peerState.destroyCalls).toBe(0);
+      joined.destroyPeer();
+    },
+  );
+
+  it("still rejects and destroys a peer when the initial join fails", async () => {
+    const joining = joinRoom("ABCDE");
+    await flush();
+    peerState.emitPeer("error", Object.assign(new Error("not registered"), { type: "socket-error" }));
+    await expect(joining).rejects.toThrow("Failed to connect: not registered");
+    expect(peerState.destroyCalls).toBe(1);
+  });
+
+  it("recovers guest signaling with backoff without redialing the initial game connection", async () => {
+    vi.useFakeTimers();
+    const joining = joinRoom("ABCDE");
+    await vi.advanceTimersByTimeAsync(0);
+    peerState.emitPeer("open");
+    peerState.connHandlers.get("open")!();
+    const joined = await joining;
+    peerState.emitPeer("disconnected");
+    peerState.emitPeer("disconnected");
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(peerState.reconnectCalls).toBe(1);
+    peerState.emitPeer("disconnected");
+    await vi.advanceTimersByTimeAsync(1999);
+    expect(peerState.reconnectCalls).toBe(1);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(peerState.reconnectCalls).toBe(2);
+    peerState.emitPeer("open");
+    expect(peerState.dials).toHaveLength(1);
+    peerState.emitPeer("disconnected");
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(peerState.reconnectCalls).toBe(3);
+    peerState.emitPeer("disconnected");
+    joined.destroyPeer();
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(peerState.reconnectCalls).toBe(3);
+  });
+
+  it("preserves a hosted room through signaling errors and cancels recovery on teardown", async () => {
+    vi.useFakeTimers();
+    const hosting = hostRoom(undefined, { preferredRoomCode: "ABCDE" });
+    await vi.advanceTimersByTimeAsync(0);
+    peerState.emitPeer("open");
+    const host = await hosting;
+    peerState.emitPeer("error", Object.assign(new Error("signaling interrupted"), { type: "socket-error" }));
+    expect(peerState.destroyCalls).toBe(0);
+    peerState.emitPeer("disconnected");
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(peerState.reconnectCalls).toBe(1);
+    peerState.emitPeer("disconnected");
+    host.destroy();
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(peerState.reconnectCalls).toBe(1);
   });
 });

--- a/client/src/network/connection.ts
+++ b/client/src/network/connection.ts
@@ -144,6 +144,31 @@ function traceP2P(side: "Host" | "Guest", event: string, data?: Record<string, u
   console.debug(`[P2P ${side} Trace]`, performance.now().toFixed(1), event, data ?? {});
 }
 
+/** Restore signaling without tearing down established WebRTC connections.
+ * PeerJS retains those connections on `disconnected`; `destroy()` does not.
+ * Use its reconnect API with bounded backoff until recovery or owner teardown. */
+function maintainSignaling(peer: Peer): void {
+  let retryTimer: ReturnType<typeof setTimeout> | null = null;
+  let retryDelay = 1000;
+  const clearRetry = () => {
+    if (retryTimer !== null) clearTimeout(retryTimer);
+    retryTimer = null;
+  };
+  peer.on("disconnected", () => {
+    if (peer.destroyed || retryTimer !== null) return;
+    retryTimer = setTimeout(() => {
+      retryTimer = null;
+      if (!peer.destroyed && peer.disconnected) peer.reconnect();
+    }, retryDelay);
+    retryDelay = Math.min(retryDelay * 2, 30_000);
+  });
+  peer.on("open", () => {
+    clearRetry();
+    retryDelay = 1000;
+  });
+  peer.on("close", clearRetry);
+}
+
 // ICE nomination typically settles within 1-2s of channel open; on slow links
 // nomination may take longer. The first stat may be a `prflx` that later
 // upgrades to `srflx`/`host`. 2000ms is a heuristic balance between accuracy
@@ -417,6 +442,7 @@ export async function hostRoom(
   // — fresh hosts generate random codes so the collision would be
   // unrecoverable anyway.
   const peer = await openHostPeer(peerId, roomCode, isResume, signal);
+  maintainSignaling(peer);
   traceP2P("Host", "peer-open-final", { peerId, roomCode });
 
   // Multi-fire connection handler: every guest gets wrapped on `open`.
@@ -459,26 +485,12 @@ export async function hostRoom(
     });
   });
 
-  // Top-level Peer errors: PeerJS surfaces transient issues here too. Only
-  // FATAL errors should trigger destroy — transient ones are recoverable.
+  // PeerJS owns error teardown. Once registered, its abort path disconnects
+  // signaling while preserving DataConnections. Calling destroy here would
+  // turn a signaling outage into a disconnect for every guest in the game.
   peer.on("error", (err: Error & { type?: string }) => {
-    const fatal = err.type === "browser-incompatible"
-      || err.type === "invalid-id"
-      || err.type === "invalid-key"
-      || err.type === "unavailable-id"
-      || err.type === "ssl-unavailable"
-      || err.type === "server-error"
-      || err.type === "socket-error"
-      || err.type === "socket-closed";
-    if (fatal) {
-      traceP2P("Host", "peer-fatal-error", { peerId, type: err.type, message: err.message });
-      console.error("[P2P Host] fatal Peer error, destroying:", err);
-      destroyed = true;
-      try { peer.destroy(); } catch { /* best-effort */ }
-    } else {
-      traceP2P("Host", "peer-nonfatal-error", { peerId, type: err.type, message: err.message });
-      console.warn("[P2P Host] non-fatal Peer error:", err);
-    }
+    traceP2P("Host", "peer-error", { peerId, type: err.type, message: err.message });
+    console.warn("[P2P Host] Peer error (existing connections preserved):", err);
   });
 
   return {
@@ -535,7 +547,9 @@ export async function joinRoom(
     };
     signal?.addEventListener("abort", onAbort, { once: true });
 
-    peer.on("open", () => {
+    // A signaling reconnect also emits open; only the initial registration
+    // should dial the host. The adapter owns subsequent game-channel dials.
+    peer.once("open", () => {
       if (signal?.aborted) {
         try { peer.destroy(); } catch { /* best-effort */ }
         return;
@@ -558,6 +572,7 @@ export async function joinRoom(
         clearTimeout(timeout);
         signal?.removeEventListener("abort", onAbort);
         opened = true;
+        maintainSignaling(peer);
         resolve({
           conn,
           peer,
@@ -587,17 +602,9 @@ export async function joinRoom(
     });
 
     // PeerJS emits connection failures on the peer, not the conn (issue #1281).
-    // Mirror the host's classifier: post-open, only fatal types destroy the
-    // Peer. The same fatal set applies on both sides of the signaling server.
+    // Before the initial game connection opens, reject a failed join. After
+    // that, preserve existing channels and let PeerJS manage signaling loss.
     peer.on("error", (err: Error & { type?: string }) => {
-      const fatal = err.type === "browser-incompatible"
-        || err.type === "invalid-id"
-        || err.type === "invalid-key"
-        || err.type === "unavailable-id"
-        || err.type === "ssl-unavailable"
-        || err.type === "server-error"
-        || err.type === "socket-error"
-        || err.type === "socket-closed";
       if (!opened) {
         traceP2P("Guest", "peer-preopen-error", { peerId, type: err.type, message: err.message });
         // Pre-open: any peer error means the initial connect failed — reject.
@@ -605,14 +612,8 @@ export async function joinRoom(
         try { peer.destroy(); } catch { /* best-effort */ }
         return;
       }
-      if (fatal) {
-        traceP2P("Guest", "peer-fatal-error", { peerId, type: err.type, message: err.message });
-        console.error("[P2P Guest] fatal Peer error, destroying:", err);
-        try { peer.destroy(); } catch { /* best-effort */ }
-      } else {
-        traceP2P("Guest", "peer-nonfatal-error", { peerId, type: err.type, message: err.message });
-        console.warn("[P2P Guest] non-fatal Peer error (Peer kept alive for reconnect):", err);
-      }
+      traceP2P("Guest", "peer-error", { peerId, type: err.type, message: err.message });
+      console.warn("[P2P Guest] Peer error (existing connections preserved):", err);
     });
   });
 }


### PR DESCRIPTION
An established game's signaling socket can fail while its WebRTC data channels are still healthy. Both room connection handlers classified signaling errors as fatal and explicitly called `peer.destroy()`, closing all of that peer's game connections. A signaling interruption on a three-player host could therefore disconnect both guests. Separately, disconnected PeerJS instances were never reconnected to signaling, preventing later game-channel reconnects.

Let PeerJS own post-registration error teardown and use its `disconnected`/`open`/`close` lifecycle to reconnect signaling with exponential backoff capped at 30 seconds. Teardown cancels retries. Guest registration now uses `once("open")` so recovering signaling cannot repeat the initial game-channel dial. Initial join failures still reject and destroy the unsuccessful peer. No game rules, wire formats, heartbeat timing, or adapter reconnect policies change.

The installed PeerJS implementation records `_lastServerId` on its first successful registration; its `_abort` path preserves established connections by calling `disconnect()` after that point. Our error listeners ran inside `_abort` and escalated this to `destroy()`. The distinction is also documented at https://peerjs.com/client/api/peer#disconnected and https://peerjs.com/client/api/peer#peerreconnect.

Validation: Six new regression cases failed against the original code. After the fix, all 13 connection tests and the full 6,674-test frontend suite passed under Tilt. Coverage includes host/guest signaling errors, duplicate loss notifications, retry backoff/reset, no duplicate initial dial after recovery, teardown cancellation, and initial join rejection. TypeScript/lint, `cargo fmt --all`, and diff whitespace checks passed. All required CI checks passed, including frontend and repository-wide Rust checks. Android, WASM, Worker, and card-data checks passed. CodeRabbit and Superagent completed without actionable findings; the generic docstring-coverage warning does not identify a correctness defect.

Incident attribution remains unconfirmed: preview telemetry recorded a disconnect-related pause on build `6e70845`, and the reporter confirms that the affected group was fully refreshed. Existing events lack the triggering transport reason. This fixes an independently reproduced disconnect path. #8832 adds bounded transport diagnostics for subsequent incidents.

Additional browser validation: Headless Chrome loaded the actual connection module from the local Vite server and created three real PeerJS peers (one host, two guests) through public signaling. For each peer, the test emitted a signaling socket error followed by `peer.disconnect()`, matching PeerJS's abort event sequence. Bidirectional data delivery continued during loss and after automatic signaling recovery. Result: three successful signaling recoveries, 28 delivered messages, zero channel closures, and exactly two host channels throughout. This is a transport smoke test, not a complete three-player game simulation.
