### PR TITLE
fix(ui): clear zone-choice selection between prompts

### DIFF
--- a/client/src/components/modal/CardChoiceModal.tsx
+++ b/client/src/components/modal/CardChoiceModal.tsx
@@ -1138,6 +1138,14 @@ function EffectZoneModal({ data }: { data: EffectZoneChoice["data"] }) {
   const isUpTo = data.up_to === true;
   const minCount = data.min_count ?? 0;
 
+  // A resolution can advance directly from one zone-choice prompt to another
+  // (for example, a sacrifice into a graveyard-to-battlefield return). The
+  // component instance is retained across that transition, so its local pick
+  // must not answer the next engine prompt.
+  useEffect(() => {
+    setSelected(new Set());
+  }, [data]);
+
   const toggleSelect = useCallback(
     (id: ObjectId) => {
       setSelected((prev) => {

--- a/client/src/components/modal/CardChoiceModal.tsx
+++ b/client/src/components/modal/CardChoiceModal.tsx
@@ -1137,6 +1137,16 @@ function EffectZoneModal({ data }: { data: EffectZoneChoice["data"] }) {
     !isTapUntapChoice;
   const isUpTo = data.up_to === true;
   const minCount = data.min_count ?? 0;
+  const selectionPromptKey = [
+    data.source_id,
+    data.cards.join(","),
+    data.count,
+    minCount,
+    isUpTo,
+    data.effect_kind,
+    data.zone,
+    data.destination ?? "",
+  ].join("|");
 
   // A resolution can advance directly from one zone-choice prompt to another
   // (for example, a sacrifice into a graveyard-to-battlefield return). The
@@ -1144,7 +1154,7 @@ function EffectZoneModal({ data }: { data: EffectZoneChoice["data"] }) {
   // must not answer the next engine prompt.
   useEffect(() => {
     setSelected(new Set());
-  }, [data]);
+  }, [selectionPromptKey]);
 
   const toggleSelect = useCallback(
     (id: ObjectId) => {

--- a/client/src/components/modal/CardChoiceModal.tsx
+++ b/client/src/components/modal/CardChoiceModal.tsx
@@ -23,6 +23,10 @@ import type {
   WaitingFor,
   Zone,
 } from "../../adapter/types.ts";
+import type {
+  InteractionId,
+  ViewerInteraction,
+} from "../../adapter/generated/interaction/index.ts";
 import { useCanActForWaitingState } from "../../hooks/usePlayerId.ts";
 import {
   CancelButton,
@@ -117,6 +121,32 @@ type DamageSourceChoice = Extract<WaitingFor, { type: "DamageSourceChoice" }>;
 type LearnChoice = Extract<WaitingFor, { type: "LearnChoice" }>;
 type BeholdChoice = Extract<WaitingFor, { type: "BeholdChoice" }>;
 
+function effectZoneChoiceInteractionId(
+  interaction: ViewerInteraction | null,
+): InteractionId | null {
+  for (const opportunity of interaction?.opportunities ?? []) {
+    if (opportunity.response.type !== "schema") continue;
+    if (opportunity.response.data.spec.type === "select") {
+      return opportunity.interactionId;
+    }
+  }
+  return null;
+}
+
+function effectZoneChoiceFallbackKey(data: EffectZoneChoice["data"]): string {
+  return [
+    data.player,
+    data.source_id,
+    data.cards.join(","),
+    data.count,
+    data.min_count ?? 0,
+    data.up_to === true,
+    data.effect_kind,
+    data.zone,
+    data.destination ?? "",
+  ].join("|");
+}
+
 /**
  * Generic card choice modal for Scry, Dig, Surveil, Reveal, Search, and NamedChoice.
  * Renders based on the WaitingFor type.
@@ -126,6 +156,9 @@ export function CardChoiceModal() {
   const canActForWaitingState = useCanActForWaitingState();
   const waitingFor = useGameStore((s) => s.waitingFor);
   const objects = useGameStore((s) => s.gameState?.objects);
+  const effectZoneInteractionId = useGameStore((s) =>
+    effectZoneChoiceInteractionId(s.viewerInteraction),
+  );
 
   if (!waitingFor) return null;
 
@@ -206,7 +239,12 @@ export function CardChoiceModal() {
     case "EffectZoneChoice":
       if (!canActForWaitingState) return null;
       if (getBoardChoiceView(waitingFor, objects)) return null;
-      return <EffectZoneModal data={waitingFor.data} />;
+      return (
+        <EffectZoneModal
+          key={effectZoneInteractionId ?? effectZoneChoiceFallbackKey(waitingFor.data)}
+          data={waitingFor.data}
+        />
+      );
     case "DrawnThisTurnTopdeckChoice":
       if (!canActForWaitingState) return null;
       return <DrawnThisTurnTopdeckModal data={waitingFor.data} />;
@@ -1137,24 +1175,6 @@ function EffectZoneModal({ data }: { data: EffectZoneChoice["data"] }) {
     !isTapUntapChoice;
   const isUpTo = data.up_to === true;
   const minCount = data.min_count ?? 0;
-  const selectionPromptKey = [
-    data.source_id,
-    data.cards.join(","),
-    data.count,
-    minCount,
-    isUpTo,
-    data.effect_kind,
-    data.zone,
-    data.destination ?? "",
-  ].join("|");
-
-  // A resolution can advance directly from one zone-choice prompt to another
-  // (for example, a sacrifice into a graveyard-to-battlefield return). The
-  // component instance is retained across that transition, so its local pick
-  // must not answer the next engine prompt.
-  useEffect(() => {
-    setSelected(new Set());
-  }, [selectionPromptKey]);
 
   const toggleSelect = useCallback(
     (id: ObjectId) => {

--- a/client/src/components/modal/__tests__/DiscardCostModal.test.tsx
+++ b/client/src/components/modal/__tests__/DiscardCostModal.test.tsx
@@ -347,6 +347,41 @@ describe("Discard cost modal", () => {
     });
   });
 
+  it("retains a zone-choice pick when the same prompt is refreshed", () => {
+    const prompt = buildEffectZoneChoiceWaitingFor({
+      player: 0,
+      cards: [10],
+      count: 1,
+      min_count: 0,
+      up_to: false,
+      source_id: 1,
+      effect_kind: "ChangeZone",
+      zone: "Graveyard",
+      destination: "Battlefield",
+    });
+    const objects: Record<string, GameObject> = {
+      10: { ...makeObject(10, "Midnight Reaper"), zone: "Graveyard" },
+    };
+
+    setWaitingFor(prompt, objects);
+    render(<CardChoiceModal />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Loading Midnight Reaper" }));
+
+    act(() => {
+      setWaitingFor({ ...prompt, data: { ...prompt.data } }, objects);
+    });
+
+    const confirm = screen.getByRole("button", { name: "Put (1/1)" });
+    expect(confirm).toBeEnabled();
+    fireEvent.click(confirm);
+
+    expect(dispatchMock).toHaveBeenCalledWith({
+      type: "SelectCards",
+      data: { cards: [10] },
+    });
+  });
+
   it("allocates any-combination mana with color steppers", () => {
     setWaitingFor({
       type: "ChooseManaColor",

--- a/client/src/components/modal/__tests__/DiscardCostModal.test.tsx
+++ b/client/src/components/modal/__tests__/DiscardCostModal.test.tsx
@@ -1,6 +1,10 @@
 import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import type {
+  InteractionId,
+  ViewerInteraction,
+} from "../../../adapter/generated/interaction/index.ts";
 import type { GameObject, WaitingFor } from "../../../adapter/types.ts";
 import { useGameStore } from "../../../stores/gameStore.ts";
 import { useMultiplayerStore } from "../../../stores/multiplayerStore.ts";
@@ -67,7 +71,11 @@ function makeObject(id: number, name: string, zone: GameObject["zone"] = "Hand")
   });
 }
 
-function setWaitingFor(waitingFor: WaitingFor, objects?: Record<string, GameObject>) {
+function setWaitingFor(
+  waitingFor: WaitingFor,
+  objects?: Record<string, GameObject>,
+  viewerInteraction: ViewerInteraction | null = null,
+) {
   const state = buildGameState({
     objects: objects ?? {},
     waiting_for: waitingFor,
@@ -78,7 +86,46 @@ function setWaitingFor(waitingFor: WaitingFor, objects?: Record<string, GameObje
     gameMode: "online",
     gameState: state,
     waitingFor,
+    viewerInteraction,
   });
+}
+
+function effectZoneChoiceInteraction(interactionId: string): ViewerInteraction {
+  return {
+    waitingForKind: { simultaneous: null, terminal: false, code: "select" },
+    authorizedSubmitters: [0],
+    canSubmit: true,
+    autoPassRecommended: false,
+    opportunities: [
+      {
+        interactionId: interactionId as InteractionId,
+        response: {
+          type: "schema",
+          data: {
+            spec: {
+              type: "select",
+              data: {
+                constraint: { type: "count", data: { min: 1, max: 1 } },
+                confirm: "explicit",
+              },
+            },
+            candidates: [],
+          },
+        },
+        surfaces: [],
+        progress: {
+          selected: 0,
+          minimum: 1,
+          maximum: 1,
+          aggregate: null,
+          confirmable: false,
+        },
+      },
+    ],
+    attachmentFans: {},
+    attachmentViews: {},
+    availability: { type: "inputRequired" },
+  };
 }
 
 describe("Discard cost modal", () => {
@@ -362,14 +409,19 @@ describe("Discard cost modal", () => {
     const objects: Record<string, GameObject> = {
       10: { ...makeObject(10, "Midnight Reaper"), zone: "Graveyard" },
     };
+    const interaction = effectZoneChoiceInteraction("zone-choice-1");
 
-    setWaitingFor(prompt, objects);
+    setWaitingFor(prompt, objects, interaction);
     render(<CardChoiceModal />);
 
     fireEvent.click(screen.getByRole("button", { name: "Loading Midnight Reaper" }));
 
     act(() => {
-      setWaitingFor({ ...prompt, data: { ...prompt.data } }, objects);
+      setWaitingFor(
+        { ...prompt, data: { ...prompt.data } },
+        objects,
+        interaction,
+      );
     });
 
     const confirm = screen.getByRole("button", { name: "Put (1/1)" });
@@ -380,6 +432,38 @@ describe("Discard cost modal", () => {
       type: "SelectCards",
       data: { cards: [10] },
     });
+  });
+
+  it("clears a pick for a distinct zone-choice interaction with identical data", () => {
+    const prompt = buildEffectZoneChoiceWaitingFor({
+      player: 0,
+      cards: [10],
+      count: 1,
+      min_count: 0,
+      up_to: false,
+      source_id: 1,
+      effect_kind: "ChangeZone",
+      zone: "Graveyard",
+      destination: "Battlefield",
+    });
+    const objects: Record<string, GameObject> = {
+      10: { ...makeObject(10, "Midnight Reaper"), zone: "Graveyard" },
+    };
+
+    setWaitingFor(prompt, objects, effectZoneChoiceInteraction("zone-choice-1"));
+    render(<CardChoiceModal />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Loading Midnight Reaper" }));
+
+    act(() => {
+      setWaitingFor(
+        { ...prompt, data: { ...prompt.data } },
+        objects,
+        effectZoneChoiceInteraction("zone-choice-2"),
+      );
+    });
+
+    expect(screen.getByRole("button", { name: "Put (0/1)" })).toBeDisabled();
   });
 
   it("allocates any-combination mana with color steppers", () => {

--- a/client/src/components/modal/__tests__/DiscardCostModal.test.tsx
+++ b/client/src/components/modal/__tests__/DiscardCostModal.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { GameObject, WaitingFor } from "../../../adapter/types.ts";
@@ -296,6 +296,55 @@ describe("Discard cost modal", () => {
     expect(screen.getByText("Exile")).toBeInTheDocument();
     expect(screen.getByText("Choose 1 card to exile")).toBeInTheDocument();
     expect(screen.queryByText(/battlefield/i)).not.toBeInTheDocument();
+  });
+
+  it("clears a prior zone-choice pick before confirming the next prompt", () => {
+    const firstPrompt = buildEffectZoneChoiceWaitingFor({
+      player: 0,
+      cards: [10],
+      count: 1,
+      min_count: 0,
+      up_to: false,
+      source_id: 1,
+      effect_kind: "ChangeZone",
+      zone: "Graveyard",
+      destination: "Battlefield",
+    });
+    const secondPrompt = buildEffectZoneChoiceWaitingFor({
+      player: 0,
+      cards: [11],
+      count: 1,
+      min_count: 0,
+      up_to: false,
+      source_id: 1,
+      effect_kind: "ChangeZone",
+      zone: "Graveyard",
+      destination: "Battlefield",
+    });
+    const objects: Record<string, GameObject> = {
+      10: { ...makeObject(10, "Midnight Reaper"), zone: "Graveyard" },
+      11: { ...makeObject(11, "Verdant Sun's Avatar"), zone: "Graveyard" },
+    };
+
+    setWaitingFor(firstPrompt, objects);
+    render(<CardChoiceModal />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Loading Midnight Reaper" }));
+
+    act(() => {
+      setWaitingFor(secondPrompt, objects);
+    });
+
+    const confirm = screen.getByRole("button", { name: "Put (0/1)" });
+    expect(confirm).toBeDisabled();
+
+    fireEvent.click(screen.getByRole("button", { name: "Loading Verdant Sun's Avatar" }));
+    fireEvent.click(confirm);
+
+    expect(dispatchMock).toHaveBeenCalledWith({
+      type: "SelectCards",
+      data: { cards: [11] },
+    });
   });
 
   it("allocates any-combination mana with color steppers", () => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed card selections carrying over between different, sequential zone-choice prompts.
  - New prompts now begin with no prior card selection, while refreshed versions of the same prompt retain the current selection.
  - Confirming a new prompt now dispatches only cards selected for that prompt.

- **Tests**
  - Added coverage for changed prompts and refreshed prompts to verify selection reset and retention behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->