### PR TITLE
fix(engine): match changeling cards against a revealed chosen creature type

### DIFF
--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -16437,31 +16437,19 @@ pub(crate) fn evaluate_condition(
                 }),
             };
             let filter_matches = match additional_filter {
-                // CR 205.3m: "of the chosen type" — check the revealed card's subtype
-                // against the source permanent's chosen creature type.
-                Some(FilterProp::IsChosenCreatureType) => {
-                    let source = state.objects.get(&ability.source_id);
-                    let subject_subtypes = subject.as_ref().and_then(|(id, lki)| match lki {
-                        Some(lki) => Some(lki.subtypes.as_slice()),
-                        None => state
-                            .objects
-                            .get(id)
-                            .map(|object| object.card_types.subtypes.as_slice()),
-                    });
-                    source
-                        .and_then(|src| src.chosen_creature_type())
-                        .zip(subject_subtypes)
-                        .is_some_and(|(chosen_type, subtypes)| {
-                            subtypes
-                                .iter()
-                                .any(|subtype| subtype.eq_ignore_ascii_case(chosen_type))
-                        })
-                }
                 // CR 202.3 + CR 700.1: Generic property gates on the revealed card
                 // (e.g. Kellan, Daring Traveler's "creature card with mana value 3
                 // or less" → `FilterProp::Cmc`). Evaluate the property against the
                 // revealed subject through the shared filter evaluator, exactly as
                 // `subtype_filter` does above.
+                //
+                // CR 205.3m + CR 702.73a: `IsChosenCreatureType` ("of the chosen
+                // type" — Herald's Horn) routes through this same arm on purpose.
+                // The shared evaluator resolves the chosen type via
+                // `subtype_matches_with_changeling`, so a Changeling card in the
+                // library (Morophon, the Boundless under a Horn naming Slivers)
+                // matches every creature type. A hand-rolled subtype string
+                // comparison here would silently drop that expansion.
                 Some(prop) => subject.as_ref().is_some_and(|(id, lki)| {
                     let filter = TargetFilter::Typed(crate::types::ability::TypedFilter {
                         type_filters: vec![],
@@ -32069,6 +32057,106 @@ mod tests {
                 .count(),
             1,
             "land-card rider must create a Treasure after the parent ChangeZone moved a land",
+        );
+    }
+
+    /// CR 205.3m + CR 702.73a: Herald's Horn naming Slivers must offer Morophon,
+    /// the Boundless off the top of the library. Morophon prints no Sliver
+    /// subtype — it is a Shapeshifter with Changeling, so it IS every creature
+    /// type, including in the library where the layer system does not run.
+    ///
+    /// This pins the `RevealedHasCardType { additional_filter }` gate to the
+    /// shared filter evaluator (`subtype_matches_with_changeling`). A hand-rolled
+    /// subtype string comparison at this site passes the plain-Sliver case and
+    /// silently drops every Changeling card — the whole class (Herald's Horn,
+    /// Vanquisher's Banner-style chosen-type reveals, Kindred Discovery) is
+    /// affected, not just this printing.
+    #[test]
+    fn revealed_chosen_creature_type_matches_a_changeling_card_in_the_library() {
+        let mut state = GameState::new_two_player(42);
+        state.all_creature_types = vec![
+            "Sliver".to_string(),
+            "Shapeshifter".to_string(),
+            "Goblin".to_string(),
+        ];
+
+        let horn = create_object(
+            &mut state,
+            CardId(99),
+            PlayerId(0),
+            "Herald's Horn".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let obj = state.objects.get_mut(&horn).unwrap();
+            obj.card_types.core_types.push(CoreType::Artifact);
+            obj.base_card_types = obj.card_types.clone();
+            obj.chosen_attributes
+                .push(crate::types::ability::ChosenAttribute::CreatureType(
+                    "Sliver".to_string(),
+                ));
+        }
+
+        // Morophon: Shapeshifter creature card with Changeling, sitting on top
+        // of the library. No printed Sliver subtype.
+        let morophon = create_object(
+            &mut state,
+            CardId(100),
+            PlayerId(0),
+            "Morophon, the Boundless".to_string(),
+            Zone::Library,
+        );
+        {
+            let obj = state.objects.get_mut(&morophon).unwrap();
+            obj.card_types.core_types.push(CoreType::Creature);
+            obj.card_types.subtypes.push("Shapeshifter".to_string());
+            obj.base_card_types = obj.card_types.clone();
+            obj.keywords
+                .push(crate::types::keywords::Keyword::Changeling);
+        }
+
+        // Control: a plain Goblin creature card, no Changeling, no Sliver type.
+        let goblin = create_object(
+            &mut state,
+            CardId(101),
+            PlayerId(0),
+            "Mogg Fanatic".to_string(),
+            Zone::Library,
+        );
+        {
+            let obj = state.objects.get_mut(&goblin).unwrap();
+            obj.card_types.core_types.push(CoreType::Creature);
+            obj.card_types.subtypes.push("Goblin".to_string());
+            obj.base_card_types = obj.card_types.clone();
+        }
+
+        let ability = ResolvedAbility::new(
+            Effect::Draw {
+                count: QuantityExpr::Fixed { value: 1 },
+                target: TargetFilter::Controller,
+            },
+            vec![],
+            horn,
+            PlayerId(0),
+        );
+        let condition = AbilityCondition::RevealedHasCardType {
+            card_types: vec![CoreType::Creature],
+            additional_filter: Some(FilterProp::IsChosenCreatureType),
+            subtype_filter: None,
+        };
+
+        state.last_revealed_ids.push(morophon);
+        assert!(
+            evaluate_condition(&condition, &state, &ability),
+            "Changeling card must satisfy \"creature card of the chosen type\" \
+             (CR 702.73a) — Herald's Horn naming Slivers must offer Morophon",
+        );
+
+        state.last_revealed_ids.clear();
+        state.last_revealed_ids.push(goblin);
+        assert!(
+            !evaluate_condition(&condition, &state, &ability),
+            "a non-Changeling Goblin must NOT satisfy the chosen type Sliver",
         );
     }
 

--- a/crates/engine/tests/integration/heralds_horn_changeling_chosen_type.rs
+++ b/crates/engine/tests/integration/heralds_horn_changeling_chosen_type.rs
@@ -1,0 +1,210 @@
+//! CR 702.73a + CR 205.3m: a Changeling card satisfies "a creature card of the
+//! chosen type" while it is still in the library.
+//!
+//! Reported from live play: Herald's Horn naming Slivers triggered on upkeep
+//! with Morophon, the Boundless on top of the library, and the player was never
+//! offered the card. Morophon prints no Sliver subtype — it is a Shapeshifter
+//! with Changeling, so per CR 702.73a it IS every creature type.
+//!
+//! The layer system physically expands a Changeling permanent's subtypes only
+//! on the battlefield, so a card sitting in the LIBRARY keeps its printed
+//! `Shapeshifter`. The reveal gate therefore has to ask the shared filter
+//! authority (`subtype_matches_with_changeling`) rather than compare printed
+//! subtype strings, which is what this test pins.
+//!
+//! Three legs, because the negative leg is only meaningful next to a positive
+//! one that proves the pipeline actually reaches the offer:
+//!
+//!   * `metallic_sliver` — a real printed Sliver. REACH GUARD: if this stops
+//!     being offered the scenario itself has broken, and the Grizzly Bears leg
+//!     below would start passing for the wrong reason.
+//!   * `morophon, the boundless` — the regression. Fails before the fix.
+//!   * `grizzly bears` — an ordinary non-Sliver, non-Changeling creature. Must
+//!     NOT be offered, or the fix would just be "always true".
+
+use engine::game::scenario::{GameScenario, P0};
+use engine::game::scenario_db::GameScenarioDbExt;
+use engine::types::ability::ChosenAttribute;
+use engine::types::actions::GameAction;
+use engine::types::game_state::WaitingFor;
+use engine::types::identifiers::ObjectId;
+use engine::types::phase::Phase;
+use engine::types::zones::Zone;
+
+use crate::support::shared_card_db as load_db;
+
+/// What Herald's Horn's upkeep trigger did with the top card of the library.
+struct HornUpkeep {
+    /// Whether the "you may ... put it into your hand" offer was made.
+    offered: bool,
+    /// Zone of the top card after accepting any offer that was made.
+    top_card_zone: Zone,
+}
+
+/// Put Herald's Horn onto the battlefield with `chosen_type` named, stack
+/// `top_card` on top of the controller's library, and run to the controller's
+/// upkeep trigger.
+///
+/// Returns `None` when the card fixture is unavailable (CI without card data).
+fn run_horn_upkeep(chosen_type: &str, top_card: &str) -> Option<HornUpkeep> {
+    let db = load_db()?;
+
+    let mut scenario = GameScenario::new();
+    let horn = scenario.add_real_card(P0, "Herald's Horn", Zone::Battlefield, db);
+    let top = scenario.add_real_card(P0, top_card, Zone::Library, db);
+    // A little library depth so no draw/empty-library state-based action
+    // (CR 704.5b) interferes with the upkeep window.
+    for _ in 0..3 {
+        scenario.add_real_card(P0, "Grizzly Bears", Zone::Library, db);
+    }
+    let mut runner = scenario.build();
+
+    {
+        let state = runner.state_mut();
+
+        // CR 205.3m: the Changeling expansion is bounded by the runtime creature
+        // subtype catalog. Production seeds this from the whole card corpus in
+        // `load_and_hydrate_decks`; mirror that here so "Sliver" is a real
+        // catalog entry rather than a value this test invented.
+        state.all_creature_types = db.creature_type_vocabulary().to_vec();
+
+        // `add_real_card` abandons as-enters choices during scenario setup, so
+        // Herald's Horn's "As this artifact enters, choose a creature type"
+        // (CR 614.12) leaves no choice behind. Name the type directly — this
+        // test is about the reveal gate, not about the enters-choice prompt.
+        state
+            .objects
+            .get_mut(&horn)
+            .expect("Herald's Horn is on the battlefield")
+            .chosen_attributes
+            .push(ChosenAttribute::CreatureType(chosen_type.to_string()));
+
+        // Put the card under test on TOP of the library (CR 701.20a looks at
+        // the top card, so library order is the whole setup).
+        let player = state.players.iter_mut().find(|p| p.id == P0).unwrap();
+        player.library.retain(|id| *id != top);
+        player.library.push_front(top);
+    }
+
+    runner.advance_to_upkeep();
+
+    // Reach guard: the trigger must actually be on the stack. Without this a
+    // silently-missing trigger would make every "not offered" assertion below
+    // pass for the wrong reason.
+    assert_eq!(
+        runner.state().phase,
+        Phase::Upkeep,
+        "scenario must reach the controller's upkeep"
+    );
+    assert_eq!(
+        runner.state().active_player,
+        P0,
+        "the upkeep reached must be the Horn controller's own (CR 506.1)"
+    );
+    assert!(
+        runner
+            .state()
+            .stack
+            .iter()
+            .any(|entry| entry.source_id == horn),
+        "Herald's Horn's upkeep trigger must be on the stack, stack was {:?}",
+        runner.stack_names()
+    );
+
+    // CR 603.3b + CR 608.1: both players pass, the trigger resolves, and the
+    // look-at-top / reveal chain runs.
+    runner
+        .act(GameAction::PassPriority)
+        .expect("controller passes priority");
+    runner
+        .act(GameAction::PassPriority)
+        .expect("opponent passes priority");
+
+    let offered = matches!(
+        runner.state().waiting_for,
+        WaitingFor::OptionalEffectChoice { .. }
+    );
+
+    if offered {
+        runner
+            .act(GameAction::DecideOptionalEffect { accept: true })
+            .expect("accepting the Horn's optional reveal");
+    }
+
+    Some(HornUpkeep {
+        offered,
+        top_card_zone: zone_of(&runner, top),
+    })
+}
+
+fn zone_of(runner: &engine::game::scenario::GameRunner, id: ObjectId) -> Zone {
+    runner
+        .state()
+        .objects
+        .get(&id)
+        .expect("the top card still exists")
+        .zone
+}
+
+/// CR 702.73a: the regression. Morophon has Changeling and therefore IS a
+/// Sliver, even in the library where the layer system does not run. Before the
+/// fix the gate compared printed subtypes (`Shapeshifter`) against the chosen
+/// type and the offer was never made.
+#[test]
+fn heralds_horn_offers_a_changeling_card_of_the_chosen_type() {
+    let Some(result) = run_horn_upkeep("Sliver", "Morophon, the Boundless") else {
+        return;
+    };
+
+    assert!(
+        result.offered,
+        "Herald's Horn naming Slivers must offer Morophon, the Boundless — \
+         Changeling makes it every creature type (CR 702.73a)"
+    );
+    assert_eq!(
+        result.top_card_zone,
+        Zone::Hand,
+        "accepting the offer must put the Changeling card into its owner's hand"
+    );
+}
+
+/// CR 205.3m: REACH GUARD for the negative test below. A real printed Sliver
+/// must be offered. If this leg ever fails, the scenario stopped reaching the
+/// offer at all and the `grizzly_bears` assertion would be vacuous.
+#[test]
+fn heralds_horn_offers_a_printed_card_of_the_chosen_type() {
+    let Some(result) = run_horn_upkeep("Sliver", "Metallic Sliver") else {
+        return;
+    };
+
+    assert!(
+        result.offered,
+        "Herald's Horn naming Slivers must offer a printed Sliver"
+    );
+    assert_eq!(
+        result.top_card_zone,
+        Zone::Hand,
+        "accepting the offer must put the Sliver into its owner's hand"
+    );
+}
+
+/// CR 205.3m: the Changeling expansion must not leak into ordinary creatures.
+/// Grizzly Bears is a Bear with no Changeling, so naming Slivers must leave it
+/// on top of the library with no offer made.
+#[test]
+fn heralds_horn_does_not_offer_an_ordinary_creature_of_another_type() {
+    let Some(result) = run_horn_upkeep("Sliver", "Grizzly Bears") else {
+        return;
+    };
+
+    assert!(
+        !result.offered,
+        "an ordinary Bear must NOT satisfy \"creature card of the chosen type\" \
+         when Slivers were named"
+    );
+    assert_eq!(
+        result.top_card_zone,
+        Zone::Library,
+        "a card that fails the chosen-type gate stays on top of the library"
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -376,6 +376,7 @@ mod head_of_the_hunt_token_controller_7086;
 mod heart_shaped_herb_monarch;
 mod heist_production_path_handoff;
 mod hellkite_tyrant_steal_artifacts_2906;
+mod heralds_horn_changeling_chosen_type;
 mod heroic_defiance_recipient_color_4590;
 mod heroic_return_enters_this_way;
 mod heroic_sacrifice_redirect;


### PR DESCRIPTION
## Summary

Herald's Horn naming Slivers did not offer **Morophon, the Boundless** off the top of the library. Morophon prints no Sliver subtype — it's a Shapeshifter with **Changeling**, so per **CR 702.73a** it *is* every creature type.

Reported from live play: Horn triggered on upkeep, top card was Morophon, no "put it into your hand" prompt appeared.

## Root cause

`AbilityCondition::RevealedHasCardType` had a hand-rolled special case for `additional_filter: IsChosenCreatureType` that compared the revealed card's **printed** subtypes against the chosen type with a raw string match:

```rust
subtypes.iter().any(|s| s.eq_ignore_ascii_case(chosen_type))
```

That never consults the Changeling expansion. The layer system physically expands subtypes only for permanents **on the battlefield**, so a card sitting in the library keeps its printed `Shapeshifter`, the gate returned `false`, and the `optional: true` "you may reveal it and put it into your hand" prompt was never offered.

## Fix

Delete the special case so the arm falls through to the generic `Some(prop)` branch directly below it, which routes the property through the shared filter evaluator. That path already resolves `IsChosenCreatureType` via `subtype_matches_with_changeling` on **both** the live-object and LKI-snapshot rungs — and that helper is documented as the canonical fallback for exactly the non-battlefield zones the layer system doesn't reach.

Net **−20/+15** lines of logic. No new enum variants, no new surface — this deletes a bespoke path in favour of the single authority the rest of the codebase already uses for this question.

## This fixes the class, not the card

Any chosen-type reveal gate was equally blind to changelings. Herald's Horn is simply the printing that surfaced it.

`subtype_matches_with_changeling` keeps the **CR 205.3m** gate intact: changeling confers only *creature* subtypes, bounded by the runtime `all_creature_types` catalog, so a Changeling card still does not match artifact/land/enchantment subtypes.

## Verification against shipped card data

Confirmed the diagnosis end-to-end in `client/public/card-data.json` rather than from memory — Herald's Horn's upkeep trigger lowers to `Dig` → `RevealTop` with:

```json
"condition": {
  "type": "RevealedHasCardType",
  "card_types": ["Creature"],
  "additional_filter": { "type": "IsChosenCreatureType" }
}
```

and Morophon carries `"keywords": ["Changeling"]`. Oracle text checked against the card's own entry, and the printed ruling confirms the intended behaviour ("you may put it into your hand").

## Test

Adds `revealed_chosen_creature_type_matches_a_changeling_card_in_the_library`, pinning both directions at the building-block level:

- a Changeling card in the **library** satisfies "creature card of the chosen type"
- a plain non-Changeling Goblin does **not** satisfy chosen type Sliver

The negative leg matters: it's what keeps the fix from degenerating into "always true".

## Checks

| Check | Result |
|---|---|
| `cargo fmt --all` | clean |
| `cargo clippy -p phase-engine --all-targets -- -D warnings` | clean |
| `cargo test -p phase-engine --lib` | **21195 passed, 0 failed** |

Also ran the full integration suite on the pre-rebase commit (6893 passed). The one failure there was `cr733_authority_matrix_covers_the_fresh_write_census`, which shells out to `python3` — on Windows that resolves to the Microsoft Store alias stub rather than a real interpreter. Environmental and unrelated to this change; filing separately.

## Notes

- Branch is committed directly on top of `c811f2b9`, so CI sees current `main`.
- Runtime-only change: no parser or AST change, so no card-data regeneration is required.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed revealed-card filtering for effects that check whether a card is a creature of the chosen type.
  - Changeling cards now correctly qualify as the chosen creature type, while non-Changeling creatures only qualify when their actual type matches.
  - Added coverage to verify the filtering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->