### PR TITLE
fix(p2p): keep games connected when heartbeat replies are delayed

### DIFF
--- a/client/src/adapter/__tests__/p2p-adapter-multiplayer.test.ts
+++ b/client/src/adapter/__tests__/p2p-adapter-multiplayer.test.ts
@@ -832,6 +832,22 @@ async function joinGuest(
 }
 
 describe("P2PHostAdapter — 3-4p multiplayer", () => {
+  it("shares host-measured latency for both guests with every participant", async () => {
+    const { adapter, emitConnection } = makeHost(3);
+    const events = vi.fn();
+    adapter.onEvent(events);
+    await adapter.initialize();
+    const first = await joinGuest(emitConnection, { type: "guest_deck", deckData: { player: { main_deck: [], sideboard: [] } } });
+    const second = await joinGuest(emitConnection, { type: "guest_deck", deckData: { player: { main_deck: [], sideboard: [] } } });
+    await first.simulateData({ type: "pong", timestamp: Date.now() - 42 });
+    await second.simulateData({ type: "pong", timestamp: Date.now() - 120 });
+    const latencies = { 0: 0, 1: 42, 2: 120 };
+    expect(events).toHaveBeenLastCalledWith({ type: "playerLatencies", latencies });
+    for (const conn of [first, second]) {
+      expect(await conn.getSentMessages()).toContainEqual(expect.objectContaining({ type: "player_latencies", latencies }));
+    }
+    adapter.dispose();
+  });
   beforeEach(() => {
     // `toFake` opt-in: keep `queueMicrotask` real so the binary wire-format
     // encode/decode chain (CompressionStream, Response.text) drives stream
@@ -1245,7 +1261,7 @@ describe("P2PHostAdapter — 3-4p multiplayer", () => {
       .toBeLessThan(send.mock.invocationCallOrder[0]!);
     await vi.waitFor(async () => {
       expect((await reconnect.getSentMessages()).map((message) => (message as { type: string }).type))
-        .toEqual(["reconnect_ack", "terminal_result"]);
+        .toEqual(["reconnect_ack", "terminal_result", "player_latencies"]);
     });
     adapter.dispose();
   });
@@ -2562,6 +2578,7 @@ describe("P2PHostAdapter — 3-4p multiplayer", () => {
     expect(messages.map((message) => (message as { type: string }).type)).toEqual([
       "reconnect_ack",
       "ai_driver_fault",
+      "player_latencies",
     ]);
     expect(messages[1]).toMatchObject({ type: "ai_driver_fault", ...fault });
   });
@@ -3529,6 +3546,17 @@ describe("P2PHostAdapter — 3-4p multiplayer", () => {
     await adapter.initializeGame();
     return { adapter, conn };
   }
+
+  it("accepts host latency updates after the handshake and rejects invalid readings", async () => {
+    const { adapter, conn } = await joinedGuest();
+    const events = vi.fn();
+    adapter.onEvent(events);
+    await conn.simulateData({ type: "player_latencies", latencies: { 0: 0, 1: 42, 2: null } });
+    expect(events).toHaveBeenCalledExactlyOnceWith({ type: "playerLatencies", latencies: { 0: 0, 1: 42, 2: null } });
+    await conn.simulateData({ type: "player_latencies", latencies: { 1: -5 } });
+    expect(events).toHaveBeenCalledTimes(1);
+    adapter.dispose();
+  });
 
   it("guest submission the host never answers rejects at the timeout instead of parking forever", async () => {
     const { adapter, conn } = await joinedGuest();
@@ -5381,7 +5409,7 @@ describe("P2PHostAdapter — per-guest eventual state delivery", () => {
   function deliveryFramesIn(messages: unknown[]): unknown[] {
     return messages.filter((m) => {
       const type = (m as { type?: string }).type;
-      return type !== "ping" && type !== "pong";
+      return type !== "ping" && type !== "pong" && type !== "player_latencies";
     });
   }
 

--- a/client/src/adapter/p2p-adapter.ts
+++ b/client/src/adapter/p2p-adapter.ts
@@ -94,6 +94,7 @@ import i18n from "i18next";
  * handlers — the UI never sees wire types.
  */
 export type P2PAdapterEvent =
+  | { type: "playerLatencies"; latencies: Record<number, number | null> }
   | { type: "playerIdentity"; playerId: PlayerId; playerNames?: Record<number, string> }
   | { type: "roomCreated"; roomCode: string }
   | { type: "waitingForGuest" }
@@ -881,6 +882,7 @@ export class P2PHostAdapter implements EngineAdapter {
   private readonly engineClaim = Symbol("p2p-host-engine-claim");
 
   private guestSessions = new Map<PlayerId, PeerSession>();
+  private sessionLatencies = new WeakMap<PeerSession, number | null>();
   /**
    * A reconnecting transport has proved its token but is not a game session
    * until its complete reconnect acknowledgement has been written. This is
@@ -1804,6 +1806,18 @@ export class P2PHostAdapter implements EngineAdapter {
     this.initialized = true;
   }
 
+  private publishPlayerLatencies(): void {
+    if (!this.ownsAuthority()) return;
+    const latencies: Record<number, number | null> = { 0: 0 };
+    for (const [pid, session] of this.guestSessions) {
+      latencies[pid] = this.sessionLatencies.get(session) ?? null;
+    }
+    this.emit({ type: "playerLatencies", latencies });
+    for (const session of this.guestSessions.values()) {
+      void this.send(session, { type: "player_latencies", latencies });
+    }
+  }
+
   private handleNewConnection(conn: DataConnection): void {
     if (!this.ownsAuthority()) {
       const session = createPeerSession(conn, {});
@@ -1815,6 +1829,11 @@ export class P2PHostAdapter implements EngineAdapter {
     // join or a reconnect. We attach a one-shot pre-handler to peek at the
     // first message before wrapping in a PeerSession with full handlers.
     const session = createPeerSession(conn, {
+      onLatency: (latencyMs) => {
+        if (![...this.guestSessions.values()].includes(session)) return;
+        this.sessionLatencies.set(session, latencyMs);
+        this.publishPlayerLatencies();
+      },
       onSessionEnd: () => {
         this.closedPregameSessions.add(session);
         // Find which seat this session belonged to (if any) and route to the
@@ -1971,6 +1990,7 @@ export class P2PHostAdapter implements EngineAdapter {
       this.playerTokens.set(pid, token);
       this.guestSessions.set(pid, session);
       this.guestDecks.set(pid, guestDeck);
+      this.publishPlayerLatencies();
       if (displayName) this.guestNames.set(pid, displayName);
       this.pregameSeatState.seats[pid] = { type: "JoinedHuman" };
       this.pregameSeatState.tokens[pid] = token;
@@ -3297,6 +3317,7 @@ export class P2PHostAdapter implements EngineAdapter {
     if (this.disconnectedSeats.has(pid)) return;
 
     this.guestSessions.delete(pid);
+    this.publishPlayerLatencies();
 
     if (!this.gameStarted) {
       void this.enqueuePregameOp(async () => {
@@ -3491,6 +3512,7 @@ export class P2PHostAdapter implements EngineAdapter {
       this.disconnectedSeats.delete(pid);
       this.guestSessions.set(pid, session);
       session.onMessage((msg) => this.handleGuestMessage(pid, session, msg));
+      this.publishPlayerLatencies();
 
       for (const [otherPid, otherSession] of this.guestSessions) {
         if (otherPid !== pid) void this.send(otherSession, { type: "player_reconnected", playerId: pid });
@@ -3765,6 +3787,7 @@ export class P2PGuestAdapter implements EngineAdapter {
     { resolve: (preview: InteractionPreview) => void; reject: (error: Error) => void }
   >();
   private session: PeerSession | null = null;
+  private hostLatencies: Record<number, number | null> = {};
   /** The current transport becomes authenticated only after its setup ACK. */
   private authenticatedSession: PeerSession | null = null;
   private playerToken: string | null = null;
@@ -3864,6 +3887,11 @@ export class P2PGuestAdapter implements EngineAdapter {
     }
     traceAdapter("Guest", "attach-session", { connOpen: conn.open });
     const session = createPeerSession(conn, {
+      onLatency: (latencyMs) => {
+        if (this.session !== session || latencyMs !== null) return;
+        this.hostLatencies = Object.fromEntries(Object.keys(this.hostLatencies).map((pid) => [pid, null]));
+        this.emit({ type: "playerLatencies", latencies: this.hostLatencies });
+      },
       onSessionEnd: () => {
         this.handleHostDisconnect(session);
       },
@@ -4175,6 +4203,15 @@ export class P2PGuestAdapter implements EngineAdapter {
     }
     if (!this.acceptsHostAuthority(msg)) return;
     switch (msg.type) {
+      case "player_latencies": {
+        if (typeof msg.latencies !== "object" || msg.latencies === null || Array.isArray(msg.latencies)) return;
+        const entries = Object.entries(msg.latencies);
+        if (entries.some(([pid, ms]) => !Number.isSafeInteger(Number(pid)) || Number(pid) < 0
+          || (ms !== null && (typeof ms !== "number" || !Number.isFinite(ms) || ms < 0)))) return;
+        this.hostLatencies = msg.latencies;
+        this.emit({ type: "playerLatencies", latencies: this.hostLatencies });
+        break;
+      }
       case "game_setup": {
         this.authenticatedSession = session;
         this.assignedPlayerId = msg.assignedPlayerId;

--- a/client/src/components/board/OpponentSeatHeader.tsx
+++ b/client/src/components/board/OpponentSeatHeader.tsx
@@ -27,6 +27,7 @@ import { AvatarHoverPreview } from "../hud/AvatarHoverPreview.tsx";
 import { EnchantmentsBadge } from "../hud/EnchantmentsBadge.tsx";
 import { KickConfirmDialog } from "../hud/KickConfirmDialog.tsx";
 import { NextUpBadge } from "../hud/NextUpBadge.tsx";
+import { PlayerLatency } from "../hud/PlayerLatency.tsx";
 
 interface OpponentSeatHeaderProps {
   playerId: PlayerId;
@@ -161,6 +162,7 @@ export function OpponentSeatHeader({ playerId, compact = false, onKickPlayer }: 
             />
           )}
           <LifeTotal playerId={playerId} size="sm" hideLabel />
+          <PlayerLatency playerId={playerId} />
           {/* The enclosing identity block is pointer-events-none (so the
               header's full-area target button owns clicks while this seat is a
               legal target). Re-enable pointer events on the badge cluster so the

--- a/client/src/components/hud/OpponentHud.tsx
+++ b/client/src/components/hud/OpponentHud.tsx
@@ -1,6 +1,7 @@
 import { type CSSProperties, useCallback, useEffect, useId, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { useTranslation } from "react-i18next";
+import { PlayerLatency } from "./PlayerLatency.tsx";
 
 import type { PlayerId } from "../../adapter/types.ts";
 import { useCanActForWaitingState, usePerspectivePlayerId } from "../../hooks/usePlayerId.ts";
@@ -314,6 +315,7 @@ export function OpponentHud({
               ))}
               {opponentCompanion ? <StatusBadge label={t("badges.companion")} /> : null}
               {isOnline ? <ConnectionDotInline disconnected={isDisconnected} /> : null}
+              <PlayerLatency playerId={opponentId} />
             </>
           }
         >
@@ -769,6 +771,7 @@ function OpponentTab({
         <UnboundedBadge key={u.family} family={u.family} state={u.state} />
       ))}
       {isOnline && <ConnectionDotInline disconnected={isDisconnected} />}
+      <PlayerLatency playerId={playerId} />
       {onKick && !isEliminated && (
         // Stop propagation so clicking the kick affordance doesn't also fire
         // the parent button's `onClick` (focus / target select).

--- a/client/src/components/hud/PlayerHud.tsx
+++ b/client/src/components/hud/PlayerHud.tsx
@@ -20,6 +20,7 @@ import { EnchantmentsBadge } from "./EnchantmentsBadge.tsx";
 import { HudPlate } from "./HudPlate.tsx";
 import { NextUpBadge } from "./NextUpBadge.tsx";
 import { StormCounter } from "./StormCounter.tsx";
+import { PlayerLatency } from "./PlayerLatency.tsx";
 
 export function PlayerHud() {
   const { t } = useTranslation("game");
@@ -135,6 +136,7 @@ export function PlayerHud() {
       >
         <div className={`flex min-w-0 items-center ${compact ? "gap-1" : "gap-2"}`}>
           <LifeTotal playerId={playerId} size={compact ? "sm" : "lg"} hideLabel />
+          <PlayerLatency playerId={playerId} />
           <ManaPoolSummary playerId={playerId} size={compact ? "sm" : "default"} />
         </div>
       </HudPlate>

--- a/client/src/components/hud/PlayerLatency.tsx
+++ b/client/src/components/hud/PlayerLatency.tsx
@@ -1,0 +1,20 @@
+import { useTranslation } from "react-i18next";
+
+import { useMultiplayerStore } from "../../stores/multiplayerStore";
+
+/** Host-measured RTT, shared with every participant in a P2P game. */
+export function PlayerLatency({ playerId }: { playerId: number }) {
+  const { t } = useTranslation("game");
+  const latency = useMultiplayerStore((s) => s.playerLatencies[playerId]);
+  const disconnected = useMultiplayerStore((s) => s.disconnectedPlayers.has(playerId));
+  if (latency === undefined || disconnected) return null;
+  return (
+    <span
+      className={`shrink-0 whitespace-nowrap text-[10px] tabular-nums ${latency === null ? "text-amber-400" : "text-gray-400"}`}
+      title={t("playerLatency.description")}
+    >
+      {latency === null ? t("playerLatency.waiting") : playerId === 0
+        ? t("playerLatency.host") : t("playerLatency.value", { ms: latency })}
+    </span>
+  );
+}

--- a/client/src/components/hud/__tests__/PlayerLatency.test.tsx
+++ b/client/src/components/hud/__tests__/PlayerLatency.test.tsx
@@ -1,0 +1,26 @@
+import { act } from "react";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, expect, it } from "vitest";
+
+import { useMultiplayerStore } from "../../../stores/multiplayerStore";
+import { PlayerLatency } from "../PlayerLatency";
+
+beforeEach(() => useMultiplayerStore.setState({ playerLatencies: {}, disconnectedPlayers: new Set() }));
+afterEach(cleanup);
+
+it("shows each seat's host latency and replaces stale readings with Waiting", () => {
+  useMultiplayerStore.setState({ playerLatencies: { 0: 0, 1: 42, 2: 180 } });
+  render(<><PlayerLatency playerId={0} /><PlayerLatency playerId={1} /><PlayerLatency playerId={2} /></>);
+  expect(screen.getByText("Host")).toBeInTheDocument();
+  expect(screen.getByText("42 ms")).toBeInTheDocument();
+  expect(screen.getByText("180 ms")).toBeInTheDocument();
+  act(() => useMultiplayerStore.setState({ playerLatencies: { 0: 0, 1: null, 2: 180 } }));
+  expect(screen.queryByText("42 ms")).not.toBeInTheDocument();
+  expect(screen.getByText("Waiting")).toBeInTheDocument();
+});
+
+it("does not invent latency for unmeasured or disconnected seats", () => {
+  useMultiplayerStore.setState({ playerLatencies: { 1: 42 }, disconnectedPlayers: new Set([1]) });
+  const { container } = render(<><PlayerLatency playerId={1} /><PlayerLatency playerId={2} /></>);
+  expect(container).toBeEmptyDOMElement();
+});

--- a/client/src/i18n/locales/de/game.json
+++ b/client/src/i18n/locales/de/game.json
@@ -1,4 +1,5 @@
 {
+  "playerLatency": {"host":"Host","waiting":"Warten","value":"{{ms}} ms","description":"Hin- und Rücklaufzeit zum Host. Eine fehlende Antwort trennt das Spiel nicht."},
   "abilityBlock": {
     "badge": "Blockiert",
     "cantBeActivated": "Diese Fähigkeit kann nicht aktiviert werden",

--- a/client/src/i18n/locales/en/game.json
+++ b/client/src/i18n/locales/en/game.json
@@ -1,4 +1,5 @@
 {
+  "playerLatency": {"host":"Host","waiting":"Waiting","value":"{{ms}} ms","description":"Round-trip latency to the host. A missing reply does not disconnect the game."},
   "abilityBlock": {
     "badge": "Blocked",
     "cantBeActivated": "This ability can't be activated",

--- a/client/src/i18n/locales/es/game.json
+++ b/client/src/i18n/locales/es/game.json
@@ -1,4 +1,5 @@
 {
+  "playerLatency": {"host":"Anfitrión","waiting":"Esperando","value":"{{ms}} ms","description":"Latencia de ida y vuelta al anfitrión. La falta de respuesta no desconecta la partida."},
   "abilityBlock": {
     "badge": "Bloqueada",
     "cantBeActivated": "Esta habilidad no puede activarse",

--- a/client/src/i18n/locales/fr/game.json
+++ b/client/src/i18n/locales/fr/game.json
@@ -1,4 +1,5 @@
 {
+  "playerLatency": {"host":"Hôte","waiting":"En attente","value":"{{ms}} ms","description":"Latence aller-retour vers l’hôte. Une réponse manquante ne déconnecte pas la partie."},
   "abilityBlock": {
     "badge": "Bloquée",
     "cantBeActivated": "Cette capacité ne peut pas être activée",

--- a/client/src/i18n/locales/it/game.json
+++ b/client/src/i18n/locales/it/game.json
@@ -1,4 +1,5 @@
 {
+  "playerLatency": {"host":"Host","waiting":"In attesa","value":"{{ms}} ms","description":"Latenza di andata e ritorno verso l’host. Una risposta mancante non disconnette la partita."},
   "abilityBlock": {
     "badge": "Bloccata",
     "cantBeActivated": "Questa abilità non può essere attivata",

--- a/client/src/i18n/locales/pl/game.json
+++ b/client/src/i18n/locales/pl/game.json
@@ -1,4 +1,5 @@
 {
+  "playerLatency": {"host":"Host","waiting":"Oczekiwanie","value":"{{ms}} ms","description":"Opóźnienie w obie strony do hosta. Brak odpowiedzi nie rozłącza gry."},
   "abilityBlock": {
     "badge": "Zablokowana",
     "cantBeActivated": "Tej zdolności nie można aktywować",

--- a/client/src/i18n/locales/pt/game.json
+++ b/client/src/i18n/locales/pt/game.json
@@ -1,4 +1,5 @@
 {
+  "playerLatency": {"host":"Anfitrião","waiting":"Aguardando","value":"{{ms}} ms","description":"Latência de ida e volta até o anfitrião. A falta de resposta não desconecta a partida."},
   "abilityBlock": {
     "badge": "Bloqueada",
     "cantBeActivated": "Esta habilidade não pode ser ativada",

--- a/client/src/network/__tests__/peer.test.ts
+++ b/client/src/network/__tests__/peer.test.ts
@@ -350,7 +350,7 @@ describe("PeerSession keep-alive", () => {
     }
   });
 
-  it("still disconnects a silent peer during a slow game handler", async () => {
+  it("keeps a silent peer connected during a slow game handler", async () => {
     vi.useFakeTimers();
     const conn = new SilentPeerConnection();
     const session = createPeerSession(conn as never);
@@ -368,11 +368,11 @@ describe("PeerSession keep-alive", () => {
       await vi.advanceTimersByTimeAsync(0);
       const second = conn.simulateData({ type: "concede" });
       await vi.advanceTimersByTimeAsync(10_000);
-      expect(onDisconnect).toHaveBeenCalledExactlyOnceWith("Ping timeout");
+      expect(onDisconnect).not.toHaveBeenCalled();
 
       release();
       await Promise.all([first, second]);
-      expect(received).toEqual(["concede"]);
+      expect(received).toEqual(["concede", "concede"]);
     } finally {
       release();
       session.close();
@@ -380,31 +380,29 @@ describe("PeerSession keep-alive", () => {
     }
   });
 
-  it("disconnects a peer that stops answering pings", async () => {
+  it("marks latency stale without closing a channel that stops answering pings", async () => {
     vi.useFakeTimers();
+    const conn = new SilentPeerConnection();
+    const onLatency = vi.fn();
+    const session = createPeerSession(conn as never, { onLatency });
     try {
-      const conn = new SilentPeerConnection();
-      const session = createPeerSession(conn as never);
       const onDisconnect = vi.fn();
       session.onDisconnect(onDisconnect);
-
-      // First tick: a ping goes out, but only 5s of silence has accrued.
-      await vi.advanceTimersByTimeAsync(5_000);
+      await conn.simulateData({ type: "pong", timestamp: Date.now() - 42 });
+      expect(onLatency).toHaveBeenLastCalledWith(42);
+      await vi.advanceTimersByTimeAsync(15_000);
+      expect(onLatency).toHaveBeenLastCalledWith(null);
+      await conn.simulateData({ type: "emote", emote: "still here" });
+      await vi.advanceTimersByTimeAsync(45_000);
       expect(onDisconnect).not.toHaveBeenCalled();
-
-      // Second tick: 10s with no pong, and the inter-tick gap is a healthy 5s,
-      // so the silence is real evidence.
-      await vi.advanceTimersByTimeAsync(5_000);
-      expect(onDisconnect).toHaveBeenCalledWith("Ping timeout");
-      expect(trackEvent).toHaveBeenCalledExactlyOnceWith("p2p_disconnect", expect.objectContaining({
-        reason: "ping-timeout",
-        pong_age_ms: 10_000,
-        receive_age_ms: -1,
-        pending_sends: 0,
-        pending_decodes: 0,
-        channel_open: true,
-      }));
+      expect(conn.open).toBe(true);
+      expect(trackEvent).not.toHaveBeenCalled();
+      await conn.simulateData({ type: "pong", timestamp: Date.now() - 21 });
+      expect(onLatency).toHaveBeenLastCalledWith(21);
+      conn.close();
+      expect(onDisconnect).toHaveBeenCalledExactlyOnceWith("Connection closed");
     } finally {
+      session.close();
       vi.useRealTimers();
     }
   });
@@ -448,10 +446,7 @@ describe("PeerSession keep-alive", () => {
       // observe a healthy 5s gap, and would pass against any implementation.
       vi.setSystemTime(Date.now() + 300_000);
 
-      // Resume: the next tick observes a 305s gap since its predecessor. A
-      // bare `now - lastPongAt` check cannot tell that from 305s of real
-      // silence and would disconnect here; the inter-tick gap can, and
-      // re-baselines instead.
+      // Resume: elapsed wall time must never tear down the channel.
       await vi.advanceTimersByTimeAsync(5_000);
 
       expect(onDisconnect).not.toHaveBeenCalled();
@@ -461,7 +456,7 @@ describe("PeerSession keep-alive", () => {
     }
   });
 
-  it("re-baselines after the wall clock moves backward", async () => {
+  it("does not disconnect when the wall clock moves backward", async () => {
     vi.useFakeTimers();
     try {
       const conn = new SilentPeerConnection();
@@ -478,13 +473,11 @@ describe("PeerSession keep-alive", () => {
       // so ticks keep their 5s spacing — only `Date.now()` jumps.
       vi.setSystemTime(Date.now() - 60_000);
 
-      // The peer has never ponged, so it must still be declared dead. Without
-      // the negative-gap re-baseline, `lastPongAt` is stranded a minute in the
-      // future and `now - lastPongAt` stays negative, so this detector would
-      // stay disabled until the clock caught up — the failure this guards.
+      // Missing pongs and clock adjustments affect measurement only.
       await vi.advanceTimersByTimeAsync(20_000);
 
-      expect(onDisconnect).toHaveBeenCalledWith("Ping timeout");
+      expect(onDisconnect).not.toHaveBeenCalled();
+      session.close();
     } finally {
       vi.useRealTimers();
     }

--- a/client/src/network/peer.ts
+++ b/client/src/network/peer.ts
@@ -34,9 +34,11 @@ export interface PeerSessionOptions {
    * adapter that created the `Peer`.
    */
   onSessionEnd?: () => void;
+  /** Round-trip latency, or null when the last measurement is stale. */
+  onLatency?: (latencyMs: number | null) => void;
 }
 
-type DisconnectCause = "ping-timeout" | "send-error" | "connection-close"
+type DisconnectCause = "send-error" | "connection-close"
   | "connection-error" | "remote-disconnect" | "local-close";
 
 export function createPeerSession(
@@ -52,23 +54,13 @@ export function createPeerSession(
 
   const pendingMessages: P2PMessage[] = [];
 
-  // Ping/pong keep-alive. We probe every `PING_INTERVAL_MS`; a channel that
-  // has produced no pong for `PONG_TIMEOUT_MS` is declared dead. This is the
-  // only detector for a HALF-OPEN channel — one where `conn.open` is still
-  // true and `conn.on("close")` will never fire because nothing ever formally
-  // closed.
+  // Probes measure latency only. A delayed pong is not evidence that a live
+  // WebRTC channel should be destroyed (state traffic can still be arriving).
   const PING_INTERVAL_MS = 5_000;
-  const PONG_TIMEOUT_MS = 10_000;
-
+  const LATENCY_STALE_MS = 15_000;
   let pingInterval: ReturnType<typeof setInterval> | null = null;
-  // `Date.now()` of the most recent pong, and of the previous interval tick.
-  // Wall clock specifically because it is the clock a test can move
-  // independently of the timer queue (`vi.setSystemTime`), which is what makes
-  // the suspend discriminator below observable at all. Whether
-  // `performance.now()` also advances across a suspend is browser-dependent and
-  // is deliberately NOT the reason stated here.
-  let lastPongAt = 0;
-  let lastTickAt = 0;
+  let lastPongAt = Date.now();
+  let latencyStale = false;
   let lastReceivedAt: number | null = null;
   let lastReceivedType: P2PMessage["type"] | "" = "";
   let pendingSends = 0;
@@ -128,61 +120,13 @@ export function createPeerSession(
   };
 
   const startKeepAlive = () => {
-    lastPongAt = lastTickAt = Date.now();
     pingInterval = setInterval(() => {
       if (!conn.open) return;
-
       const now = Date.now();
-      const sinceLastTick = now - lastTickAt;
-      lastTickAt = now;
-
-      // Suspend discriminator. A bare `now - lastPongAt` is NOT enough: a tab
-      // frozen for five minutes and a channel silent for five minutes produce
-      // the identical gap, and disconnecting every resumed tab (routine on
-      // mobile) is worse than missing a dead channel. The gap since the
-      // PREVIOUS TICK is what tells them apart — a tick that arrives a whole
-      // silence budget after its predecessor did not observe the interval it
-      // was scheduled for, so the elapsed time is no evidence about the peer.
-      // Re-baseline and start measuring again.
-      //
-      // ACCEPTED CONSEQUENCE: re-baselining disables this detector for as long
-      // as ticks keep arriving a full budget apart, and it does NOT distinguish
-      // WHY they do. Any cause counts — a frozen tab, Chrome's intensive
-      // throttling tier (hidden >= 5 min, ~1 tick/minute), or a long
-      // synchronous WASM engine call blocking a FOREGROUNDED main thread. Note
-      // ordinary hidden-tab throttling (~1/sec) does not delay a 5s interval at
-      // all, so a merely-backgrounded tab usually keeps detecting normally.
-      // Detection resumes two ticks after normal 5s pacing returns.
-      //
-      // The symmetric case is the PEER's, and this change newly reaches it: a
-      // foregrounded tab sees healthy 5s gaps, so it never re-baselines, and it
-      // will drop a peer whose page the browser has frozen for a whole budget.
-      // Two things bound the damage. Pong replies ride `conn.on("data")`
-      // rather than a timer, so ordinary hidden-tab throttling never silences a
-      // peer; and a dropped peer auto-reconnects inside the host's 30s
-      // `DEFAULT_GRACE_PERIOD_MS` (p2p-adapter.ts). A device locked past that
-      // grace now loses the seat where it previously survived until ICE failed.
-      //
-      // That is the intended trade. The alternative — concluding silence from a
-      // gap the tick cannot explain — false-disconnects a healthy peer, which
-      // is the harm this whole branch exists to prevent.
-      // `Date.now()` is wall-clock, so it can also move BACKWARD (an NTP step,
-      // a manual clock change, a VM restore). That strands `lastPongAt` in the
-      // future, and every later comparison then reads as "answered recently"
-      // until the clock catches up — the detector silently disables itself for
-      // the width of the jump. A negative gap is a discontinuity for the same
-      // reason an oversized one is: the tick observed no interval it can vouch
-      // for, so the elapsed time is no evidence about the peer. Re-baseline.
-      if (sinceLastTick >= PONG_TIMEOUT_MS || sinceLastTick < 0) {
-        lastPongAt = now;
-      } else if (now - lastPongAt >= PONG_TIMEOUT_MS) {
-        handleDisconnect("Ping timeout", "ping-timeout");
-        return;
+      if (!latencyStale && (now - lastPongAt >= LATENCY_STALE_MS || now < lastPongAt)) {
+        latencyStale = true;
+        options.onLatency?.(null);
       }
-
-      // Fire-and-forget: real `conn.send` failures fire `handleDisconnect`
-      // from inside the queue's catch; the silence check above bounds
-      // detection latency for everything else.
       void trySend({ type: "ping", timestamp: now });
     }, PING_INTERVAL_MS);
   };
@@ -190,9 +134,7 @@ export function createPeerSession(
   const beforeUnloadHandler = () => {
     // Best-effort farewell over the queued path. Compression is async, so the
     // message may not flush before the tab is torn down. If it doesn't, the
-    // remote side falls back to its own keep-alive silence check (~10s), which
-    // covers a foregrounded peer but is deliberately inert while that peer's
-    // tab is backgrounded — see `startKeepAlive`.
+    // remote side relies on WebRTC channel closure/error detection.
     if (!closed && conn.open) void trySend({ type: "disconnect", reason: "Page closed" });
   };
   window.addEventListener("beforeunload", beforeUnloadHandler);
@@ -292,8 +234,11 @@ export function createPeerSession(
       }
 
       if (msg.type === "pong") {
-        // Sole liveness evidence the keep-alive tick reads.
+        const elapsed = Date.now() - msg.timestamp;
+        if (!Number.isFinite(elapsed) || elapsed < 0) return;
         lastPongAt = Date.now();
+        latencyStale = false;
+        options.onLatency?.(Math.round(elapsed));
         return;
       }
 

--- a/client/src/network/protocol.ts
+++ b/client/src/network/protocol.ts
@@ -427,6 +427,8 @@ export type P2PMessage = P2PAuthorityWire & (
   | { type: "interaction_preview"; requestId: string; answer: P2PInteractionPreviewAnswer }
   | { type: "ping"; timestamp: number }
   | { type: "pong"; timestamp: number }
+  /** Host-measured round-trip latency for each connected human seat. */
+  | { type: "player_latencies"; latencies: Record<number, number | null> }
   | { type: "disconnect"; reason: string }
   | { type: "emote"; emote: string }
   | { type: "concede" }
@@ -508,6 +510,7 @@ const VALID_TYPES = new Set([
   "interaction_preview",
   "ping",
   "pong",
+  "player_latencies",
   "disconnect",
   "emote",
   "concede",

--- a/client/src/providers/GameProvider.tsx
+++ b/client/src/providers/GameProvider.tsx
@@ -828,6 +828,9 @@ export function GameProvider({
           void Notification.requestPermission().catch(() => {});
         }
         p2pUnsubscribe = adapter.onEvent((event) => {
+          if (event.type === "playerLatencies") {
+            useMultiplayerStore.setState({ playerLatencies: event.latencies });
+          }
           if (event.type === "playerIdentity") {
             useMultiplayerStore.getState().setActivePlayerId(event.playerId);
             if (event.playerNames) {
@@ -1137,6 +1140,7 @@ export function GameProvider({
         ac.abort();
         if (controller) controller.dispose();
         if (p2pUnsubscribe) p2pUnsubscribe();
+        useMultiplayerStore.setState({ playerLatencies: {} });
         // `adapter.dispose()` is the SOLE tear-down path for the host/guest
         // Peer (see plan §4 "Peer ownership"). It also closes per-guest
         // sessions, clears timers, and disposes the WASM engine.

--- a/client/src/stores/multiplayerStore.ts
+++ b/client/src/stores/multiplayerStore.ts
@@ -1253,6 +1253,7 @@ interface MultiplayerState {
   // Action round-trip tracking (ephemeral — not persisted)
   actionPending: boolean;
   latencyMs: number | null;
+  playerLatencies: Record<number, number | null>;
   // Hosting session (ephemeral — not persisted)
   hostGameCode: string | null;
   hostIsPublic: boolean;
@@ -2401,6 +2402,7 @@ export const useMultiplayerStore = create<MultiplayerState & MultiplayerActions>
       disconnectedPlayers: new Set(),
       actionPending: false,
       latencyMs: null,
+      playerLatencies: {},
       hostGameCode: null,
       hostIsPublic: false,
       hostingStatus: "idle" as HostingStatus,


### PR DESCRIPTION
Production v0.81.2 telemetry captured a ping timeout with WebRTC and ICE still connected and a state_update received only 68 ms earlier. The pong-only watchdog destroyed a channel that was still delivering game traffic.

Remove automatic channel teardown for missed pongs. Retain five-second probes for round-trip latency, mark measurements stale after fifteen seconds, and keep existing explicit close/error/send-failure handling and reconnect behavior. A silently stalled channel can consequently take longer to be recognized as disconnected; missed heartbeat replies now affect the display rather than pausing a game.

Publish the host's per-seat latency measurements to authenticated guests and render compact readings on local, opponent, and split-board HUDs. The host is labeled Host, stale readings show Waiting, and unknown/AI/disconnected seats do not receive invented latency numbers. Session ownership guards prevent unassigned peers from publishing latency updates; the guest validates received values. Latencies are transient transport state and do not enter engine snapshots or persistence.

Validation: all 6,704 frontend tests pass under Tilt (499 files; 12 existing todos), including 23 peer transport tests, three-player adapter fan-out, invalid measurement rejection, and per-seat/stale/hidden HUD readings. Type-check and lint pass (existing warnings only), cargo fmt and git diff --check pass. An isolated real-browser render confirms Host / 42 ms / Waiting states. Existing state-delivery and reconnect-order tests retain their assertions while accounting for the additional transport-metadata message.

Review: CodeRabbit and the security scan completed without actionable findings at 6ec834c766. The aggregate docstring-coverage warning identifies no missing behavioral contract and does not warrant expanding this incident fix with unrelated documentation changes.
