### PR TITLE
fix(cost): refuse an unreadable additional cost instead of casting for free

### DIFF
--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -15777,6 +15777,14 @@ fn can_cast_prepared_now_with_probe(
                 return false;
             }
         }
+        // CR 601.2f + CR 601.2h: a REQUIRED additional cost the parser could not
+        // read is part of the total cost and has no payment procedure, so it
+        // can't be paid and the spell can't be cast. Gate enumeration here so
+        // the action never reaches `legal_actions_full`; the payment step in
+        // `casting_costs.rs` is the backstop for a directly submitted `CastSpell`.
+        if matches!(cost, AbilityCost::Unimplemented { .. }) {
+            return false;
+        }
     }
 
     // CR 118.3 + CR 601.2f-h: A mandatory choice of additional costs is

--- a/crates/engine/src/game/casting_costs.rs
+++ b/crates/engine/src/game/casting_costs.rs
@@ -323,6 +323,16 @@ pub(crate) fn additional_cost_declaration_is_offerable(
     pending: &PendingCast,
     cost: AbilityCost,
 ) -> Result<bool, EngineError> {
+    // CR 601.2h: "Unpayable costs can't be paid." A cost the parser could not
+    // read has no payment procedure at all, so it can never be declared — a
+    // required one makes the cast illegal (CR 601.2 + CR 733.1), and an optional
+    // one is simply never offered. `AbilityCost::is_payable` deliberately answers
+    // true for `Unimplemented` so unrelated fallback paths stay ungated (see the
+    // comment on that arm in `cost_payability.rs`), so the refusal belongs here,
+    // at the declaration authority, rather than in that shared predicate.
+    if matches!(cost, AbilityCost::Unimplemented { .. }) {
+        return Ok(false);
+    }
     let exile_this_way_cost = is_exile_any_number_effect_cost(&cost);
     let split = split_declared_mana_addition_and_residual(state, pending, cost)?;
     if let Some(residual) = split.residual.as_ref() {
@@ -7027,6 +7037,18 @@ pub(super) fn check_additional_cost_or_pay_with_distribute(
                 pending.cast_timing_permission = cast_timing_permission;
                 pending.origin_zone = origin_zone;
                 pending.payment_mode = payment_mode;
+                // CR 601.2f + CR 601.2h: a required additional cost the parser
+                // could not read is part of the total cost and has no payment
+                // procedure, so the cast is illegal. Refused here rather than by
+                // the generic check below only so the message names the cost, in
+                // the wording the activation-cost sibling in `costs.rs` and the
+                // payment-step backstop below both use.
+                if let AbilityCost::Unimplemented { description } = req_cost {
+                    super::casting::handle_cancel_cast(state, &pending, events);
+                    return Err(EngineError::ActionNotAllowed(format!(
+                        "Cost not implemented: {description}"
+                    )));
+                }
                 // CR 601.2b + CR 601.2f: Required additional cost whose
                 // residual object choice is unavailable or whose declared mana
                 // total is unaffordable makes the spell uncastable.
@@ -8489,6 +8511,39 @@ fn pay_additional_cost_with_source(
                     spell: Box::new(pending),
                 },
             });
+        }
+        AbilityCost::Unimplemented { description } => {
+            // CR 601.2f + CR 601.2h: an additional cost the parser could not read
+            // is part of the total cost and cannot be paid, so the payment step
+            // must refuse it. Without this arm it falls into the catch-all below,
+            // which does nothing and then continues to `finish_pending_cost_or_cast`
+            // — i.e. the unpayable cost is silently declared PAID and the spell is
+            // cast for free.
+            //
+            // BACKSTOP, AND DELIBERATELY UNCOVERED BY TEST. Every path a shipping
+            // card takes today is already refused upstream — enumeration by
+            // `can_cast_prepared_now_with_probe`, declaration by
+            // `additional_cost_declaration_is_offerable`, and a directly submitted
+            // announcement by the `Required` arm of
+            // `check_additional_cost_or_pay_with_distribute`. Deleting this arm
+            // breaks no test, and that is expected rather than a gap in the suite.
+            //
+            // It is not dead code: the `AdditionalCost::Required` arm of the
+            // additional-cost QUEUE walk calls this function directly, without
+            // re-consulting the offerable gate. No corpus card puts a
+            // `Required(Unimplemented)` on that queue today — a card's own single
+            // additional cost travels via `additional_cost_flow` — so the path is
+            // reachable in principle and unreached in practice. Removing the arm
+            // to satisfy coverage would restore the silent-satisfaction hole for
+            // the first card that does queue one.
+            //
+            // The wording matches the activation-cost sibling in `costs.rs`, which
+            // has always refused here (CR 602.2b extends CR 601.2h to an
+            // activation cost).
+            super::casting::handle_cancel_cast(state, &pending, events);
+            return Err(EngineError::ActionNotAllowed(format!(
+                "Cost not implemented: {description}"
+            )));
         }
         _ => {
             // Other cost types (Exile, etc.) — not yet interactive

--- a/crates/engine/src/game/casting_tests.rs
+++ b/crates/engine/src/game/casting_tests.rs
@@ -56637,3 +56637,320 @@ mod fixed_mana_ability_tap_cost_rejects_partial_payment {
         );
     }
 }
+
+/// CR 601.2f + CR 601.2h (#8701): an additional cost the parser cannot read is
+/// still part of the total cost, and "unpayable costs can't be paid" — so the
+/// spell must be honestly refused rather than cast with the cost silently
+/// treated as satisfied. Before this fix `AbilityCost::Unimplemented` had no arm
+/// in the cast-time payment match and fell into its catch-all, which does
+/// nothing and then continues to `finish_pending_cost_or_cast`: the spell cast
+/// and resolved for free.
+///
+/// Every fixture below is built with `from_oracle_text`, so it exercises the
+/// real parser rather than a hand-assembled cost.
+#[cfg(test)]
+mod unreadable_additional_cost_is_refused_not_free {
+    use super::*;
+    use crate::game::scenario::{GameScenario, P0, P1};
+
+    const CLOSE_ENCOUNTER_ORACLE: &str = "As an additional cost to cast this spell, choose a creature you control or a warped creature card you own in exile.\nClose Encounter deals damage equal to the power of the chosen creature or card to target creature.";
+
+    fn setup() -> (
+        crate::game::scenario::GameRunner,
+        ObjectId,
+        ObjectId,
+        ObjectId,
+    ) {
+        let mut scenario = GameScenario::new();
+        scenario.at_phase(Phase::PreCombatMain);
+        scenario.add_basic_land(P0, ManaColor::Green);
+        scenario.add_basic_land(P0, ManaColor::Green);
+        let mine = scenario.add_creature(P0, "Chosen Creature", 3, 3).id();
+        let victim = scenario.add_creature(P1, "Victim", 0, 5).id();
+        let spell = scenario
+            .add_spell_to_hand(P0, "Close Encounter", true)
+            .with_mana_cost(ManaCost::Cost {
+                shards: vec![ManaCostShard::Green],
+                generic: 1,
+            })
+            .from_oracle_text(CLOSE_ENCOUNTER_ORACLE)
+            .id();
+        (scenario.build(), spell, mine, victim)
+    }
+
+    /// Anti-vacuity guard: the real parser must actually attach
+    /// `Required(Unimplemented)` to this object, otherwise every assertion
+    /// below is about the wrong shape.
+    #[test]
+    fn fixture_really_carries_required_unimplemented() {
+        let (runner, spell, _mine, _victim) = setup();
+        assert!(
+            matches!(
+                runner.state().objects[&spell].additional_cost,
+                Some(AdditionalCost::Required(AbilityCost::Unimplemented { .. }))
+            ),
+            "fixture must be the production choose-behold shape, got {:?}",
+            runner.state().objects[&spell].additional_cost
+        );
+    }
+
+    /// The cast must not be enumerated as a legal action.
+    #[test]
+    fn cast_is_not_offered() {
+        let (runner, spell, _mine, _victim) = setup();
+        let offered: Vec<_> = crate::ai_support::legal_actions_full(runner.state())
+            .0
+            .into_iter()
+            .filter(|a| matches!(a, GameAction::CastSpell { object_id, .. } if *object_id == spell))
+            .collect();
+        assert!(
+            offered.is_empty(),
+            "a spell whose required additional cost is unreadable must not be castable: {offered:?}"
+        );
+    }
+
+    /// Driving the full cast pipeline must be refused, not silently accepted.
+    #[test]
+    fn full_cast_is_refused_not_silently_free() {
+        let (mut runner, spell, _mine, victim) = setup();
+        let outcome = runner.cast(spell).target_object(victim).try_resolve();
+        let err = match outcome {
+            Ok(o) => panic!(
+                "the cast must be refused; instead it resolved (spell zone {:?})",
+                o.state().objects.get(&spell).map(|obj| obj.zone)
+            ),
+            Err(e) => e,
+        };
+        assert!(
+            format!("{err:?}").contains("Cost not implemented"),
+            "refusal must name the unimplemented cost, got {err:?}"
+        );
+    }
+
+    /// CR 601.2 + CR 733.1: a force-submitted cast that is refused mid-
+    /// announcement must not wedge — `CancelCast` returns the game to the
+    /// moment before the proposal.
+    #[test]
+    fn refused_cast_is_recoverable_via_cancel() {
+        let (mut runner, spell, _mine, victim) = setup();
+        let card_id = runner.state().objects[&spell].card_id;
+        runner
+            .act(GameAction::CastSpell {
+                object_id: spell,
+                card_id,
+                targets: vec![],
+                payment_mode: CastPaymentMode::Auto,
+            })
+            .expect("the reducer still accepts a force-submitted announcement");
+        runner
+            .act(GameAction::SelectTargets {
+                targets: vec![TargetRef::Object(victim)],
+            })
+            .expect_err("the unreadable additional cost must refuse the cast");
+        // CR 733.1: the rejected action was rolled back, so the announcement is
+        // still live and must be backed out explicitly.
+        assert_eq!(runner.state().stack.len(), 1);
+        runner
+            .act(GameAction::CancelCast)
+            .expect("cancelling the stuck announcement must be accepted");
+        assert!(
+            runner.state().stack.is_empty(),
+            "cancel must clear the announced spell: {:?}",
+            runner.state().stack
+        );
+        assert_eq!(runner.state().objects[&spell].zone, Zone::Hand);
+        assert!(
+            matches!(runner.state().waiting_for, WaitingFor::Priority { .. }),
+            "after cancel the game must be back at priority, got {:?}",
+            runner.state().waiting_for
+        );
+    }
+
+    // ---------------------------------------------------------------------
+    // The cards the parser change newly reaches: an unreadable REQUIRED cost
+    // (Main Event Horizon) and an unreadable OPTIONAL one (Myntasha, Honored
+    // One). Both were `additional_cost: None` before the fix — no cost at all.
+    // ---------------------------------------------------------------------
+
+    const MAIN_EVENT_HORIZON_ORACLE: &str = "As an additional cost to cast this spell, choose A through M or N through Z.\nDestroy each creature whose name begins with a letter in the chosen range.";
+
+    fn main_event_horizon() -> (crate::game::scenario::GameRunner, ObjectId, ObjectId) {
+        let mut scenario = GameScenario::new();
+        scenario.at_phase(Phase::PreCombatMain);
+        for _ in 0..5 {
+            scenario.add_basic_land(P0, ManaColor::White);
+        }
+        let bystander = scenario.add_creature(P0, "Bystander", 2, 2).id();
+        let spell = scenario
+            .add_spell_to_hand(P0, "Main Event Horizon", false)
+            .with_mana_cost(ManaCost::Cost {
+                shards: vec![ManaCostShard::White, ManaCostShard::White],
+                generic: 3,
+            })
+            .from_oracle_text(MAIN_EVENT_HORIZON_ORACLE)
+            .id();
+        (scenario.build(), spell, bystander)
+    }
+
+    /// Anti-vacuity guard: before asserting the cast is refused, prove the
+    /// parser actually attached a required unreadable cost to this face. On
+    /// pre-fix parser code this is `None` and the two tests below are asserting
+    /// about a spell that simply has no additional cost.
+    #[test]
+    fn main_event_horizon_carries_a_required_unreadable_cost() {
+        let (runner, spell, _) = main_event_horizon();
+        match &runner.state().objects[&spell].additional_cost {
+            Some(AdditionalCost::Required(AbilityCost::Unimplemented { description })) => {
+                assert_eq!(description, "choose A through M or N through Z");
+            }
+            other => panic!("expected Required(Unimplemented), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn main_event_horizon_is_not_offered_and_is_refused() {
+        let (mut runner, spell, bystander) = main_event_horizon();
+        let offered: Vec<_> = crate::ai_support::legal_actions_full(runner.state())
+            .0
+            .into_iter()
+            .filter(|a| matches!(a, GameAction::CastSpell { object_id, .. } if *object_id == spell))
+            .collect();
+        assert!(
+            offered.is_empty(),
+            "a spell whose required additional cost is unreadable must not be castable: {offered:?}"
+        );
+        let card_id = runner.state().objects[&spell].card_id;
+        let err = runner
+            .act(GameAction::CastSpell {
+                object_id: spell,
+                card_id,
+                targets: vec![],
+                payment_mode: CastPaymentMode::Auto,
+            })
+            .expect_err("a force-submitted cast must be refused, not silently cast for free");
+        assert!(
+            format!("{err:?}").contains("Cost not implemented"),
+            "the refusal must name the unreadable cost, got {err:?}"
+        );
+        // CR 733.1: the illegal action is reversed — nothing was destroyed, no
+        // mana was spent, and the spell is still in hand.
+        assert_eq!(runner.state().objects[&spell].zone, Zone::Hand);
+        assert_eq!(runner.state().objects[&bystander].zone, Zone::Battlefield);
+        assert_eq!(
+            runner
+                .state()
+                .objects
+                .values()
+                .filter(|o| o.zone == Zone::Battlefield && o.tapped)
+                .count(),
+            0,
+            "a refused cast must not leave lands tapped"
+        );
+    }
+
+    const MYNTASHA_ORACLE: &str = "As an additional cost to cast this spell, you may open a sealed Magic booster pack and put the cards on the bottom of your booster pile in a random order.\nSpells you cast have booster cascade.";
+
+    /// CR 601.2b: an unreadable OPTIONAL additional cost must NOT brick the
+    /// spell. Declining an optional additional cost is always legal, and an
+    /// unpayable one can never be declared (CR 601.2h), so the prompt is skipped
+    /// and the spell casts normally. This is the guard against the fix being
+    /// wrong in the restrictive direction.
+    #[test]
+    fn optional_unreadable_cost_leaves_the_spell_castable() {
+        let mut scenario = GameScenario::new();
+        scenario.at_phase(Phase::PreCombatMain);
+        for _ in 0..4 {
+            scenario.add_basic_land(P0, ManaColor::Green);
+        }
+        let spell = scenario
+            .add_creature_to_hand_from_oracle(P0, "Myntasha, Honored One", 4, 4, MYNTASHA_ORACLE)
+            .with_mana_cost(ManaCost::Cost {
+                shards: vec![ManaCostShard::Green, ManaCostShard::Green],
+                generic: 2,
+            })
+            .id();
+        let mut runner = scenario.build();
+        // Anti-vacuity: the parser really did attach an unreadable OPTIONAL cost.
+        match &runner.state().objects[&spell].additional_cost {
+            Some(AdditionalCost::Optional {
+                cost: AbilityCost::Unimplemented { .. },
+                ..
+            }) => {}
+            other => panic!("expected Optional(Unimplemented), got {other:?}"),
+        }
+        let offered: Vec<_> = crate::ai_support::legal_actions_full(runner.state())
+            .0
+            .into_iter()
+            .filter(|a| matches!(a, GameAction::CastSpell { object_id, .. } if *object_id == spell))
+            .collect();
+        assert!(
+            !offered.is_empty(),
+            "an OPTIONAL unreadable additional cost must not make the spell uncastable"
+        );
+        let resolved = runner
+            .cast(spell)
+            .try_resolve()
+            .expect("the spell must cast and resolve with the optional cost declined");
+        assert_eq!(resolved.state().objects[&spell].zone, Zone::Battlefield);
+    }
+
+    /// CR 601.2h: an unpayable optional cost must never be OFFERED, not merely be
+    /// declinable. This is what `additional_cost_declaration_is_offerable` uniquely
+    /// contributes: at the `AdditionalCost::Optional` arm of the queue walk it
+    /// drops the instance and finishes the cast, where without it the engine calls
+    /// `make_optional_cost_choice` and parks on `WaitingFor::OptionalCostChoice`,
+    /// asking the player to decide about a cost that has no payment procedure.
+    ///
+    /// `optional_unreadable_cost_leaves_the_spell_castable` above cannot see this:
+    /// the spell resolves either way, because a prompt that is offered is then
+    /// simply declined. The prompt's ABSENCE is the observable.
+    ///
+    /// Revert-failing: delete the `AbilityCost::Unimplemented` early return from
+    /// `additional_cost_declaration_is_offerable` and the cast parks on
+    /// `OptionalCostChoice` instead of proceeding.
+    #[test]
+    fn an_unpayable_optional_cost_is_never_offered_to_the_player() {
+        let mut scenario = GameScenario::new();
+        scenario.at_phase(Phase::PreCombatMain);
+        for _ in 0..4 {
+            scenario.add_basic_land(P0, ManaColor::Green);
+        }
+        let spell = scenario
+            .add_creature_to_hand_from_oracle(P0, "Myntasha, Honored One", 4, 4, MYNTASHA_ORACLE)
+            .with_mana_cost(ManaCost::Cost {
+                shards: vec![ManaCostShard::Green, ManaCostShard::Green],
+                generic: 2,
+            })
+            .id();
+        let mut runner = scenario.build();
+
+        // Anti-vacuity: the fixture must really carry an unreadable OPTIONAL cost,
+        // or the absence of a prompt below proves nothing.
+        match &runner.state().objects[&spell].additional_cost {
+            Some(AdditionalCost::Optional {
+                cost: AbilityCost::Unimplemented { .. },
+                ..
+            }) => {}
+            other => panic!("expected Optional(Unimplemented), got {other:?}"),
+        }
+
+        let card_id = runner.state().objects[&spell].card_id;
+        runner
+            .act(GameAction::CastSpell {
+                object_id: spell,
+                card_id,
+                targets: vec![],
+                payment_mode: CastPaymentMode::Auto,
+            })
+            .expect("announcing the cast must be accepted");
+
+        assert!(
+            !matches!(
+                runner.state().waiting_for,
+                WaitingFor::OptionalCostChoice { .. }
+            ),
+            "an unpayable optional cost must be skipped, not offered — got {:?}",
+            runner.state().waiting_for
+        );
+    }
+}

--- a/crates/engine/src/parser/oracle_casting.rs
+++ b/crates/engine/src/parser/oracle_casting.rs
@@ -37,11 +37,21 @@ pub(crate) fn split_additional_cost_trailing_spell_reduction<'a>(
 /// - "you may blight N" → `Optional(Blight { count: N })`
 /// - "blight N or pay {M}" → `Choice(Blight { count: N }, Mana { cost: M })`
 /// - General "X or Y" → `Choice(X, Y)` using `parse_single_cost` for each fragment
+/// - Anything no arm can read → an honest `Unimplemented` cost (`Optional` for a
+///   "you may" body, otherwise `Required`), NOT `None`. CR 601.2f + CR 601.2h:
+///   the cost is part of the total cost and cannot be silently dropped. Only a
+///   line whose "…to cast this spell, " prefix matched gets this treatment; a
+///   line imposing a cost on OTHER spells still answers `None`.
 pub fn parse_additional_cost_line(lower: &str, raw: &str) -> Option<AdditionalCost> {
-    // Strip the standard additional-cost prefix.
-    let after_prefix = tag::<_, _, OracleError<'_>>("as an additional cost to cast this spell, ")
-        .parse(lower)
-        .map_or(lower, |(rest, _)| rest);
+    // Strip the standard additional-cost prefix. `names_this_spell` records
+    // whether that prefix actually matched, which the honest-decline tail below
+    // depends on: a line that instead imposes a cost on OTHER spells ("As an
+    // additional cost to cast creature spells, ..." — Chorus of the Conclave) is
+    // not a cost on this object at all, so no cost may be stapled to its face.
+    let (after_prefix, names_this_spell) =
+        tag::<_, _, OracleError<'_>>("as an additional cost to cast this spell, ")
+            .parse(lower)
+            .map_or((lower, false), |(rest, _)| (rest, true));
     // Use TextPair for case-preserving parallel slicing, then strip trailing period.
     let tp = TextPair::new(&raw[raw.len() - after_prefix.len()..], after_prefix);
     let tp = tp.trim_end_matches('.');
@@ -122,6 +132,42 @@ pub fn parse_additional_cost_line(lower: &str, raw: &str) -> Option<AdditionalCo
     let cost = super::oracle_cost::parse_single_cost(body_raw);
     if !matches!(cost, AbilityCost::Unimplemented { .. }) {
         return Some(AdditionalCost::Required(cost));
+    }
+
+    // CR 601.2f + CR 601.2h: every arm above has declined, so this IS an
+    // additional-cost line the parser cannot read — not the absence of one. The
+    // sole production caller (`oracle.rs`, gated on the "as an additional cost"
+    // opener) consumes the line either way, so answering `None` here does not
+    // hand it to another arm; it erases the cost from the total cost the spell
+    // may never be cast without. Surface the unreadable cost honestly instead,
+    // exactly as the choose-behold guard above does: coverage names it, and the
+    // cast-time payment authority refuses a cost it has no procedure for
+    // ("Unpayable costs can't be paid").
+    //
+    // Gated on `names_this_spell` so only a cost this object itself must pay is
+    // surfaced; an unmatched prefix leaves the `None` untouched.
+    if names_this_spell {
+        // CR 601.2b: "you may <cost>" is an OPTIONAL additional cost the player
+        // announces an intention to pay. Surfacing it as `Required` would make
+        // the spell uncastable, which is wrong in the restrictive direction —
+        // declining an optional cost is always legal. This runs only after the
+        // "you may" arm above has already declined, so it steals no dispatch.
+        let (unreadable_raw, optional) = tag::<_, _, OracleError<'_>>("you may ")
+            .parse(body_lower)
+            .map_or((body_raw, false), |(rest, _)| {
+                (&body_raw[body_raw.len() - rest.len()..], true)
+            });
+        let unreadable = AbilityCost::Unimplemented {
+            description: unreadable_raw.to_string(),
+        };
+        return Some(if optional {
+            AdditionalCost::Optional {
+                cost: unreadable,
+                repeatability: crate::types::ability::AdditionalCostRepeatability::Once,
+            }
+        } else {
+            AdditionalCost::Required(unreadable)
+        });
     }
 
     None
@@ -2453,5 +2499,95 @@ Trample";
             restrictions, None,
             "trailing conjunct must not be swallowed into an unconditional turn restriction"
         );
+    }
+
+    /// CR 601.2f + CR 601.2h (#8701): an additional-cost line whose body no arm
+    /// can read must surface an honest `Unimplemented` cost, not vanish. The
+    /// old tail answered `None` — "this spell has NO additional cost" — which
+    /// erased a printed cost from the total cost and left the spell castable
+    /// without it. Three real corpus lines, one per unreadable shape.
+    #[test]
+    fn unreadable_required_additional_cost_is_surfaced_not_dropped() {
+        for (lower, raw, expected_description) in [
+            (
+                "as an additional cost to cast this spell, discard x cards at random.",
+                "As an additional cost to cast this spell, discard X cards at random.",
+                "discard X cards at random",
+            ),
+            (
+                "as an additional cost to cast this spell, gobble x.",
+                "As an additional cost to cast this spell, gobble X.",
+                "gobble X",
+            ),
+            (
+                "as an additional cost to cast this spell, choose a through m or n through z.",
+                "As an additional cost to cast this spell, choose A through M or N through Z.",
+                "choose A through M or N through Z",
+            ),
+        ] {
+            match parse_additional_cost_line(lower, raw) {
+                Some(AdditionalCost::Required(AbilityCost::Unimplemented { description })) => {
+                    assert_eq!(
+                        description, expected_description,
+                        "the description must be the prefix-stripped body, not the whole line"
+                    );
+                }
+                other => panic!("Expected Required(Unimplemented) for {raw:?}, got {other:?}"),
+            }
+        }
+    }
+
+    /// CR 601.2b: an unreadable "you may <cost>" additional cost is OPTIONAL.
+    /// Surfacing it as `Required` would make the spell uncastable, which is
+    /// wrong in the restrictive direction — declining an optional additional
+    /// cost is always legal (Myntasha, Honored One).
+    #[test]
+    fn unreadable_optional_additional_cost_stays_optional() {
+        let lower = "as an additional cost to cast this spell, you may open a sealed magic booster pack and put the cards on the bottom of your booster pile in a random order.";
+        let raw = "As an additional cost to cast this spell, you may open a sealed Magic booster pack and put the cards on the bottom of your booster pile in a random order.";
+        match parse_additional_cost_line(lower, raw) {
+            Some(AdditionalCost::Optional {
+                cost: AbilityCost::Unimplemented { description },
+                repeatability: crate::types::ability::AdditionalCostRepeatability::Once,
+            }) => {
+                assert_eq!(
+                    description,
+                    "open a sealed Magic booster pack and put the cards on the bottom of your booster pile in a random order",
+                    "the \"you may \" opener is the optionality marker, not part of the cost"
+                );
+            }
+            other => panic!("Expected Optional(Unimplemented, Once), got {other:?}"),
+        }
+    }
+
+    /// CR 601.2b: "As an additional cost to cast creature SPELLS, ..." (Chorus
+    /// of the Conclave) is a static ability imposing a cost on OTHER spells —
+    /// it is not a cost on this object. The honest-decline tail is gated on the
+    /// "...to cast this spell, " prefix having actually matched precisely so
+    /// this line keeps answering `None` instead of stapling a required cost
+    /// onto Chorus's own face.
+    #[test]
+    fn additional_cost_imposed_on_other_spells_is_not_a_cost_on_this_face() {
+        let lower = "as an additional cost to cast creature spells, you may pay any amount of mana. if you do, that creature enters with that many additional +1/+1 counters on it";
+        let raw = "As an additional cost to cast creature spells, you may pay any amount of mana. If you do, that creature enters with that many additional +1/+1 counters on it";
+        assert_eq!(
+            parse_additional_cost_line(lower, raw),
+            None,
+            "a cost imposed on other spells must not become this object's own additional cost"
+        );
+    }
+
+    /// Anti-vacuity guard for the two tests above: a READABLE body must still
+    /// reach the typed single-cost fallback and never the new honest-decline
+    /// tail. If the tail ever started swallowing readable lines, the
+    /// `Unimplemented` assertions above would pass for the wrong reason.
+    #[test]
+    fn readable_additional_cost_still_parses_to_a_typed_cost() {
+        let lower = "as an additional cost to cast this spell, sacrifice a creature.";
+        let raw = "As an additional cost to cast this spell, sacrifice a creature.";
+        match parse_additional_cost_line(lower, raw) {
+            Some(AdditionalCost::Required(AbilityCost::Sacrifice(_))) => {}
+            other => panic!("a readable body must stay a typed cost, got {other:?}"),
+        }
     }
 }


### PR DESCRIPTION
## Summary

**Closes #8701.** `parse_additional_cost_line` ended with a bare `None`, which means *"this line carries no additional cost"* — so a cost the parser could not read became a spell with **no** additional cost, castable for free. And `Required(Unimplemented)` was then silently treated as **satisfied** downstream, so surfacing the cost would not have refused the cast on its own.

This is not the one-line change the issue proposed. Two investigations changed its shape, and one of them found the naive fix would have been actively harmful.

## Files changed

- `crates/engine/src/parser/oracle_casting.rs`
- `crates/engine/src/game/casting_costs.rs`
- `crates/engine/src/game/casting.rs`
- `crates/engine/src/game/casting_tests.rs`

## Track

Developer

## LLM

Model: claude-opus-5
Tier: Frontier
Thinking: high

## Implementation method (required)

Method: not-applicable — resolves a previously filed engine issue (#8701) across the parser and the casting path, rather than implementing a card. The `review-impl` lenses were run against the committed head; findings and their disposition are below.

## CR references

- `CR 601.2f` — the total cost includes additional costs.
- `CR 601.2h` — "Partial payments are not allowed. Unpayable costs can't be paid." A cost with no payment procedure can never be declared.
- `CR 601.2 + CR 733.1` — a cast that cannot legally complete is reversed entirely, which is why the refused announcement is cancellable rather than wedged.
- `CR 602.2b` — cited where the activation-cost sibling's wording is reused, since 601.2h is written about casting.

All verified against `docs/MagicCompRules.txt`.

## Verification

- [x] Required checks ran clean, or the exact CI-owned alternative is stated below.
- [x] Gate A output below is for the current committed head.
- [x] Final review-impl below is clean for the current committed head.
- [x] Both anchors cite existing analogous code at the same seam.

- `cargo test -p phase-engine --lib` — **21206 passed; 0 failed; 8 ignored**
- `cargo test -p phase-engine --test integration` — **6901 passed; 0 failed; 4 ignored**
- `cargo fmt --all -- --check` — clean
- `cargo clippy -p phase-engine --all-targets` — clean
- `scripts/check-parser-combinators.sh` — Gate A PASS, Gate G PASS
- `scripts/check-prelowered-ratchet.sh` — Gate P PASS
- `scripts/check-cr-citation-anchors.sh` — PASS

**Revert-failing in both halves**, each revert actually run: reverting the parser hunks fails 5 tests; reverting the runtime hunks fails 4, capturing the free cast live — *"the cast must be refused; instead it resolved (spell zone Some(Graveyard))"* alongside `ZoneChanged{Hand->Stack}` + `SpellCast` + `ManaExpended{amount_spent: 2}`.

## Gate A

Gate A PASS head=ee46df2d6a76faeb894df4ce3ba60173c514933a base=280d6e1f0b5661ee70876b476b0260aec2fc2887

## Anchored on

- `crates/engine/src/parser/oracle_casting.rs` — the `is_choose_behold_prefix` guard a few lines above already returns `Some(Required(Unimplemented))` for one prefix, with the same stated reason: *"Surface an honest unimplemented cost so coverage stays red."* This generalises that shape rather than inventing one.
- `crates/engine/src/game/costs.rs` — the activation-cost sibling has always refused an `Unimplemented` cost at the payment step. The new cast-side arms reuse its wording, so the two channels now fail the same way.

## Claimed parse impact

**4 cards**, measured by re-parsing all 35,436 corpus faces through `parse_oracle_text` on both sides — never by reading the export's `abilities` field.

| Card | Before | After |
|---|---|---|
| Devastating Dreams | additional cost **absent** | `Required(Unimplemented)` |
| Main Event Horizon | additional cost **absent** | `Required(Unimplemented)` |
| Pie-Eating Contest | additional cost **absent** | `Required(Unimplemented)` |
| Myntasha, Honored One | additional cost **absent** | `Optional(Unimplemented, Once)` |

Those first three become honestly uncastable instead of castable for free. Myntasha stays castable — see below.

## Scope Expansion

None. The three earlier `if !matches!(..Unimplemented..)` guards are deliberately untouched: they are *dispatch*, letting a later arm try, and 9–10 shipping cards depend on the third declining so the final fallback can answer with the correct `Or`-filtered cost.

## Validation Failures

None.

## CI Failures

None.

---

### The naive fix would have broken a working card

The sole caller consumes the line whether the result is `Some` or `None`, so there is no hijack-by-dispatch risk. But its gate (`"as an additional cost"`) is **looser** than the prefix this function strips (`"as an additional cost to cast this spell, "`). A blanket fix staples a required cost onto **Chorus of the Conclave**, whose line imposes a cost on *other* spells.

So the honest decline is gated on that prefix having actually matched. That gate is verified load-bearing: relaxing it to `|| true` makes exactly two tests fail, one of them the pre-existing `swallow_check` test whose premise asserts Chorus parses to no cost.

Knowingly excluded by the same gate: **Banned Eldraine Card** (`"...to play <name>"`) — a genuine self-cost, but an acorn card, and it stays red as a `SilentDrop` either way. Named rather than left silent.

### And a uniform `Required` would have broken another

Myntasha, Honored One's line is *"you may open a sealed Magic booster pack..."* — an **optional** cost. `Required(Unimplemented)` would make the card uncastable, wrong in the restrictive direction. It surfaces as `Optional(Unimplemented, Once)` and, being unpayable, is simply never offered.

### Review found two untested hunks; both are addressed

The `review-impl` pass returned 2 LAND and 1 NEEDS_WORK. The NEEDS_WORK findings were both real, and I reproduced each before acting:

- **The widest hunk had no test.** `additional_cost_declaration_is_offerable`'s gate — 12 call sites — could be removed with all 11 tests still passing. It is now pinned by `an_unpayable_optional_cost_is_never_offered_to_the_player`, which observes what the gate *uniquely* does: without it the engine parks on `WaitingFor::OptionalCostChoice`, asking the player to decide about `"open a sealed Magic booster pack"`. The pre-existing optional test cannot see this, because the spell resolves either way once an offered prompt is declined. The new test is the only one that fails under that mutation.

- **The payment backstop is untested, and now says so.** Deleting it breaks nothing, because every path a shipping card takes is refused upstream. That is expected rather than a gap, and the comment now states it plainly instead of implying coverage. It is still not dead code: the `Required` arm of the additional-cost **queue** walk calls payment *without* re-consulting the gate, and no corpus card queues a `Required(Unimplemented)` today. Removing it to satisfy a coverage metric would restore the silent-satisfaction hole for the first card that does.

### One correction to the issue I filed

#8701 said the choose-behold author had declined to generalise this fix. That was wrong — they solved one card and never looked at the fallback. The deliberate, reasoned endorsement is #8677's own doc comment, which states in-tree that *"the honest repair there is a `Required(Unimplemented)` at that call site"*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Spells with required additional costs that cannot be understood are no longer presented as castable or silently treated as free.
  - Direct attempts to cast such spells are refused with a clear “Cost not implemented” message, and the game state is restored.
  - Unreadable optional costs no longer block casting; the optional cost prompt is skipped.
  - Additional-cost parsing now correctly distinguishes costs applying to the selected spell from unrelated spells.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->